### PR TITLE
Preserve new lines in installed theme stylesheets

### DIFF
--- a/src/browser/base/zen-components/actors/ZenThemeMarketplaceParent.sys.mjs
+++ b/src/browser/base/zen-components/actors/ZenThemeMarketplaceParent.sys.mjs
@@ -122,10 +122,10 @@ export class ZenThemeMarketplaceParent extends JSWindowActorParent {
   }
 
   getStyleSheetFullContent(style = '') {
-    let stylesheet = '@-moz-document url-prefix("chrome:") {';
+    let stylesheet = '@-moz-document url-prefix("chrome:") {\n';
 
     for (const line of style.split('\n')) {
-      stylesheet += `  ${line}`;
+      stylesheet += `  ${line}\n`;
     }
 
     stylesheet += '}';


### PR DESCRIPTION
In ZenThemeMarketplaceParent.sys.mjs, we split on new lines but don't add any, so we end up with one long line with some crazy whitespace scattered around.

Given that we loop over each line and add a bit of indentation, I'm assuming we want to preserve the original new lines, so this short pull request just adds one \n per line, plus one for the new at rule.