### PR TITLE
Fix browser background with macOS transparency on Twilight

### DIFF
--- a/src/browser/base/content/zen-styles/zen-browser-ui.css
+++ b/src/browser/base/content/zen-styles/zen-browser-ui.css
@@ -39,9 +39,26 @@
 }
 
 
-@supports (-moz-osx-font-smoothing: auto) {
-  #zen-main-app-wrapper {
+@media (-moz-platform: macos) {
+  #navigator-toolbox {
     appearance: -moz-window-titlebar !important;
+  }
+  
+  #zen-appcontent-wrapper {
+      appearance: -moz-window-titlebar !important;
+  }
+  
+  #zen-sidebar-splitter {
+      appearance: -moz-window-titlebar !important;
+      opacity: 1 !important;
+  }
+  
+  #browser {
+      background: var(--zen-main-browser-background) !important;
+  }
+
+  #zen-main-app-wrapper {
+      background: transparent !important;
   }
 }
 


### PR DESCRIPTION
This PR fixes the browser background on macOS, allowing the background to be shown with transparency on macOS.

Instead of setting the whole window to be transparent, this approach sets the background for the whole window, then sets transparency for sidebar, splitter, navbar, and website view.
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/40a96ed2-d8a0-4795-b7fe-e43523be0d79">

made in collaboration w/ mauro on zen discord