### PR TITLE
chore: Update flatpak manifest runtime versions to 24.08

### DIFF
--- a/flatpak/io.github.zen_browser.zen.yml.template
+++ b/flatpak/io.github.zen_browser.zen.yml.template
@@ -1,13 +1,13 @@
 app-id: io.github.zen_browser.zen
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 base: org.mozilla.firefox.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
-    version: 23.08
+    version: '24.08'
     add-ld-path: .
 command: launch-script.sh
 finish-args:


### PR DESCRIPTION
Seems to work as per my local testing (test build also available on the now closed https://github.com/flathub/io.github.zen_browser.zen/pull/54)