### PR TITLE
Improve corner radius on windows for a more native and consistent look (very minor change, not tested)

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -102,11 +102,7 @@ pref('zen.rice.share.notice.accepted', false);
 #ifdef XP_MACOSX
 pref('zen.theme.border-radius', 10); // In pixels
 #else
-#ifdef XP_WIN
-pref('zen.theme.border-radius', 10); // In pixels
-#else
 pref('zen.theme.border-radius', 8); // In pixels
-#endif
 #endif
 
 pref('zen.theme.color-prefs.use-workspace-colors', true);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0100835e-9847-4596-b204-f7f5d8cb061f)
And apparently, the good-looking radius = the fallback radius. So be it, thus I simplified the entire conditional this way.