### PR TITLE
feature(workspace-quick-switcher): Add quick-switch workspace UI

### DIFF
--- a/src/browser/base/content/zen-popupset.inc.xhtml
+++ b/src/browser/base/content/zen-popupset.inc.xhtml
@@ -131,7 +131,7 @@
 
 <menupopup id="zenWorkspaceActionsMenu"
             onpopupshowing="ZenWorkspaces.updateContextMenu(this);"
-            onpopuphidden="ZenWorkspaces.onContextMenuClose();">
+            onpopuphidden="ZenWorkspaces.onContextMenuClose(this);">
   <menuitem id="context_zenOpenWorkspace" oncommand="ZenWorkspaces.openWorkspace();" data-l10n-id="zen-workspaces-panel-context-open"/>
   <menuseparator/>
   <menuitem id="context_zenSetAsDefaultWorkspace" oncommand="ZenWorkspaces.setDefaultWorkspace();" data-l10n-id="zen-workspaces-panel-context-set-default"/>

--- a/src/browser/base/content/zen-styles/zen-workspaces.css
+++ b/src/browser/base/content/zen-styles/zen-workspaces.css
@@ -19,6 +19,42 @@
   pointer-events: none;
 }
 
+.zen-workspaces-button-minimalist {
+  border:none !important;
+  border-radius: 0;
+  max-height:1rem;
+  box-shadow:none;
+}
+
+#zen-workspace-quick-switch-container {
+  max-height:5rem;
+  justify-content: center;
+  align-items: center;
+  display: none;
+  gap: 0.5rem;
+  padding: 1rem 0.5rem ;
+  margin: 0 auto;
+  flex-wrap: wrap;
+
+  .zen-workspace-button {
+    height: 20px;
+    width: 20px;
+    display:flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.5rem;
+    -moz-window-dragging: no-drag;
+    opacity: 80%;
+    filter: brightness(50%);
+
+    &.zen-workspace-button-active {
+      opacity: 100%;
+      filter: brightness(100%);
+    }
+  }
+
+}
+
 @media (-moz-bool-pref: 'zen.view.sidebar-expanded') {
   /** Keep these selectors in sync with the ones in vertical-tabs.css */
   #navigator-toolbox:is(
@@ -55,6 +91,10 @@
       padding: 2px 10px;
       width: calc(100% - var(--zen-tabbrowser-padding) * 6) !important;
       gap: 0.5ch;
+    }
+
+    & #zen-workspace-quick-switch-container {
+      display:flex;
     }
   }
 }

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -887,4 +887,9 @@ Preferences.addAll([
     type: 'bool',
     default: true,
   },
+  {
+    id: 'zen.workspaces.quick-switch',
+    type: 'bool',
+    default: false,
+  },
 ]);

--- a/src/browser/components/preferences/zenWorkspaces.inc.xhtml
+++ b/src/browser/components/preferences/zenWorkspaces.inc.xhtml
@@ -27,6 +27,9 @@
             <checkbox id="zenWorkspacesAllowPinnedTabsForDifferentWorkspaces"
                   data-l10n-id="zen-settings-workspaces-allow-pinned-tabs-for-different-workspaces"
                   preference="zen.workspaces.individual-pinned-tabs"/>
+            <checkbox id="zenWorkspacesShowWorkspacesQuickSwitch"
+                      data-l10n-id="zen-settings-workspaces-show-quick-switch"
+                      preference="zen.workspaces.quick-switch"/>
       </vbox>
 </groupbox>
 


### PR DESCRIPTION
This PR introduces a new UI element to the sidebar for quickly switching between workspaces.

### Why "Quick Switch"?

The quick switcher enables faster workspace switching by eliminating the need to open the workspace menu. With this feature, users can save at least one click—or even two—by using the `SHIFT + mouse wheel` while hovering over the quick switch component for rapid switching.

Additionally, a toggle in the settings makes this component entirely optional, allowing users to enable or disable it based on their preferences.

This PR is part of a set of 3 related PRs for the workspace quick switcher:
https://github.com/zen-browser/components/pull/20
https://github.com/zen-browser/l10n-packs/pull/50

https://github.com/user-attachments/assets/9ec92c16-9d11-4ebf-85cc-86064498d04f


