### PR TITLE
Feature: Workspace theme color

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -131,6 +131,7 @@ pref('zen.workspaces.hide-default-container-indicator', true);
 pref('zen.workspaces.individual-pinned-tabs', true);
 pref('zen.workspaces.show-icon-strip', true);
 pref('zen.workspaces.icons', '["🌐", "📁", "💼", "📝", "📅", "📊","🧠"]');
+pref('services.sync.engine.workspaces', false);
 
 // Zen Watermark
 pref('zen.watermark.enabled', true, sticky);

--- a/src/browser/base/content/zen-assets.inc.xhtml
+++ b/src/browser/base/content/zen-assets.inc.xhtml
@@ -32,6 +32,7 @@
 <script src="chrome://browser/content/zen-components/ZenTabUnloader.mjs" />
 <script src="chrome://browser/content/zen-components/ZenWorkspaces.mjs" />
 <script src="chrome://browser/content/zen-components/ZenWorkspacesStorage.mjs" />
+<script src="chrome://browser/content/zen-components/ZenWorkspacesSync.mjs" />
 <script src="chrome://browser/content/zen-components/ZenViewSplitter.mjs"/>
 <script src="chrome://browser/content/zen-components/ZenProfileDialogUI.mjs" />
 <script src="chrome://browser/content/zen-components/ZenKeyboardShortcuts.mjs" />

--- a/src/browser/base/content/zen-assets.jar.inc.mn
+++ b/src/browser/base/content/zen-assets.jar.inc.mn
@@ -9,6 +9,7 @@
         content/browser/zen-components/ZenThemesCommon.mjs      (content/zen-components/src/ZenThemesCommon.mjs)
         content/browser/zen-components/ZenWorkspaces.mjs        (content/zen-components/src/ZenWorkspaces.mjs)
         content/browser/zen-components/ZenWorkspacesStorage.mjs (content/zen-components/src/ZenWorkspacesStorage.mjs)
+        content/browser/zen-components/ZenWorkspacesSync.mjs    (content/zen-components/src/ZenWorkspacesSync.mjs)
         content/browser/zen-components/ZenSidebarManager.mjs    (content/zen-components/src/ZenSidebarManager.mjs)
         content/browser/zen-components/ZenProfileDialogUI.mjs   (content/zen-components/src/ZenProfileDialogUI.mjs)
         content/browser/zen-components/ZenKeyboardShortcuts.mjs (content/zen-components/src/ZenKeyboardShortcuts.mjs)

--- a/src/browser/base/content/zen-popupset.inc.xhtml
+++ b/src/browser/base/content/zen-popupset.inc.xhtml
@@ -102,6 +102,7 @@
       <vbox>
         <h1 data-l10n-id="zen-panel-ui-workspaces-create-text"></h1>
         <html:input autofocus="true" id="PanelUI-zen-workspaces-create-input" type="text" placeholder="Enter workspace name" oninput="ZenWorkspaces.onWorkspaceCreationNameChange(this);" />
+        <html:div id="PanelUI-zen-workspaces-create-color-picker" class="zen-color-picker"></html:div>
         <hbox id="PanelUI-zen-workspaces-create-icons-container">
         </hbox>
       </vbox>
@@ -116,6 +117,7 @@
       <vbox>
         <h1 data-l10n-id="zen-panel-ui-workspaces-edit-text"></h1>
         <html:input autofocus="true" id="PanelUI-zen-workspaces-edit-input" type="text" placeholder="Enter workspace name" oninput="ZenWorkspaces.onWorkspaceEditChange();" />
+        <html:div id="PanelUI-zen-workspaces-edit-color-picker" class="zen-color-picker"></html:div>
         <hbox id="PanelUI-zen-workspaces-edit-icons-container">
         </hbox>
       </vbox>

--- a/src/browser/base/content/zen-styles/zen-workspaces.css
+++ b/src/browser/base/content/zen-styles/zen-workspaces.css
@@ -300,3 +300,28 @@
 #PanelUI-zen-workspaces-edit-footer button[default='true'] {
   width: 100%;
 }
