### PR TITLE
Update tabbar to fade out tabs on both edges

### DIFF
--- a/src/browser/components/tabbrowser/content/tabs-js.patch
+++ b/src/browser/components/tabbrowser/content/tabs-js.patch
@@ -1,8 +1,23 @@
 diff --git a/browser/components/tabbrowser/content/tabs.js b/browser/components/tabbrowser/content/tabs.js
-index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a9865299561a6cc 100644
+index f3a2f226a9056c5a75023281fdeb704cec49b4a6..e2ed5eaffff90d1cf96724aa1e1b5236a2baf93b 100644
 --- a/browser/components/tabbrowser/content/tabs.js
 +++ b/browser/components/tabbrowser/content/tabs.js
-@@ -894,7 +894,7 @@
+@@ -47,14 +47,6 @@
+       this.arrowScrollbox.addEventListener("wheel", this, true);
+       this.arrowScrollbox.addEventListener("underflow", this);
+       this.arrowScrollbox.addEventListener("overflow", this);
+-      // Override arrowscrollbox.js method, since our scrollbox's children are
+-      // inherited from the scrollbox binding parent (this).
+-      this.arrowScrollbox._getScrollableElements = () => {
+-        return this.allTabs.filter(this.arrowScrollbox._canScrollToElement);
+-      };
+-      this.arrowScrollbox._canScrollToElement = tab => {
+-        return !tab._pinnedUnscrollable && tab.visible;
+-      };
+ 
+       this.baseConnect();
+ 
+@@ -894,7 +886,7 @@
              let postTransitionCleanup = () => {
                tab.removeAttribute("tabdrop-samewindow");
  
@@ -11,7 +26,7 @@ index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a986529
                if (dropIndex !== false) {
                  gBrowser.moveTabTo(tab, dropIndex);
                  if (incrementDropIndex) {
-@@ -904,7 +904,7 @@
+@@ -904,7 +896,7 @@
  
                gBrowser.syncThrobberAnimations(tab);
              };
@@ -20,7 +35,7 @@ index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a986529
                postTransitionCleanup();
              } else {
                let onTransitionEnd = transitionendEvent => {
-@@ -1284,7 +1284,7 @@
+@@ -1284,7 +1276,7 @@
          }
        }
  
@@ -29,7 +44,7 @@ index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a986529
        this._allTabs = allChildren;
        return allChildren;
      }
-@@ -1480,7 +1480,7 @@
+@@ -1480,7 +1472,7 @@
            let rect = ele => {
              return window.windowUtils.getBoundsWithoutFlushing(ele);
            };
@@ -38,7 +53,7 @@ index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a986529
            if (tab && rect(tab).width <= this._tabClipWidth) {
              this.setAttribute("closebuttons", "activetab");
            } else {
-@@ -1499,10 +1499,12 @@
+@@ -1499,10 +1491,12 @@
  
      _handleTabSelect(aInstant) {
        let selectedTab = this.selectedItem;
@@ -54,7 +69,7 @@ index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a986529
        selectedTab._notselectedsinceload = false;
      }
  
-@@ -1550,7 +1552,7 @@
+@@ -1550,7 +1544,7 @@
          if (isEndTab && !this._hasTabTempMaxWidth) {
            return;
          }
@@ -63,7 +78,7 @@ index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a986529
          // Force tabs to stay the same width, unless we're closing the last tab,
          // which case we need to let them expand just enough so that the overall
          // tabbar width is the same.
-@@ -1565,7 +1567,7 @@
+@@ -1565,7 +1559,7 @@
          let tabsToReset = [];
          for (let i = numPinned; i < tabs.length; i++) {
            let tab = tabs[i];
@@ -72,7 +87,7 @@ index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a986529
            if (!isEndTab) {
              // keep tabs the same width
              tab.style.transition = "none";
-@@ -1630,13 +1632,13 @@
+@@ -1630,13 +1624,13 @@
        let verticalTabsContainer = document.getElementById(
          "vertical-pinned-tabs-container"
        );
@@ -89,7 +104,7 @@ index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a986529
          }
        }
  
-@@ -1660,7 +1662,7 @@
+@@ -1660,7 +1654,7 @@
  
      _positionPinnedTabs() {
        let tabs = this._getVisibleTabs();
@@ -98,7 +113,7 @@ index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a986529
        let absPositionHorizontalTabs =
          this.overflowing && tabs.length > numPinned && numPinned > 0;
  
-@@ -1934,7 +1936,7 @@
+@@ -1934,7 +1928,7 @@
        }
  
        let pinned = draggedTab.pinned;
@@ -107,7 +122,7 @@ index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a986529
        let tabs = this._getVisibleTabs().slice(
          pinned ? 0 : numPinned,
          pinned ? numPinned : undefined
-@@ -2059,8 +2061,8 @@
+@@ -2059,8 +2053,8 @@
        }
      }
  
@@ -118,7 +133,7 @@ index f3a2f226a9056c5a75023281fdeb704cec49b4a6..39c46b141145864fb3b8043d2a986529
          return;
        }
  
