### PR TITLE
makes the workspace button resize better

### DIFF
--- a/src/browser/base/content/zen-styles/zen-workspaces.css
+++ b/src/browser/base/content/zen-styles/zen-workspaces.css
@@ -19,15 +19,18 @@
     appearance: unset !important;
     height: fit-content;
     gap: 3px;
+    width: 100%;
 
     & toolbarbutton {
       margin: auto;
-      width: 25px;
+      width: auto;
       display: flex;
       justify-content: center;
       padding: 0 !important;
       align-items: center;
       position: relative;
+      flex: 1 1 4px !important;       
+      min-width: 0;
 
       @media (-moz-bool-pref: 'zen.workspaces.hide-deactivated-workspaces') {
         &:not([active='true']):not(:hover) {


### PR DESCRIPTION
i made it so that the workspaces width will fill 100% of the space so it looks like this:
![image](https://github.com/user-attachments/assets/09edccf6-49ef-4912-9c18-b5d284a55eeb)


and not this:

https://github.com/user-attachments/assets/ebe91f75-548f-4dfe-b7a1-44c3bf40ef9a



it also resizes like this:

https://github.com/user-attachments/assets/1a59b4fa-f146-4249-9d60-4af6143ae8a1

