### PR TITLE
Fix: Restore pinned tabs to their pinned URLs on startup if the option is checked

### DIFF
--- a/src/browser/base/zen-components/ZenPinnedTabManager.mjs
+++ b/src/browser/base/zen-components/ZenPinnedTabManager.mjs
@@ -68,9 +68,9 @@
       return this._enabled;
     }
 
-    async _refreshPinnedTabs() {
+    async _refreshPinnedTabs({ init = false } = {}) {
       await this._initializePinsCache();
-      this._initializePinnedTabs();
+      this._initializePinnedTabs(init);
     }
 
     async _initializePinsCache() {
@@ -109,7 +109,7 @@
       return this._pinsCache;
     }
 
-    _initializePinnedTabs() {
+    _initializePinnedTabs(init = false) {
       const pins = this._pinsCache;
       if (!pins?.length) {
         return;
@@ -130,6 +130,10 @@
           // This is a valid pinned tab that matches a pin
           pinnedTabsByUUID.set(pinId, tab);
           pinsToCreate.delete(pinId);
+
+          if(lazy.zenPinnedTabRestorePinnedTabsToPinnedUrl && init) {
+            this._resetTabToStoredState(tab);
+          }
         } else {
           // This is a pinned tab that no longer has a corresponding pin
           gBrowser.removeTab(tab);

--- a/src/browser/base/zen-components/ZenPinnedTabsStorage.mjs
+++ b/src/browser/base/zen-components/ZenPinnedTabsStorage.mjs
@@ -48,7 +48,7 @@ var ZenPinnedTabsStorage = {
         CREATE INDEX IF NOT EXISTS idx_zen_pins_changes_uuid ON zen_pins_changes(uuid)
       `);
 
-      await gZenPinnedTabManager._refreshPinnedTabs();
+      await gZenPinnedTabManager._refreshPinnedTabs({init: true});
     });
   },
 


### PR DESCRIPTION
This change modifies the pinned tab initialization logic to restore pinned tabs to their original pinned URLs when the browser starts. Previously, pinned tabs would open to their last visited URL, even if the option for restoring them to the pinned URL was checked.

Fixes https://github.com/zen-browser/desktop/issues/2817