### PR TITLE
Enhance tab grouping functionality

### DIFF
--- a/src/browser/base/content/zen-styles/zen-tabs.css
+++ b/src/browser/base/content/zen-styles/zen-tabs.css
@@ -17,3 +17,40 @@
     display: none !important;
   }
 }
+
+/* Styles for tab grouping */
+.tab-group {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--tab-group-border-color, #ccc);
+  border-radius: var(--tab-group-border-radius, 4px);
+  margin: var(--tab-group-margin, 4px);
+  padding: var(--tab-group-padding, 4px);
+}
+
+.tab-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: var(--tab-group-header-bg-color, #f0f0f0);
+  padding: var(--tab-group-header-padding, 4px);
+  border-bottom: 1px solid var(--tab-group-header-border-color, #ccc);
+}
+
+.tab-group-title {
+  font-weight: bold;
+  font-size: var(--tab-group-title-font-size, 14px);
+}
+
+.tab-group-close-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--tab-group-close-button-padding, 4px);
+}
+
+.tab-group-content {
+  display: flex;
+  flex-direction: column;
+  padding: var(--tab-group-content-padding, 4px);
+}

--- a/src/browser/base/content/zen-styles/zen-tabs/horizontal-tabs.css
+++ b/src/browser/base/content/zen-styles/zen-tabs/horizontal-tabs.css
@@ -333,3 +333,46 @@
     }
   }
 }
