### PR TITLE
Fix text rendering issues by decreasing gfx.canvas.accelerated.cache-size back to Firefox default

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -425,7 +425,7 @@ pref("browser.aboutwelcome.enabled", false);
 
 // ---- Experimental settings to try make zen faster
 pref("gfx.canvas.accelerated.cache-items", 32768);
-pref("gfx.canvas.accelerated.cache-size", 4096);
+pref("gfx.canvas.accelerated.cache-size", 256);
 pref("gfx.content.skia-font-cache-size", 80);
 
 pref("media.memory_cache_max_size", 1048576);


### PR DESCRIPTION
Fixes #3541. This change is not tested as I do not experience the issue, but a large number of people have reported that changing the value manually works.