### PR TITLE
Disable POLLY (polyhedral optimisation)

### DIFF
--- a/configs/linux/mozconfig
+++ b/configs/linux/mozconfig
@@ -48,7 +48,7 @@ if test "$ZEN_RELEASE"; then
         export RUSTFLAGS="$RUSTFLAGS -C target-cpu=x86-64-v3 -C target-feature=+sse4.1 -C target-feature=+avx2 -C codegen-units=1 -Clink-args=--icf=safe"
     fi
     export VERBOSE=1
-    export POLLY="-mllvm -polly -mllvm -polly-2nd-level-tiling -mllvm -polly-loopfusion-greedy -mllvm -polly-pattern-matching-based-opts -mllvm -polly-position=before-vectorizer -mllvm -polly-vectorizer=stripmine"
+    #export POLLY="-mllvm -polly -mllvm -polly-2nd-level-tiling -mllvm -polly-loopfusion-greedy -mllvm -polly-pattern-matching-based-opts -mllvm -polly-position=before-vectorizer -mllvm -polly-vectorizer=stripmine"
 fi
 
 ac_add_options --target=x86_64-pc-linux

--- a/configs/macos/mozconfig
+++ b/configs/macos/mozconfig
@@ -36,4 +36,4 @@ else
     export RUSTFLAGS="-C target-feature=+v8.3a -C codegen-units=1 -Ctarget-cpu=apple-m1"
 fi
 export VERBOSE=1
-export POLLY="-mllvm -polly -mllvm -polly-2nd-level-tiling -mllvm -polly-loopfusion-greedy -mllvm -polly-pattern-matching-based-opts -mllvm -polly-position=before-vectorizer -mllvm -polly-vectorizer=stripmine"
+#export POLLY="-mllvm -polly -mllvm -polly-2nd-level-tiling -mllvm -polly-loopfusion-greedy -mllvm -polly-pattern-matching-based-opts -mllvm -polly-position=before-vectorizer -mllvm -polly-vectorizer=stripmine"

--- a/configs/windows/mozconfig
+++ b/configs/windows/mozconfig
@@ -49,7 +49,7 @@ else
   export LDFLAGS="-Wl,-O3 -march=x86-64-v3"
   export RUSTFLAGS="-Clink-args=--icf=safe -C target-feature=+avx2 -C codegen-units=1 -Ctarget-cpu=x86-64-v3"    
 fi
-export POLLY="-mllvm -polly -mllvm -polly-2nd-level-tiling -mllvm -polly-loopfusion-greedy -mllvm -polly-pattern-matching-based-opts -mllvm -polly-position=before-vectorizer -mllvm -polly-vectorizer=stripmine"
+#export POLLY="-mllvm -polly -mllvm -polly-2nd-level-tiling -mllvm -polly-loopfusion-greedy -mllvm -polly-pattern-matching-based-opts -mllvm -polly-position=before-vectorizer -mllvm -polly-vectorizer=stripmine"
 export VERBOSE=1
 
 if test "$ZEN_CROSS_COMPILING"; then


### PR DESCRIPTION
It's not that great, and it's risky on non-compatible devices, that's why most projects don't use it, it's only meant for personal use with perfect hardware setup only.

Firefox itself has already implemented similar mechanics to optimize for repetitive tasks, for Javascript it's `dom.script_loader.bytecode_cache.enabled`, for smooth scroll/zooming it's APZ, we don't really need POLLY.

> In simple terms, polyhedral optimisation tunes the browser's inner loops to make maximum use of the CPU and memory. This speeds up repetitive tasks like rendering, scrolling, and video playback that rely on loops. The end result is a faster, smoother browsing experience for the user. [↩](https://github.com/BrowserWorks/Waterfox/releases?page=4#fnref-1)

> As previously mentioned, when you use a web browser, it has to repeat similar tasks over and over - like rendering webpage elements, running JavaScript code, scrolling the page, and displaying videos.

> These tasks involve loops, where the browser does the same kind of work over and over. Polyhedral optimisation makes the browser's loops run faster by reorganizing them. It finds the best way to access data repeatedly in the most efficient order.

> For example, when scrolling a page with lots of images, polyhedral optimisation could optimise the loops that decode and display the image data. It finds the fastest way to reuse image data in the CPU cache.

> This means scrolling feels much smoother. The images decode quicker as you scroll up and down. The browser feels snappier.

> So in simple terms, polyhedral optimisation tunes the browser's inner loops to make maximum use of the CPU and memory. This speeds up repetitive tasks like rendering, scrolling, and video playback that rely on loops. The end result is a faster, smoother browsing experience for the user. [↩](https://github.com/BrowserWorks/Waterfox/releases?page=4#fnref-3)

