### PR TITLE
Fix splitview overlay becoming misaligned when tabs not expanded.

### DIFF
--- a/src/browser/base/content/zen-styles/zen-browser-ui.css
+++ b/src/browser/base/content/zen-styles/zen-browser-ui.css
@@ -46,6 +46,7 @@
 #tabbrowser-tabbox {
   display: flex;
   flex-direction: row;
+  position: relative;
 }
 
 .titlebar-buttonbox-container {


### PR DESCRIPTION
When using "don't expand tabs by default" the 'navigator-toolbox' gets moved to the 'zen-tabbox-wrapper'. This causes the 'zen-splitview-overlay-wrapper' to be positioned on top of the sidebar which miss aligns the splitters and dropzone in splitview.

This can be solved by positioning 'tabbrowser-tabbox' relative instead of static.