### PR TITLE
Toggle to remove focus of the search bar at startup

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -122,6 +122,7 @@ pref('zen.urlbar.behavior', 'floating-on-type'); // default, floating-on-type, f
 pref('zen.urlbar.wait-to-clear', 45000); // in ms (default 45s)
 pref('zen.urlbar.show-domain-only-in-sidebar', true);
 pref('zen.urlbar.hide-one-offs', true);
+pref('zen.urlbar.disable-initial-focus', false);
 
 #ifdef XP_MACOSX
 // Disable for macos in the meantime until @HarryHeres finds a solution for hight DPI screens

--- a/src/browser/base/content/ZenStartup.mjs
+++ b/src/browser/base/content/ZenStartup.mjs
@@ -125,8 +125,9 @@
     },
 
     _initSearchBar() {
-      // Only focus the url bar
-      gURLBar.focus();
+      if (!Services.prefs.getBoolPref('zen.urlbar.disable-initial-focus', false)) {
+        gURLBar.focus();
+      }
 
       gURLBar._initCopyCutController();
       gURLBar._initPasteAndGo();


### PR DESCRIPTION
When the browser launches, the urlbar is always focused, instead of the homepage. This behavior doesn't happen on Firefox and doesn't work for users that have a homepage with a searchbar.

This PR uses a toggle to disable the focusing of the urlbar: zen.urlbar.disable-initial-focus
The default value is false so it doesn't change anything for existing users.

There was already an PR without an toggle: https://github.com/zen-browser/desktop/pull/1742
Also an issue: https://github.com/zen-browser/desktop/issues/973
And a discussion: https://github.com/zen-browser/desktop/discussions/1169

I'm not really familiar with the codebase and would appreciate feedback :) 
