### PR TITLE
Make zen sidebar draggable

### DIFF
--- a/src/browser/base/content/zen-sidebar-panel.inc.xhtml
+++ b/src/browser/base/content/zen-sidebar-panel.inc.xhtml
@@ -26,7 +26,9 @@
       </toolbar>
       <toolbarbutton id="zen-sidebar-add-panel-button" class="zen-sidebar-panel-button toolbarbutton-1 chromeclass-toolbar-additional" onclick="gZenBrowserManagerSidebar._openAddPanelDialog();"/>
     </toolbar>
-    <html:span id="zen-sidebar-web-panel-splitter"></html:span>
-    <html:span id="zen-sidebar-web-panel-hsplitter"></html:span>
+    <html:span class="zen-sidebar-web-panel-splitter" side="left"></html:span>
+    <html:span class="zen-sidebar-web-panel-splitter" side="right"></html:span>
+    <html:span class="zen-sidebar-web-panel-splitter" orient="horizontal" side="top"></html:span>
+    <html:span class="zen-sidebar-web-panel-splitter" orient="horizontal" side="bottom"></html:span>
   </box>
 </hbox>

--- a/src/browser/base/content/zen-styles/zen-sidebar-panels.css
+++ b/src/browser/base/content/zen-styles/zen-sidebar-panels.css
@@ -70,7 +70,7 @@
 #zen-sidebar-web-panel-wrapper:has(#zen-sidebar-web-panel[pinned='true']) {
   position: absolute;
   z-index: 1;
-  width: -moz-available;
+  width: calc(100% - var(--zen-sidebar-web-panel-spacing) * 3);
   margin: var(--zen-sidebar-web-panel-spacing);
   /* Why times 3? 
    *  + 1 for the top margin, making the element overflow the view.

--- a/src/browser/base/content/zen-styles/zen-sidebar-panels.css
+++ b/src/browser/base/content/zen-styles/zen-sidebar-panels.css
@@ -101,10 +101,10 @@
   height: unset !important;
 }
 
-#zen-sidebar-web-panel-splitter {
+.zen-sidebar-web-panel-splitter {
   position: absolute;
   top: 0;
-  right: 0;
+  left: 0;
   height: 100%;
   width: 4px;
   background: transparent;
@@ -112,15 +112,20 @@
   cursor: ew-resize;
 }
 
-#zen-sidebar-web-panel-hsplitter {
-  position: absolute;
-  bottom: -2px;
-  left: 0;
+.zen-sidebar-web-panel-splitter[side='right'] {
+  left: initial;
+  right: 0;
+}
+
+.zen-sidebar-web-panel-splitter[orient='horizontal'] {
   width: 100%;
   height: 7px;
-  background: transparent;
-  border: none;
   cursor: ns-resize;
+}
+
+.zen-sidebar-web-panel-splitter[side='bottom'] {
+  top: initial;
+  bottom: -2px;
 }
 
 #zen-sidebar-web-panel[hidden='true'] #zen-sidebar-web-panel-hsplitter,

--- a/src/browser/base/content/zen-styles/zen-sidebar-panels.css
+++ b/src/browser/base/content/zen-styles/zen-sidebar-panels.css
@@ -128,10 +128,10 @@
   bottom: -2px;
 }
 
-#zen-sidebar-web-panel[hidden='true'] #zen-sidebar-web-panel-hsplitter,
-#zen-sidebar-web-panel-wrapper[hidden='true'] + #zen-sidebar-web-panel-splitter,
-#zen-sidebar-web-panel-wrapper[hidden='true'] + #zen-sidebar-web-panel-hsplitter,
-#zen-sidebar-web-panel:not([pinned='true']) #zen-sidebar-web-panel-hsplitter {
+#zen-sidebar-web-panel[hidden='true'] .zen-sidebar-web-panel-splitter,
+#zen-sidebar-web-panel-wrapper[hidden='true'] + .zen-sidebar-web-panel-splitter,
+#zen-sidebar-web-panel:not([pinned='true']) .zen-sidebar-web-panel-splitter[orient='horizontal'],
+#zen-sidebar-web-panel:not([pinned='true']) .zen-sidebar-web-panel-splitter[side='left'] {
   display: none;
   margin: 0;
 }


### PR DESCRIPTION
Make the zen sidebar draggable, also made it resizable on all 4 sides. Made sure the sidebar will never leave it's wrapper.

![zen_q0llhrJOtu](https://github.com/user-attachments/assets/8869e574-5489-4038-a260-6138403469b2)


Components pr: https://github.com/zen-browser/components/pull/28