### PR TITLE
ci: add winget releaser workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -635,6 +635,32 @@ jobs:
       - name: Wait 2 minutes for the Flatpak repo to update
         run: sleep 120
 
+  release-winget:
+    if: ${{ inputs.create_release && (inputs.update_branch == 'release' || inputs.update_branch == 'twilight') }}
+    permissions: write-all
+    name: Release Winget
+    needs: [release, build-data]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Publish Stable build
+        if: ${{ inputs.update_branch == 'release' }}
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: Zen-Team.Zen-Browser
+          version: ${{ needs.build-data.outputs.version }}
+          release-tag: ${{ needs.build-data.outputs.version }}
+          token: ${{ secrets.DEPLOY_KEY }}
+      - name: Publish Twilight build
+        if: ${{ inputs.update_branch == 'twilight' }}
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: Zen-Team.Zen-Browser.Twilight
+          version: ${{ needs.build-data.outputs.version }}
+          release-tag: ${{ needs.build-data.outputs.version }}
+          max-versions-to-keep: 1
+          token: ${{ secrets.DEPLOY_KEY }}
+
   release-flatpak:
     if: ${{ inputs.create_release && inputs.update_branch == 'release' }}
     permissions: write-all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -653,6 +653,8 @@ jobs:
           release-notes-url: https://zen-browser.app/release-notes/#${{ needs.build-data.outputs.version }}
           token: ${{ secrets.DEPLOY_KEY }}
       - name: Publish Twilight build
+        env:
+          SKIP_PR_CHECK: true
         if: ${{ inputs.update_branch == 'twilight' }}
         uses: vedantmgoyal9/winget-releaser@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -650,6 +650,7 @@ jobs:
           identifier: Zen-Team.Zen-Browser
           version: ${{ needs.build-data.outputs.version }}
           release-tag: ${{ needs.build-data.outputs.version }}
+          release-notes-url: https://zen-browser.app/release-notes/#${{ needs.build-data.outputs.version }}
           token: ${{ secrets.DEPLOY_KEY }}
       - name: Publish Twilight build
         if: ${{ inputs.update_branch == 'twilight' }}


### PR DESCRIPTION
Continuation of #637

> [This action](https://github.com/vedantmgoyal9/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.
> 
> 
> **Before merging this:**
> 
> 1. Ensure the `${{ secrets.DEPLOY_KEY }}` token has the `public_repo` permission:
> 
> ![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)
> 
> 2. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under @zen-browser. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
> 3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.
> 
> If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).

