### PR TITLE
Pass new tab URL to Zen `selectEmptyTab`

### DIFF
--- a/src/browser/base/content/ZenUIManager.mjs
+++ b/src/browser/base/content/ZenUIManager.mjs
@@ -620,9 +620,9 @@ var gZenVerticalTabsManager = {
       }
 
       gZenCompactModeManager.updateCompactModeContext(isSingleToolbar);
-      document.getElementById("urlbar").removeAttribute('--urlbar-height');
+      document.getElementById('urlbar').removeAttribute('--urlbar-height');
       if (!isSingleToolbar) {
-        document.getElementById("urlbar").style.setProperty('--urlbar-height', '32px');
+        document.getElementById('urlbar').style.setProperty('--urlbar-height', '32px');
       } else {
         gURLBar.updateLayoutBreakout();
       }

--- a/src/browser/base/zen-components/ZenWorkspaces.mjs
+++ b/src/browser/base/zen-components/ZenWorkspaces.mjs
@@ -111,12 +111,13 @@ var ZenWorkspaces = new (class extends ZenMultiWindowFeature {
     );
   }
 
-  selectEmptyTab() {
+  selectEmptyTab(newTabTarget = null) {
     if (this._emptyTab && gZenVerticalTabsManager._canReplaceNewTab) {
       gBrowser.selectedTab = this._emptyTab;
       return this._emptyTab;
     }
-    let tab = gZenUIManager.openAndChangeToTab(Services.prefs.getStringPref('browser.startup.homepage'));
+    const newTabUrl = newTabTarget || Services.prefs.getStringPref('browser.startup.homepage');
+    let tab = gZenUIManager.openAndChangeToTab(newTabUrl);
     if (window.uuid) {
       tab.setAttribute('zen-workspace-id', this.activeWorkspace);
     }

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabbrowser.js b/browser/components/tabbrowser/content/tabbrowser.js
-index 628aa6596627c85efe361fc1ece8fd58f7ee653e..c62727bad57eda3b9d9a73c1df739a92f194f0c2 100644
+index 628aa6596627c85efe361fc1ece8fd58f7ee653e..6bd5149f4be6c18cbf733b5b9ee01534af61bef9 100644
 --- a/browser/components/tabbrowser/content/tabbrowser.js
 +++ b/browser/components/tabbrowser/content/tabbrowser.js
 @@ -412,11 +412,50 @@
@@ -476,7 +476,7 @@ index 628aa6596627c85efe361fc1ece8fd58f7ee653e..c62727bad57eda3b9d9a73c1df739a92
 -        this.addTrustedTab(BROWSER_NEW_TAB_URL, {
 -          skipAnimation: true,
 -        });
-+        ZenWorkspaces.selectEmptyTab();
++        ZenWorkspaces.selectEmptyTab(BROWSER_NEW_TAB_URL);
        } else {
          TabBarVisibility.update();
        }


### PR DESCRIPTION
This will ensure private browsing mode to not open the standard new tab.

Untested since I still can't build the browser locally.

Fix #6182 #5855 