### PR TITLE
Fix vertical tabs on the right overflow.

### DIFF
--- a/src/browser/base/content/zen-styles/zen-compact-mode.css
+++ b/src/browser/base/content/zen-styles/zen-compact-mode.css
@@ -179,6 +179,10 @@
       transform: translateX(calc(100% - (var(--zen-compact-toolbox-margin-single) / 2))) !important;;
     }
 
+    #navigator-toolbox > vbox {
+      float: right;
+    }
+
     #navigator-toolbox:hover,
     #navigator-toolbox:focus-within,
     #navigator-toolbox[zen-user-show],


### PR DESCRIPTION
The `vbox` overflows the parent `#navigator-toolbox`. It's fine for tabs on the left but when they are on the right the overflow is out of the window/screen. With `float: right` the `vbox` overflows to the left and is fully visible and has the same distance to the window edge.