### PR TITLE
chore: remove severity from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,19 +29,6 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: severity
-    attributes:
-      label: Severity impact
-      description: See label descriptions for more information.
-      options:
-        - Low
-        - Medium
-        - High
-        - Critical
-    validations:
-      required: true
-
-  - type: dropdown
     id: platform
     attributes:
       label: What platform are you seeing the problem on?


### PR DESCRIPTION
Determining criticality should be done by a maintainer, not by a user reporting a bug or issue. Giving users the ability to determine the criticality of their issue, in combination with using a bot for auto flagging, I see the following 2 problems arising:
- Non-technical users misjudging an issue. This can go both ways. Either they underestimate the problem, even though it is a serious problem, or they overestimate it, even though the problem may be minor or not serious at all.
- It is deliberately misused to artificially draw attention to a particular problem or mistake by knowingly choosing a higher severity for an issue than it actually is.

I created this PR because, in my opinion, I already see bug reports that apply to one of the two problems mentioned above. I am not going to point fingers right now, but filter for critical severity and decide on your own.

Having this labeling automatism will make it harder for maintainers, (future) contributors and people who just want to follow the current state of this project, as those labels do not reflect the assessment of severity by the maintainers of the project, instead the assessment is done by "random people on the internet". Maintainers would be required to re-label the issues if the previous label was wrong and contributors looking for work may focus on a specific severity and stumble across issues actually not fitting the label of severity they were looking for.

My suggestion would be (not included in this PR) to let the bot label all new issues with "Triage" (or something similar), so that those Issues then receive a correct lable by a maintainer that can actually assess the criticality.

This PR is obviously just a suggestion. So i am totally fine with this PR getting rejected in case the idea does not appeal.