### PR TITLE
Use user's prefered search engine as private search by default

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -376,6 +376,7 @@ pref('widget.macos.titlebar-blend-mode.behind-window', true);
 pref("browser.urlbar.maxRichResults", 6);
 pref("browser.urlbar.trimHttps", true);
 pref("browser.search.separatePrivateDefault.ui.enabled", true);
+pref("browser.search.separatePrivateDefault", false);
 pref("browser.urlbar.update2.engineAliasRefresh", true);
 pref("browser.search.suggest.enabled", false);
 pref("browser.urlbar.quicksuggest.enabled", false);


### PR DESCRIPTION
When going through setup if ddg is selected as preferred search engine private windows will still use google before this change. After this the "Use this search engine in Private Windows" checkbox will be toggled on by default, so the user's choice of search engine on the setup screen will be respected in private windows.