### PR TITLE
Fix zen gradient generator overflow

### DIFF
--- a/src/browser/base/content/zen-styles/zen-gradient-generator.css
+++ b/src/browser/base/content/zen-styles/zen-gradient-generator.css
@@ -5,6 +5,13 @@
   min-width: var(--panel-width);
 }
 
+#PanelUI-zen-gradient-generator .panel-viewcontainer,
+#PanelUI-zen-gradient-generator .panel-viewstack {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
 #PanelUI-zen-gradient-degrees {
   position: relative;
   border-radius: 999px;


### PR DESCRIPTION
This PR fixes https://github.com/zen-browser/desktop/issues/2457

Some users are experiencing issues with the way the gradient picker is displayed inside its panel. The width of the content appears larger than the width of the panel:

![2024-12-10-At-10h53m26s](https://github.com/user-attachments/assets/94d3cbb2-16e1-436c-a4e0-79a7f3a9fe35)

This very simple fix add styling to children to fix the overflow:

![2024-12-10-At-10h53m38s](https://github.com/user-attachments/assets/a987b422-88f0-45c5-89e6-3e3e140b4a3e)

I hope this fix is okay for you!