### PR TITLE
Various fixes to Homebrew Cask

### DIFF
--- a/.github/workflows/src/update-homebrew.sh
+++ b/.github/workflows/src/update-homebrew.sh
@@ -1,8 +1,8 @@
 
 latest_version=$1
-sed -i "s/version(.*)/version('${latest_version}')/" ./Casks/zen-browser.rb
+sed -i "s/version \".*\"/version \"${latest_version}\"/" ./Casks/zen-browser.rb
 
 sha_x64=$(shasum -a 256 zen.macos-x64.dmg)
 sha_arm=$(shasum -a 256 zen.macos-aarch64.dmg)
 
-sed -i "s/sha256(.*)/sha256(arm:'${sha_arm}', intel:'${sha_x64}')/" ./Casks/zen-browser.rb
+sed -i "N;s/sha256 arm:   \".*\",\n         intel: \".*\"/sha256 arm:   \"${sha_arm}\",\n         intel: \"${sha_x64}\"/" ./Casks/zen-browser.rb

--- a/Casks/zen-browser.rb
+++ b/Casks/zen-browser.rb
@@ -1,19 +1,19 @@
-cask("zen-browser") do
-  arch(arm: "aarch64", intel: "x64")
+cask "zen-browser" do
+  arch arm: "aarch64", intel: "x64"
 
-  version("1.0.0-a.34")
-  sha256(arm:   "6cc6e72c4a6a11d0139489d438ccf811715e170eebc01da739da32ace2580747",
-         intel: "b9cb48f21a4ee39f3f3ae2361b9b0a55ae7219638cf798e1483c0eb8cf4660a6")
+  version "1.0.0-a.34"
+  sha256 arm:   "6cc6e72c4a6a11d0139489d438ccf811715e170eebc01da739da32ace2580747",
+         intel: "b9cb48f21a4ee39f3f3ae2361b9b0a55ae7219638cf798e1483c0eb8cf4660a6"
 
-  url("https://github.com/zen-browser/desktop/releases/download/#{version}/zen.macos-#{arch}.dmg")
-  name("Zen Browser")
-  desc("Beautifully designed, privacy-focused browser packed with awesome features")
-  homepage("https://zen-browser.app/")
+  url "https://github.com/zen-browser/desktop/releases/download/#{version}/zen.macos-#{arch}.dmg"
+  name "Zen Browser"
+  desc "Beautifully designed, privacy-focused browser packed with awesome features"
+  homepage "https://zen-browser.app/"
 
-  app("Zen Browser.app")
+  app "Zen Browser.app"
 
   postflight do
-    system("xattr -c '/Applications/Zen Browser.app/'")
+    system "xattr -c '/Applications/Zen Browser.app/'"
   end
 
   zap trash: [

--- a/Casks/zen-browser.rb
+++ b/Casks/zen-browser.rb
@@ -21,7 +21,11 @@ cask "zen-browser" do
   end
 
   zap trash: [
-    "~/Library/Preferences/org.mozilla.com.zen.browser.plist",
-    "~/Library/Saved Application State/org.mozilla.com.zen.browser.savedState",
-  ]
+        "~/Library/Application Support/zen",
+        "~/Library/Caches/Mozilla/updates/Applications/Zen Browser",
+        "~/Library/Caches/zen",
+        "~/Library/Preferences/org.mozilla.com.zen.browser.plist",
+        "~/Library/Saved Application State/org.mozilla.com.zen.browser.savedState",
+      ],
+      rmdir: "~/Library/Caches/Mozilla"
 end

--- a/Casks/zen-browser.rb
+++ b/Casks/zen-browser.rb
@@ -11,6 +11,9 @@ cask "zen-browser" do
   desc "Beautifully designed, privacy-focused browser packed with awesome features"
   homepage "https://zen-browser.app/"
 
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
   app "Zen Browser.app"
 
   postflight do

--- a/Casks/zen-browser.rb
+++ b/Casks/zen-browser.rb
@@ -17,7 +17,7 @@ cask "zen-browser" do
   app "Zen Browser.app"
 
   postflight do
