### PR TITLE
Add a "Discussions" link to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
-blank_issues_enabled: false
+blank_issues_enabled: false 
+contact_links:
+  - name: Feature Request
+    url: https://github.com/zen-browser/desktop/discussions
+    about: Please use GitHub discussions for feature requests.


### PR DESCRIPTION
This commit adds a second button when creating a new issue that tells the user to go to GitHub discussions for feature requests with a link to the Discussions page. I think this will lead to less confusion and clutter the issues tab less.