### PR TITLE
Add feature: copy current URL as markdown

### DIFF
--- a/src/browser/base/zen-components/ZenCommonUtils.mjs
+++ b/src/browser/base/zen-components/ZenCommonUtils.mjs
@@ -60,23 +60,10 @@ class ZenPreloadedFeature {
 
 var gZenCommonActions = {
   copyCurrentURLToClipboard() {
-    let urlStringToCopy = "";
-    if (Services.prefs.getBoolPref('zen.keyboard.shortcuts.copy-current-url.copy-all-in-split-view', false)) {
-      const currentTabs = gZenViewSplitter.getTabsInCurrentView();
-      if (currentTabs) {
-        const stringArray = currentTabs.map(t => `${t.linkedBrowser.currentURI.spec}`);
-        urlStringToCopy = stringArray.join("\n");
-      }
-    } else {
-      const currentUrl = gBrowser.currentURI.spec;
-      if (currentUrl) {
-
-        urlStringToCopy = `${currentUrl}`
-      }
-    }
-    if (urlStringToCopy) {
+    const currentUrl = gBrowser.currentURI.spec;
+    if (currentUrl) {
       let str = Cc['@mozilla.org/supports-string;1'].createInstance(Ci.nsISupportsString);
-      str.data = urlStringToCopy;
+      str.data = currentUrl;
       let transferable = Cc['@mozilla.org/widget/transferable;1'].createInstance(Ci.nsITransferable);
       transferable.init(getLoadContext());
       transferable.addDataFlavor('text/plain');
@@ -86,29 +73,18 @@ var gZenCommonActions = {
     }
   },
   CopyCurrentURLAsMarkdownToClipboard() {
-    let markdownString = "";
-    if (Services.prefs.getBoolPref('zen.keyboard.shortcuts.copy-current-url-as-markdown.copy-all-in-split-view', false)) {
-      const currentTabs = gZenViewSplitter.getTabsInCurrentView();
-      if (currentTabs) {
-        const stringArray = currentTabs.map(t => `[${t.label}](${t.linkedBrowser.currentURI.spec})`);
-        markdownString = stringArray.join("\n");
-      }
-    } else {
-      const currentUrl = gBrowser.currentURI.spec;
-      const tabTitle = gBrowser.selectedTab.label;
-      if (currentUrl && tabTitle) {
-        markdownString = `[${tabTitle}](${currentUrl})`;
-      }
-    }
-    if (markdownString) {
-      let str = Cc['@mozilla.org/supports-string;1'].createInstance(Ci.nsISupportsString);
-      str.data = markdownString;
-      let transferable = Cc['@mozilla.org/widget/transferable;1'].createInstance(Ci.nsITransferable);
-      transferable.init(getLoadContext());
-      transferable.addDataFlavor('text/plain');
-      transferable.setTransferData('text/plain', str);
-      Services.clipboard.setData(transferable, null, Ci.nsIClipboard.kGlobalClipboard);
-      ConfirmationHint.show(document.getElementById('PanelUI-menu-button'), 'zen-copy-current-url-confirmation');
+    const currentUrl = gBrowser.currentURI.spec;
+    const tabTitle = gBrowser.selectedTab.label;
+    if (currentUrl && tabTitle) {
+        const markdownLink = `[${tabTitle}](${currentUrl})`;
+        let str = Cc['@mozilla.org/supports-string;1'].createInstance(Ci.nsISupportsString);
+        str.data = markdownLink;
+        let transferable = Cc['@mozilla.org/widget/transferable;1'].createInstance(Ci.nsITransferable);
+        transferable.init(getLoadContext());
+        transferable.addDataFlavor('text/plain');
+        transferable.setTransferData('text/plain', str);
+        Services.clipboard.setData(transferable, null, Ci.nsIClipboard.kGlobalClipboard);
+        ConfirmationHint.show(document.getElementById('PanelUI-menu-button'), 'zen-copy-current-url-confirmation');
     }
   },
 

--- a/src/browser/base/zen-components/ZenCommonUtils.mjs
+++ b/src/browser/base/zen-components/ZenCommonUtils.mjs
@@ -60,10 +60,12 @@ class ZenPreloadedFeature {
 
 var gZenCommonActions = {
   copyCurrentURLToClipboard() {
-    const currentUrl = gBrowser.currentURI.spec;
-    if (currentUrl) {
+    const currentTabs = gZenViewSplitter.getTabsInCurrentView()
+    if (currentTabs) {
+      const stringArray = currentTabs.map(t => `${t.linkedBrowser.currentURI.spec}`)
+      const markdownString = stringArray.join("\n")
       let str = Cc['@mozilla.org/supports-string;1'].createInstance(Ci.nsISupportsString);
-      str.data = currentUrl;
+      str.data = markdownString;
       let transferable = Cc['@mozilla.org/widget/transferable;1'].createInstance(Ci.nsITransferable);
       transferable.init(getLoadContext());
       transferable.addDataFlavor('text/plain');

--- a/src/browser/base/zen-components/ZenCommonUtils.mjs
+++ b/src/browser/base/zen-components/ZenCommonUtils.mjs
@@ -61,7 +61,7 @@ class ZenPreloadedFeature {
 var gZenCommonActions = {
   copyCurrentURLToClipboard() {
     let urlStringToCopy = "";
-    if (Services.prefs.getBoolPref('zen.keyboard.shortcuts.copy-all-tab-urls-in-view', false)) {
+    if (Services.prefs.getBoolPref('zen.keyboard.shortcuts.copy-current-url.copy-all-in-split-view', false)) {
       const currentTabs = gZenViewSplitter.getTabsInCurrentView();
       if (currentTabs) {
         const stringArray = currentTabs.map(t => `${t.linkedBrowser.currentURI.spec}`);
@@ -87,7 +87,7 @@ var gZenCommonActions = {
   },
   CopyCurrentURLAsMarkdownToClipboard() {
     let markdownString = "";
-    if (Services.prefs.getBoolPref('zen.keyboard.shortcuts.copy-all-tab-urls-in-view', false)) {
+    if (Services.prefs.getBoolPref('zen.keyboard.shortcuts.copy-current-url-as-markdown.copy-all-in-split-view', false)) {
       const currentTabs = gZenViewSplitter.getTabsInCurrentView();
       if (currentTabs) {
         const stringArray = currentTabs.map(t => `[${t.label}](${t.linkedBrowser.currentURI.spec})`);

--- a/src/browser/base/zen-components/ZenCommonUtils.mjs
+++ b/src/browser/base/zen-components/ZenCommonUtils.mjs
@@ -72,6 +72,21 @@ var gZenCommonActions = {
       ConfirmationHint.show(document.getElementById('PanelUI-menu-button'), 'zen-copy-current-url-confirmation');
     }
   },
+  CopyCurrentURLAsMarkdownToClipboard() {
+    const currentUrl = gBrowser.currentURI.spec;
+    const tabTitle = gBrowser.selectedTab.label;
+    if (currentUrl && tabTitle) {
+        const markdownLink = `[${tabTitle}](${currentUrl})`
+        let str = Cc['@mozilla.org/supports-string;1'].createInstance(Ci.nsISupportsString);
+        str.data = markdownLink;
+        let transferable = Cc['@mozilla.org/widget/transferable;1'].createInstance(Ci.nsITransferable);
+        transferable.init(getLoadContext());
+        transferable.addDataFlavor('text/plain');
+        transferable.setTransferData('text/plain', str);
+        Services.clipboard.setData(transferable, null, Ci.nsIClipboard.kGlobalClipboard);
+        ConfirmationHint.show(document.getElementById('PanelUI-menu-button'), 'zen-copy-current-url-confirmation');
+    }
+  },
 
   throttle(f, delay) {
     let timer = 0;

--- a/src/browser/base/zen-components/ZenCommonUtils.mjs
+++ b/src/browser/base/zen-components/ZenCommonUtils.mjs
@@ -60,12 +60,23 @@ class ZenPreloadedFeature {
 
 var gZenCommonActions = {
   copyCurrentURLToClipboard() {
-    const currentTabs = gZenViewSplitter.getTabsInCurrentView()
-    if (currentTabs) {
-      const stringArray = currentTabs.map(t => `${t.linkedBrowser.currentURI.spec}`)
-      const markdownString = stringArray.join("\n")
+    let urlStringToCopy = "";
+    if (Services.prefs.getBoolPref('zen.keyboard.shortcuts.copy-all-tab-urls-in-view', false)) {
+      const currentTabs = gZenViewSplitter.getTabsInCurrentView();
+      if (currentTabs) {
+        const stringArray = currentTabs.map(t => `${t.linkedBrowser.currentURI.spec}`);
+        urlStringToCopy = stringArray.join("\n");
+      }
+    } else {
+      const currentUrl = gBrowser.currentURI.spec;
+      if (currentUrl) {
+
+        urlStringToCopy = `${currentUrl}`
+      }
+    }
+    if (urlStringToCopy) {
       let str = Cc['@mozilla.org/supports-string;1'].createInstance(Ci.nsISupportsString);
-      str.data = markdownString;
+      str.data = urlStringToCopy;
       let transferable = Cc['@mozilla.org/widget/transferable;1'].createInstance(Ci.nsITransferable);
       transferable.init(getLoadContext());
       transferable.addDataFlavor('text/plain');
@@ -75,10 +86,21 @@ var gZenCommonActions = {
     }
   },
   CopyCurrentURLAsMarkdownToClipboard() {
-    const currentTabs = gZenViewSplitter.getTabsInCurrentView()
-    if (currentTabs) {
-      const stringArray = currentTabs.map(t => `[${t.label}](${t.linkedBrowser.currentURI.spec})`)
-      const markdownString = stringArray.join("\n")
+    let markdownString = "";
+    if (Services.prefs.getBoolPref('zen.keyboard.shortcuts.copy-all-tab-urls-in-view', false)) {
+      const currentTabs = gZenViewSplitter.getTabsInCurrentView();
+      if (currentTabs) {
+        const stringArray = currentTabs.map(t => `[${t.label}](${t.linkedBrowser.currentURI.spec})`);
+        markdownString = stringArray.join("\n");
+      }
+    } else {
+      const currentUrl = gBrowser.currentURI.spec;
+      const tabTitle = gBrowser.selectedTab.label;
+      if (currentUrl && tabTitle) {
+        markdownString = `[${tabTitle}](${currentUrl})`;
+      }
+    }
+    if (markdownString) {
       let str = Cc['@mozilla.org/supports-string;1'].createInstance(Ci.nsISupportsString);
       str.data = markdownString;
       let transferable = Cc['@mozilla.org/widget/transferable;1'].createInstance(Ci.nsITransferable);

--- a/src/browser/base/zen-components/ZenCommonUtils.mjs
+++ b/src/browser/base/zen-components/ZenCommonUtils.mjs
@@ -73,18 +73,18 @@ var gZenCommonActions = {
     }
   },
   CopyCurrentURLAsMarkdownToClipboard() {
-    const currentUrl = gBrowser.currentURI.spec;
-    const tabTitle = gBrowser.selectedTab.label;
-    if (currentUrl && tabTitle) {
-        const markdownLink = `[${tabTitle}](${currentUrl})`
-        let str = Cc['@mozilla.org/supports-string;1'].createInstance(Ci.nsISupportsString);
-        str.data = markdownLink;
-        let transferable = Cc['@mozilla.org/widget/transferable;1'].createInstance(Ci.nsITransferable);
-        transferable.init(getLoadContext());
-        transferable.addDataFlavor('text/plain');
-        transferable.setTransferData('text/plain', str);
-        Services.clipboard.setData(transferable, null, Ci.nsIClipboard.kGlobalClipboard);
-        ConfirmationHint.show(document.getElementById('PanelUI-menu-button'), 'zen-copy-current-url-confirmation');
+    const currentTabs = gZenViewSplitter.getTabsInCurrentView()
+    if (currentTabs) {
+      const stringArray = currentTabs.map(t => `[${t.label}](${t.linkedBrowser.currentURI.spec})`)
+      const markdownString = stringArray.join("\n")
+      let str = Cc['@mozilla.org/supports-string;1'].createInstance(Ci.nsISupportsString);
+      str.data = markdownString;
+      let transferable = Cc['@mozilla.org/widget/transferable;1'].createInstance(Ci.nsITransferable);
+      transferable.init(getLoadContext());
+      transferable.addDataFlavor('text/plain');
+      transferable.setTransferData('text/plain', str);
+      Services.clipboard.setData(transferable, null, Ci.nsIClipboard.kGlobalClipboard);
+      ConfirmationHint.show(document.getElementById('PanelUI-menu-button'), 'zen-copy-current-url-confirmation');
     }
   },
 

--- a/src/browser/base/zen-components/ZenKeyboardShortcuts.mjs
+++ b/src/browser/base/zen-components/ZenKeyboardShortcuts.mjs
@@ -909,19 +909,19 @@ class ZenKeyboardShortcutsVersioner {
       window.addEventListener('zen-devtools-keyset-added', listener);
     }
     if (version < 8) {
-        // Migrate from 7 to 8
-        // In this new version, we add the "Copy URL as Markdown" shortcut to the default shortcuts
-        data.push(
-            new KeyShortcut(
-                'zen-copy-url-markdown',
-                'C',
-                '',
-                ZEN_OTHER_SHORTCUTS_GROUP,
-                KeyShortcutModifiers.fromObject({ accel: true, shift: true, alt: true }),
-                'code:gZenCommonActions.CopyCurrentURLAsMarkdownToClipboard()',
-                'zen-text-action-copy-url-markdown-shortcut'
-              )
+      // Migrate from 7 to 8
+      // In this new version, we add the "Copy URL as Markdown" shortcut to the default shortcuts
+      data.push(
+        new KeyShortcut(
+          'zen-copy-url-markdown',
+          'C',
+          '',
+          ZEN_OTHER_SHORTCUTS_GROUP,
+          KeyShortcutModifiers.fromObject({ accel: true, shift: true, alt: true }),
+          'code:gZenCommonActions.CopyCurrentURLAsMarkdownToClipboard()',
+          'zen-text-action-copy-url-markdown-shortcut'
         )
+      )
     }
     return data;
   }

--- a/src/browser/base/zen-components/ZenKeyboardShortcuts.mjs
+++ b/src/browser/base/zen-components/ZenKeyboardShortcuts.mjs
@@ -80,6 +80,7 @@ const defaultKeyboardGroups = {
     'zen-search-find-again-shortcut-prev',
   ],
   pageOperations: [
+    'zen-text-action-copy-url-markdown-shortcut',
     'zen-text-action-copy-url-shortcut',
     'zen-location-open-shortcut',
     'zen-location-open-shortcut-alt',
@@ -755,7 +756,7 @@ class ZenKeyboardShortcutsLoader {
 }
 
 class ZenKeyboardShortcutsVersioner {
-  static LATEST_KBS_VERSION = 7;
+  static LATEST_KBS_VERSION = 8;
 
   constructor() {}
 
@@ -906,6 +907,21 @@ class ZenKeyboardShortcutsVersioner {
       // and we need to wait for it to be added.
       gZenKeyboardShortcutsManager._hasToLoadDefaultDevtools = true;
       window.addEventListener('zen-devtools-keyset-added', listener);
+    }
+    if (version < 8) {
+        // Migrate from 7 to 8
+        // In this new version, we add the "Copy URL as Markdown" shortcut to the default shortcuts
+        data.push(
+            new KeyShortcut(
+                'zen-copy-url-markdown',
+                'C',
+                '',
+                ZEN_OTHER_SHORTCUTS_GROUP,
+                KeyShortcutModifiers.fromObject({ accel: true, shift: true, alt: true }),
+                'code:gZenCommonActions.CopyCurrentURLAsMarkdownToClipboard()',
+                'zen-text-action-copy-url-markdown-shortcut'
+              )
+        )
     }
     return data;
   }

--- a/src/browser/base/zen-components/ZenViewSplitter.mjs
+++ b/src/browser/base/zen-components/ZenViewSplitter.mjs
@@ -1136,15 +1136,6 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
       : [gBrowser.selectedTab, tabs[nextTabIndex]];
     this.splitTabs(selected_tabs, gridType);
   }
-
-  /**
-   * Gets all the tabs in the current view.
-   * @returns {Tab[]} The tabs in the current view.
-   */
-  getTabsInCurrentView() {
-    if (this.currentView < 0) return [gBrowser.selectedTab];
-    return this._data[this.currentView].tabs;
-  }
 }
 
 window.gZenViewSplitter = new ZenViewSplitter();

--- a/src/browser/base/zen-components/ZenViewSplitter.mjs
+++ b/src/browser/base/zen-components/ZenViewSplitter.mjs
@@ -1136,6 +1136,15 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
       : [gBrowser.selectedTab, tabs[nextTabIndex]];
     this.splitTabs(selected_tabs, gridType);
   }
+
+  /**
+   * Gets all the tabs in the current view.
+   * @returns {Tab[]} The tabs in the current view.
+   */
+  getTabsInCurrentView() {
+    if (this.currentView < 0) return [gBrowser.selectedTab];
+    return this._data[this.currentView].tabs;
+  }
 }
 
 window.gZenViewSplitter = new ZenViewSplitter();


### PR DESCRIPTION
A copy URL shortcut a la Arc was recently added, but my preference "Copy URL as Markdown" wasn't! As a lot of people are currently moving over from Arc I thought it would be good to have this option as well.

I also updated both shortcuts to copy all urls in a split view.

Video demo:

https://github.com/user-attachments/assets/b6d3b44d-cfae-4c5d-aea5-a4657e6bcfb2

The default shortcut `CTRL` + `SHIFT` + `ALT` + `C` was chosen as that is the same shortcut used in Arc.
![image](https://github.com/user-attachments/assets/98596889-a440-47b7-8a4c-7ace080e6b04)

I choose not to add a specific notification string as Arc uses the same notification for both `Copy current tab URL` and `Copy current tab URL as Markdown`
![Arc_Ce23EqJBHe](https://github.com/user-attachments/assets/4c4b1c9d-6628-4b32-bc0e-f1d2363f110c)

This feature was discussed in #576 and https://github.com/zen-browser/desktop/discussions/794

Depends on: https://github.com/zen-browser/l10n-packs/pull/122