### PR TITLE
Fix compact mode and expand on hover conflicts in look and feel page

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -512,10 +512,16 @@ var gZenLooksAndFeel = {
       ) {
         radio.checked = true;
       }
+      const disableExpandTabsOnHover = () => {
+        if (Services.prefs.getBoolPref('zen.view.sidebar-expanded.on-hover')) {
+          document.querySelector(`#zen-expand-tabbar-strat [value='expand']`).click();
+        }
+      }
       radio.addEventListener('change', (e) => {
         let value = e.target.value;
         switch (value) {
           case 'left':
+            disableExpandTabsOnHover();
             Services.prefs.setBoolPref('zen.view.compact.hide-tabbar', true);
             Services.prefs.setBoolPref('zen.view.compact.hide-toolbar', false);
             break;
@@ -524,6 +530,7 @@ var gZenLooksAndFeel = {
             Services.prefs.setBoolPref('zen.view.compact.hide-toolbar', true);
             break;
           default:
+            disableExpandTabsOnHover();
             Services.prefs.setBoolPref('zen.view.compact.hide-tabbar', true);
             Services.prefs.setBoolPref('zen.view.compact.hide-toolbar', true);
             break;
@@ -544,6 +551,14 @@ var gZenLooksAndFeel = {
     } else {
       form.querySelector('input[value="none"]').checked = true;
     }
+    const disableCompactTabbar = () => {
+      const toolbarEnable = Services.prefs.getBoolPref('zen.view.compact.hide-toolbar');
+      if (toolbarEnable) {
+        document.querySelector(`#ZenCompactModeStyle input[value='top']`).click();
+      } else if (Services.prefs.getBoolPref('zen.view.compact')) {
+        document.getElementById('zenLooksAndFeelShowCompactView').click();
+      }
+    }
     for (let radio of radios) {
       radio.addEventListener('change', (e) => {
         switch (e.target.value) {
@@ -556,6 +571,7 @@ var gZenLooksAndFeel = {
             Services.prefs.setBoolPref(defaultExpandPref, false);
             break;
           case 'hover':
+            disableCompactTabbar();
             Services.prefs.setBoolPref(onHoverPref, true);
             Services.prefs.setBoolPref(defaultExpandPref, true);
             break;

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -500,23 +500,21 @@ var gZenLooksAndFeel = {
   setCompactModeStyle() {
     const chooser = document.getElementById('zen-compact-mode-styles-form');
     const radios = [...chooser.querySelectorAll('input')];
+
+    let value = '';
+    if (Services.prefs.getBoolPref('zen.view.compact.hide-tabbar')
+          && Services.prefs.getBoolPref('zen.view.compact.hide-toolbar')) {
+      value = 'both';
+    } else {
+      value = Services.prefs.getBoolPref('zen.view.compact.hide-tabbar') ? 'left' : 'top';
+    }
+    chooser.querySelector(`[value='${value}']`).checked = true;
+    const disableExpandTabsOnHover = () => {
+      if (Services.prefs.getBoolPref('zen.view.sidebar-expanded.on-hover')) {
+        document.querySelector(`#zen-expand-tabbar-strat input[value='expand']`).click();
+      }
+    }
     for (let radio of radios) {
-      if (radio.value === 'left' && Services.prefs.getBoolPref('zen.view.compact.hide-tabbar')) {
-        radio.checked = true;
-      } else if (radio.value === 'top' && Services.prefs.getBoolPref('zen.view.compact.hide-toolbar')) {
-        radio.checked = true;
-      } else if (
-        radio.value === 'both' &&
-        !Services.prefs.getBoolPref('zen.view.compact.hide-tabbar') &&
-        !Services.prefs.getBoolPref('zen.view.compact.hide-toolbar')
-      ) {
-        radio.checked = true;
-      }
-      const disableExpandTabsOnHover = () => {
-        if (Services.prefs.getBoolPref('zen.view.sidebar-expanded.on-hover')) {
-          document.querySelector(`#zen-expand-tabbar-strat [value='expand']`).click();
-        }
-      }
       radio.addEventListener('change', (e) => {
         let value = e.target.value;
         switch (value) {


### PR DESCRIPTION
Automatically disable compact mode or change the mode when there is a conflict when selecting expand on hover and vice versa.

Also fixed a bug where 'both' would not be properly selected on page load.