### PR TITLE
Change name in .desktop during twilight AppImage build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,6 +322,10 @@ jobs:
           cp configs/branding/${{ inputs.update_branch }}/logo128.png AppDir/usr/share/icons/hicolor/128x128/apps/zen.png
           cp configs/branding/${{ inputs.update_branch }}/logo128.png AppDir/zen.png && ln -s zen.png AppDir/.DirIcon
 
+          if [ "${{ inputs.update_branch }}" = "twilight" ]; then
+            sed -i -e 's/Name=Zen Browser/name=Zen Twilight/g' AppDir/zen.desktop
+          fi
+
           APPDIR=AppDir
           tar -xvf *.tar.* && rm -rf *.tar.*
           mv zen/* $APPDIR/


### PR DESCRIPTION
While the twilight AppImage has a different Icon, the name in the `.desktop` file stays "Zen Browser". This PR changes a simple find-replace to the GitHub Action, replacing the name when building for twilight.

NOTE: I have not been able to test the bash if statement in this case, as I don't know of any way to run GitHub Actions locally. This implementation assumes `${{ inputs.update_branch }}` will be replaced with the exact input, without any quotation marks.