### PR TITLE
Added a preference to toggle the sidebar opening on hover in compact mode

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -123,7 +123,7 @@ pref('zen.view.compact.toolbar-hide-after-hover.duration', 1000);
 pref('zen.view.compact.color-toolbar', true);
 pref('zen.view.compact.color-sidebar', true);
 pref('zen.view.compact.animate-sidebar', true);
-pref('zen.view.compact.show-sidebar-on-hover', true);
+pref('zen.view.compact.show-sidebar-and-toolbar-on-hover', true);
 
 pref('zen.urlbar.behavior', 'floating-on-type'); // default, floating-on-type, float
 

--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -123,6 +123,7 @@ pref('zen.view.compact.toolbar-hide-after-hover.duration', 1000);
 pref('zen.view.compact.color-toolbar', true);
 pref('zen.view.compact.color-sidebar', true);
 pref('zen.view.compact.animate-sidebar', true);
+pref('zen.view.compact.show-sidebar-on-hover', true);
 
 pref('zen.urlbar.behavior', 'floating-on-type'); // default, floating-on-type, float
 

--- a/src/browser/base/zen-components/ZenCompactMode.mjs
+++ b/src/browser/base/zen-components/ZenCompactMode.mjs
@@ -276,7 +276,10 @@ var gZenCompactModeManager = {
   },
 
   get hoverableElements() {
-    const showSidebarOnHover = Services.prefs.getBoolPref('zen.view.compact.show-sidebar-on-hover', true);
+    if (typeof this._showSidebarOnHover === 'undefined') {
+      this._showSidebarOnHover = Services.prefs.getBoolPref('zen.view.compact.show-sidebar-on-hover', true);
+    }
+    const showSidebarOnHover = this._showSidebarOnHover;
     return [
       ...(showSidebarOnHover
         ? [

--- a/src/browser/base/zen-components/ZenCompactMode.mjs
+++ b/src/browser/base/zen-components/ZenCompactMode.mjs
@@ -276,19 +276,20 @@ var gZenCompactModeManager = {
   },
 
   get hoverableElements() {
-    const panels = [];
-    if (Services.prefs.getBoolPref('zen.view.compact.show-sidebar-on-hover', true)) {
-      panels.push({
-        element: this.sidebar,
-        screenEdge: this.sidebarIsOnRight ? 'right' : 'left',
-        keepHoverDuration: 100,
-      });
-    }
-    panels.push({
-      element: document.getElementById('zen-appcontent-navbar-container'),
-      screenEdge: 'top',
-    });
-    return panels;
+    const showSidebarOnHover = Services.prefs.getBoolPref('zen.view.compact.show-sidebar-on-hover', true);
+    return showSidebarOnHover
+      ? [
+          {
+            element: this.sidebar,
+            screenEdge: this.sidebarIsOnRight ? 'right' : 'left',
+            keepHoverDuration: 100,
+          },
+          {
+            element: document.getElementById('zen-appcontent-navbar-container'),
+            screenEdge: 'top',
+          },
+        ]
+      : [];
   },
 
   flashSidebar(duration = lazyCompactMode.COMPACT_MODE_FLASH_DURATION) {

--- a/src/browser/base/zen-components/ZenCompactMode.mjs
+++ b/src/browser/base/zen-components/ZenCompactMode.mjs
@@ -282,19 +282,24 @@ var gZenCompactModeManager = {
         true
       );
     }
-    return !this._showSidebarAndToolbarOnHover
-      ? []
-      : [
-          {
-            element: this.sidebar,
-            screenEdge: this.sidebarIsOnRight ? 'right' : 'left',
-            keepHoverDuration: 100,
-          },
-          {
-            element: document.getElementById('zen-appcontent-navbar-container'),
-            screenEdge: 'top',
-          },
-        ];
+    return [
+      ...(!this._showSidebarAndToolbarOnHover
+        ? []
+        : [
+            {
+              element: this.sidebar,
+              screenEdge: this.sidebarIsOnRight ? 'right' : 'left',
+              keepHoverDuration: 100,
+            },
+            {
+              element: document.getElementById('zen-appcontent-navbar-container'),
+              screenEdge: 'top',
+            },
+          ]),
+      {
+        element: gZenVerticalTabsManager.actualWindowButtons,
+      },
+    ];
   },
 
   flashSidebar(duration = lazyCompactMode.COMPACT_MODE_FLASH_DURATION) {

--- a/src/browser/base/zen-components/ZenCompactMode.mjs
+++ b/src/browser/base/zen-components/ZenCompactMode.mjs
@@ -276,11 +276,13 @@ var gZenCompactModeManager = {
   },
 
   get hoverableElements() {
-    if (typeof this._showSidebarOnHover === 'undefined') {
-      this._showSidebarOnHover = Services.prefs.getBoolPref('zen.view.compact.show-sidebar-on-hover', true);
+    if (typeof this._showSidebarAndToolbarOnHover === 'undefined') {
+      this._showSidebarAndToolbarOnHover = Services.prefs.getBoolPref(
+        'zen.view.compact.show-sidebar-and-toolbar-on-hover',
+        true
+      );
     }
-    const showSidebarOnHover = this._showSidebarOnHover;
-    return !showSidebarOnHover
+    return !this._showSidebarAndToolbarOnHover
       ? []
       : [
           {

--- a/src/browser/base/zen-components/ZenCompactMode.mjs
+++ b/src/browser/base/zen-components/ZenCompactMode.mjs
@@ -280,21 +280,19 @@ var gZenCompactModeManager = {
       this._showSidebarOnHover = Services.prefs.getBoolPref('zen.view.compact.show-sidebar-on-hover', true);
     }
     const showSidebarOnHover = this._showSidebarOnHover;
-    return [
-      ...(showSidebarOnHover
-        ? [
-            {
-              element: this.sidebar,
-              screenEdge: this.sidebarIsOnRight ? 'right' : 'left',
-              keepHoverDuration: 100,
-            },
-          ]
-        : []),
-      {
-        element: document.getElementById('zen-appcontent-navbar-container'),
-        screenEdge: 'top',
-      },
-    ];
+    return !showSidebarOnHover
+      ? []
+      : [
+          {
+            element: this.sidebar,
+            screenEdge: this.sidebarIsOnRight ? 'right' : 'left',
+            keepHoverDuration: 100,
+          },
+          {
+            element: document.getElementById('zen-appcontent-navbar-container'),
+            screenEdge: 'top',
+          },
+        ];
   },
 
   flashSidebar(duration = lazyCompactMode.COMPACT_MODE_FLASH_DURATION) {

--- a/src/browser/base/zen-components/ZenCompactMode.mjs
+++ b/src/browser/base/zen-components/ZenCompactMode.mjs
@@ -277,19 +277,21 @@ var gZenCompactModeManager = {
 
   get hoverableElements() {
     const showSidebarOnHover = Services.prefs.getBoolPref('zen.view.compact.show-sidebar-on-hover', true);
-    return showSidebarOnHover
-      ? [
-          {
-            element: this.sidebar,
+    return [
+      ...(showSidebarOnHover
+        ? [
+            {
+              element: this.sidebar,
             screenEdge: this.sidebarIsOnRight ? 'right' : 'left',
-            keepHoverDuration: 100,
-          },
-          {
-            element: document.getElementById('zen-appcontent-navbar-container'),
-            screenEdge: 'top',
-          },
-        ]
-      : [];
+              keepHoverDuration: 100,
+            },
+          ]
+        : []),
+      {
+        element: document.getElementById('zen-appcontent-navbar-container'),
+        screenEdge: 'top',
+      },
+    ];
   },
 
   flashSidebar(duration = lazyCompactMode.COMPACT_MODE_FLASH_DURATION) {

--- a/src/browser/base/zen-components/ZenCompactMode.mjs
+++ b/src/browser/base/zen-components/ZenCompactMode.mjs
@@ -282,7 +282,7 @@ var gZenCompactModeManager = {
         ? [
             {
               element: this.sidebar,
-            screenEdge: this.sidebarIsOnRight ? 'right' : 'left',
+              screenEdge: this.sidebarIsOnRight ? 'right' : 'left',
               keepHoverDuration: 100,
             },
           ]

--- a/src/browser/base/zen-components/ZenCompactMode.mjs
+++ b/src/browser/base/zen-components/ZenCompactMode.mjs
@@ -276,17 +276,19 @@ var gZenCompactModeManager = {
   },
 
   get hoverableElements() {
-    return [
-      {
+    const panels = [];
+    if (Services.prefs.getBoolPref('zen.view.compact.show-sidebar-on-hover', true)) {
+      panels.push({
         element: this.sidebar,
         screenEdge: this.sidebarIsOnRight ? 'right' : 'left',
         keepHoverDuration: 100,
-      },
-      {
-        element: document.getElementById('zen-appcontent-navbar-container'),
-        screenEdge: 'top',
-      },
-    ];
+      });
+    }
+    panels.push({
+      element: document.getElementById('zen-appcontent-navbar-container'),
+      screenEdge: 'top',
+    });
+    return panels;
   },
 
   flashSidebar(duration = lazyCompactMode.COMPACT_MODE_FLASH_DURATION) {


### PR DESCRIPTION
This addresses #3760.
I keep accidentally opening the sidebar even after a few weeks of using zen, so It would be nice to have the option of not opening the sidebar when hovering near it.
This would make it so it would only open with the keyboard shortcut to toggle compact mode.