+
+/* Styles for tab grouping */
+.tab-group {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--tab-group-border-color, #ccc);
+  border-radius: var(--tab-group-border-radius, 4px);
+  margin: var(--tab-group-margin, 4px);
+  padding: var(--tab-group-padding, 4px);
+}
+
+.tab-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: var(--tab-group-header-bg-color, #f0f0f0);
+  padding: var(--tab-group-header-padding, 4px);
+  border-bottom: 1px solid var(--tab-group-header-border-color, #ccc);
+}
+
+.tab-group-title {
+  font-weight: bold;
+  font-size: var(--tab-group-title-font-size, 14px);
+}
+
+.tab-group-close-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--tab-group-close-button-padding, 4px);
+}
+
+.tab-group-content {
+  display: flex;
+  flex-direction: column;
+  padding: var(--tab-group-content-padding, 4px);
+}
+
+/* Styles for permanent tab groups */
+.tab-group[permanent="true"] {
+  border: 2px solid var(--tab-group-permanent-border-color, #000);
+  background-color: var(--tab-group-permanent-bg-color, #e0e0e0);
+}

--- a/src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css
+++ b/src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css
@@ -1262,3 +1262,46 @@
   transform: translateX(-100%);
   min-width: 100%;
 }
+
+/* Styles for tab grouping */
+.tab-group {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--tab-group-border-color, #ccc);
+  border-radius: var(--tab-group-border-radius, 4px);
+  margin: var(--tab-group-margin, 4px);
+  padding: var(--tab-group-padding, 4px);
+}
+
+.tab-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: var(--tab-group-header-bg-color, #f0f0f0);
+  padding: var(--tab-group-header-padding, 4px);
+  border-bottom: 1px solid var(--tab-group-header-border-color, #ccc);
+}
+
+.tab-group-title {
+  font-weight: bold;
+  font-size: var(--tab-group-title-font-size, 14px);
+}
+
+.tab-group-close-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--tab-group-close-button-padding, 4px);
+}
+
+.tab-group-content {
+  display: flex;
+  flex-direction: column;
+  padding: var(--tab-group-content-padding, 4px);
+}
+
+/* Styles for permanent tab groups */
+.tab-group[permanent="true"] {
+  border: 2px solid var(--tab-group-permanent-border-color, #000);
+  background-color: var(--tab-group-permanent-bg-color, #e0e0e0);
+}

--- a/src/browser/components/tabbrowser/content/tabbrowser.js
+++ b/src/browser/components/tabbrowser/content/tabbrowser.js
@@ -1,0 +1,128 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+class TabGroup {
+  constructor(title, permanent = false) {
+    this.title = title;
+    this.permanent = permanent;
+    this.tabs = [];
+  }
+
+  addTab(tab) {
+    this.tabs.push(tab);
+  }
+
+  removeTab(tab) {
+    const index = this.tabs.indexOf(tab);
+    if (index > -1) {
+      this.tabs.splice(index, 1);
+    }
+  }
+
+  isEmpty() {
+    return this.tabs.length === 0;
+  }
+}
+
+class TabGroupManager {
+  constructor() {
+    this.groups = [];
+  }
+
+  createGroup(title, permanent = false) {
+    const group = new TabGroup(title, permanent);
+    this.groups.push(group);
+    return group;
+  }
+
+  removeGroup(group) {
+    const index = this.groups.indexOf(group);
+    if (index > -1) {
+      this.groups.splice(index, 1);
+    }
+  }
+
+  getGroupByTitle(title) {
+    return this.groups.find(group => group.title === title);
+  }
+
+  getGroupByTab(tab) {
+    return this.groups.find(group => group.tabs.includes(tab));
+  }
+
+  arrangeGroups(newOrder) {
+    this.groups = newOrder;
+  }
+}
+
+const tabGroupManager = new TabGroupManager();
+
+class Tabbrowser {
+  constructor() {
+    this.tabs = [];
+    this.selectedTab = null;
+  }
+
+  addTab(tab, groupTitle = null) {
+    this.tabs.push(tab);
+    if (groupTitle) {
+      const group = tabGroupManager.getGroupByTitle(groupTitle);
+      if (group) {
+        group.addTab(tab);
+      } else {
+        const newGroup = tabGroupManager.createGroup(groupTitle);
+        newGroup.addTab(tab);
+      }
+    }
+  }
+
+  removeTab(tab) {
+    const group = tabGroupManager.getGroupByTab(tab);
+    if (group) {
+      group.removeTab(tab);
+      if (group.isEmpty() && !group.permanent) {
+        tabGroupManager.removeGroup(group);
+      }
+    }
+    const index = this.tabs.indexOf(tab);
+    if (index > -1) {
+      this.tabs.splice(index, 1);
+    }
+  }
+
+  createNewTab(groupTitle = null) {
+    const newTab = {}; // Placeholder for actual tab creation logic
+    this.addTab(newTab, groupTitle);
+    return newTab;
+  }
+
+  pinTab(tab, groupTitle = null) {
+    tab.pinned = true;
+    if (groupTitle) {
+      const group = tabGroupManager.getGroupByTitle(groupTitle);
+      if (group) {
+        group.addTab(tab);
+      } else {
+        const newGroup = tabGroupManager.createGroup(groupTitle);
+        newGroup.addTab(tab);
+      }
+    }
+  }
+
+  unpinTab(tab) {
+    tab.pinned = false;
+    const group = tabGroupManager.getGroupByTab(tab);
+    if (group) {
+      group.removeTab(tab);
+    }
+  }
+
+  arrangeGroups(newOrder) {
+    tabGroupManager.arrangeGroups(newOrder);
+  }
+}
+
+const tabbrowser = new Tabbrowser();

--- a/src/browser/components/tabbrowser/content/tabs.js
+++ b/src/browser/components/tabbrowser/content/tabs.js
@@ -1,0 +1,128 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+class TabGroup {
+  constructor(title, permanent = false) {
+    this.title = title;
+    this.permanent = permanent;
+    this.tabs = [];
+  }
+
+  addTab(tab) {
+    this.tabs.push(tab);
+  }
+
+  removeTab(tab) {
+    const index = this.tabs.indexOf(tab);
+    if (index > -1) {
+      this.tabs.splice(index, 1);
+    }
+  }
+
+  isEmpty() {
+    return this.tabs.length === 0;
+  }
+}
+
+class TabGroupManager {
+  constructor() {
+    this.groups = [];
+  }
+
+  createGroup(title, permanent = false) {
+    const group = new TabGroup(title, permanent);
+    this.groups.push(group);
+    return group;
+  }
+
+  removeGroup(group) {
+    const index = this.groups.indexOf(group);
+    if (index > -1) {
+      this.groups.splice(index, 1);
+    }
+  }
+
+  getGroupByTitle(title) {
+    return this.groups.find(group => group.title === title);
+  }
+
+  getGroupByTab(tab) {
+    return this.groups.find(group => group.tabs.includes(tab));
+  }
+
+  arrangeGroups(newOrder) {
+    this.groups = newOrder;
+  }
+}
+
+const tabGroupManager = new TabGroupManager();
+
+class Tabbrowser {
+  constructor() {
+    this.tabs = [];
+    this.selectedTab = null;
+  }
+
+  addTab(tab, groupTitle = null) {
+    this.tabs.push(tab);
+    if (groupTitle) {
+      const group = tabGroupManager.getGroupByTitle(groupTitle);
+      if (group) {
+        group.addTab(tab);
+      } else {
+        const newGroup = tabGroupManager.createGroup(groupTitle);
+        newGroup.addTab(tab);
+      }
+    }
+  }
+
+  removeTab(tab) {
+    const group = tabGroupManager.getGroupByTab(tab);
+    if (group) {
+      group.removeTab(tab);
+      if (group.isEmpty() && !group.permanent) {
+        tabGroupManager.removeGroup(group);
+      }
+    }
+    const index = this.tabs.indexOf(tab);
+    if (index > -1) {
+      this.tabs.splice(index, 1);
+    }
+  }
+
+  createNewTab(groupTitle = null) {
+    const newTab = {}; // Placeholder for actual tab creation logic
+    this.addTab(newTab, groupTitle);
+    return newTab;
+  }
+
+  pinTab(tab, groupTitle = null) {
+    tab.pinned = true;
+    if (groupTitle) {
+      const group = tabGroupManager.getGroupByTitle(groupTitle);
+      if (group) {
+        group.addTab(tab);
+      } else {
+        const newGroup = tabGroupManager.createGroup(groupTitle);
+        newGroup.addTab(tab);
+      }
+    }
+  }
+
+  unpinTab(tab) {
+    tab.pinned = false;
+    const group = tabGroupManager.getGroupByTab(tab);
+    if (group) {
+      group.removeTab(tab);
+    }
+  }
+
+  arrangeGroups(newOrder) {
+    tabGroupManager.arrangeGroups(newOrder);
+  }
+}
+
+const tabbrowser = new Tabbrowser();


### PR DESCRIPTION
Add support for tab grouping and customization in the tab bar.

* **Styles for Tab Grouping:**
  - Add styles for tab grouping in `src/browser/base/content/zen-styles/zen-tabs.css`, `src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css`, and `src/browser/base/content/zen-styles/zen-tabs/horizontal-tabs.css`.
  - Include styles for tab group headers, titles, close buttons, and content.
  - Add styles for permanent tab groups in `src/browser/base/content/zen-styles/zen-tabs/vertical-tabs.css` and `src/browser/base/content/zen-styles/zen-tabs/horizontal-tabs.css`.

* **Tab Group Management:**
  - Add `tabbrowser.js` and `tabs.js` to handle tab group creation, removal, and management.
  - Implement logic for permanent tab groups, logical tab creation within groups, arranging tab groups, and pinning tabs inside groups.


One important thing to mention:
This was not tested on my machine or any other

"Why didn't you test it before sending this PR?"

Answer: Well, I tried to build Zen Browser on my machine,

but it almost exploded when I did that and it wouldn't even start, it kept compiling endlessly and my card almost fried, so I gave up on doing it and I'm doing it without checking the browser

Otherwise, feel free to just reject the PR, since I didn't test it because I don't run or build it on my machine or someone gets the changes I'm sending in this PR to see if the functionality is working as expected

Cheers to everyone ;)

