### PR TITLE
Re-enable the built-in password manager

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -385,7 +385,6 @@ pref("browser.formfill.enable", false);
 pref("security.insecure_connection_text.enabled", true);
 pref("security.insecure_connection_text.pbmode.enabled", true);
 pref("network.IDN_show_punycode", true);
-pref("signon.rememberSignons", false);
 
 // Telemetry
 pref("datareporting.policy.dataSubmissionEnabled", false, locked);


### PR DESCRIPTION
Having the password manager enabled is a good default, because the alternative for the average person isn't adopting a third party manager, it's either having no manager or bouncing off Zen entirely.

I don't hold the [Principle of Least Astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) as sacred law or anything, but it definitely seems applicable here, especially for a browser with the stated goals of being featureful and taking the backseat.