### PR TITLE
Fix change on hover setting not doing anything.

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1006,7 +1006,7 @@ Preferences.addAll([
     default: true,
   },
   {
-    id: 'zen.view.split-view.change-on-hover',
+    id: 'zen.splitView.change-on-hover',
     type: 'bool',
     default: true,
   },

--- a/src/browser/components/preferences/zenLooksAndFeel.inc.xhtml
+++ b/src/browser/components/preferences/zenLooksAndFeel.inc.xhtml
@@ -271,7 +271,7 @@
 
       <checkbox id="zenLooksAndFeelSplitViewChangeOnHover"
             data-l10n-id="zen-split-view-change-on-hover"
-            preference="zen.view.split-view.change-on-hover"/>
+            preference="zen.splitView.change-on-hover"/>
 </groupbox>
 
 <hbox id="zenVerticalTabsCategory"


### PR DESCRIPTION
Change on hover didn't work because it changed a different pref than the one in zenViewSplitter.mjs, I chose to keep the version which is most consistent with other splitview prefs.

Closes: https://github.com/zen-browser/desktop/issues/1823