### PR TITLE
Fix right vertical tabs leftovers in fullscreen mode.

### DIFF
--- a/src/browser/base/content/zen-styles/zen-browser-container.css
+++ b/src/browser/base/content/zen-styles/zen-browser-container.css
@@ -2,14 +2,14 @@
 :root:not([inDOMFullscreen="true"]):not([chromehidden~="location"]):not([chromehidden~="toolbar"]) {
   & #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     width: -moz-available;
-    margin: 0 var(--zen-element-separation) var(--zen-element-separation) 0;
+    margin: 0 var(--zen-element-separation) var(--zen-element-separation) 2px;
+    @media (-moz-bool-pref: "zen.tabs.vertical.right-side") {
+      margin: 0 2px var(--zen-element-separation) var(--zen-element-separation);
+    }
     box-shadow: 0 0 0 1px var(--zen-colors-border);
     clip-path: inset(-5px -5px -5px round var(--zen-webview-border-radius, var(--zen-border-radius)));
     border-radius: var(--zen-webview-border-radius, var(--zen-border-radius));
     transform: translate3d(0, 0, 0);
     overflow: hidden;
-
-    /* This fixes an issue with the left border */
-    margin-left: 2px;
   }
 }

--- a/src/browser/base/content/zen-styles/zen-compact-mode.css
+++ b/src/browser/base/content/zen-styles/zen-compact-mode.css
@@ -131,7 +131,13 @@
   #PersonalToolbar[collapsed="true"]{ display: none }
 
   :root:not([inDOMFullscreen="true"]) #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
-    margin-left: var(--zen-element-separation) !important;
+    @media (not (-moz-bool-pref: "zen.tabs.vertical.right-side")) {
+      margin-left: var(--zen-element-separation) !important;
+    }
+
+    @media (-moz-bool-pref: "zen.tabs.vertical.right-side") {
+      margin-right: var(--zen-element-separation) !important;
+    }
   }
 
   @media (-moz-bool-pref: "zen.view.compact.hide-toolbar") {

--- a/src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css
+++ b/src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css
@@ -302,14 +302,20 @@
         #mainPopupSet[zen-user-hover="true"]:has(> #appMenu-popup:hover) ~ toolbox,
         #navigator-toolbox[zen-user-hover="true"]:has(*[open="true"]:not(tab):not(#zen-sidepanel-button)), 
       :not([zen-user-hover="true"])) {
-      --zen-hover-animation: zen-sidebar-panel-animation-2;
       --zen-navigation-toolbar-min-width: 155px;
       min-width: var(--zen-navigation-toolbar-min-width) !important;
       align-items: start;
       transition: .2s;
       width: 170px;
       border: none;
-      padding-left: 2px;
+      @media (not (-moz-bool-pref: "zen.tabs.vertical.right-side")) {
+        padding-left: 2px;
+        --zen-hover-animation: zen-sidebar-panel-animation-2;
+      }
+      @media (-moz-bool-pref: "zen.tabs.vertical.right-side") {
+        padding-right: 2px;
+        --zen-hover-animation: zen-sidebar-panel-animation-right;
+      }
       animation: var(--zen-hover-animation) 0.3s backwards;
 
       #vertical-pinned-tabs-container {
@@ -332,7 +338,7 @@
           display: block;
         }
       }
-    
+
       & .tab-label-container {
         display: block;
       }
@@ -416,7 +422,17 @@
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(var(--tab-min-height), 1fr));
         padding: calc(var(--zen-tabbrowser-padding) / 2);
-        padding-right: 0;
+      }
+        
+      @media (not (-moz-bool-pref: "zen.tabs.vertical.right-side")) {
+        & #tabbrowser-arrowscrollbox::part(scrollbox) {
+          padding-right: 0;
+        }
+      }
+      @media (-moz-bool-pref: "zen.tabs.vertical.right-side") {
+        & #tabbrowser-arrowscrollbox::part(scrollbox) { 
+          padding-left: 0;
+        }
       }
     
       & .tabbrowser-tab:not([pinned]),
@@ -456,8 +472,6 @@
   @media (-moz-bool-pref: "zen.tabs.vertical.right-side") and (not (-moz-bool-pref: "zen.view.compact")) {
     #navigator-toolbox {
       order: 8 !important;
-      padding-left: 0 !important;
-      --zen-hover-animation: zen-sidebar-panel-animation-right !important;
     }
 
     :root:not([zen-sidebar-legacy="true"]) {
@@ -466,11 +480,6 @@
 
     #zen-sidebar-splitter {
       order: 7 !important;
-    }
-
-    #tabbrowser-tabpanels .browserSidebarContainer {
-      margin-left: var(--zen-element-separation) !important;
-      margin-right: 0 !important;
     }
   }
 


### PR DESCRIPTION
Fix #1100
- Use margin instead of padding as it's done for vertical tabs on the left.
- Move overrides close to the original values so it's easier to maintain the same selectors, get rid of `!important` and thus get better themes compatibility.