-    system "xattr -c '/Applications/Zen Browser.app/'"
+    system "xattr -d com.apple.quarantine '/Applications/Zen Browser.app/'"
   end
 
   zap trash: [

--- a/Casks/zen-browser.rb
+++ b/Casks/zen-browser.rb
@@ -1,21 +1,23 @@
 cask("zen-browser") do
   arch(arm: "aarch64", intel: "x64")
+
   version("1.0.0-a.34")
-  sha256(arm: "6cc6e72c4a6a11d0139489d438ccf811715e170eebc01da739da32ace2580747", intel: "b9cb48f21a4ee39f3f3ae2361b9b0a55ae7219638cf798e1483c0eb8cf4660a6")
+  sha256(arm:   "6cc6e72c4a6a11d0139489d438ccf811715e170eebc01da739da32ace2580747",
+         intel: "b9cb48f21a4ee39f3f3ae2361b9b0a55ae7219638cf798e1483c0eb8cf4660a6")
 
   url("https://github.com/zen-browser/desktop/releases/download/#{version}/zen.macos-#{arch}.dmg")
   name("Zen Browser")
   desc("Beautifully designed, privacy-focused browser packed with awesome features")
   homepage("https://zen-browser.app/")
 
-  zap trash: [
-    "~/Library/Preferences/org.mozilla.com.zen.browser.plist",
-    "~/Library/Saved Application State/org.mozilla.com.zen.browser.savedState"
-  ]
-
   app("Zen Browser.app")
 
   postflight do
     system("xattr -c '/Applications/Zen Browser.app/'")
   end
+
+  zap trash: [
+    "~/Library/Preferences/org.mozilla.com.zen.browser.plist",
+    "~/Library/Saved Application State/org.mozilla.com.zen.browser.savedState",
+  ]
 end

--- a/Casks/zen-browser.rb
+++ b/Casks/zen-browser.rb
@@ -5,7 +5,8 @@ cask "zen-browser" do
   sha256 arm:   "6cc6e72c4a6a11d0139489d438ccf811715e170eebc01da739da32ace2580747",
          intel: "b9cb48f21a4ee39f3f3ae2361b9b0a55ae7219638cf798e1483c0eb8cf4660a6"
 
-  url "https://github.com/zen-browser/desktop/releases/download/#{version}/zen.macos-#{arch}.dmg"
+  url "https://github.com/zen-browser/desktop/releases/download/#{version}/zen.macos-#{arch}.dmg",
+      verified: "github.com/zen-browser/desktop/"
   name "Zen Browser"
   desc "Beautifully designed, privacy-focused browser packed with awesome features"
   homepage "https://zen-browser.app/"

--- a/Casks/zen-browser.rb
+++ b/Casks/zen-browser.rb
@@ -1,9 +1,9 @@
 cask "zen-browser" do
   arch arm: "aarch64", intel: "x64"
 
-  version "1.0.0-a.34"
-  sha256 arm:   "6cc6e72c4a6a11d0139489d438ccf811715e170eebc01da739da32ace2580747",
-         intel: "b9cb48f21a4ee39f3f3ae2361b9b0a55ae7219638cf798e1483c0eb8cf4660a6"
+  version "1.0.0-a.37"
+  sha256 arm:   "0cf18406f61225c53ca20391b37dcdcbfd3dd80bf758639b56962e38085e529d",
+         intel: "4de8907641989639ee159681cd131a22a20fcf414373543a62ee0f9df2739845"
 
   url "https://github.com/zen-browser/desktop/releases/download/#{version}/zen.macos-#{arch}.dmg",
       verified: "github.com/zen-browser/desktop/"

--- a/README.md
+++ b/README.md
@@ -40,18 +40,18 @@ Zen is built with performance in mind, and we have optimized the browser to be a
 ## MacOS
 
 ### Homebrew (recommended)
-You can install the Zen Browser using Homebrew: 
+You can install the Zen Browser using Homebrew:
 
 ```
-brew tap zen-browser/browser https://github.com/zen-browser/desktop.git 
-brew install zen-browser
+brew tap zen-browser/browser https://github.com/zen-browser/desktop.git
+brew install --cask zen-browser
 ```
 
-To upgrade the browser to a newer version, you can either use the embedded update functionality in `About Zen` or use the following commands: 
+To upgrade the browser to a newer version, you can either use the embedded update functionality in `About Zen` or use the following commands:
 
 ```
 brew update
-brew upgrade zen-browser
+brew upgrade --greedy zen-browser
 ```
 
 ### Manual installation
@@ -71,7 +71,7 @@ git clone https://github.com/zen-browser/desktop.git --recurse-submodules
 cd desktop
 ```
 
-Install dependencies 
+Install dependencies
 
 ```bash
 npm i
@@ -121,4 +121,3 @@ Zen couldn't be in its current state without the help of these amazing projects!
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=zen-browser/desktop&type=Date" />
  </picture>
 </a>
-


### PR DESCRIPTION
This PR makes various changes to `zen-browser.rb` so that it is conformant with the [style guidelines](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#style-guide) outlined by the Homebrew Cask project.

It fixes the stanza order, adds URL verification to the `url` stanza, adds the missing `auto_updates` and `depends_on` stanza, makes the `postflight` stanza only clear the quarantine attribute, and expands the `zap` stanza so that it clear more files when uninstalling with `--zap`.

In addition, the version number on the cask has been updated, as previous GH Actions failed to do so.