### PR TITLE
Feature: Clear All Tabs Button – Add functionality to the New Tab Button

### DIFF
--- a/src/browser/base/content/ZenUIManager.mjs
+++ b/src/browser/base/content/ZenUIManager.mjs
@@ -84,6 +84,59 @@ var gZenVerticalTabsManager = {
     gZenCompactModeManager.addEventListener(updateEvent);
     this._updateEvent();
     this.initRightSideOrderContextMenu();
+
+    // Add clear all tabs handler to the new tab button
+    let newTabButton = document.getElementById('vertical-tabs-newtab-button');
+
+    if (newTabButton) {
+      newTabButton.addEventListener('mousedown', (event) => {
+        if (event.button === 1) {
+          event.stopPropagation();
+          event.preventDefault();
+          event.target.setAttribute("data-l10n-id", "tabs-toolbar-new-tab-clear-all");
+        }
+      });
+
+      newTabButton.addEventListener('mouseup', (event) => {
+        if (event.button === 1) {
+          event.stopPropagation();
+          event.preventDefault();
+          event.target.setAttribute("data-l10n-id", "tabs-toolbar-new-tab");
+
+          // Get the current workspace ID
+          let currentWorkspaceId = gBrowser.selectedTab.getAttribute("zen-workspace-id");
+
+          // Create a new tab in the current workspace or window
+          let newTab = gBrowser.addTrustedTab("about:newtab", {
+            userContextId: gBrowser.selectedTab.userContextId,
+          });
+
+          // If in a workspace, set the workspace ID for the new tab
+          if (currentWorkspaceId) {
+            newTab.setAttribute("zen-workspace-id", currentWorkspaceId);
+          }
+
+          // Get all tabs to close
+          let tabsToClose = Array.from(gBrowser.tabs).filter(tab =>
+            tab !== newTab &&
+            !tab.pinned &&
+            (!currentWorkspaceId || tab.getAttribute("zen-workspace-id") === currentWorkspaceId)
+          );
+
+          // Select the new tab
+          gBrowser.selectedTab = newTab;
+
+          // Close all unpinned tabs in the current workspace or window
+          gBrowser.removeTabs(tabsToClose);
+        }
+      });
+
+      newTabButton.addEventListener('mouseleave', (event) => {
+        if (event.target.getAttribute("data-l10n-id") === "tabs-toolbar-new-tab-clear-all") {
+          event.target.setAttribute("data-l10n-id", "tabs-toolbar-new-tab");
+        }
+      });
+    }
   },
 
   get navigatorToolbox() {

--- a/src/browser/base/content/ZenUIManager.mjs
+++ b/src/browser/base/content/ZenUIManager.mjs
@@ -87,8 +87,16 @@ var gZenVerticalTabsManager = {
 
     // Add clear all tabs handler to the new tab button
     let newTabButton = document.getElementById('vertical-tabs-newtab-button');
-
+    
     if (newTabButton) {
+
+      newTabButton.addEventListener('click', (event) => {
+        if (event.button === 1) {
+          event.stopPropagation();
+          event.preventDefault();
+        }
+      });
+      
       newTabButton.addEventListener('mousedown', (event) => {
         if (event.button === 1) {
           event.stopPropagation();
@@ -106,26 +114,13 @@ var gZenVerticalTabsManager = {
           // Get the current workspace ID
           let currentWorkspaceId = gBrowser.selectedTab.getAttribute("zen-workspace-id");
 
-          // Create a new tab in the current workspace or window
-          let newTab = gBrowser.addTrustedTab("about:newtab", {
-            userContextId: gBrowser.selectedTab.userContextId,
-          });
-
-          // If in a workspace, set the workspace ID for the new tab
-          if (currentWorkspaceId) {
-            newTab.setAttribute("zen-workspace-id", currentWorkspaceId);
-          }
-
+          
           // Get all tabs to close
           let tabsToClose = Array.from(gBrowser.tabs).filter(tab =>
-            tab !== newTab &&
             !tab.pinned &&
             (!currentWorkspaceId || tab.getAttribute("zen-workspace-id") === currentWorkspaceId)
           );
-
-          // Select the new tab
-          gBrowser.selectedTab = newTab;
-
+          
           // Close all unpinned tabs in the current workspace or window
           gBrowser.removeTabs(tabsToClose);
         }

--- a/src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css
+++ b/src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css
@@ -299,6 +299,10 @@
       min-width: unset !important;
     }
 
+    #vertical-tabs-newtab-button[data-l10n-id="tabs-toolbar-new-tab-clear-all"] {
+      background: rgba(253, 50, 50, 0.48) !important;
+    }
+
     & #zen-sidebar-icons-wrapper {
       display: flex;
       flex-direction: column;

--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -982,7 +982,10 @@ menuitem[id='placesContext_new:separator'] {
 
 #vertical-tabs-newtab-button[data-l10n-id="tabs-toolbar-new-tab-clear-all"] {
   list-style-image: url(close-all.svg);
-  background: rgba(253, 50, 50, 0.48) !important;
+
+  & .toolbarbutton-icon {
+    background: rgba(253, 50, 50, 0.48) !important;
+  }
 }
 
 .customize-context-reportExtension,

--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -980,6 +980,11 @@ menuitem[id='placesContext_new:separator'] {
   --menu-image: url('close-all.svg');
 }
 
+#vertical-tabs-newtab-button[data-l10n-id="tabs-toolbar-new-tab-clear-all"] {
+  list-style-image: url(close-all.svg);
+  background: rgba(253, 50, 50, 0.48) !important;
+}
+
 .customize-context-reportExtension,
 .unified-extensions-context-menu-report-extension {
   --menu-image: url('report.svg');


### PR DESCRIPTION
### Description:
This update introduces a new feature where a middle mouse click on the "New Tab" button will close all tabs in the current workspace (if the option is enabled), excluding pinned tabs.

Additional behavior:
- Holding the middle mouse button on the "New Tab" button and moving the cursor away will cancel the operation.

Related to https://github.com/zen-browser/l10n-packs/pull/53


https://github.com/user-attachments/assets/225dbbb8-e9f1-4b60-9927-1233d2985392

