### PR TITLE
Feature: Open new tab on middle click in tab bar

### DIFF
--- a/src/browser/base/content/ZenUIManager.mjs
+++ b/src/browser/base/content/ZenUIManager.mjs
@@ -84,6 +84,20 @@ var gZenVerticalTabsManager = {
     gZenCompactModeManager.addEventListener(updateEvent);
     this._updateEvent();
     this.initRightSideOrderContextMenu();
+
+    let tabs = document.getElementById("tabbrowser-tabs");
+
+    if (tabs) {
+      tabs.addEventListener("mouseup", this.openNewTabOnTabsMiddleClick.bind(this));
+    }
+  },
+
+  openNewTabOnTabsMiddleClick(event) {
+    if (event.button === 1 && event.target.id === "tabbrowser-tabs") {
+      BrowserCommands.openTab({ event });
+      event.stopPropagation();
+      event.preventDefault();
+    }
   },
 
   get navigatorToolbox() {


### PR DESCRIPTION
This PR adds the ability to open a new tab by middle-clicking the tab bar.

Middle-clicking the empty space in the sidebar will open a new tab, middle clicking a tab functionality is preserved and will close the tab.


https://github.com/user-attachments/assets/39ef0ca8-2dda-49a8-b3d0-15404072fe40

