### PR TITLE
Feature: Add option to change workspaces with side button and right-click

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -102,6 +102,7 @@ pref('zen.view.sidebar-collapsed.hide-mute-button', true);
 
 pref('zen.tabs.dim-pending', true);
 pref('zen.tabs.newtab-on-middle-click', true);
+pref('zen.tabs.change-workspace-on-side-button-and-right-click', true);
 
 pref('zen.keyboard.shortcuts.enabled', true);
 pref('zen.keyboard.shortcuts.version', 0); // Empty string means default shortcuts

--- a/src/browser/base/content/ZenUIManager.mjs
+++ b/src/browser/base/content/ZenUIManager.mjs
@@ -87,18 +87,41 @@ var gZenVerticalTabsManager = {
     let tabs = document.getElementById('tabbrowser-tabs');
 
     XPCOMUtils.defineLazyPreferenceGetter(this, 'canOpenTabOnMiddleClick', 'zen.tabs.newtab-on-middle-click', true);
+    XPCOMUtils.defineLazyPreferenceGetter(this, 'canChangeWorkspaceOnSideButtonAndRightClick', 'zen.tabs.change-workspace-on-side-button-and-right-click', true);
 
     if (tabs) {
-      tabs.addEventListener('mouseup', this.openNewTabOnTabsMiddleClick.bind(this));
+      tabs.addEventListener('mouseup', this.tabsMouseUpHandler.bind(this));
     }
   },
 
-  openNewTabOnTabsMiddleClick(event) {
-    if (event.button === 1 && event.target.id === 'tabbrowser-tabs' && this.canOpenTabOnMiddleClick) {
-      document.getElementById('cmd_newNavigatorTabNoEvent').doCommand();
-      event.stopPropagation();
-      event.preventDefault();
-    }
+  tabsMouseUpHandler(event) {
+    const { buttons, button, target } = event;
+    const isTargetTabbrowserTabs = target.id === 'tabbrowser-tabs';
+
+    const handleEvent = (condition, action) => {
+      if (condition && isTargetTabbrowserTabs) {
+        action();
+        event.stopPropagation();
+        event.preventDefault();
+        return true;
+      }
+      return false;
+    };
+
+    if (handleEvent(
+        buttons === 8 && this.canChangeWorkspaceOnSideButtonAndRightClick,
+        () => ZenWorkspaces.changeWorkspaceShortcut(-1)
+    )) return;
+
+    if (handleEvent(
+        buttons === 16 && this.canChangeWorkspaceOnSideButtonAndRightClick,
+        () => ZenWorkspaces.changeWorkspaceShortcut()
+    )) return;
+
+    handleEvent(
+        button === 1 && this.canOpenTabOnMiddleClick,
+        () => document.getElementById('cmd_newNavigatorTabNoEvent').doCommand()
+    );
   },
 
   get navigatorToolbox() {

--- a/src/browser/base/content/ZenUIManager.mjs
+++ b/src/browser/base/content/ZenUIManager.mjs
@@ -96,10 +96,9 @@ var gZenVerticalTabsManager = {
 
   tabsMouseUpHandler(event) {
     const { buttons, button, target } = event;
-    const isTargetTabbrowserTabs = target.id === 'tabbrowser-tabs';
 
     const handleEvent = (condition, action) => {
-      if (condition && isTargetTabbrowserTabs) {
+      if (condition) {
         action();
         event.stopPropagation();
         event.preventDefault();
@@ -119,7 +118,7 @@ var gZenVerticalTabsManager = {
     )) return;
 
     handleEvent(
-        button === 1 && this.canOpenTabOnMiddleClick,
+        button === 1 && this.canOpenTabOnMiddleClick && target.id === 'tabbrowser-tabs',
         () => document.getElementById('cmd_newNavigatorTabNoEvent').doCommand()
     );
   },


### PR DESCRIPTION
This PR introduces a new preference (`zen.tabs.change-workspace-on-side-button-and-right-click`) that allows users to change workspaces using the mouse side button and right-click on the tab bar.

### Why not just mouse side buttons? 
Because Mozilla made it very hard to capture only mouse side buttons and this seems the best way to implement it.