### PR TITLE
New workspace functionality when closing last tab

### DIFF
--- a/src/browser/base/content/zen-styles/zen-animations.css
+++ b/src/browser/base/content/zen-styles/zen-animations.css
@@ -100,28 +100,6 @@
   }
 }
 
-@keyframes zen-slide-in {
-  from {
-    transform: translateX(-150%);
-    opacity: 0;
-  }
-  to {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-@keyframes zen-slide-in-reverse {
-  from {
-    transform: translateX(150%);
-    opacity: 0;
-  }
-  to {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
 @keyframes zen-deck-fadeIn {
   0% {
     transform: scale(0.9);

--- a/src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css
+++ b/src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css
@@ -242,23 +242,6 @@
   & .tabbrowser-tab {
     transition: scale 0.07s ease;
     #tabbrowser-tabs &:not([zen-essential='true']) {
-      #tabbrowser-tabs[zen-workspace-animation='previous'] & {
-        animation: zen-slide-in;
-      }
-
-      #tabbrowser-tabs[zen-workspace-animation='next'] & {
-        animation: zen-slide-in-reverse;
-      }
-
-      #tabbrowser-tabs[zen-workspace-animation] & {
-        opacity: 0;
-        transform: translateX(-100%);
-        animation-delay: 0.2s;
-        animation-fill-mode: forwards;
-        animation-duration: 0.2s;
-        animation-timing-function: ease;
-      }
-
       #tabbrowser-tabs[dont-animate-tabs] & {
         opacity: 0;
       }

--- a/src/browser/base/zen-components/ZenGradientGenerator.mjs
+++ b/src/browser/base/zen-components/ZenGradientGenerator.mjs
@@ -658,7 +658,7 @@
               setTimeout(() => {
                 // Reactivate the transition after the animation
                 appWrapper.removeAttribute('post-animating');
-              });
+              }, 100);
             }, 700);
           });
         }

--- a/src/browser/base/zen-components/ZenWorkspaces.mjs
+++ b/src/browser/base/zen-components/ZenWorkspaces.mjs
@@ -425,6 +425,7 @@ var ZenWorkspaces = new (class extends ZenMultiWindowFeature {
       return null;
     }
 
+    // TODO: handle different actions depending on the user preference
     const shouldOpenNewTabIfLastUnpinnedTabIsClosed = this.shouldOpenNewTabIfLastUnpinnedTabIsClosed;
 
     let tabs = gBrowser.tabs.filter(

--- a/src/browser/base/zen-components/ZenWorkspaces.mjs
+++ b/src/browser/base/zen-components/ZenWorkspaces.mjs
@@ -430,7 +430,7 @@ var ZenWorkspaces = new (class extends ZenMultiWindowFeature {
 
     let tabs = gBrowser.tabs.filter(
       (t) =>
-        t.getAttribute('zen-workspace-id') === workspaceID &&
+        (t.getAttribute('zen-workspace-id') === workspaceID || t.hasAttribute("zen-essential")) &&
         (!shouldOpenNewTabIfLastUnpinnedTabIsClosed || !t.pinned || t.getAttribute('pending') !== 'true')
     );
 

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabbrowser.js b/browser/components/tabbrowser/content/tabbrowser.js
-index ce68c339f35416574b7bc7ebf8c93378f653242b..46d25e4381eaae71f3aec1025788684c593a60c7 100644
+index ce68c339f35416574b7bc7ebf8c93378f653242b..07e3f7fcdb3e219c523201929cf07b6878d4d394 100644
 --- a/browser/components/tabbrowser/content/tabbrowser.js
 +++ b/browser/components/tabbrowser/content/tabbrowser.js
 @@ -409,11 +409,39 @@
@@ -237,7 +237,7 @@ index ce68c339f35416574b7bc7ebf8c93378f653242b..46d25e4381eaae71f3aec1025788684c
        if (
          !this._beginRemoveTab(aTab, {
            closeWindowFastpath: true,
-@@ -4556,7 +4657,7 @@
+@@ -4556,14 +4657,14 @@
          !!this.tabsInCollapsedTabGroups.length;
        if (
          aTab.visible &&
@@ -246,6 +246,14 @@ index ce68c339f35416574b7bc7ebf8c93378f653242b..46d25e4381eaae71f3aec1025788684c
          !anyRemainingTabsInCollapsedTabGroups
        ) {
          closeWindow =
+           closeWindowWithLastTab != null
+             ? closeWindowWithLastTab
+             : !window.toolbar.visible ||
+-              Services.prefs.getBoolPref("browser.tabs.closeWindowWithLastTab");
++              Services.prefs.getBoolPref("browser.tabs.closeWindowWithLastTab") && !ZenWorkspaces._isClosingWindow;
+ 
+         if (closeWindow) {
+           // We've already called beforeunload on all the relevant tabs if we get here,
 @@ -5411,10 +5512,10 @@
        SessionStore.deleteCustomTabValue(aTab, "hiddenBy");
      }


### PR DESCRIPTION
How they should work:

- [x] Should close window if `browser.tabs.closeWindowWithLastTab` is set to `true` even if other workspaces have tabs
- [x] Should make a new tab if the first condition is not met
- [x] Should make a new tab if the only remaining tabs are pinned and the first condition is not met (`zen.workspaces.open-new-tab-if-last-unpinned-tab-is-closed` should be enabled)