### PR TITLE
feat(sessionstore): Store zen pinned entry in tab state

### DIFF
--- a/src/browser/components/sessionstore/TabState-sys-mjs.patch
+++ b/src/browser/components/sessionstore/TabState-sys-mjs.patch
@@ -1,17 +1,15 @@
 diff --git a/browser/components/sessionstore/TabState.sys.mjs b/browser/components/sessionstore/TabState.sys.mjs
-index 26f5671c849d9b0a126d79b07bc7d3d7870826ec..d5cc8494a7eb7d6326f764490d7d959a7dbbcafd 100644
+index 26f5671c849d9b0a126d79b07bc7d3d7870826ec..21d63856a06cd46424e1c1a3697b2f3d225d5c08 100644
 --- a/browser/components/sessionstore/TabState.sys.mjs
 +++ b/browser/components/sessionstore/TabState.sys.mjs
-@@ -98,6 +98,13 @@ var TabStateInternal = {
+@@ -98,6 +98,11 @@ var TabStateInternal = {
        tabData.muteReason = tab.muteReason;
      }
  
 +    tabData.zenWorkspace = tab.getAttribute("zen-workspace-id");
 +    tabData.zenDefaultUserContextId = tab.getAttribute("zenDefaultUserContextId");
-+    tabData.zenPinnedUrl = tab.getAttribute("zen-pinned-url");
-+    tabData.zenPinnedTitle = tab.getAttribute("zen-pinned-title");
++    tabData.zenPinnedEntry = tab.getAttribute("zen-pinned-entry");
 +    tabData.zenPinnedIcon = tab.getAttribute("zen-pinned-icon");
-+    tabData.zenPinnedTriggeringPrincipal = tab.getAttribute("zen-pinned-triggering-principal");
 +
      tabData.searchMode = tab.ownerGlobal.gURLBar.getSearchMode(browser, true);
  


### PR DESCRIPTION
This commit adds the `zenPinnedEntry` property to the `TabState` object, which stores the full zen pinned entry data. This information will be used to restore the pinned entry when a tab is restored from the session.

The following changes were made:

- Added `zenPinnedEntry` to `TabState`
- Removed `zenPinnedUrl`, `zenPinnedTitle`, `zenPinnedIcon`, and `zenPinnedTriggeringPrincipal` as they are now included in `zenPinnedEntry`.
- Updated the `TabState` serialization and deserialization logic to handle the new `zenPinnedEntry` property.

Depends on https://github.com/zen-browser/components/pull/51