### PR TITLE
Feature: Force container tabs to a workspace where that container is set as default

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -135,6 +135,7 @@ pref('zen.workspaces.enabled', true);
 pref('zen.workspaces.hide-default-container-indicator', true);
 pref('zen.workspaces.individual-pinned-tabs', true);
 pref('zen.workspaces.show-icon-strip', true);
+pref('zen.workspaces.force-container-workspace', true);
 pref('zen.workspaces.icons', '["🌐", "📁", "💼", "📝", "📅", "📊","🧠"]');
 pref('services.sync.prefs.sync.zen.workspaces.icons', true);
 pref('services.sync.engine.workspaces', false);

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1030,4 +1030,9 @@ Preferences.addAll([
     type: 'string',
     default: 'switch',
   },
+  {
+    id: 'zen.workspaces.force-container-workspace',
+    type: 'bool',
+    default: true,
+  },
 ]);

--- a/src/browser/components/preferences/zenTabsManagement.inc.xhtml
+++ b/src/browser/components/preferences/zenTabsManagement.inc.xhtml
@@ -30,6 +30,9 @@
             <checkbox id="zenWorkspacesDisplayAsIconStrip"
                   data-l10n-id="zen-settings-workspaces-display-as-icon-strip"
                   preference="zen.workspaces.show-icon-strip"/>
+            <checkbox id="zenWorkspacesForceContainerTabsToWorkspace"
+                      data-l10n-id="zen-settings-workspaces-force-container-tabs-to-workspace"
+                      preference="zen.workspaces.force-container-workspace"/>
       </vbox>
 </groupbox>
 


### PR DESCRIPTION
This PR introduces a new preference, "zen.workspaces.force-container-workspace", that allows users to control whether container tabs are automatically placed in a  workspace where that container is set as default. When enabled, this feature ensures that all tabs from a container are grouped together within a specific workspace.

When used alongside `Firefox Multi-Account Containers` extension, it enables always opening specific sites in a specific workspace.

The following files were modified:

- `src/browser/components/preferences/zen-settings.js`: Added the new preference definition.
- `src/browser/app/profile/zen-browser.js`: Set the default value for the new preference.
- `src/browser/components/preferences/zenTabsManagement.inc.xhtml`: Added a checkbox to control the new preference in the settings UI.


https://github.com/user-attachments/assets/4f616019-5d0e-4ac1-a04d-4d8a72c88090


https://github.com/user-attachments/assets/b648e49e-be8a-4c0e-8160-87d82c748b78




Depends on:
https://github.com/zen-browser/components/pull/53
https://github.com/zen-browser/l10n-packs/pull/74