### PR TITLE
Disable Reader Mode's parse on load

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -148,4 +148,7 @@ pref("devtools.chrome.enabled", true);
 pref("sidebar.revamp", false, locked);
 pref("sidebar.verticalTabs", false, locked);
 
+// Disable Reader Mode's parse on load (costs extra CPU after page load, Reader Mode works fine just lazier)
+pref("reader.parse-on-load.enabled", false);
+
 


### PR DESCRIPTION
Disable Reader Mode's parse on load (costs extra CPU after page load, Reader Mode works fine just lazier)