### PR TITLE
some adjustment for "-moz-gtk-csd-reversed-placement"

### DIFF
--- a/src/browser/base/content/zen-styles/zen-browser-ui.css
+++ b/src/browser/base/content/zen-styles/zen-browser-ui.css
@@ -105,3 +105,16 @@
     margin-inline-end: 8px;
   }
 }
+
+@media(-moz-gtk-csd-reversed-placement){
+    #zen-sidebar-top-buttons .titlebar-buttonbox-container {
+        padding-top: 5px;
+        padding-left: 6px
+    }
+}
+@media(-moz-gtk-csd-reversed-placement){
+    #nav-bar .titlebar-buttonbox-container {
+        padding-top: 5px; 
+        padding-left: 6px;
+    }
+}


### PR DESCRIPTION
adds padding to titlebar-buttonbox-container when "-moz-gtk-csd-reversed-placement" is true

before
> ![image](https://github.com/user-attachments/assets/5bed04ee-85d4-428d-86ca-28cbe6ca1840)

after
> ![image](https://github.com/user-attachments/assets/28fdb34b-b325-49c1-a390-afc1e8ea2029)
