### PR TITLE
Display Add to Essentials tab context menu item before Pin Tab

### DIFF
--- a/src/browser/base/zen-components/ZenPinnedTabManager.mjs
+++ b/src/browser/base/zen-components/ZenPinnedTabManager.mjs
@@ -455,7 +455,7 @@
                       oncommand="gZenPinnedTabManager.removeEssentials();"/>
         `);
 
-      document.getElementById('context_pinTab')?.after(element);
+      document.getElementById('context_pinTab')?.before(element);
     }
 
     resetPinnedTabData(tabData) {


### PR DESCRIPTION
Add to Essentials is displayed before Pin tab context menu item so it follows the order in which the tabs are displayed in the sidebar as essentials are above pinned tabs.