### PR TITLE
fix: make 'Always floating' setting work on new tabs

### DIFF
--- a/src/browser/base/content/browser-commands-js.patch
+++ b/src/browser/base/content/browser-commands-js.patch
@@ -1,8 +1,32 @@
 diff --git a/browser/base/content/browser-commands.js b/browser/base/content/browser-commands.js
-index 352de44dda36e3f6672eb353f42978ede0cd2681..d6956a318c34bfb12b0ba957edab1166e1a4edaf 100644
+index 352de44dda36e3f6672eb353f42978ede0cd2681..916876ed2924cada725dc68e42cfac0c3abedae0 100644
 --- a/browser/base/content/browser-commands.js
 +++ b/browser/base/content/browser-commands.js
-@@ -407,8 +407,8 @@ var BrowserCommands = {
+@@ -7,6 +7,13 @@
+ 
+ "use strict";
+ 
++XPCOMUtils.defineLazyPreferenceGetter(
++  lazy,
++  "ZEN_URLBAR_BEHAVIOR",
++  "zen.urlbar.behavior",
++  'default'
++);
++
+ var kSkipCacheFlags =
+   Ci.nsIWebNavigation.LOAD_FLAGS_BYPASS_PROXY |
+   Ci.nsIWebNavigation.LOAD_FLAGS_BYPASS_CACHE;
+@@ -345,6 +352,9 @@ var BrowserCommands = {
+             }
+           }
+           openTrustedLinkIn(url, where, options);
++          if (lazy.ZEN_URLBAR_BEHAVIOR === 'float' && url === BROWSER_NEW_TAB_URL) {
++            gURLBar.view.input.startQuery();
++          }
+         }),
+       },
+       "browser-open-newtab-start"
+@@ -407,8 +417,8 @@ var BrowserCommands = {
        (event.ctrlKey || event.metaKey || event.altKey) &&
        gBrowser.selectedTab.pinned
      ) {


### PR DESCRIPTION
## Description
The "Always floating" setting wasn't being applied when opening new tabs.  
Fixed by making the setting properly apply to newly opened tabs.

Note: This is my first PR as I'm discovering the codebase - any feedback is welcome if something needs to be improved!

## Demo
### Before
https://github.com/user-attachments/assets/906621d6-d4af-4357-a453-ed659034f82d

### After
https://github.com/user-attachments/assets/bd456858-0737-4bc0-88e2-9020b22b31b9