### PR TITLE
Automatically fill in credit card and payment method for more country

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -243,3 +243,7 @@ pref("network.proxy.type", 0);
 
 pref("security.tls.enable_kyber", true);
 pref("network.http.http3.enable_kyber", true);
+
+// Enable Automatically fill in credit card and payment method data on Web forms for more country
+pref("extensions.formautofill.creditCards.supportedCountries", 'AF,AX,AL,DZ,AS,AD,AO,AI,AQ,AG,AR,AM,AW,AU,AT,AZ,BS,BH,BD,BB,BY,BE,BZ,BJ,BM,BT,BO,BA,BW,BV,BR,IO,BN,BG,BF,BI,KH,CM,CA,CV,KY,CF,TD,CL,CN,CX,CC,CO,KM,CG,CD,CK,CR,CI,HR,CU,CY,CZ,DK,DJ,DM,DO,EC,EG,SV,GQ,ER,EE,ET,FK,FO,FJ,FI,FR,GF,PF,TF,GA,GM,GE,DE,GH,GI,GR,GL,GD,GP,GU,GT,GG,GN,GW,GY,HT,HM,VA,HN,HK,HU,IS,IN,ID,IR,IQ,IE,IM,IL,IT,JM,JP,JE,JO,KZ,KE,KI,KR,KW,KG,LA,LV,LB,LS,LR,LY,LI,LT,LU,MO,MK,MG,MW,MY,MV,ML,MT,MH,MQ,MR,MU,YT,MX,FM,MD,MC,MN,ME,MS,MA,MZ,MM,NA,NR,NP,NL,AN,NC,NZ,NI,NE,NG,NU,NF,MP,NO,OM,PK,PW,PS,PA,PG,PY,PE,PH,PN,PL,PT,PR,QA,RE,RO,RU,RW,BL,SH,KN,LC,MF,PM,VC,WS,SM,ST,SA,SN,RS,SC,SL,SG,SK,SI,SB,SO,ZA,GS,ES,LK,SD,SR,SJ,SZ,SE,CH,SY,TW,TJ,TZ,TH,TL,TG,TK,TO,TT,TN,TR,TM,TC,TV,UG,UA,AE,GB,US,UM,UY,UZ,VU,VE,VN,VG,VI,WF,EH,YE,ZM,ZW');
+pref("extensions.formautofill.creditCards.supported", true);


### PR DESCRIPTION
Firefox arbitrarily limit credit card autofill to 10 countries only, but nowadays almost 100% country supports credit card payment, there's no reason to limit it.

[Fixed this](https://old.reddit.com/r/zen_browser/comments/1g7floh/why_doesnt_zen_remember_credit_card_details/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automatic credit card and payment method autofill support for a wider range of countries.
  
- **Bug Fixes**
	- Enhanced security protocols by enabling the use of the Kyber algorithm for TLS and HTTP/3 connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->