### PR TITLE
feat(ui): Add new "Pin Tab Globally" context menu option

### DIFF
--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -893,7 +893,8 @@ menuitem[contexttype='fullscreen'][label*='Exit'] {
 #context_pinSelectedTabs,
 #context_unpinSelectedTabs,
 .customize-context-moveToPanel,
-#context_zen-replace-pinned-url-with-current {
+#context_zen-replace-pinned-url-with-current,
+#context_zen-pin-tab-global{
   --menu-image: url('pin.svg');
 }
 


### PR DESCRIPTION
This PR introduces a new context menu option called "Pin Tab Globally" which allows users to pin tabs to the global pin list, making them accessible from any workspace.

The icon for this option is set to the same as the existing "Pin Tab" context menu option.