### PR TITLE
Fix: Broken release notes link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
     Documentation
   </a>
   •
-  <a href="https//zen-browser.app/release-notes/latest">
+  <a href="https://zen-browser.app/release-notes/latest">
     Release Notes
   </a>
 </div>


### PR DESCRIPTION
It was missing a ":" and linked to an invalid URL
![image](https://github.com/user-attachments/assets/1a99aa83-183a-4c29-9968-fe54bdceb6bc)
