### PR TITLE
Make compact mode easier to use when windowed or more than 1 screen

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -85,6 +85,7 @@ pref('zen.theme.color-prefs.colorful', false);
 
 pref('zen.view.compact.toolbar-flash-popup', true);
 pref('zen.view.compact.toolbar-flash-popup.duration', 800);
+pref('zen.view.compact.visible-on-mouse-pass-duration', 1300);
 
 pref('zen.view.sidebar-height-throttle', 200); // in ms
 pref('zen.view.sidebar-expanded', false);

--- a/src/browser/base/content/ZenUIManager.mjs
+++ b/src/browser/base/content/ZenUIManager.mjs
@@ -270,7 +270,7 @@ var gZenCompactModeManager = {
 
     if (mousePassedSidebarSide) {
       this.sidebar.setAttribute('mouse-passed', '');
-      addEventListener('mouse-passed', () => {
+      addEventListener('mousemove', () => {
         this.sidebar.removeAttribute('mouse-passed');
         clearTimeout(this._visibleOnMousePassTimeout)
       }, {once: true});

--- a/src/browser/base/content/ZenUIManager.mjs
+++ b/src/browser/base/content/ZenUIManager.mjs
@@ -154,7 +154,7 @@ var gZenCompactModeManager = {
     Services.prefs.addObserver('zen.tabs.vertical.right-side', this._updateSidebarIsOnRight.bind(this));
 
     this.sidebar.addEventListener('contextmenu', this.keepSidebarVisibleOnContextMenu.bind(this));
-    document.body.addEventListener('mouseleave', this.keepVisibleOnMousePass.bind(this));
+    this.sidebar.addEventListener('mouseleave', this.keepVisibleOnMousePass.bind(this));
   },
 
   get prefefence() {

--- a/src/browser/base/content/zen-styles/zen-compact-mode.css
+++ b/src/browser/base/content/zen-styles/zen-compact-mode.css
@@ -108,6 +108,7 @@
   #navigator-toolbox:focus-within,
   #navigator-toolbox[zen-user-show],
   #navigator-toolbox[flash-popup],
+  #navigator-toolbox[mouse-passed],
   #navigator-toolbox[has-popup-menu],
   #navigator-toolbox[movingtab],
   #mainPopupSet:has(> #appMenu-popup:hover) ~ toolbox,


### PR DESCRIPTION
Make compact mode easier to use when windowed or more than 1 screen by keeping it visible for a duration if the mouse went fully over it. As soon as the mouse touches the browser window again this effect gets removed.

It doesn't change anything in full screen but makes it way easier to use compact mode while windowed or if you have more than 1 screen.

Closes: https://github.com/zen-browser/desktop/issues/1371
Partially resolves: https://github.com/zen-browser/desktop/issues/1555

(I noticed there is currently an issue where the sidebar is positioned 1 pixel to the right which makes it very annoying to hover. This is not caused by this PR)