### PR TITLE
Windows build fix

### DIFF
--- a/configs/common/mozconfig
+++ b/configs/common/mozconfig
@@ -4,7 +4,7 @@ ac_add_options --with-app-basename=Zen
 ac_add_options --enable-official-branding
 
 # Localization
-ac_add_options --with-l10n-base="$PWD/browser/locales"
+ac_add_options --with-l10n-base="../../engine/browser/locales"
 
 export MOZ_USER_DIR="${name}"
 export MOZ_APP_BASENAME=Zen


### PR DESCRIPTION
Encountered the following error while building:
```
0:00:12 ERROR: Invalid value --with-l10n-base, /g/desktop/engine/browser/locales doesn't exist
00:00:12 W Exception when writing resource usage file: [Errno 2] No such file or directory: 'G:/desktop/engine/obj-x86_64-pc-windows-msvc\\.mozbuild\\profile_build_resources.json'
00:00:13  Config object not found by mach.
00:00:13 *** Fix above errors and then restart with "./mach build"
```
The `$PWD` path may not work in Windows. So I updated the path to `../../engine/browser/locales` to resolve the issue.