### PR TITLE
fix crash on sleep by switching appimage runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -384,6 +384,8 @@ jobs:
       - name: Execute AppImage build
         run: |
           set -eux
+          export ARCH=${{ matrix.arch }}
+          UPINFO="gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|desktop|latest|zen-$ARCH.AppImage.zsync"
           rm AppDir/.DirIcon || true
           cp configs/branding/${{ inputs.update_branch }}/logo128.png AppDir/usr/share/icons/hicolor/128x128/apps/zen.png
           cp configs/branding/${{ inputs.update_branch }}/logo128.png AppDir/zen.png && ln -s zen.png AppDir/.DirIcon
@@ -396,18 +398,23 @@ jobs:
           APPDIR=AppDir
           tar -xvf *.tar.* && rm -rf *.tar.*
           mv zen/* $APPDIR/
-          wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+          wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+          wget "https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-squashfs-lite-$ARCH"
           chmod +x *.AppImage
+          chmod +x ./uruntime-appimage-squashfs-lite-"$ARCH"
           chmod +x ./AppDir/AppRun
+
+          # keep the uruntime mountpoint (massively speeds up launch time)
+          sed -i 's|URUNTIME_MOUNT=[0-9]|URUNTIME_MOUNT=0|' ./uruntime-appimage-squashfs-lite-"$ARCH"
+
           echo "AppDir: $APPDIR"
           ls -al
           find .
           ls -al "$APPDIR"
-          ARCH=${{ matrix.arch }} ./appimagetool-x86_64.AppImage --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 10 \
-          -u "gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|desktop|latest|zen-${{ matrix.arch }}.AppImage.zsync" \
-          "$APPDIR" zen-${{ matrix.arch }}.AppImage
+          ./appimagetool-x86_64.AppImage -u "$UPINFO" "$APPDIR" zen-"$ARCH".AppImage --runtime-file ./uruntime-appimage-squashfs-lite-"$ARCH"
           mkdir dist
           mv zen*AppImage* dist/.
+          unset ARCH
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes #4089 #3732 #4457

The [uruntime](https://github.com/VHSgunzo/uruntime) is an alternative appimage runtime written in rust, it does not have the current bug that causes a crash on sleep, and it is fully 100% compliant to the appimage spec, including being static-pie which is not actually mentioned in the spec but needed for appimagelauncher to work.

It also has editable settings in the ELF that can change the mount behaviour, one of such is keeping the mount point, which means the appimage has launch times as fast as if it was a native application, for benchmarks see https://github.com/psadi/ghostty-appimage/pull/54

Review carefully please, I ran all the commands manually on my PC to make sure I had no errors in the steps but I can't be 100% sure without running the actual CI. 

* I also did a slight refactor by declaring `ARCH=${{ matrix.arch }}` this way it is easy to read and there is no need to specify the arch when calling appimagetool, also moved the update information to its own variable to make it easier to read as well. 

* Also removed the manual `--comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 10` flags since they were added to speed up the launch time slightly before by not going too high on the compression level, which isn't needed anymore, appimagetool defaults to zstd 15 when not specified. 