### PR TITLE
`alpha.yml` add zsync update to appimage

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -288,10 +288,11 @@ jobs:
           ls -al
           find .
           ls -al "$APPDIR"
-          ARCH=x86_64 ./appimagetool-x86_64.AppImage --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 10 "$APPDIR" zen.AppImage
+          ARCH=x86_64 ./appimagetool-x86_64.AppImage --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 10 \
+          -u "gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|desktop|latest|zen-${{ matrix.generic == true && 'generic' || 'specific' }}.AppImage.zsync" \
+          "$APPDIR" zen-${{ matrix.generic == true && 'generic' || 'specific' }}.AppImage
           mkdir dist
-          mv zen.AppImage* dist/.
-          mv ./dist/zen.AppImage ./dist/zen-${{ matrix.generic == true && 'generic' || 'specific' }}.AppImage
+          mv zen*AppImage* dist/.
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This change would enable the appimage to be updated with [AppImageUpdate](https://github.com/AppImageCommunity/AppImageUpdate) (delta updates). 

I also did a small change, originally appimagetool was being told to make a `zen.AppImage` and once it got moved to `dist` it was renamed with that `${{ matrix.generic == true && 'generic' || 'specific' }}` that determines the type. 

I instead just told appimagetool to make the appimage have that name directly. 

Something I'm a bit worried is that the same `${{ matrix.generic == true && 'generic' || 'specific' }}` also goes to the zsync file, hopefully it goes right. I tried to run the workflow on my fork to check that but I really don't know how it works 😅