+
+.zen-color-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: auto 0;
+  padding-left: 3px;
+  margin-top: 8px;
+}
+
+.zen-color-option {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+.zen-color-option[selected] {
+  border-color: var(--zen-colors-primary);
+}
+
+.zen-color-option[data-color="null"] {
+  background: repeating-conic-gradient(#ccc 0% 25%, transparent 0% 50%) 50% / 10px 10px;
+}

--- a/src/browser/components/preferences/dialogs/syncChooseWhatToSync-js.patch
+++ b/src/browser/components/preferences/dialogs/syncChooseWhatToSync-js.patch
@@ -1,0 +1,12 @@
+diff --git a/browser/components/preferences/dialogs/syncChooseWhatToSync.js b/browser/components/preferences/dialogs/syncChooseWhatToSync.js
+index 2cc965b4e1b20e1ae422bfb5c90a237dcd31fcf6..cfed9dfa67c7c34cd812885a72d66dd37ba414fc 100644
+--- a/browser/components/preferences/dialogs/syncChooseWhatToSync.js
++++ b/browser/components/preferences/dialogs/syncChooseWhatToSync.js
+@@ -13,6 +13,7 @@ Preferences.addAll([
+   { id: "services.sync.engine.passwords", type: "bool" },
+   { id: "services.sync.engine.addresses", type: "bool" },
+   { id: "services.sync.engine.creditcards", type: "bool" },
++  { id: "services.sync.engine.workspaces", type: "bool" },
+ ]);
+ 
+ let gSyncChooseWhatToSync = {

--- a/src/browser/components/preferences/dialogs/syncChooseWhatToSync-xhtml.patch
+++ b/src/browser/components/preferences/dialogs/syncChooseWhatToSync-xhtml.patch
@@ -1,0 +1,17 @@
+diff --git a/browser/components/preferences/dialogs/syncChooseWhatToSync.xhtml b/browser/components/preferences/dialogs/syncChooseWhatToSync.xhtml
+index 83bd09c0c3f8fd5febf1721e6b462ca90e54327b..71c9e8e4056edaeb354cf7844494bd83c2089561 100644
+--- a/browser/components/preferences/dialogs/syncChooseWhatToSync.xhtml
++++ b/browser/components/preferences/dialogs/syncChooseWhatToSync.xhtml
+@@ -82,6 +82,12 @@
+           preference="services.sync.engine.prefs"
+         />
+       </html:div>
++      <html:div class="sync-engine-workspaces">
++        <checkbox
++                data-l10n-id="sync-engine-workspaces"
++                preference="services.sync.engine.workspaces"
++        />
++      </html:div>
+     </html:div>
+   </dialog>
+ </window>

--- a/src/browser/components/preferences/sync-inc-xhtml.patch
+++ b/src/browser/components/preferences/sync-inc-xhtml.patch
@@ -1,0 +1,15 @@
+diff --git a/browser/components/preferences/sync.inc.xhtml b/browser/components/preferences/sync.inc.xhtml
+index 492491a369b53797aded1d3e4cf24d6f11394267..b294aa3005b11276ba8f1c58730b85043a19bf3f 100644
+--- a/browser/components/preferences/sync.inc.xhtml
++++ b/browser/components/preferences/sync.inc.xhtml
+@@ -229,6 +229,10 @@
+                     <image class="sync-engine-image sync-engine-prefs" alt=""/>
+                     <label data-l10n-id="sync-currently-syncing-settings"/>
+                   </html:div>
++                  <html:div engine_preference="services.sync.engine.workspaces">
++                    <image class="sync-engine-image sync-engine-workspaces" alt=""/>
++                    <label data-l10n-id="sync-currently-syncing-workspaces"/>
++                  </html:div>
+                 </html:div>
+                 <hbox>
+                   <button id="syncChangeOptions"

--- a/src/browser/locales/en-US/browser/preferences/preferences-ftl.patch
+++ b/src/browser/locales/en-US/browser/preferences/preferences-ftl.patch
@@ -1,0 +1,24 @@
+diff --git a/browser/locales/en-US/browser/preferences/preferences.ftl b/browser/locales/en-US/browser/preferences/preferences.ftl
+index d197d876dac5e9024c944d33454525123775ea02..59fa0a7921f337dc01eac3364c1d01c71afc4f7a 100644
+--- a/browser/locales/en-US/browser/preferences/preferences.ftl
++++ b/browser/locales/en-US/browser/preferences/preferences.ftl
+@@ -925,6 +925,7 @@ sync-currently-syncing-addresses = Addresses
+ sync-currently-syncing-payment-methods = Payment methods
+ sync-currently-syncing-addons = Add-ons
+ sync-currently-syncing-settings = Settings
++sync-currently-syncing-workspaces = Workspaces
+ 
+ sync-change-options =
+     .label = Change…
+@@ -980,6 +981,11 @@ sync-engine-settings =
+     .tooltiptext = General, Privacy, and Security settings you’ve changed
+     .accesskey = s
+ 
++sync-engine-workspaces =
++    .label = Workspaces
++    .tooltiptext = Workspace names, icons and associated containers
++    .accesskey = w
++
+ ## The device name controls.
+ 
+ sync-device-name-header = Device Name

--- a/src/browser/themes/shared/preferences/preferences-css.patch
+++ b/src/browser/themes/shared/preferences/preferences-css.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/themes/shared/preferences/preferences.css b/browser/themes/shared/preferences/preferences.css
-index 8f2652f030b9990de83bbffb891f2a52731f478b..322d7e43a516f80de5964b0e25a455c8806fef1a 100644
+index ddb6ea0e9ec0099f7c9513fe45f8151978137ac5..7dbb4ce25a681a1dca6c23c290a1ccebf9b8fff4 100644
 --- a/browser/themes/shared/preferences/preferences.css
 +++ b/browser/themes/shared/preferences/preferences.css
 @@ -33,7 +33,7 @@
@@ -11,3 +11,15 @@ index 8f2652f030b9990de83bbffb891f2a52731f478b..322d7e43a516f80de5964b0e25a455c8
  }
  
  /*
+@@ -911,6 +911,11 @@ dialog > .sync-engines-list + hbox {
+   list-style-image: url("chrome://formautofill/content/icon-credit-card-generic.svg");
+ }
+ 
++.sync-engine-workspaces .checkbox-icon,
++.sync-engine-workspaces.sync-engine-image {
++  list-style-image: url("chrome://devtools/skin/images/tool-storage.svg");
++}
++
+ .fxaMobilePromo {
+   margin-top: 2px !important;
+ }


### PR DESCRIPTION
This commit adds a color picker to the workspace creation and editing UI. This allows users to choose a custom color for their workspace, making it easier to distinguish between different workspaces.

The color picker is implemented using a series of color swatches that the user can click on to select a color.

Depends on:
https://github.com/zen-browser/components/pull/38


https://github.com/user-attachments/assets/08446a49-cdb8-46ba-b6e0-a6823e7be54f

