### PR TITLE
Update zen-browser.js to enable Browser Toolbox by default

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -132,3 +132,8 @@ pref("network.dns.disablePrefetchFromHTTPS", false);
 pref("network.predictor.enable-hover-on-ssl", true);
 pref("network.http.speculative-parallel-limit", 10);
 pref("network.http.rcwn.enabled", false);
+
+// Enable Browser Toolbox, Ctrl+Shift+Alt+I for debugging and modifying UI
+pref("devtools.debugger.remote-enabled", true);
+pref("devtools.chrome.enabled", true);
+


### PR DESCRIPTION
This is very helpful for people who want to tinker with Zen's UI.

Maybe for convenience we should create `chrome` folder inside Zen's profile by default, and `userChrome.css`+`userContent.css` like Floorp.

Press Ctrl+Shift+Alt+I to open Browser Toolbox and click Style Editor, filter `userChrome.css` to start modifying.

