### PR TITLE
Finish the "Show sidebar on hover" PR

### DIFF
--- a/src/browser/base/content/zen-styles/zen-compact-mode.css
+++ b/src/browser/base/content/zen-styles/zen-compact-mode.css
@@ -113,7 +113,6 @@
       }
     }
 
-    #navigator-toolbox:hover,
     #navigator-toolbox[zen-has-hover],
     #navigator-toolbox[zen-user-show],
     #navigator-toolbox[flash-popup],
@@ -303,7 +302,6 @@
         }
       }
 
-      & #zen-appcontent-navbar-container:hover,
       & #zen-appcontent-navbar-container[zen-has-hover],
       & #zen-appcontent-navbar-container:focus-within,
       & #zen-appcontent-navbar-container[zen-user-show],


### PR DESCRIPTION
In #4792 I made the `zen-has-hover` property be added to the sidebar and toolbar only if `zen.view.compact.show-sidebar-and-toolbar-on-hover` is true.

There was an oversight, though. The animation for the sidebar and toolbar was being triggered both by `zen-has-hover` and `hover`, like this

```css
#navigator-toolbox:hover,
#navigator-toolbox[zen-has-hover],
```

This meant that `:hover` was overriding `[zen-has-hover]`.

This PR makes both bars depend on `zen-has-hover` and removes `hover`.


I have tested this with the Browser Toolbox and it works perfectly :)