### PR TITLE
Update & format installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ pnpm start
 
 To view changes you've made, run
 ```bash
-pnpm build:i && pnpm start
+pnpm build:ui && pnpm start
 ```
 
 ## Special Thanks

--- a/README.md
+++ b/README.md
@@ -102,30 +102,31 @@ cd desktop
 Install dependencies
 
 ```bash
-npm i
+pnpm install
 ```
 
 Download and bootstrap the browser
 
-```
-npm run init
+```bash
+pnpm run init
 ```
 
 Copy a language pack
-```
+
+```bash
 sh scripts/update-en-US-packs.sh
 ```
 
 Start building the browser
 
-```
-npm run build
+```bash
+pnpm run build
 ```
 
 Finally, run the browser!
 
-```
-npm start
+```bash
+pnpm start
 ```
 
 ## Special Thanks

--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ Finally, run the browser!
 pnpm start
 ```
 
+### Development
+
+To view changes you've made, run
+```bash
+pnpm build:i && pnpm start
+```
+
 ## Special Thanks
 
 - [IAmJafeth](https://github.com/IAmJafeth) (For sponsoring the domain)


### PR DESCRIPTION
Update installation instructions to use `pnpm` commands instead of `npm` commands, add formatting corrections to look pretty. Also adds instructions for development and viewing local changes.