### PR TITLE
No more Kyber, too unstable to be on by default

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -240,7 +240,3 @@ pref("network.fetchpriority.enabled", true);
 // No Proxy should be default, Use system proxy allows antivirus, virus or system proxy to MITM or slowing down Zen
 pref("network.proxy.type", 0);
 
-// ZEN EXPERIMENTAL:
-
-pref("security.tls.enable_kyber", true);
-pref("network.http.http3.enable_kyber", true);


### PR DESCRIPTION
No more Kyber, too unstable to be on by default

Firefox's kyber is far from finished, it's lacking a lot of features that's why they don't enable it by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Continued support for user interface behavior and privacy settings, ensuring a smooth user experience.
  
- **Bug Fixes**
	- Removed experimental feature flags that were no longer supported, streamlining configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->