### PR TITLE
Added collapsable header for about:support in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -78,4 +78,3 @@ body:
           Select this line and paste your about:support clipboard
           ```
         </details>
-      render: shell

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,4 +69,13 @@ body:
     attributes:
       label: Data from about:support if applicable (click on the "Copy text to clipboard" button)
       description: Please copy and paste about:support data if you think it might be relevant. This will help us understand your environment.
+      value: |
+        <details>
+          <summary>about:support</summary>
+          <!-- Please leave one blank line below for enabling the code block rendering. -->
+
+          ```
+          Select this line and paste your about:support clipboard
+          ```
+        </details>
       render: shell


### PR DESCRIPTION
currently if you don't do this, you get issues where the first entry is massive because of this block. doing this will make it so that the output is in a collapsed block in markdown and takes up less space