### PR TITLE
Make sidebar compact mode animation smoother

### DIFF
--- a/src/browser/base/content/zen-styles/zen-compact-mode.css
+++ b/src/browser/base/content/zen-styles/zen-compact-mode.css
@@ -24,7 +24,7 @@
         --zen-compact-float: calc(var(--zen-element-separation) - 1px);
         position: absolute;
         z-index: 10;
-        transition: transform 0.25s ease-in-out, opacity 0.1s ease-in-out;
+        transition: transform 0.25s ease, opacity 0.1s ease-in-out;
         right: calc(100% - var(--zen-element-separation));
         top: 0;
         bottom: var(--zen-element-separation);


### PR DESCRIPTION
Hi, I noticed that the sidebar in compact mode appears in a kinda linear animation. This is a really small tweak that makes it a lot smoother.
I just changed it from `ease-in-out` to `ease`.
The initial animation after the change is something that happens just one time while debugging and changing this value, it doesn't actually happen.

https://github.com/user-attachments/assets/a395c064-01b3-48b3-8355-bc68aea861f8

