### PR TITLE
Feature: Expand default workspace icons

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -130,7 +130,7 @@ pref('zen.workspaces.enabled', true);
 pref('zen.workspaces.hide-default-container-indicator', true);
 pref('zen.workspaces.individual-pinned-tabs', true);
 pref('zen.workspaces.show-icon-strip', true);
-pref('zen.workspaces.icons', '["🌐", "📁", "💼", "📝", "📅", "📊", "🧠", "🚀", "🎯", "🔒", "💡", "🎨", "🛠️", "🧩", "💻", "📱", "🎓", "📚", "⚙️", "🎉", "🕹️", "🛒", "🔍"]');
+pref('zen.workspaces.icons', '["🌐", "📁", "💼", "📝", "📅", "📊", "🧠", "🚀", "🎯", "🔒", "💡", "🎨", "🛠️", "🧩", "💻", "📱", "🎓", "📚", "⚙️", "🎉", "🕹️", "🛒", "🔍","🧪","🔧","🗝️","🎧","🎮"]');
 pref('services.sync.engine.workspaces', false);
 
 // Zen Watermark

--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -130,7 +130,7 @@ pref('zen.workspaces.enabled', true);
 pref('zen.workspaces.hide-default-container-indicator', true);
 pref('zen.workspaces.individual-pinned-tabs', true);
 pref('zen.workspaces.show-icon-strip', true);
-pref('zen.workspaces.icons', '["🌐", "📁", "💼", "📝", "📅", "📊","🧠"]');
+pref('zen.workspaces.icons', '["🌐", "📁", "💼", "📝", "📅", "📊", "🧠", "🚀", "🎯", "🔒", "💡", "🎨", "🛠️", "🧩", "💻", "📱", "🎓", "📚", "⚙️", "🎉", "🕹️", "🛒", "🔍"]');
 pref('services.sync.engine.workspaces', false);
 
 // Zen Watermark

--- a/src/browser/base/content/zen-styles/zen-workspaces.css
+++ b/src/browser/base/content/zen-styles/zen-workspaces.css
@@ -185,7 +185,12 @@
 #PanelUI-zen-workspaces-edit-icons-container {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(30px, 1fr));
+  grid-auto-flow: dense;
   gap: 8px;
+  overflow-x: hidden;
+  justify-items: center;
+  max-height: calc(2 * (42px + 8px));
+  overflow-y: auto;
 }
 
 #PanelUI-zen-workspaces-create-icons-container toolbarbutton.toolbarbutton-1,


### PR DESCRIPTION
- Added additional default workspace icons to expand the available options.

- Improved the styling of the workspace icon selector to enhance the user experience when displaying more than two rows of icons. The container height is now limited to two rows, with a scrollbar introduced for any overflow, preventing the container from expanding beyond two rows.


https://github.com/user-attachments/assets/4ddc2b16-4bbd-447b-a385-df8e5084a019

