### PR TITLE
Faster macOS Github Actions

### DIFF
--- a/.github/workflows/macos-release-build.yml
+++ b/.github/workflows/macos-release-build.yml
@@ -73,6 +73,12 @@ jobs:
           brew install watchman
 
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+          source $HOME/.cargo/env
+          if test "${{ matrix.arch }}" = "aarch64"; then
+            rustup target add aarch64-apple-darwin
+          else
+            rustup target add x86_64-apple-darwin
+          fi
 
       - name: Force usage fo gnu-tar
         run: |

--- a/.github/workflows/macos-release-build.yml
+++ b/.github/workflows/macos-release-build.yml
@@ -15,7 +15,7 @@ jobs:
   mac-build:
     name: Build macOS - ${{ matrix.arch }}
     
-    runs-on: macos-latest
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macos-release-build.yml
+++ b/.github/workflows/macos-release-build.yml
@@ -15,15 +15,11 @@ jobs:
   mac-build:
     name: Build macOS - ${{ matrix.arch }}
     
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - arch: aarch64
-            os: macos-14
-          - arch: x86_64
-            os: macos-13
+        arch: [x86_64, aarch64]
 
     steps:
       - name: Install Node.js


### PR DESCRIPTION
Try switching the x86_64 macOS build to cross compile on macOS aarch64, makes the x86_64 building go from ~3.5-4 hours to ~1.5 hours from my actions test run https://github.com/omove/desktop/actions/runs/11993727306/job/33435040303