### PR TITLE
fix: use generic fullscreen detection pseudo-class

### DIFF
--- a/src/browser/base/content/zen-styles/zen-browser-container.css
+++ b/src/browser/base/content/zen-styles/zen-browser-container.css
@@ -1,5 +1,5 @@
 
-:root:not([inDOMFullscreen="true"]):not([chromehidden~="location"]):not([chromehidden~="toolbar"]) {
+:root:not([inFullscreen="true"]):not([chromehidden~="location"]):not([chromehidden~="toolbar"]) {
   & #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     width: -moz-available;
     margin: 0 var(--zen-element-separation) var(--zen-element-separation) 0;

--- a/src/browser/base/content/zen-styles/zen-browser-ui.css
+++ b/src/browser/base/content/zen-styles/zen-browser-ui.css
@@ -18,11 +18,11 @@ html#main-window > body {
   background: var(--zen-main-browser-background) !important;
 }
 
-:not([inDOMFullscreen="true"]) #appcontent {
+:not([inFullscreen="true"]) #appcontent {
   overflow: hidden;
 }
 
-:not([inDOMFullscreen="true"]) #appcontent,
+:not([inFullscreen="true"]) #appcontent,
 #sidebar-box {
   /** Sidebar is already hidden in full screen mode */
   box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px;

--- a/src/browser/base/content/zen-styles/zen-compact-mode.css
+++ b/src/browser/base/content/zen-styles/zen-compact-mode.css
@@ -117,7 +117,7 @@
   #navigator-toolbox[inFullscreen] > #PersonalToolbar,
   #PersonalToolbar[collapsed="true"]{ display: none }
 
-  :root:not([inDOMFullscreen="true"]) #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+  :root:not([inFullscreen="true"]) #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     margin-left: var(--zen-element-separation) !important;
   }
 
@@ -147,7 +147,7 @@
       opacity: 1;
     }
 
-    :root:not([inDOMFullscreen="true"]) #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    :root:not([inFullscreen="true"]) #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
       margin-top: var(--zen-element-separation) !important;
     }
 

--- a/src/browser/base/content/zen-styles/zen-sidebar.css
+++ b/src/browser/base/content/zen-styles/zen-sidebar.css
@@ -189,13 +189,13 @@
   display: none;
 }
 
-:root:not([inDOMFullscreen="true"]) #zen-sidebar-splitter {
+:root:not([inFullscreen="true"]) #zen-sidebar-splitter {
   display: block;
   width: 1px;
   opacity: 0;
 }
 
-:root[inDOMFullscreen="true"] #zen-sidebar-splitter {
+:root[inFullscreen="true"] #zen-sidebar-splitter {
   display: none;
 }
 

--- a/src/browser/base/content/zen-styles/zen-toolbar.css
+++ b/src/browser/base/content/zen-styles/zen-toolbar.css
@@ -3,6 +3,6 @@
   background: transparent;
 }
 
-:root[inDOMFullscreen="true"] #zen-appcontent-navbar-container {
+:root[inFullscreen="true"] #zen-appcontent-navbar-container {
   display: none;
 }


### PR DESCRIPTION
Closes #614 

Replaces all instances of `inDOMFullscreen` pseudo-class with `inFullscreen` pseudo-class to ensure consistent behavior regardless of how window became (borderless) fullscreen.

Most notably, it allows toolbars to disappear whenever fullscreen state is initiated.