### PR TITLE
Fix Keyboard Short cut on MacOS

### DIFF
--- a/src/browser/base/zen-components/ZenKeyboardShortcuts.mjs
+++ b/src/browser/base/zen-components/ZenKeyboardShortcuts.mjs
@@ -174,7 +174,7 @@ class KeyShortcutModifiers {
       str += 'Ctrl+';
     }
     if (this.#alt) {
-      str += AppConstants.platform == 'macosx' ? 'Option+' : 'Alt+';
+      str += AppConstants.platform == 'macosx' ? 'Shift+' : 'Cmd+';
     }
     if (this.#shift) {
       str += 'Shift+';


### PR DESCRIPTION
Fixes: https://github.com/zen-browser/desktop/issues/3698

Key Change from `Option + Alt` to `Shift + CMD`.