### PR TITLE
Disable back and forward button inside web panel when they can't be used.

### DIFF
--- a/src/browser/base/content/zen-styles/zen-sidebar-panels.css
+++ b/src/browser/base/content/zen-styles/zen-sidebar-panels.css
@@ -187,7 +187,7 @@
 }
 
 #zen-sidebar-web-header toolbarbutton {
-  opacity: 0.7;
+  fill: color-mix(in srgb, var(--toolbarbutton-icon-fill) 70%, transparent);
 }
 
 #zen-sidebar-panels-wrapper {


### PR DESCRIPTION
Ensure the back and forward button for web panel are disabled and greyed out when they can't be used.

Components pr: https://github.com/zen-browser/components/pull/33