### PR TITLE
Fix URL reset button for pinned tabs

### DIFF
--- a/src/browser/components/tabbrowser/content/tab-js.patch
+++ b/src/browser/components/tabbrowser/content/tab-js.patch
@@ -41,7 +41,7 @@ index d41c486c02a6f09dcff5741a59ad8b617294c481..abaccd1935fc117924c44dd22cae0b32
        }
 +
 +      if (event.target.classList.contains("tab-reset-button")) {
-+        gZenPinnedTabManager._onCloseTabShortcut(event, this, 'unload-switch');
++        gZenPinnedTabManager._onCloseTabShortcut(event, this);
 +        gBrowser.tabContainer._blockDblClick = true;
 +      }
      }


### PR DESCRIPTION
Fixed the reset button for pinned tabs where it would unload and switch tabs but not reset the pinned tab to its original URL, even when the correct setting was selected in settings. Now defaults to lazy fetch the preference set.

Originally: `gZenPinnedTabManager._onCloseTabShortcut(event, this, 'unload-switch');`
Now: `gZenPinnedTabManager._onCloseTabShortcut(event, this);`

Per the function signature, it should now get the correct behavior by not specifying a behavior
`_onCloseTabShortcut(event, selectedTab = gBrowser.selectedTab, behavior = lazy.zenPinnedTabCloseShortcutBehavior)`

Fixes https://github.com/zen-browser/desktop/issues/5276, https://github.com/zen-browser/desktop/issues/5114, https://github.com/zen-browser/desktop/issues/4754