-@@ -2218,9 +2220,9 @@
+@@ -2218,9 +2212,9 @@
        function newIndex(aTab, index) {
          // Don't allow mixing pinned and unpinned tabs.
          if (aTab.pinned) {

--- a/src/browser/themes/shared/tabbrowser/tabs-css.patch
+++ b/src/browser/themes/shared/tabbrowser/tabs-css.patch
@@ -1,8 +1,8 @@
 diff --git a/browser/themes/shared/tabbrowser/tabs.css b/browser/themes/shared/tabbrowser/tabs.css
-index 9f7331f2f00a8b0de6ce28a7029358a86eeb8873..2dc56a8455df9009bd1f524b377b8fdf09e124ca 100644
+index d48aad3a397909056ee43be4e65797875e80b772..20fc0f1c0e87831ff80bb5c2420c80193cfb5e54 100644
 --- a/browser/themes/shared/tabbrowser/tabs.css
 +++ b/browser/themes/shared/tabbrowser/tabs.css
-@@ -15,7 +15,7 @@
+@@ -26,7 +26,7 @@
    --tab-icon-end-margin: 5.5px;
    --tab-icon-overlay-fill: light-dark(black, white);
    --tab-icon-overlay-stroke: light-dark(white, black);
@@ -11,7 +11,7 @@ index 9f7331f2f00a8b0de6ce28a7029358a86eeb8873..2dc56a8455df9009bd1f524b377b8fdf
    --tab-hover-background-color: color-mix(in srgb, currentColor 11%, transparent);
    --tab-selected-textcolor: var(--toolbar-color);
    --tab-selected-bgcolor: var(--toolbar-bgcolor);
-@@ -132,8 +132,7 @@
+@@ -145,8 +145,7 @@
    }
  
    #tabbrowser-tabs[positionpinnedtabs] > #tabbrowser-arrowscrollbox > &[pinned] {
@@ -21,7 +21,26 @@ index 9f7331f2f00a8b0de6ce28a7029358a86eeb8873..2dc56a8455df9009bd1f524b377b8fdf
    }
  
    #tabbrowser-tabs[movingtab] > #tabbrowser-arrowscrollbox > &:is([selected], [multiselected]) {
-@@ -952,7 +951,7 @@ sidebar-main[expanded] > #vertical-tabs > #tabbrowser-tabs[orient="vertical"] >
+@@ -848,9 +847,17 @@ tab-group {
+     overflow-y: auto;
+   }
+ 
+-  &[overflowing]:not([scrolledtoend]) {
++  &[overflowing][scrolledtostart]:not([scrolledtoend]) {
+     mask-image: linear-gradient(to bottom, black 98%, transparent 100%);
+   }
++
++  &[overflowing][scrolledtoend]:not([scrolledtostart]) {
++    mask-image: linear-gradient(to bottom, transparent 0%, black 2%);
++  }
++
++  &[overflowing]:not([scrolledtostart]):not([scrolledtoend]) {
++    mask-image: linear-gradient(to bottom, transparent 0%, black 2%, black 98%, transparent 100%);
++  }
+ }
+ 
+ #tabbrowser-arrowscrollbox[orient="vertical"] > #tabbrowser-arrowscrollbox-periphery > #tabs-newtab-button,
+@@ -1052,7 +1059,7 @@ tab-group {
    toolbarbutton:not(#firefox-view-button),
    toolbarpaletteitem:not(#wrapper-firefox-view-button)
  ) ~ #tabbrowser-tabs {
@@ -30,7 +49,7 @@ index 9f7331f2f00a8b0de6ce28a7029358a86eeb8873..2dc56a8455df9009bd1f524b377b8fdf
    padding-inline-start: calc(var(--tab-overflow-pinned-tabs-width) + 2px);
    margin-inline-start: 2px;
  }
-@@ -987,7 +986,6 @@ toolbar:not(#TabsToolbar) #firefox-view-button {
+@@ -1087,7 +1094,6 @@ toolbar:not(#TabsToolbar) #firefox-view-button {
    list-style-image: url(chrome://global/skin/icons/plus.svg);
  }
  


### PR DESCRIPTION
This fixes the scroll edge detection of the tabbar by reverting it to use the elements list directly instead of filtering the tab list, which yields incorrect bounds due to Zen's changes to the tabbar. Additionally, the mask effect is now also applied to the top edge of the scroll zone when not fully scrolled to the top, similar to what was done on the bottom edge.

There seems to be a rendering bug when an element utilizing `backdrop-filter` is masked, resulting in the masking effect stopping at that element. This means that whenever the selected tab is repainted onscreen, it and any tabs below it do not have the mask effect applied on that repaint. Any individual non-selected tabs that are then updated by hovering over them will have the mask applied since then they do not share a repaint with the selected tab. According to [Chromium bug report 40284528](https://issues.chromium.org/issues/40854528), this may be due to how the specification for those two styles are defined.