### PR TITLE
Fix: Update gradient generator logic

### DIFF
--- a/src/browser/base/content/zen-popupset.inc.xhtml
+++ b/src/browser/base/content/zen-popupset.inc.xhtml
@@ -101,7 +101,7 @@
   </vbox>
 </panelview>
 
-<panel flip="side" type="arrow" orient="vertical" id="PanelUI-zen-gradient-generator" position="bottomright topright" mainview="true" side="left">
+<panel flip="side" type="arrow" orient="vertical" id="PanelUI-zen-gradient-generator" position="bottomright topright" mainview="true" side="left" onpopuphidden="gZenThemePicker.handlePanelClose();">
   <panelmultiview id="PanelUI-zen-gradient-generator-multiview" mainViewId="PanelUI-zen-gradient-generator-view">
     <panelview id="PanelUI-zen-gradient-generator-view" class="PanelUI-subView zen-theme-picker" role="document" mainview-with-header="true" has-custom-header="true">
       <hbox class="zen-theme-picker-gradient"></hbox>


### PR DESCRIPTION
#### Add onpopuphidden event handler to gradient generator panel

This PR adds an `onpopuphidden` event handler to the gradient generator panel, which calls the `gZenThemePicker.handlePanelClose()` function when the panel is hidden. This ensures that the theme picker is properly updated and handles the panel's closing behavior.

Depends on:
https://github.com/zen-browser/components/pull/66