### PR TITLE
keep the "pinned" attribute of the side web panel and the button in sync

### DIFF
--- a/src/browser/base/content/zen-sidebar-panel.inc.xhtml
+++ b/src/browser/base/content/zen-sidebar-panel.inc.xhtml
@@ -10,7 +10,7 @@
       </hbox>
       <hbox>
         <toolbarbutton id="zen-sidebar-web-panel-home" class="toolbarbutton-1 chromeclass-toolbar-additional" oncommand="gZenBrowserManagerSidebar.home();"/>
-        <toolbarbutton id="zen-sidebar-web-panel-pinned" class="toolbarbutton-1 chromeclass-toolbar-additional" oncommand="gZenBrowserManagerSidebar.togglePinned(this);"/>
+        <toolbarbutton id="zen-sidebar-web-panel-pinned" class="toolbarbutton-1 chromeclass-toolbar-additional" pinned="true" oncommand="gZenBrowserManagerSidebar.togglePinned(this);"/>
         <toolbarbutton id="zen-sidebar-web-panel-close" class="toolbarbutton-1 chromeclass-toolbar-additional" oncommand="gZenBrowserManagerSidebar.close();"/>
       </hbox>
     </toolbar>

--- a/src/browser/base/zen-components/ZenSidebarManager.mjs
+++ b/src/browser/base/zen-components/ZenSidebarManager.mjs
@@ -33,6 +33,7 @@ class ZenBrowserManagerSidebar extends ZenDOMOperatedFeature {
     this.listenForPrefChanges();
     this.insertIntoContextMenu();
     this.addPositioningListeners();
+    this.syncPinnedState();
   }
 
   onlySafeWidthAndHeight() {
@@ -96,6 +97,17 @@ class ZenBrowserManagerSidebar extends ZenDOMOperatedFeature {
       .forEach((s) => s.addEventListener('mousedown', this.handleSplitterMouseDown.bind(this)));
     this.sidebarHeader.addEventListener('mousedown', this.handleDragPanel.bind(this));
     window.addEventListener('resize', this.onWindowResize.bind(this));
+  }
+
+  syncPinnedState() {
+    const sidebar = document.getElementById('zen-sidebar-web-panel');
+    const pinButton = document.getElementById('zen-sidebar-web-panel-pinned');
+    
+    if (sidebar.hasAttribute('pinned')) {
+      pinButton.setAttribute('pinned', 'true');
+    } else {
+      pinButton.removeAttribute('pinned');
+    }
   }
 
   handleSplitterMouseDown(mouseDownEvent) {


### PR DESCRIPTION
I just added `pinned="true"` attribute to web panel pin icon, so that its initial state matches with the panel state.
Also added a function to keep the pinned state of the side web panel and the button in sync.  

**fixes:** #4322 