### PR TITLE
Make expand on hover work properly when compact mode is enabled.

### DIFF
--- a/src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css
+++ b/src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css
@@ -416,7 +416,7 @@
   }
 
   /* Mark: Expand on hover */
-  @media (-moz-bool-pref: 'zen.view.sidebar-expanded.on-hover') and (not (-moz-bool-pref: 'zen.view.compact')) {
+  @media (-moz-bool-pref: 'zen.view.sidebar-expanded.on-hover') and (not ((-moz-bool-pref: 'zen.view.compact') and (-moz-bool-pref: 'zen.view.compact.hide-tabbar'))) {
     #zen-sidebar-splitter {
       display: none !important;
     }


### PR DESCRIPTION
Apply expand on hover css when compact mode is enabled but hide-tabbar is disabled. (when only hide top)