### PR TITLE
Feature: container specific Essentials

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -177,6 +177,7 @@ pref('zen.workspaces.icons', '["⌚","⌛","⏪","⏫","⏬","⏰","⏳","⚽","
 pref('services.sync.prefs.sync.zen.workspaces.icons', true);
 pref('services.sync.engine.workspaces', false);
 pref('zen.essentials.enabled', true);
+pref('zen.workspaces.container-specific-essentials-enabled', false);
 
 // Zen Watermark
 pref('zen.watermark.enabled', true, sticky);

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1106,6 +1106,11 @@ Preferences.addAll([
     default: true,
   },
   {
+    id: 'zen.workspaces.container-specific-essentials-enabled',
+    type: 'bool',
+    default: false,
+  },
+  {
     id: "zen.tabs.show-newtab-vertical",
     type: "bool",
     default: true,


### PR DESCRIPTION
Added a pref to make essentials container specific, i.e. if a workspace has a container assigned to it, on that workspace only essentials opened in that container will be visible.