### PR TITLE
Restore AI chat settings default while keeping shortcuts disabled

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -438,11 +438,7 @@ pref("browser.preferences.moreFromMozilla", false, locked);
 pref("browser.aboutwelcome.enabled", false);
 
 // AI/ML stuff
-pref("browser.ml.chat.enabled", false);
 pref("browser.ml.chat.shortcuts", false);
-pref("browser.ml.chat.shortcuts.custom", false);
-pref("browser.ml.chat.sidebar", false);
-pref("browser.ml.enable", false);
 
 // ---- Experimental settings to try make zen faster
 pref("gfx.canvas.accelerated.cache-items", 32768);


### PR DESCRIPTION
The main issue with the AI chat is the unnecessary visual clutter added by the shortcut that appears on text selection, controlled by `browser.ml.chat.shortcuts`. Hence, this will stay disabled by default. Everything else stays out of the way and does not interfere with any actions unless the user seeks them. The AI chatbot sidebar only loads on opening and only uses 3rd-parties, so it does not compromise on users' privacy except by intentional action.
Disabling these configs by default may pose an annoyance for those seeking to use this feature, as they will need to seek multiple configs to toggle manually.
This commit ensures a more balanced default, where the chatbot features remain easily accessible but do not interfere with normal interactions like highlighting text.