### PR TITLE
(feat) Hide pinned tabs not in active workspace

### DIFF
--- a/src/browser/base/zen-components/ZenPinnedTabManager.mjs
+++ b/src/browser/base/zen-components/ZenPinnedTabManager.mjs
@@ -196,6 +196,10 @@
 
         gBrowser.pinTab(newTab);
 
+        if(newTab.getAttribute("zen-workspace-id") !== ZenWorkspaces.activeWorkspace && newTab.getAttribute("zen-essential") !== "true") {
+          gBrowser.hideTab(newTab, undefined, true);
+        }
+
         newTab.initialize();
       }
 


### PR DESCRIPTION
When a new pinned tab is opened and it does not belong to the currently active workspace and is not marked as essential, it will now be hidden.  This prevents pinned tabs from cluttering the tab bar when switching between workspaces.

