### PR TITLE
Fix: Add functionality to move workspace to the end and disable reorder mode on panel close

### DIFF
--- a/src/browser/base/content/zen-popupset.inc.xhtml
+++ b/src/browser/base/content/zen-popupset.inc.xhtml
@@ -101,7 +101,7 @@
   </vbox>
 </panelview>
 
-<panel flip="slide" type="arrow" orient="vertical" id="PanelUI-zen-workspaces" position="bottomright topright" mainview="true" side="left">
+<panel flip="slide" type="arrow" orient="vertical" id="PanelUI-zen-workspaces" position="bottomright topright" mainview="true" side="left" onpopuphidden="ZenWorkspaces.handlePanelHidden();">
   <panelmultiview id="PanelUI-zen-workspaces-multiview" mainViewId="PanelUI-zen-workspaces-view">
     <panelview id="PanelUI-zen-workspaces-view" class="PanelUI-subView" role="document" mainview-with-header="true" has-custom-header="true" closemenu="none">
       <vbox>

--- a/src/browser/base/content/zen-styles/zen-workspaces.css
+++ b/src/browser/base/content/zen-styles/zen-workspaces.css
@@ -345,6 +345,11 @@
   border-radius: 5px;
 }
 
+.zen-workspace-last-place-drop-target.dragover {
+  background-color: var(--toolbarbutton-icon-fill-attention);
+}
+
+
 #PanelUI-zen-workspaces-reorder-mode[active='true'] {
   color: var(--toolbarbutton-icon-fill-attention) !important;
 }
@@ -360,6 +365,17 @@
   .zen-workspace-actions-reorder-icon {
     display: flex;
   }
+}
+
+#PanelUI-zen-workspaces-list[reorder-mode='true'] .zen-workspace-last-place-drop-target {
+  display: block;
+}
+
+.zen-workspace-last-place-drop-target {
+  display: none;
+  height: 4px;
+  width: 100%;
+  border-radius: 5px;
 }
 
 #PanelUI-zen-workspaces-view > vbox:nth-child(2) {


### PR DESCRIPTION
Depends on:
https://github.com/zen-browser/components/pull/63

Closes https://github.com/zen-browser/desktop/issues/2209