### PR TITLE
Updated old mod marketplace dead link with working new one

### DIFF
--- a/src/browser/components/preferences/zenMarketplace.inc.xhtml
+++ b/src/browser/components/preferences/zenMarketplace.inc.xhtml
@@ -15,7 +15,7 @@
       </hbox>
       <description class="description-deemphasized" data-l10n-id="zen-theme-marketplace-description" />
       <hbox class="indent">
-            <html:a id="zenThemeMarketplaceLink" href="https://zen-browser.app/themes" target="_blank" data-l10n-id="zen-theme-marketplace-link" />
+            <html:a id="zenThemeMarketplaceLink" href="https://zen-browser.app/mods/" target="_blank" data-l10n-id="zen-theme-marketplace-link" />
             <button id="zenThemeMarketplaceCheckForUpdates" data-l10n-id="zen-theme-marketplace-check-for-updates-button" />
       </hbox>
 


### PR DESCRIPTION
Changed button referencing "https://zen-browser.app/themes/" in settings page which doesnt work anymore to the new link "https://zen-browser.app/mods/"