### PR TITLE
Disable Color Management like Chrome to maximize performance and havi…

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -240,3 +240,5 @@ pref("network.fetchpriority.enabled", true);
 // No Proxy should be default, Use system proxy allows antivirus, virus or system proxy to MITM or slowing down Zen
 pref("network.proxy.type", 0);
 
+// Disable Color Management like Chrome to maximize performance and having similar color display as Chrome. Read: https://reddit.com/r/firefox/comments/1g988kf/
+pref("gfx.color_management.mode", 0);


### PR DESCRIPTION
…ng similar color display as Chrome

Disable Color Management like Chrome to maximize performance and having similar color display as Chrome.

By default, Firefox itself do all the Color Management, and of course it must cost extra CPU Usage, disabling it and rely on System Color Management like Chrome instead.

Read: https://reddit.com/r/firefox/comments/1g988kf/just_switched_from_chrome_but_why_are_the_colours/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a preference setting to disable color management in the Zen browser for improved performance.
  
- **Performance Improvements**
	- Enhanced rendering speed by aligning color display with Chrome, eliminating unnecessary color management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->