### PR TITLE
remove unnecessary declaration of several variables

### DIFF
--- a/AppDir/AppRun
+++ b/AppDir/AppRun
@@ -1,15 +1,6 @@
 #!/bin/sh
-SELF=$(readlink -f "$0")
-HERE=${SELF%/*}
-export PATH="${HERE}:${HERE}/usr/bin/:${HERE}/usr/sbin/:${HERE}/usr/games/:${HERE}/bin/:${HERE}/sbin/${PATH:+:$PATH}"
-export LD_LIBRARY_PATH="${HERE}/usr/lib/:${HERE}/usr/lib/i386-linux-gnu/:${HERE}/usr/lib/x86_64-linux-gnu/:${HERE}/usr/lib32/:${HERE}/usr/lib64/:${HERE}/lib/:${HERE}/lib/i386-linux-gnu/:${HERE}/lib/x86_64-linux-gnu/:${HERE}/lib32/:${HERE}/lib64/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-export PYTHONPATH="${HERE}/usr/share/pyshared/${PYTHONPATH:+:$PYTHONPATH}"
+CURRENTDIR="$(dirname "$(readlink -f "$0")")"
+export PATH="${CURRENTDIR}:${PATH}"
 export MOZ_LEGACY_PROFILES=1 # Prevent per installation profiles
-DEFAULT_XDG_DATA_DIRS='./share/:/usr/share/gnome:/usr/local/share/:/usr/share/'
-export XDG_DATA_DIRS="${HERE}/usr/share/:${XDG_DATA_DIRS:-$DEFAULT_XDG_DATA_DIRS}"
-export PERLLIB="${HERE}/usr/share/perl5/:${HERE}/usr/lib/perl5/${PERLLIB:+:$PERLLIB}"
-export GSETTINGS_SCHEMA_DIR="${HERE}/usr/share/glib-2.0/schemas/${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}"
-export MOZ_APP_LAUNCHER="${APPIMAGE}"
-export QT_PLUGIN_PATH="${HERE}/usr/lib/qt4/plugins/:${HERE}/usr/lib/i386-linux-gnu/qt4/plugins/:${HERE}/usr/lib/x86_64-linux-gnu/qt4/plugins/:${HERE}/usr/lib32/qt4/plugins/:${HERE}/usr/lib64/qt4/plugins/:${HERE}/usr/lib/qt5/plugins/:${HERE}/usr/lib/i386-linux-gnu/qt5/plugins/:${HERE}/usr/lib/x86_64-linux-gnu/qt5/plugins/:${HERE}/usr/lib32/qt5/plugins/:${HERE}/usr/lib64/qt5/plugins/${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}"
-EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2 | cut -d " " -f 1)
-exec "${EXEC}" "$@"
+export MOZ_APP_LAUNCHER="${APPIMAGE}" # Allows setting as default browser
+exec "${CURRENTDIR}/zen" "$@"


### PR DESCRIPTION
Likely fixes #2748

The reason is that the AppRun is setting a lot of env variables that don't need to be set. More importantly it is setting `LD_LIBRARY_PATH` which would make everything being launched by the browser try the libraries in the AppImage first, which likely causes that issue with `xdg-open` since env variables are inhereted by child processes. 

See https://github.com/pkgforge-dev/Citron-AppImage/issues/3 for an example of such issue.

Since the AppImage is already based off the portable tar build. there is no need to  be setting those env variables, since the binary already knows to look for the libraries bundled with it.

Another change is that the `AppRun` will not look into the `.desktop` to find the name of the zen binary, since it is always going to be zen right?

If there are plans for the binary name to change in the future let me know, that way I can revert that change. 