### PR TITLE
fix: remove a typo in the update details url

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -116,7 +116,7 @@ pref('media.eme.enabled', true);
 pref('webgl.disabled', false);
 
 pref("app.update.url.manual", "https://www.zen-browser.app/download");
-pref("app.update.url.details", "hhttps://www.zen-browser.app/download");
+pref("app.update.url.details", "https://www.zen-browser.app/download");
 pref("app.releaseNotesURL", "https://www.zen-browser.app/release-notes");
 pref("app.releaseNotesURL.aboutDialog", "https://www.zen-browser.app/release-notes");
 


### PR DESCRIPTION
The URL to visit when a user clicks “More information about this update” in the software update wizard.