### PR TITLE
Feature: Pinned Tab URL Reset & Base URL Persistence

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -111,6 +111,7 @@ pref('zen.themes.updated-value-observer', false);
 pref('zen.tab-unloader.enabled', true);
 pref('zen.tab-unloader.timeout-minutes', 20);
 pref('zen.tab-unloader.excluded-urls', "example.com,example.org");
+pref('zen.tab-unloader.reset-pinned-tab-on-close-shortcut', true);
 
 // Pref to enable the new profiles (TODO: Check this out!)
 //pref("browser.profiles.enabled", true);

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -996,4 +996,9 @@ Preferences.addAll([
     type: 'bool',
     default: false,
   },
+  {
+    id: 'zen.tab-unloader.reset-pinned-tab-on-close-shortcut',
+    type: 'bool',
+    default: true,
+  },
 ]);

--- a/src/browser/components/preferences/zenTabsManagement.inc.xhtml
+++ b/src/browser/components/preferences/zenTabsManagement.inc.xhtml
@@ -48,6 +48,10 @@
             data-l10n-id="zen-tabs-unloader-enabled"
             preference="zen.tab-unloader.enabled"/>
 
+      <checkbox id="zenPinnedTabResetOnCloseShortcutEnable"
+                data-l10n-id="zen-tabs-pinned-reset-close-shortcut-enabled"
+                preference="zen.tab-unloader.reset-pinned-tab-on-close-shortcut"/>
+
       <label><html:h2 data-l10n-id="zen-tabs-unloader-unload-delay"/></label>
       <hbox id="zenTabsUnloadDelayContainer">
             <description class="description-deemphasized" data-l10n-id="zen-tabs-unloader-unload-delay-description" />

--- a/src/browser/components/sessionstore/TabState-sys-mjs.patch
+++ b/src/browser/components/sessionstore/TabState-sys-mjs.patch
@@ -1,13 +1,15 @@
 diff --git a/browser/components/sessionstore/TabState.sys.mjs b/browser/components/sessionstore/TabState.sys.mjs
-index 26f5671c849d9b0a126d79b07bc7d3d7870826ec..26f80d69a28f1196096e67a0e628a69b5b367727 100644
+index 26f5671c849d9b0a126d79b07bc7d3d7870826ec..3726c8d89c9a8f797fda4ef3c18e4fa81f3ad130 100644
 --- a/browser/components/sessionstore/TabState.sys.mjs
 +++ b/browser/components/sessionstore/TabState.sys.mjs
-@@ -98,6 +98,9 @@ var TabStateInternal = {
+@@ -98,6 +98,11 @@ var TabStateInternal = {
        tabData.muteReason = tab.muteReason;
      }
  
 +    tabData.zenWorkspace = tab.getAttribute("zen-workspace-id");
 +    tabData.zenDefaultUserContextId = tab.getAttribute("zenDefaultUserContextId");
++    tabData.zenPinnedUrl = tab.getAttribute("zen-pinned-url");
++    tabData.zenPinnedTitle = tab.getAttribute("zen-pinned-title");
 +
      tabData.searchMode = tab.ownerGlobal.gURLBar.getSearchMode(browser, true);
  

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabbrowser.js b/browser/components/tabbrowser/content/tabbrowser.js
-index ef857bd81f2cd7c163ecc74ac1cf81a0b63ce838..807eb0c493f15643412b05d8dad81d36d7470155 100644
+index ef857bd81f2cd7c163ecc74ac1cf81a0b63ce838..7ffa8f7d64f2ed13018e3f32f94e7b6835bdacdb 100644
 --- a/browser/components/tabbrowser/content/tabbrowser.js
 +++ b/browser/components/tabbrowser/content/tabbrowser.js
 @@ -452,11 +452,26 @@
@@ -68,7 +68,7 @@ index ef857bd81f2cd7c163ecc74ac1cf81a0b63ce838..807eb0c493f15643412b05d8dad81d36
            if (!tabData.pinned) {
              this.unpinTab(tab);
            } else {
-@@ -3297,6 +3328,13 @@
+@@ -3297,6 +3328,12 @@
              preferredRemoteType,
            });
  
