### PR TITLE
Feature: Workspace theme color - no sync

### DIFF
--- a/src/browser/base/content/zen-popupset.inc.xhtml
+++ b/src/browser/base/content/zen-popupset.inc.xhtml
@@ -102,6 +102,7 @@
       <vbox>
         <h1 data-l10n-id="zen-panel-ui-workspaces-create-text"></h1>
         <html:input autofocus="true" id="PanelUI-zen-workspaces-create-input" type="text" placeholder="Enter workspace name" oninput="ZenWorkspaces.onWorkspaceCreationNameChange(this);" />
+        <html:div id="PanelUI-zen-workspaces-create-color-picker" class="zen-color-picker"></html:div>
         <hbox id="PanelUI-zen-workspaces-create-icons-container">
         </hbox>
       </vbox>
@@ -116,6 +117,7 @@
       <vbox>
         <h1 data-l10n-id="zen-panel-ui-workspaces-edit-text"></h1>
         <html:input autofocus="true" id="PanelUI-zen-workspaces-edit-input" type="text" placeholder="Enter workspace name" oninput="ZenWorkspaces.onWorkspaceEditChange();" />
+        <html:div id="PanelUI-zen-workspaces-edit-color-picker" class="zen-color-picker"></html:div>
         <hbox id="PanelUI-zen-workspaces-edit-icons-container">
         </hbox>
       </vbox>

--- a/src/browser/base/content/zen-styles/zen-workspaces.css
+++ b/src/browser/base/content/zen-styles/zen-workspaces.css
@@ -300,3 +300,28 @@
 #PanelUI-zen-workspaces-edit-footer button[default='true'] {
   width: 100%;
 }
