### PR TITLE
Disable remote debugging by default 

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -13,7 +13,7 @@ pref("browser.tabs.hoverPreview.enabled", true);
 pref("browser.tabs.cardPreview.delayMs", 100);
 
 #ifdef MOZ_UPDATE_CHANNEL
-pref("devtools.debugger.prompt-connection", false);
+pref("devtools.debugger.prompt-connection", true);
 #endif
 
 // Dont download the multilingual dictionary
@@ -162,7 +162,7 @@ pref("network.http.speculative-parallel-limit", 10);
 pref("network.http.rcwn.enabled", false);
 
 // Enable Browser Toolbox, Ctrl+Shift+Alt+I for debugging and modifying UI
-pref("devtools.debugger.remote-enabled", true);
+pref("devtools.debugger.remote-enabled", false);
 pref("devtools.chrome.enabled", true);
 
 // Disable firefox's revamp


### PR DESCRIPTION
For some reason, Zen is currently not only exposing Remote Debugging... but also disabling prompting for it?

This is very concerning from a security perspective and quite literally acts as a backdoor - You can see here: https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/16222 & here: https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html for some details

Not even Firefox Developer Edition enables these prefs by default. Respectfully, I have no idea what your team was thinking flipping them, and I seriously have to question the motives here. I hope that this was simply incompetence & not malicious, but it is concerning regardless. The browser is one of the, if not the most security critical component in our lives. Treating it as a hobbyist project like this is unacceptable. Please do better in the future.

There's various other prefs I think are highly questionable that I'll leave feedback for separately - But this was the most severe & needed to be taken care of ASAP.