### PR TITLE
fix: `brew install` when using `--appdir` e.g. non-admin users

### DIFF
--- a/Casks/zen-browser.rb
+++ b/Casks/zen-browser.rb
@@ -16,10 +16,6 @@ cask "zen-browser" do
 
   app "Zen Browser.app"
 
-  postflight do
-    system "xattr -d com.apple.quarantine '/Applications/Zen Browser.app/'"
-  end
-
   zap trash: [
         "~/Library/Application Support/zen",
         "~/Library/Caches/Mozilla/updates/Applications/Zen Browser",

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ You can install the Zen Browser using Homebrew:
 
 ```
 brew tap zen-browser/browser https://github.com/zen-browser/desktop.git
-brew install --no-quarantine --cask zen-browser
+brew install --cask zen-browser
 ```
 
 To upgrade the browser to a newer version, you can either use the embedded update functionality in `About Zen` or use the following commands:
 
 ```
 brew update
-brew upgrade --no-quarantine --greedy zen-browser
+brew upgrade --greedy zen-browser
 ```
 
 ### Manual installation

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ You can install the Zen Browser using Homebrew:
 
 ```
 brew tap zen-browser/browser https://github.com/zen-browser/desktop.git
-brew install --cask zen-browser
+brew install --no-quarantine --cask zen-browser
 ```
 
 To upgrade the browser to a newer version, you can either use the embedded update functionality in `About Zen` or use the following commands:
 
 ```
 brew update
-brew upgrade --greedy zen-browser
+brew upgrade --no-quarantine --greedy zen-browser
 ```
 
 ### Manual installation


### PR DESCRIPTION
Not all macOS users are system administrators.

For example most work/school issued computers won't be given accounts with administrator privileges, also users who share a computer or want additional security by using different logins might not want to create a administrator account and instead use a restricted/standard account.

macOS users with standard accounts by default have read-only access to `/Applications`, however Homebrew can still be used by non-admin users and casks can be installed to the users home folder where they do have read/write permissions via the brew `--appdir` flag. For example installing an application in the users home folder (`/Users/<USERNAME>/Applications`):

`brew install --no-quarantine --cask --appdir=~/Applications zen-browser`

However, the `postflight` command incorrectly assumes that macOS apps will always be installed to `/Applications` and when using a different path via the `--appdir` flag the install process fails with the following error:

`xattr: No such file: /Applications/Zen Browser.app/`

Homebrew's preferred method for installing non Apple notarized apps is to use the `--no-quarantine` flag which performs this `xattr` command behind the scenes and also works correctly when applications are install into a different folder (other than `/Applications`).