### PR TITLE
Enable ctrl+tab cycling by recently-used order by default, like in Arc

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -9,6 +9,7 @@
 #endif
 
 pref("browser.tabs.hoverPreview.enabled", false);
+pref("browser.ctrlTab.sortByRecentlyUsed", true);
 
 #ifdef MOZ_UPDATE_CHANNEL
 pref("devtools.debugger.prompt-connection", true);


### PR DESCRIPTION
Here's a brief explanation on why I believe this default is necessary:
### 1. It's more suited for Zen's workflow
Traditional browsers use a conventional layout of a single sequence of tabs, from start to end. Pinned tabs are not commonly used and generally only for the sole purpose of syncing tabs or persisting across restarts. Users tend to arrange their horizontal tabs side-by-side depending on what they want to group together in their workflow. Navigating the tabs linearly offers an appropriate sense of simplicity in a simple tab management environment.
Zen is different. It divides tabs into 3 sections: ephemeral, pinned and essentials. Ephemeral tabs generally work the same way as traditional browsers, except they spawn on top by default instead of at the bottom. It is expected of users to toggle frequently between tabs in the 3 categories; the spur-of-the-moment work to be done as quickly as possible, the more permanent tabs that are frequently used in tandem with the ephemeral tabs, and certain tools that are most commonly accessed for various reasons, like communications, search engines or media, in this order. It is a common source of frustration that users would be **forced to use a mouse to toggle between tabs in these 3 categories**, as even when there are only 2-4 tabs that require accessing, there is no quick way to switch between them while you work.
Think about what it would be like if, on your desktop, apps are cycled linearly through the taskbar instead of the classic Alt+Tab switcher. If you have no pinned apps and everything is ordered arbitrarily (equivalent to traditional browsers), then you still have the ability to meticulously place apps side-by-side, and THEN use **two** separate keybinds to swap between two commonly used apps. Add to this mix the existence of pinned apps (equivalent to Zen's workflow), and suddenly, you are forced to choose between aiming with your mouse, bulldozing through every app in between, or rearranging the pinned tabs you have painstakingly placed in a convenient location and gained muscle memory for. Just as switching apps in recently used order is more suitable for a compositing desktop, switching tabs in recently used order is better-suited for this browser's workflow.
### 2. Users LOSE NOTHING from having this option on
Did you know that Ctrl+Tab is a **redundant keybind?** There already exists something that serves the same function: Ctrl+PgUp and Ctrl+PgDn. Not only does this fit in perfectly with the vertical tabs design language, it also saves having to think about "Tab with or without Shift" by simply toggling between 2 keys for the "go up" and "go down" actions. Very intuitive, significantly more efficient, and it is in fact the standard for switching tabs, but at some point was overshadowed by the Ctrl+Tab shortcut in browsers, despite its closer resemblance to Alt+Tab in operating systems. Not only does this change fit the standards excellently, it also offers a tangible benefit to **efficiency and choice in usage** that is, most notably, _missing in almost all chromium browsers_ except Arc.
![image](https://github.com/user-attachments/assets/9b3f25fc-ac24-4172-b759-2ec5230d0d49)
Isn't it beautiful?