### PR TITLE
Removed ability to adjust density in CustomizeUI mode

### DIFF
--- a/src/browser/themes/shared/customizableui/customizeMode-css.patch
+++ b/src/browser/themes/shared/customizableui/customizeMode-css.patch
@@ -1,0 +1,20 @@
+diff --git a/browser/themes/shared/customizableui/customizeMode.css b/browser/themes/shared/customizableui/customizeMode.css
+index 622eff11b121abd354b48359951a1f8d6612380c..6d753dea4ffb4d84a57a8ab496130faa764a63c0 100644
+--- a/browser/themes/shared/customizableui/customizeMode.css
++++ b/browser/themes/shared/customizableui/customizeMode.css
+@@ -392,6 +392,15 @@ toolbarpaletteitem {
+   transform: scaleX(-1);
+ }
+ 
++/* 
++  Added for zen browser
++  This is a hack to hide the density button in the customize mode
++  In order to not confuse the user with the density options
++*/
++#customization-uidensity-button {
++  display: none !important;
++}
++
+ #customization-panelWrapper,
+ #customization-panelWrapper > .panel-arrowcontent,
+ #customization-panelHolder {


### PR DESCRIPTION
Added patch to remove the Density button from the Customize UI settings. This is to avoid user confusion

Issue #2636

## After Update
<img width="1294" alt="image" src="https://github.com/user-attachments/assets/18b16567-d9a4-4e5f-be0f-390e940cad39">

## Before Update
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d99d84fa-b2b0-4f31-acb2-ffa0964e2cf6">

