### PR TITLE
fix ffmpeg VA-API decoding issue (hardware decode)

### DIFF
--- a/flatpak/io.github.zen_browser.zen.yml.template
+++ b/flatpak/io.github.zen_browser.zen.yml.template
@@ -4,6 +4,11 @@ runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.mozilla.firefox.BaseApp
 base-version: '23.08'
+add-extensions:
+  org.freedesktop.Platform.ffmpeg-full:
+    directory: lib/ffmpeg
+    version: 23.08
+    add-ld-path: .
 command: launch-script.sh
 finish-args:
   - --share=ipc
@@ -27,6 +32,7 @@ modules:
     buildsystem: simple
     build-commands:
       - mv zen /app/
+      - mkdir -p /app/lib/ffmpeg
 
       - install -Dm0755 metadata/launch-script.sh ${{FLATPAK_DEST}}/bin/launch-script.sh
       - install -Dm0644 metadata/policies.json ${{FLATPAK_DEST}}/bin/distribution/policies.json


### PR DESCRIPTION
using the current flatpak I haven't been able to get hardware-accelerated video decode working, even with setting the `media.ffmpeg.vaapi.enabled` preference in zen to `true`.
With the `MOZ_LOG="FFmpegVideo:5"` env variable, trying to play a video produces this output in terminal:
```
[RDD 377: MediaSupervisor #1]: D/FFmpegVideo FFMPEG: FFmpegVideoDecoder::FFmpegVideoDecoder MIME video/avc Codec ID 27
[RDD 377: MediaPDecoder #1]: D/FFmpegVideo FFMPEG: Initialising VA-API FFmpeg decoder
[RDD 377: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:   We're missing hardware accelerated decoder
[RDD 377: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:   couldn't find ffmpeg VA-API decoder
[RDD 377: MediaPDecoder #1]: D/FFmpegVideo FFMPEG: Initialising FFmpeg decoder
[RDD 377: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:   codec libopenh264 : OpenH264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
[RDD 377: MediaPDecoder #1]: D/FFmpegVideo FFMPEG: Set get_buffer2 for customized buffer allocation
[RDD 377: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:   FFmpeg decoder init successful.
[RDD 377: MediaPDecoder #1]: D/FFmpegVideo FFMPEG: FFmpegDataDecoder: shutdown
```

adding the ffmpeg extension to the manifest seems to fix this issue (taken from the floorp manifest), with ffmpeg being able to find the VA-API decoder and use hardware-accelerated decode on the gpu:
```
[RDD 378: MediaSupervisor #1]: D/FFmpegVideo FFMPEG: FFmpegVideoDecoder::FFmpegVideoDecoder MIME video/avc Codec ID 27
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG: Initialising VA-API FFmpeg decoder
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:   codec h264 : H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
libva info: VA-API version 1.19.0
libva info: Trying to open /usr/lib/x86_64-linux-gnu/dri/radeonsi_drv_video.so
libva info: Trying to open /usr/lib/x86_64-linux-gnu/dri/intel-vaapi-driver/radeonsi_drv_video.so
libva info: Trying to open /usr/lib/x86_64-linux-gnu/GL/lib/dri/radeonsi_drv_video.so
libva info: Found init function __vaDriverInit_1_19
libva info: va_openDriver() returns 0
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG: FFmpegVideoDecoder::GetAcceleratedFormats()
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:   Profile H264ConstrainedBaseline:
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:     codec h264 format nv12              3         12
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:     codec h264 format nv12              3         12
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:     codec h264 format p010le            3         15
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:   Profile H264Main:
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:     codec h264 format nv12              3         12
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:     codec h264 format nv12              3         12
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:     codec h264 format p010le            3         15
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:   Profile H264High:
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:     codec h264 format nv12              3         12
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:     codec h264 format nv12              3         12
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:     codec h264 format p010le            3         15
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:   Supported accelerated formats:
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:       h264
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG:   VA-API FFmpeg init successful
[RDD 378: MediaSupervisor #1]: D/FFmpegVideo FFMPEG: FFmpegVideoDecoder::FFmpegVideoDecoder MIME video/avc Codec ID 27
[RDD 378: MediaPDecoder #1]: D/FFmpegVideo FFMPEG: FFmpegDataDecoder: shutdown
[RDD 378: MediaPDecoder #2]: D/FFmpegVideo FFMPEG: Initialising VA-API FFmpeg decoder
[libopus @ 0x7433f0833c00] Could not update timestamps for skipped samples.
[RDD 378: MediaPDecoder #2]: D/FFmpegVideo FFMPEG:   Format h264 is accelerated
[RDD 378: MediaPDecoder #2]: D/FFmpegVideo FFMPEG:   codec h264 : H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
[RDD 378: MediaSupervisor #1]: D/FFmpegVideo FFMPEG: FFmpegVideoDecoder::FFmpegVideoDecoder MIME video/avc Codec ID 27
[RDD 378: MediaPDecoder #3]: D/FFmpegVideo FFMPEG: Initialising VA-API FFmpeg decoder
```

hope everything is formatted/committed correctly ^ ^ 