### PR TITLE
Remove duplication of node version for ease of maintenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Setup pnpm
         run: npm install -g pnpm
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-data]
     steps:
-      - name: Checkout repository 
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -168,7 +168,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Setup pnpm
         run: npm install -g pnpm
@@ -220,7 +220,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Setup Git
         run: |
@@ -339,7 +339,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/linux-release-build.yml
+++ b/.github/workflows/linux-release-build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Setup Git
         run: |

--- a/.github/workflows/macos-release-build.yml
+++ b/.github/workflows/macos-release-build.yml
@@ -16,7 +16,7 @@ jobs:
   mac-build:
     name: Build macOS - ${{ matrix.arch }}
     runs-on: macos-14
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -55,17 +55,17 @@ jobs:
           export PATH="$(python3 -m site --user-base)/bin":$PATH
           python3 -m pip install --user mercurial
 
-          rm '/usr/local/bin/2to3-3.11' '/usr/local/bin/2to3-3.12' '/usr/local/bin/2to3' 
-          rm '/usr/local/bin/idle3.11' '/usr/local/bin/idle3.12' '/usr/local/bin/idle3' 
-          rm '/usr/local/bin/pydoc3.11' '/usr/local/bin/pydoc3.12' '/usr/local/bin/pydoc3' 
-          rm '/usr/local/bin/python3.11' '/usr/local/bin/python3.12' '/usr/local/bin/python3' 
+          rm '/usr/local/bin/2to3-3.11' '/usr/local/bin/2to3-3.12' '/usr/local/bin/2to3'
+          rm '/usr/local/bin/idle3.11' '/usr/local/bin/idle3.12' '/usr/local/bin/idle3'
+          rm '/usr/local/bin/pydoc3.11' '/usr/local/bin/pydoc3.12' '/usr/local/bin/pydoc3'
+          rm '/usr/local/bin/python3.11' '/usr/local/bin/python3.12' '/usr/local/bin/python3'
           rm '/usr/local/bin/python3.11-config' '/usr/local/bin/python3.12-config' '/usr/local/bin/python3-config'
 
           brew install watchman
 
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
           source $HOME/.cargo/env
-          
+
           if test "${{ matrix.arch }}" = "aarch64"; then
             rustup target add aarch64-apple-darwin
           else

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Setup pnpm
         run: npm install -g pnpm

--- a/.github/workflows/twilight-release-schedule.yml
+++ b/.github/workflows/twilight-release-schedule.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       # TODO:

--- a/.github/workflows/windows-profile-build.yml
+++ b/.github/workflows/windows-profile-build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Setup Git
         run: |

--- a/.github/workflows/windows-release-build.yml
+++ b/.github/workflows/windows-release-build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Setup pnpm
         run: npm install -g pnpm

--- a/configs/common/mozconfig
+++ b/configs/common/mozconfig
@@ -28,18 +28,18 @@ ac_add_options --enable-application=browser
 
 if test "$ZEN_RELEASE"; then
   ac_add_options --enable-bootstrap
-  
+
   ac_add_options --enable-release
   ac_add_options --disable-debug
   ac_add_options --disable-debug-symbols
   ac_add_options --disable-debug-js-modules
   ac_add_options --disable-tests
-  
+
   ac_add_options --disable-vtune
 
   ac_add_options --enable-rust-simd
   ac_add_options --enable-wasm-simd
-  
+
   mk_add_options MOZ_PARALLEL_COMPILE=1
 
   ac_add_options --enable-proxy-bypass-protection


### PR DESCRIPTION
Node version can now be maintained in the `.nvmrc` file alone. GHA workflows will reuse from that file for ease of maintenance