@@ -78,11 +78,24 @@ index ef857bd81f2cd7c163ecc74ac1cf81a0b63ce838..807eb0c493f15643412b05d8dad81d36
 +          if (tabData.zenDefaultUserContextId) {
 +            tab.setAttribute("zenDefaultUserContextId", "true");
 +          }
-+
            if (select) {
              tabToSelect = tab;
            }
-@@ -4184,6 +4222,7 @@
+@@ -3331,7 +3368,13 @@
+             this.tabContainer._invalidateCachedTabs();
+           }
+         }
++        if (tabData.zenPinnedUrl) {
++          tab.setAttribute("zen-pinned-url", tabData.zenPinnedUrl);
++        }
+ 
++        if (tabData.zenPinnedTitle) {
++          tab.setAttribute("zen-pinned-title", tabData.zenPinnedTitle);
++        }
+         tab.initialize();
+       }
+ 
+@@ -4184,6 +4227,7 @@
          isLastTab ||
          aTab.pinned ||
          aTab.hidden ||
@@ -90,7 +103,7 @@ index ef857bd81f2cd7c163ecc74ac1cf81a0b63ce838..807eb0c493f15643412b05d8dad81d36
          this._removingTabs.size >
            3 /* don't want lots of concurrent animations */ ||
          !aTab.hasAttribute(
-@@ -5117,10 +5156,10 @@
+@@ -5117,10 +5161,10 @@
        SessionStore.deleteCustomTabValue(aTab, "hiddenBy");
      },
  
@@ -103,3 +116,15 @@ index ef857bd81f2cd7c163ecc74ac1cf81a0b63ce838..807eb0c493f15643412b05d8dad81d36
          aTab.selected ||
          aTab.closing ||
          // Tabs that are sharing the screen, microphone or camera cannot be hidden.
+@@ -7822,7 +7866,10 @@ var TabContextMenu = {
+     );
+     contextUnpinSelectedTabs.hidden =
+       !this.contextTab.pinned || !multiselectionContext;
+-
++    let contextResetPinnedTab = document.getElementById("context_zen-reset-pinned-tab");
++    if(contextResetPinnedTab) {
++      contextResetPinnedTab.hidden = !this.contextTab.pinned || !this.contextTab.getAttribute("zen-pinned-url") || multiselectionContext;
++    }
+     // Move Tab items
+     let contextMoveTabOptions = document.getElementById(
+       "context_moveTabOptions"

--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -769,7 +769,8 @@ menuitem[id='placesContext_deleteHost'],
 #context_reloadTab,
 #context_reloadSelectedTabs,
 #toolbar-context-reloadSelectedTab,
-#toolbar-context-reloadSelectedTabs {
+#toolbar-context-reloadSelectedTabs,
+#context_zen-reset-pinned-tab {
   --menu-image: url('reload.svg');
 }
 


### PR DESCRIPTION
This PR introduces functionality to reset a pinned tab back to its originally pinned URL. Two methods are available for resetting:

1. **Context Menu**: Use the "Reset Pinned Tab" option from the context menu.
2. **Keyboard Shortcut**: Pressing `CTRL + W` (or whatever you mapped it to) to close the tab will unload the pinned tab and reset it to the originally pinned URL (if this option is enabled in the settings).

Additionally, the default behavior for closing a pinned tab using the `CTRL + W` shortcut has been updated. It now unloads the tab and switches to the next available tab.

Related to:
https://github.com/zen-browser/l10n-packs/pull/63
https://github.com/zen-browser/components/pull/35

https://github.com/user-attachments/assets/d5e7ad73-2ea5-464d-856d-a552b655fbda

