### PR TITLE
Keep URL bar open during IME composition to prevent URL bar disappearing

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -45,6 +45,7 @@ pref('browser.urlbar.weather.featureGate', true);
 pref('browser.urlbar.quickactions.enabled', true);
 pref('browser.urlbar.clipboard.featureGate', true);
 pref('browser.urlbar.suggest.calculator', true);
+pref('browser.urlbar.keepPanelOpenDuringImeComposition', true);
 
 // new tab page
 pref('browser.newtabpage.activity-stream.feeds.topsites', false);


### PR DESCRIPTION
This default configuration addresses #3692 and related issues by preventing the floating URL bar from disappearing when composing with IME.