### PR TITLE
Better aligment for the texture input

### DIFF
--- a/src/browser/base/content/zen-styles/zen-gradient-generator.css
+++ b/src/browser/base/content/zen-styles/zen-gradient-generator.css
@@ -60,6 +60,8 @@
     font-weight: 600;
   }
 
+  align-items: end;
+
   gap: 10px;
 }
 
@@ -156,6 +158,10 @@
     border-radius: 999px;
     height: 6px;
   }
+}
+
+#PanelUI-zen-gradient-generator-texture {
+  width: 100%;
 }
 
 .zen-theme-picker-gradient {


### PR DESCRIPTION
it was weirdly floating and overflows from the menu like this:
![Image](https://github.com/user-attachments/assets/98a60510-2137-47ef-bf4a-acffca046dc8)
Now it looks like this:
![Image](https://github.com/user-attachments/assets/9b61b467-6914-4ca1-a39e-557ed65c6e4f)

I would rather adding the old "Texture" label actually, but i saw that it was purposely deleted so i just aligned it.