+
+.zen-color-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: auto 0;
+  padding-left: 3px;
+  margin-top: 8px;
+}
+
+.zen-color-option {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+.zen-color-option[selected] {
+  border-color: var(--zen-colors-primary);
+}
+
+.zen-color-option[data-color="null"] {
+  background: repeating-conic-gradient(#ccc 0% 25%, transparent 0% 50%) 50% / 10px 10px;
+}

--- a/src/browser/base/content/zen-styles/zen-workspaces.css
+++ b/src/browser/base/content/zen-styles/zen-workspaces.css
@@ -325,3 +325,132 @@
 .zen-color-option[data-color="null"] {
   background: repeating-conic-gradient(#ccc 0% 25%, transparent 0% 50%) 50% / 10px 10px;
 }
+
+/* Only apply gradient styles when the zen-gradient-theme attribute is present */
+:root[zen-gradient-theme="true"] {
+  /* Set the gradient starting point based on tab side preference */
+  @media (-moz-bool-pref: "zen.tabs.vertical.right-side") {
+    --gradient-start: circle at 95% top;
+  }
+  @media not (-moz-bool-pref: "zen.tabs.vertical.right-side") {
+    --gradient-start: circle at 5% top;
+  }
+
+  /* Default saturation and lightness values */
+  --saturation: 80%;
+  --lightness: 80%;
+  --accent-color-lightness: 58%;
+
+  /* Adjust lightness based on the color scheme */
+  @media (prefers-color-scheme: dark) {
+    --lightness: 12%;
+    --accent-color-lightness: 40%;
+  }
+
+  /* Apply the gradient background using the generated colors */
+  --zen-main-browser-background: radial-gradient(
+          var(--gradient-start),
+          var(--gradient-color1) 20%,
+          var(--gradient-color2) 40%,
+          var(--gradient-color3) 60%,
+          var(--gradient-color4) 80%
+  ) !important;
+
+  /* Apply custom accent colors to interface elements */
+  --toolbarbutton-hover-background: color-mix(
+          in srgb,
+          var(--custom-accent-color) 60%,
+          transparent
+  ) !important;
+  --toolbarbutton-active-background: color-mix(
+          in srgb,
+          var(--custom-accent-color) 80%,
+          transparent
+  ) !important;
+  --panel-item-hover-bgcolor: color-mix(
+          in srgb,
+          var(--custom-accent-color) 60%,
+          transparent
+  ) !important;
+  --zen-workspaces-strip-background-color: var(--custom-accent-color) !important;
+}
+
+/* Apply the gradient to the main browser area when the attribute is present */
+:root[zen-gradient-theme="true"] #browser {
+  background: var(--zen-main-browser-background) !important;
+}
+
+/* Makes the gradient work in compact mode */
+@media (-moz-bool-pref: "zen.view.compact.hide-toolbar") and (-moz-bool-pref: "zen.view.compact") {
+  :root[zen-gradient-theme="true"] #nav-bar::before,
+  :root[zen-gradient-theme="true"] #nav-bar,
+  :root[zen-gradient-theme="true"] #PersonalToolbar[data-l10n-id="bookmarks-toolbar"] {
+    background: var(--zen-main-browser-background) !important;
+  }
+}
+
+@media (-moz-bool-pref: "zen.view.compact.hide-tabbar") and (-moz-bool-pref: "zen.view.compact") {
+  :root[zen-gradient-theme="true"] #navigator-toolbox {
+    --zen-themed-toolbar-bg: var(--zen-main-browser-background) !important;
+  }
+}
+
+/* Make gradient work when "Expand on hover" is enabled */
+@media (-moz-bool-pref: "zen.view.sidebar-expanded") and (-moz-bool-pref: "zen.view.sidebar-expanded.on-hover") {
+  #navigator-toolbox[zen-has-hover],
+  #navigator-toolbox:focus-within,
+  #navigator-toolbox[movingtab],
+  #navigator-toolbox[flash-popup],
+  #navigator-toolbox[has-popup-menu],
+  #navigator-toolbox:has(.tabbrowser-tab:active),
+  #navigator-toolbox:has(*[open='true']:not(tab):not(#zen-sidepanel-button)) {
+    :root[zen-gradient-theme="true"] #TabsToolbar {
+      background: var(--zen-main-browser-background) !important;
+    }
+  }
+}
+
+/* Apply background to the workspaces icon strip */
+@media (-moz-bool-pref: "zen.workspaces.show-icon-strip") {
+  :root[zen-gradient-theme="true"] #zen-workspaces-button {
+    background: color-mix(
+            in srgb,
+            var(--custom-accent-color) 25%,
+            transparent
+    ) !important;
+  }
+}
+
+/* Styling for pinned tabs */
+:root[zen-gradient-theme="true"] .tabbrowser-tab[pinned] .tab-stack .tab-background {
+  background-color: color-mix(
+          in srgb,
+          var(--custom-accent-color) 35%,
+          transparent 75%
+  ) !important;
+}
+
+/* Background color when hovering over tabs */
+:root[zen-gradient-theme="true"] .tabbrowser-tab:hover .tab-stack .tab-background {
+  background-color: color-mix(
+          in srgb,
+          var(--custom-accent-color) 50%,
+          transparent 75%
+  ) !important;
+}
+
+/* Background color for selected tabs */
+:root[zen-gradient-theme="true"] .tabbrowser-tab[selected="true"] .tab-stack .tab-background,
+:root[zen-gradient-theme="true"] .tabbrowser-tab[multiselected="true"] .tab-stack .tab-background {
+  background-color: var(--custom-accent-color) !important;
+}
+
+/* Background color when hovering over selected tabs */
+:root[zen-gradient-theme="true"] .tabbrowser-tab[selected="true"]:hover .tab-stack .tab-background,
+:root[zen-gradient-theme="true"] .tabbrowser-tab[multiselected="true"]:hover .tab-stack .tab-background {
+  background-color: color-mix(
+          in srgb,
+          var(--custom-accent-color) 90%,
+          transparent
+  ) !important;
+}


### PR DESCRIPTION
This PR adds a color picker to the workspace creation and editing dialogs. This allows users to select a color for their workspace, making it easier to distinguish between different workspaces.

The color picker uses a simple set of color swatches for now.

Depends on https://github.com/zen-browser/components/pull/39

This is a version without workspaces sync implemented. For sync version check out https://github.com/zen-browser/desktop/pull/1906

