### PR TITLE
Fix #619 - Add flatpak session bus comminucation to org.freedesktop.ScreenSaver

### DIFF
--- a/flatpak/io.github.zen_browser.zen.yml.template
+++ b/flatpak/io.github.zen_browser.zen.yml.template
@@ -17,6 +17,7 @@ finish-args:
   - --filesystem=xdg-download:rw
   - --device=all
   - --talk-name=org.freedesktop.FileManager1
+  - --talk-name=org.freedesktop.ScreenSaver
   - --own-name=org.mozilla.zen.*
   - --own-name=org.mpris.MediaPlayer2.firefox.*
   - --system-talk-name=org.freedesktop.NetworkManager


### PR DESCRIPTION
Fix ScreenSaver issue #619 while video play: Allow talk to `org.freedesktop.ScreenSaver`