### PR TITLE
Feature: Enable syncing of Workspace icons by default

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -135,6 +135,7 @@ pref('zen.workspaces.hide-default-container-indicator', true);
 pref('zen.workspaces.individual-pinned-tabs', true);
 pref('zen.workspaces.show-icon-strip', true);
 pref('zen.workspaces.icons', '["🌐", "📁", "💼", "📝", "📅", "📊","🧠"]');
+pref('services.sync.prefs.sync.zen.workspaces.icons', true);
 pref('services.sync.engine.workspaces', false);
 
 // Zen Watermark


### PR DESCRIPTION
This PR adds a new preference (`services.sync.prefs.sync.zen.workspaces.icons`) to enable syncing of the Workspace icons across different devices. This allows users to maintain the same visual experience regardless of where they are using Zen.