### PR TITLE
Fix bash install command in documentation on how to install for Linux using tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ yay -S zen-browser-bin
 - `Tarball` install:
 
 ```sh
-bash <(curl -s https://updates.zen-browser.app/install.sh)`
+bash <(curl -s https://updates.zen-browser.app/install.sh)
 ```
 
 - `AppImage` install:


### PR DESCRIPTION
While copying and pasting the Bash install command from the README for other Linux distributions using the tarball, I found that the command did not work. It turns out that there is an unnecessary backtick at the end of the command?