### PR TITLE
Update zen-decks.css to fix split view spacing

### DIFF
--- a/src/browser/base/content/zen-styles/zen-decks.css
+++ b/src/browser/base/content/zen-styles/zen-decks.css
@@ -27,7 +27,7 @@
 
 #tabbrowser-tabpanels[zen-split-view='true'] > [zen-split='true'], #zen-splitview-dropzone {
   flex: 1;
-  margin: calc(var(--zen-split-column-gap) / 2) calc(var(--zen-split-row-gap) / 2);
+  margin: calc(var(--zen-split-column-gap) / 2) calc(var(--zen-split-row-gap) / 2 + 1px);
   position: absolute !important;
   overflow: hidden;
 }
@@ -45,6 +45,7 @@
 
 #tabbrowser-tabpanels[zen-split-view='true'] .browserSidebarContainer.deck-selected {
   outline: 2px solid var(--zen-primary-color) !important;
+  outline-offset: -1px;
 }
 
 #tabbrowser-tabbox {


### PR DESCRIPTION
The outline mentioned is the one visible when a tab/webview is focused in split view.

Makes the outline offset be -1px so that the outline overlays and hides the webview gray border which shouldn't be still seen when the webview has the focus outline:
`outline-offset: -1px;`
Makes the outline be inset by 1 pixel to hide the gray border.

Fixes the outline being cut out horizontally when vertical tabs are expanded:
`margin: ... calc(... + 1px);`
Adds a 1 pixel spacing for the 2 pixel wide outline because the space for the other pixel is already being accounted for from setting the outline-offset to -1px.

Before:
![image](https://github.com/user-attachments/assets/97fa1a8f-590f-4d1d-bb60-23bf101763d3)

After:
![image](https://github.com/user-attachments/assets/6672ef92-a7c6-4ca7-bd01-7497f89c93ea)

Steps to reproduce the fixed issue in the latest Zen Twilight version:
1. Open 2 tabs
2. Press CTRL + ALT + H to activate horizontal split view
3. Make sure you are not in compact mode and that the vertical tabs are expanded
4. Observe the outline cut off.