### PR TITLE
Fixed visual inconsistency with split view confirmation popup

### DIFF
--- a/src/browser/base/content/zen-styles/zen-popup.css
+++ b/src/browser/base/content/zen-styles/zen-popup.css
@@ -56,6 +56,11 @@ panel {
   --panel-border-radius: var(--zen-native-inner-radius);
 }
 
+/* split-view popup */
+#confirmation-hint {
+  --arrowpanel-background: var(--zen-colors-primary);
+}
+
 /* app menu */
 .addon-banner-item,
 .panel-banner-item {


### PR DESCRIPTION
Change : Assigned `--arrowpanel-background` to `--zen-colors-primary` for `#confirmation-hint`

![Screenshot From 2025-01-28 15-39-02](https://github.com/user-attachments/assets/a382e374-320d-4e07-bdca-4256092a76ab)
Original
![Screenshot From 2025-01-28 15-34-28](https://github.com/user-attachments/assets/aee3558c-3503-469d-b995-0b4ff84ba299)
Proposed
