### PR TITLE
Generate release notes for Github releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -516,31 +516,15 @@ jobs:
           commit_user_email: zen-browser-auto@users.noreply.github.com
           repository: ./updates-server
 
-      - name: Build release README
-        run: |
-          echo "# Zen Stable Release" > README.md
-          echo "This is the stable release of Zen Browser." >> README.md
-          echo "## Sha256 checksums" >> README.md
-          echo "```" >> README.md
-          sha256sum ./zen.source.tar.zst/* >> README.md
-          sha256sum ./zen.linux-x86_64.tar.xz/* >> README.md
-          sha256sum ./zen.linux-aarch64.tar.xz/* >> README.md
-          sha256sum ./zen-x86_64.AppImage/* >> README.md
-          sha256sum ./zen-x86_64.AppImage.zsync/* >> README.md
-          sha256sum ./zen-aarch64.AppImage/* >> README.md
-          sha256sum ./zen-aarch64.AppImage.zsync/* >> README.md
-          sha256sum ./linux-aarch64.mar/* >> README.md
-          sha256sum ./.github/workflows/object/windows-x64-signed-x86_64/zen.installer.exe >> README.md
-          sha256sum ./.github/workflows/object/windows-x64-signed-arm64/zen.installer-arm64.exe >> README.md
-          sha256sum ./zen.macos-universal.dmg/* >> README.md
-          echo "```" >> README.md
+      - name: Generate Release Notes
+        run: bash .github/workflows/src/generate_release_notes.sh
 
         # If we are on Twilight, we want to just update the Twilight tag's release
       - name: Update Twilight tag
         if: ${{ inputs.update_branch == 'twilight' }}
         uses: softprops/action-gh-release@v2
         with:
-          body_path: README.md
+          body_path: release_notes.md
           files: |
             ./zen.source.tar.zst/*
             ./zen.linux-x86_64.tar.xz/*
@@ -579,7 +563,7 @@ jobs:
           fail_on_unmatched_files: false
           generate_release_notes: false
           name: 'Release build - ${{ needs.build-data.outputs.version }} (${{ needs.build-data.outputs.build_date }})'
-          body_path: README.md
+          body_path: release_notes.md
           files: |
             ./zen.source.tar.zst/*
             ./zen.linux-x86_64.tar.xz/*

--- a/.github/workflows/src/generate_release_notes.sh
+++ b/.github/workflows/src/generate_release_notes.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+RELEASE_NOTES_URL="https://raw.githubusercontent.com/zen-browser/www/refs/heads/main/src/release-notes/stable.json"
+
+if [ "$RELEASE_BRANCH" = "release" ]; then
+  RELEASE_TYPE="Stable"
+
+  echo "Fetching release notes from GitHub..."
+  RELEASE_NOTES_JSON=$(curl -s "$RELEASE_NOTES_URL")
+
+  if [ -z "$RELEASE_NOTES_JSON" ]; then
+    echo "Error: Failed to fetch release notes from GitHub"
+    exit 1
+  fi
+
+  LATEST_RELEASE=$(echo "$RELEASE_NOTES_JSON" | jq -r 'last')
+  EXTRA_NOTES=$(echo "$LATEST_RELEASE" | jq -r '.extra // ""')
+else
+  RELEASE_TYPE="Twilight"
+fi
+
+cat << EOF > "release_notes.md"
+# Zen ${RELEASE_TYPE} Release
+EOF
+
+if [ "$RELEASE_BRANCH" = "release" ]; then
+  echo "${EXTRA_NOTES}" >> "release_notes.md"
+
+  if echo "$LATEST_RELEASE" | jq -e 'has("features")' > /dev/null; then
+    cat << EOF >> "release_notes.md"
+
+## New Features
+$(echo "$LATEST_RELEASE" | jq -r '.features[] | "- " + .')
+EOF
+  fi
+
+  if echo "$LATEST_RELEASE" | jq -e 'has("fixes")' > /dev/null; then
+    cat << EOF >> "release_notes.md"
+
+## Fixes
+EOF
+    echo "$LATEST_RELEASE" | jq -r '.fixes[] | if type=="object" then "- " + .description + " ([#" + (.issue|tostring) + "](" + "https://github.com/zen-browser/desktop/issues/" + (.issue|tostring) + "))" else "- " + . end' >> "release_notes.md"
+  fi
+
+  if echo "$LATEST_RELEASE" | jq -e 'has("breakingChanges")' > /dev/null; then
+    cat << EOF >> "release_notes.md"
+
+## Breaking Changes
+EOF
+    echo "$LATEST_RELEASE" | jq -r '.breakingChanges[] | if type=="string" then "- " + . else "- " + .description + " [Learn more](" + .link + ")" end' >> "release_notes.md"
+  fi
+
+  if echo "$LATEST_RELEASE" | jq -e 'has("themeChanges")' > /dev/null; then
+    cat << EOF >> "release_notes.md"
+
+## Theme Changes
+$(echo "$LATEST_RELEASE" | jq -r '.themeChanges[] | "- " + .')
+EOF
+  fi
+fi
+
+cat << EOF >> "release_notes.md"
+
+<details>
+<summary>File Checksums (SHA-256)</summary>
+
+\`\`\`
+EOF
+
+generate_checksum() {
+  local file=$1
+  if [ -f "$file" ]; then
+    echo "Generating checksum for $file"
+    sha256sum "$file" | awk '{print $1 "  " $2}' >> "release_notes.md"
+  else
+    echo "Warning: $file not found, skipping checksum"
+  fi
+}
+
+files=(
+  "./zen.source.tar.zst"
+  "./zen.linux-x86_64.tar.xz"
+  "./zen.linux-aarch64.tar.xz"
+  "./zen-x86_64.AppImage"
+  "./zen-x86_64.AppImage.zsync"
+  "./zen-aarch64.AppImage"
+  "./zen-aarch64.AppImage.zsync"
+  "./.github/workflows/object/windows-x64-signed-x86_64/zen.win-x86_64.zip"
+  "./.github/workflows/object/windows-x64-signed-arm64/zen.win-arm64.zip"
+  "./linux.mar"
+  "./linux-aarch64.mar"
+  "./.github/workflows/object/windows-x64-signed-x86_64/windows.mar"
+  "./.github/workflows/object/windows-x64-signed-arm64/windows-arm64.mar"
+  "./macos.mar"
+  "./.github/workflows/object/windows-x64-signed-x86_64/zen.installer.exe"
+  "./.github/workflows/object/windows-x64-signed-arm64/zen.installer-arm64.exe"
+  "./zen.macos-universal.dmg"
+)
+
+for file in "${files[@]}"; do
+  generate_checksum "$file"
+done
+
+cat << EOF >> "release_notes.md"
+\`\`\`
+</details>
+EOF
+
+echo "Release notes generated: release_notes.md"


### PR DESCRIPTION
- Fixes sha256 checksum generation
- Pulls release notes from website for stable builds

<details>
<summary>Example output (Stable build 1.9.1b)</summary>

# Zen Stable Release
Another update with stability improvements.

## New Features
- Added the option to drag-and-drop a tab to the right side of the screen to split
- Updated to Firefox 136.0.1
- Glance now asks for confirmation before closing if it's focused on an input field

## Fixes
- Fixed new tabs opening where Essentials are in some cases
- Fixed a bug where workspace-specific bookmarks don't work
- Fixed re-arranging tabs while having Glance opened
- Fixed UI issues with double toolbar in the URL bar icons
- Fixed dropping tabs outside of the window not opening the new tab
- Fixed session restore not working with closed windows
- Fixed compact mode not hiding when minimizing the window
<details>
<summary>File Checksums (SHA-256)</summary>

```
bdd20eb8eb13a071293a69ad4d762bd7b49fbf736d898c8ab28da4cd6f87a6d1  ./zen-x86_64.AppImage.zsync
e15085fdb1273498da8571feb8094301b44ad42d637ac067996fb769f26e1c98  ./linux.mar
8777674738c9d2b7eb83c6f92bc52c751f1b49c3c867f5778ef8a2ae459bfa05  ./zen.macos-universal.dmg
// ...
```
</details>
</details>

<details>
<summary>Example output (Twilight build)</summary>

# Zen Twilight Release

<details>
<summary>File Checksums (SHA-256)</summary>

```
bdd20eb8eb13a071293a69ad4d762bd7b49fbf736d898c8ab28da4cd6f87a6d1  ./zen-x86_64.AppImage.zsync
e15085fdb1273498da8571feb8094301b44ad42d637ac067996fb769f26e1c98  ./linux.mar
8777674738c9d2b7eb83c6f92bc52c751f1b49c3c867f5778ef8a2ae459bfa05  ./zen.macos-universal.dmg
// ...
```
</details>
</details>