### PR TITLE
Fix in compact mode: Keep toolbar open during drag

### DIFF
--- a/src/browser/base/content/zen-styles/zen-compact-mode.css
+++ b/src/browser/base/content/zen-styles/zen-compact-mode.css
@@ -153,6 +153,7 @@
 
     #zen-appcontent-navbar-container:hover,
     #zen-appcontent-navbar-container:focus-within,
+    #zen-appcontent-navbar-container:active,
     #zen-appcontent-navbar-container[zen-user-show],
     #mainPopupSet:has(> #appMenu-popup:hover) ~ #zen-appcontent-navbar-container,
     #zen-appcontent-navbar-container:has(*[open="true"]) {


### PR DESCRIPTION
I added the `:active` selector to the toolbar so that it doesn't disappear while dragging the window.