### PR TITLE
Enable bottom rounded corners for Linux

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -30,6 +30,10 @@ pref('browser.compactmode.show', true);
 pref("browser.privateWindowSeparation.enabled", false);
 #endif
 
+#ifdef UNIX_BUT_NOT_MAC
+pref("widget.gtk.rounded-bottom-corners.enabled", true);
+#endif
+
 pref('browser.newtabpage.activity-stream.newtabWallpapers.enabled', true);
 pref('browser.newtabpage.activity-stream.newtabWallpapers.v2.enabled', true);
 pref('browser.translations.newSettingsUI.enable', true);


### PR DESCRIPTION
On Linux, the bottom window corners are not rounded. This setting enables them as shown on the screenshots:

Before:

![Before](https://github.com/user-attachments/assets/75b6bc20-e07f-4edb-90f8-587732a1bbe5)


After: 

![After](https://github.com/user-attachments/assets/2e9d62c0-4f8b-4104-bf7b-10b8de0d2650)
