### PR TITLE
FIX: Remove Focus of the URL Bar at Startup

### DIFF
--- a/src/browser/base/content/ZenStartup.mjs
+++ b/src/browser/base/content/ZenStartup.mjs
@@ -8,7 +8,6 @@
       window.SessionStore.promiseInitialized.then(async () => {
         this._changeSidebarLocation();
         this._zenInitBrowserLayout();
-        this._focusSearchBar();
       });
     },
 


### PR DESCRIPTION
When the browser launches, the urlbar is always focused, instead of the homepage. This behavior doesnt happen on Firefox, and it can be really annoying to always click out to unfocus the urlbar.

Closes:  #1169  