### PR TITLE
Update Contribution Guidelines Branch Structure

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -13,7 +13,7 @@ dev (main branch)
  \-<- (features branches)
 ```
 
-The `central` branch is the main branch of the repository, and it is the default branch for the repository. The `twilight` branch is the feature branch, and it is branched off from the `central` branch. The `stable` branch is the release branch, and it is branched off from the `central` branch.
+The `dev` branch is the main branch of the repository, and it is the default branch for the repository. The `twilight` branch is the feature branch, and it is branched off from the `dev` branch. The `stable` branch is the release branch, and it is branched off from the `dev` branch.
 
 The `stable` branch may have hotfixes directly from the `stable` branch, and the `twilight` branch may have feature branches branched off from the `twilight` branch. This is done so that we can apply hotfixes like security patches directly to the `stable` branch without having to merge the changes from the `twilight` branch.
 


### PR DESCRIPTION
Unless I'm understanding this wrong, the `central` branch is actually called the `dev` branch. Therefore I updated the branch structure to reflect this.