### PR TITLE
Fix wrong StartupWMClass in .desktop for Twilight AppImage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,6 +354,7 @@ jobs:
 
           if [ "${{ inputs.update_branch }}" = "twilight" ]; then
             sed -i -e 's/Name=Zen Browser/Name=Zen Twilight/g' AppDir/zen.desktop
+            sed -i -e 's/StartupWMClass=zen-alpha/StartupWMClass=zen-twilight/g' AppDir/zen.desktop
           fi
 
           APPDIR=AppDir


### PR DESCRIPTION
When installing Zen Twilight through the AppImage installer script and executing it, we quickly notice that our desktop environment (GNOME, in my case) doesn't match the window to the correct `.desktop` file, causing no icon to appear.

This is because the Zen Twilight window has a different `WMClass` than the normal Zen installation: `zen-twilight` instead of `zen-alpha`. This PR is similar to #2004, as it does a simple find and replace on the `.desktop` file.

## Before this change

Zen Twilight is pinned, yet, the window appears with the default application icon next to the pinned Zen Twilight icon.
![Screenshot from 2024-10-15 17-18-43](https://github.com/user-attachments/assets/702c68d7-dad1-497c-938c-42a4d97942f8)

## After this change

The window is matches to the `.desktop` file and assigned the correct Icon
![image](https://github.com/user-attachments/assets/fef2f5a4-9325-49be-aa71-ab01b5f3bb7a)
