### PR TITLE
Fix: Update pinned tab title in storage on rename

### DIFF
--- a/src/browser/base/content/ZenUIManager.mjs
+++ b/src/browser/base/content/ZenUIManager.mjs
@@ -681,10 +681,9 @@ var gZenVerticalTabsManager = {
       } else {
         gBrowser.setTabTitle(this._tabEdited);
       }
-      const pinId = this._tabEdited.getAttribute('zen-pin-id');
-      if (pinId) {
+      if (this._tabEdited.getAttribute('zen-pin-id')) {
         // Update pin title in storage
-        await ZenPinnedTabsStorage.updatePinTitle(pinId, this._tabEdited.label);
+        await gZenPinnedTabManager.updatePinTitle(this._tabEdited, this._tabEdited.label, !!newName);
       }
 
       // Maybe add some confetti here?!?

--- a/src/browser/base/content/ZenUIManager.mjs
+++ b/src/browser/base/content/ZenUIManager.mjs
@@ -665,7 +665,7 @@ var gZenVerticalTabsManager = {
     target.appendChild(child);
   },
 
-  renameTabKeydown(event) {
+  async renameTabKeydown(event) {
     if (event.key === 'Enter') {
       let label = this._tabEdited.querySelector('.tab-label-container-editing');
       let input = this._tabEdited.querySelector('#tab-label-input');
@@ -680,6 +680,11 @@ var gZenVerticalTabsManager = {
         this._tabEdited.setAttribute('zen-has-static-label', 'true');
       } else {
         gBrowser.setTabTitle(this._tabEdited);
+      }
+      const pinId = this._tabEdited.getAttribute('zen-pin-id');
+      if (pinId) {
+        // Update pin title in storage
+        await ZenPinnedTabsStorage.updatePinTitle(pinId, this._tabEdited.label);
       }
 
       // Maybe add some confetti here?!?

--- a/src/browser/base/zen-components/ZenPinnedTabsStorage.mjs
+++ b/src/browser/base/zen-components/ZenPinnedTabsStorage.mjs
@@ -24,6 +24,19 @@ var ZenPinnedTabsStorage = {
           )
       `);
 
+      const columns = await db.execute(`PRAGMA table_info(zen_pins)`);
+      const columnNames = columns.map((row) => row.getResultByName('name'));
+
+      // Helper function to add column if it doesn't exist
+      const addColumnIfNotExists = async (columnName, definition) => {
+        if (!columnNames.includes(columnName)) {
+          await db.execute(`ALTER TABLE zen_pins ADD COLUMN ${columnName} ${definition}`);
+        }
+      };
+
+      // Add edited_title column if it doesn't exist
+      await addColumnIfNotExists('edited_title', 'BOOLEAN NOT NULL DEFAULT 0');
+
       // Create indices
       await db.execute(`
         CREATE INDEX IF NOT EXISTS idx_zen_pins_uuid ON zen_pins(uuid)
@@ -152,6 +165,7 @@ var ZenPinnedTabsStorage = {
       isEssential: Boolean(row.getResultByName('is_essential')),
       isGroup: Boolean(row.getResultByName('is_group')),
       parentUuid: row.getResultByName('parent_uuid'),
+      editedTitle: Boolean(row.getResultByName('edited_title')),
     }));
   },
 
@@ -176,6 +190,7 @@ var ZenPinnedTabsStorage = {
       isEssential: Boolean(row.getResultByName('is_essential')),
       isGroup: Boolean(row.getResultByName('is_group')),
       parentUuid: row.getResultByName('parent_uuid'),
+      editedTitle: Boolean(row.getResultByName('edited_title')),
     }));
   },
 
@@ -351,7 +366,7 @@ var ZenPinnedTabsStorage = {
     this._notifyPinsChanged('zen-pin-updated', Array.from(changedUUIDs));
   },
 
-  async updatePinTitle(uuid, newTitle, notifyObservers = true) {
+  async updatePinTitle(uuid, newTitle, isEdited = true, notifyObservers = true) {
     if (!uuid || typeof newTitle !== 'string') {
       throw new Error('Invalid parameters: uuid and newTitle are required');
     }
@@ -362,17 +377,19 @@ var ZenPinnedTabsStorage = {
       await db.executeTransaction(async () => {
         const now = Date.now();
 
-        // Update the pin's title
+        // Update the pin's title and edited_title flag
         const result = await db.execute(
           `
             UPDATE zen_pins
             SET title = :newTitle,
+                edited_title = :isEdited,
                 updated_at = :now
             WHERE uuid = :uuid
           `,
           {
             uuid,
             newTitle,
+            isEdited,
             now,
           }
         );

--- a/src/browser/base/zen-components/ZenWorkspaces.mjs
+++ b/src/browser/base/zen-components/ZenWorkspaces.mjs
@@ -154,7 +154,7 @@ var ZenWorkspaces = new (class extends ZenMultiWindowFeature {
   }
 
   get tabboxChildren() {
-    return this.activeWorkspaceStrip.children;
+    return this.activeWorkspaceStrip?.children || [];
   }
 
   get pinnedTabsContainer() {


### PR DESCRIPTION
This PR addresses an issue where renaming a pinned tab wouldn't update the title stored in `ZenPinnedTabsStorage`.

The following changes were made:

- Modified `ZenUIManager.mjs` to asynchronously call `ZenPinnedTabsStorage.updatePinTitle` when a tab is renamed via the keyboard. This ensures the stored title is synchronized with the displayed title.
- Added the `updatePinTitle` function to `ZenPinnedTabsStorage.mjs`. This function updates the title of a zen pin within the database.

This ensures consistency between the tab title displayed in the UI and the title stored for pinned tabs.