### PR TITLE
Removed hardcoding of python version so that maintenance can be done in a single place (.python-version)

### DIFF
--- a/.github/workflows/macos-release-build.yml
+++ b/.github/workflows/macos-release-build.yml
@@ -36,8 +36,7 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
+        # note: This will use the version defined in '.python-version' by default
 
       - name: Setup Git
         run: |


### PR DESCRIPTION
According to the [basic usage](https://github.com/actions/setup-python?tab=readme-ov-file#basic-usage) of the `setup-python` action, rather than hardcoding the same python version in multiple places (which can lead to maintenance issues), its better to use the `.python-version` file.