### PR TITLE
Fix: Correct sound tab icon overlay style

### DIFF
--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -566,19 +566,19 @@
 .tab-icon-overlay[soundplaying] {
   list-style-image: url('tab-audio-playing-small.svg') !important;
   background-image: none !important;
-  fill: white;
+  fill: white !important;
 }
 
 .tab-icon-overlay[muted] {
   list-style-image: url('tab-audio-muted-small.svg') !important;
   background-image: none !important;
-  fill: white;
+  fill: white !important;
 }
 
 .tab-icon-overlay[activemedia-blocked] {
   list-style-image: url('tab-audio-blocked-small.svg') !important;
   background-image: none !important;
-  fill: white;
+  fill: white !important;
 }
 
 

--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -565,15 +565,22 @@
 /* tab sound icons */
 .tab-icon-overlay[soundplaying] {
   list-style-image: url('tab-audio-playing-small.svg') !important;
+  background-image: none !important;
+  fill: white;
 }
 
 .tab-icon-overlay[muted] {
   list-style-image: url('tab-audio-muted-small.svg') !important;
+  background-image: none !important;
+  fill: white;
 }
 
 .tab-icon-overlay[activemedia-blocked] {
   list-style-image: url('tab-audio-blocked-small.svg') !important;
+  background-image: none !important;
+  fill: white;
 }
+
 
 /* reload/stop animation */
 #stop-reload-button[animate]
@@ -897,7 +904,7 @@ menuitem[contexttype='fullscreen'][label*='Exit'] {
 #context_pinSelectedTabs,
 #context_unpinSelectedTabs,
 .customize-context-moveToPanel,
-#context_zen-replace-pinned-url-with-current{
+#context_zen-replace-pinned-url-with-current {
   --menu-image: url('pin.svg');
 }
 


### PR DESCRIPTION
Fixes [issue 2448](https://github.com/zen-browser/desktop/issues/2448). 

This pull request includes updates to the `src/browser/themes/shared/zen-icons/icons.css` file to enhance the visual consistency of tab sound icons.

* Added `background-image: none !important;` to `.tab-icon-overlay[soundplaying]`, `.tab-icon-overlay[muted]`, and `.tab-icon-overlay[activemedia-blocked]` to ensure sound icons from Firefox are not displayed.
* Added `fill: white;` to `.tab-icon-overlay[soundplaying]`, `.tab-icon-overlay[muted]`, and `.tab-icon-overlay[activemedia-blocked]` to fix sound icon appearance in light mode.