### PR TITLE
Enable PGO for macOS aarch64

### DIFF
--- a/configs/macos/mozconfig
+++ b/configs/macos/mozconfig
@@ -6,9 +6,10 @@ ac_add_options --enable-eme=widevine
 export MOZ_MACBUNDLE_ID=${appId}
 export MOZ_MACBUNDLE_NAME="Zen Browser.app"
 
+export MOZ_PGO=1
+ac_add_options MOZ_PGO=1
+
 if test "$SURFER_COMPAT" = "x86_64"; then
-    export MOZ_PGO=1
-    ac_add_options MOZ_PGO=1
     ac_add_options --target=x86_64-apple-darwin
 
     ac_add_options --enable-wasm-avx


### PR DESCRIPTION
Building the aarch64 version with PGO seems to work from my github actions test run.