### PR TITLE
Fix an issue where workspace size is 0 on non-expanded toolbar

### DIFF
--- a/src/browser/base/content/zen-styles/zen-workspaces.css
+++ b/src/browser/base/content/zen-styles/zen-workspaces.css
@@ -79,7 +79,7 @@
     }
   }
 
-  :root:has(#navigator-toolbox:not([zen-expanded='true'])) &[as-button='true'] {
+  :root:has(#navigator-toolbox:not([zen-has-hover='true'])) &[as-button='true'] {
     margin: auto;
     padding: var(--toolbarbutton-inner-padding) !important;
     width: calc(2 * var(--toolbarbutton-inner-padding) + 16px) !important;


### PR DESCRIPTION
When setting "Display workspaces as an icon strip" is disabled, the selected workspace is not correctly rendered on the screen.

## Before:
![zen_xLFU6xiPhz](https://github.com/user-attachments/assets/c577a568-2c0b-42b4-a027-d4b9c1b49cb4)

## After
![zen_w3cnb5tiX8](https://github.com/user-attachments/assets/7d2e86c2-bd79-45ac-b336-1774293d0dba)

