### PR TITLE
Add method to gZenUIManager to track popups on any element

### DIFF
--- a/src/browser/base/content/ZenStartup.mjs
+++ b/src/browser/base/content/ZenStartup.mjs
@@ -41,6 +41,7 @@
         gBrowser.tabContainer.arrowScrollbox.smoothScroll = false;
 
         ZenWorkspaces.init();
+        gZenUIManager.init();
         gZenVerticalTabsManager.init();
         gZenCompactModeManager.init();
         gZenKeyboardShortcuts.init();


### PR DESCRIPTION
Refactor https://github.com/zen-browser/desktop/pull/1532 so that we can track popups on any element.

Add popup tracking to top toolbar (haven't added css yet as it currently doesn't retract and compact mode is still being worked on)