### PR TITLE
updates link to build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Some components used by @zen-browser as an attempt to make firefox forks a bette
 
 #### `Run Locally`
 
-In order to download and run zen locally, please follow [these instructions](https://docs.zen-browser.app/contribute/desktop).
+In order to download and run zen locally, please follow [these instructions](https://docs.zen-browser.app/building).
 
 #### `Special Thanks`
 


### PR DESCRIPTION
one liner to fix a broken link in the readme. Looks like the linked page was removed [here](https://github.com/zen-browser/docs/commit/4fdf4cb9d02472114f1f5ee81900c3766b163732)

Let me know if you would prefer something different