### PR TITLE
Remove Homebrew workflow job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -673,35 +673,10 @@ jobs:
           git-token: ${{ secrets.DEPLOY_KEY }}
           delete-branch: true
 
-  release-homebrew-beta:
-    if: ${{ inputs.create_release && inputs.update_branch == 'beta' }}
+  release-homebrew:
+    if: ${{ inputs.create_release && inputs.update_version && inputs.update_branch == 'twilight' }}
     permissions: write-all
-    name: Homebrew release for beta build
-    needs: [release, mac, build-data]
-    runs-on: macos-latest
-
-    steps:
-      - name: Setup Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-        with:
-          cask: true
-          test-bot: false
-
-      - name: Setup Git
-        uses: Homebrew/actions/git-user-config@master
-        with:
-          username: zen-browser-auto
-
-      - name: Bump cask
-        uses: Homebrew/actions/bump-packages@master
-        with:
-          token: ${{ secrets.DEPLOY_KEY }}
-          casks: zen-browser
-
-  release-homebrew-twilight:
-    if: ${{ inputs.create_release && inputs.update_branch == 'twilight' }}
-    permissions: write-all
-    name: Homebrew release for twilight build
+    name: Release Homebrew
     needs: [release, mac, build-data]
     runs-on: macos-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -672,28 +672,3 @@ jobs:
           base: master
           git-token: ${{ secrets.DEPLOY_KEY }}
           delete-branch: true
-
-  release-homebrew:
-    if: ${{ inputs.create_release && inputs.update_version && inputs.update_branch == 'twilight' }}
-    permissions: write-all
-    name: Release Homebrew
-    needs: [release, mac, build-data]
-    runs-on: macos-latest
-
-    steps:
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-        with:
-          cask: true
-          test-bot: false
-
-      - name: Setup git
-        uses: Homebrew/actions/git-user-config@master
-        with:
-          username: zen-browser-auto
-
-      - name: Bump cask
-        uses: Homebrew/actions/bump-packages@master
-        with:
-          token: ${{ secrets.DEPLOY_KEY }}
-          casks: zen-browser@twilight


### PR DESCRIPTION
Zen has been in Homebrew's autobump list for over two months already, so running the Homebrew job for the beta builds, and the alpha builds before that, is rather pointless (example from the most [recent workflow run](https://github.com/zen-browser/desktop/actions/runs/12252881766/job/34196380794#step:4:55)).

~~As for the Twilight builds, there is no reason to run the Homebrew job if the version number hasn't changed (see [here](https://github.com/zen-browser/desktop/actions/runs/12246670949/job/34171749916#step:4:54) as an example), so I modified it to only run when the version number is also updated.~~

The Twilight builds have been added to Homebrew's autobump list as well now, so running this job at all now is completely pointless (see this [workflow run](https://github.com/zen-browser/desktop/actions/runs/12383670979/job/34573594951#step:4:55)).