### PR TITLE
Installation of Zen on CachyOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ bash <(curl https://updates.zen-browser.app/appimage.sh)
 flatpak install flathub io.github.zen_browser.zen
 ```
 
+#### CachyOS
+##### Generic
+```
+sudo pacman -S zen-browser-bin
+```
+
+##### Optimized 
+```
+sudo pacman -S zen-browser-avx2-bin
+```
+
 To upgrade the browser to a newer version, use the embedded update functionality in `About Zen`.
 
 # Core Components


### PR DESCRIPTION
I’ve added both variants of `zen-browser-bin` and `zen-browser-avx2-bin`. CachyOS has Zen available in the repository.