### PR TITLE
Ensure tab becomes visible when selected in sidebar.

### DIFF
--- a/src/browser/components/tabbrowser/content/tabs-js.patch
+++ b/src/browser/components/tabbrowser/content/tabs-js.patch
@@ -1,0 +1,15 @@
+diff --git a/browser/components/tabbrowser/content/tabs.js b/browser/components/tabbrowser/content/tabs.js
+index 282e7f31fe158d929130c17628f7e30f690fd666..2eb7123611947c5bc3da4ae864dd6f6f68fa6f9e 100644
+--- a/browser/components/tabbrowser/content/tabs.js
++++ b/browser/components/tabbrowser/content/tabs.js
+@@ -1387,9 +1387,7 @@
+ 
+     _handleTabSelect(aInstant) {
+       let selectedTab = this.selectedItem;
+-      if (this.hasAttribute("overflow")) {
+-        this.arrowScrollbox.ensureElementIsVisible(selectedTab, aInstant);
+-      }
++      this.arrowScrollbox.ensureElementIsVisible(selectedTab, aInstant);
+ 
+       selectedTab._notselectedsinceload = false;
+     }


### PR DESCRIPTION
Ensure a tab is always visible when tab selected, new tab created. Especially useful when navigating tabs with key-binds.


![D6yBtAAbj8](https://github.com/user-attachments/assets/0ad1caed-0b0a-48f2-80d5-5ce05aeeb99f)
