### PR TITLE
Fix: file manager not opening in many scenarios

### DIFF
--- a/flatpak/io.github.zen_browser.zen.yml.template
+++ b/flatpak/io.github.zen_browser.zen.yml.template
@@ -22,6 +22,7 @@ finish-args:
   - --filesystem=xdg-download:rw
   - --device=all
   - --talk-name=org.freedesktop.FileManager1
+  - --talk-name=org.freedesktop.portal.Desktop
   - --talk-name=org.freedesktop.ScreenSaver
   - --own-name=org.mozilla.zen.*
   - --own-name=org.mpris.MediaPlayer2.firefox.*


### PR DESCRIPTION
# Bug fix. File manager not opening if Zen is installed via flatpak

On my machine (and many others), the file manager won't open even after granting read/write permissions to all files.
The fix is ​​to add `org.freedesktop.portal.Desktop` to Session Bus's Talks.
I'm new to flatpak, so please check if I've done everything correctly.

Thank you!