### PR TITLE
Allow having full url without https in sidebar

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -120,6 +120,7 @@ pref('zen.view.compact.show-sidebar-and-toolbar-on-hover', true);
 pref('zen.urlbar.replace-newtab', true);
 pref('zen.urlbar.behavior', 'floating-on-type'); // default, floating-on-type, float
 pref('zen.urlbar.wait-to-clear', 45000); // in ms (default 45s)
+pref('zen.urlbar.show-domain-only-in-sidebar', true);
 
 #ifdef XP_MACOSX
 // Disable for macos in the meantime until @HarryHeres finds a solution for hight DPI screens

--- a/src/browser/base/content/ZenUIManager.mjs
+++ b/src/browser/base/content/ZenUIManager.mjs
@@ -9,6 +9,7 @@ var gZenUIManager = {
     XPCOMUtils.defineLazyPreferenceGetter(this, 'sidebarHeightThrottle', 'zen.view.sidebar-height-throttle', 500);
     XPCOMUtils.defineLazyPreferenceGetter(this, 'contentElementSeparation', 'zen.theme.content-element-separation', 0);
     XPCOMUtils.defineLazyPreferenceGetter(this, 'urlbarWaitToClear', 'zen.urlbar.wait-to-clear', 0);
+    XPCOMUtils.defineLazyPreferenceGetter(this, 'urlbarShowDomainOnly', 'zen.urlbar.show-domain-only-in-sidebar', true);
 
     gURLBar._zenTrimURL = this.urlbarTrim.bind(this);
 
@@ -218,7 +219,7 @@ var gZenUIManager = {
   },
 
   urlbarTrim(aURL) {
-    if (gZenVerticalTabsManager._hasSetSingleToolbar) {
+    if (gZenVerticalTabsManager._hasSetSingleToolbar && this.urlbarShowDomainOnly) {
       let url = BrowserUIUtils.removeSingleTrailingSlashFromURL(aURL);
       return url.startsWith('https://') ? url.split('/')[2] : url;
     }


### PR DESCRIPTION
Before a certain update, the urlbar would show the full url without https. This is no longer possible. 

Before:
![416575944-ff6ec01e-0632-430d-979d-599482a57231](https://github.com/user-attachments/assets/2a11f657-fd5f-4144-ad6b-90afa387baa2)

Now with "trimURLS disabled and trimHTTPS enabled":
![417371889-96467bed-6e4e-47f8-8651-3872200f76fc](https://github.com/user-attachments/assets/0b6bf5a9-82b0-4ed6-bc71-b9f5a078dbf8)

Having https:// in front of the url is a waste of space, that's why I propose an additional flag that returns the old behavior. To the best of my knowledge, the changes in this pull request will fix this, but I could not manage to build the browser and test.

With this new flag disabled and trimURLS enabled, the behavior should return to the old look.


