### PR TITLE
fix: don't flash compact sidebar when opening glance

### DIFF
--- a/src/browser/components/tabbrowser/content/tabs-js.patch
+++ b/src/browser/components/tabbrowser/content/tabs-js.patch
@@ -76,7 +76,8 @@ index f7c39fe804182e2bdf53045ba3b6a5ba17079fc3..93be23da305a5e2e51bff1c5b5f28743
 -      }
 +      this.arrowScrollbox.ensureElementIsVisible(selectedTab, aInstant);
  
-+      if (!aInstant && Services.prefs.getBoolPref('zen.view.compact')
++      if (!aInstant && !gZenGlanceManager.animatingOpen
++          && Services.prefs.getBoolPref('zen.view.compact')
 +          && Services.prefs.getBoolPref('zen.view.compact.toolbar-flash-popup')) {
 +        gZenCompactModeManager.flashSidebar();
 +      }


### PR DESCRIPTION
Flashing the sidebar when opening glance is unnecessary, as the user explicitly opens the glance tab so there are no new information presented to the user in the sidebar.

On the other hand, the sidebar partially covers the glance tab, meaning that the user has to wait for a while before seeing the tab content, which breaks the flow.

Closes #3351