### PR TITLE
styles: use tabular-nums on media controls

### DIFF
--- a/src/browser/base/content/zen-styles/zen-media-controls.css
+++ b/src/browser/base/content/zen-styles/zen-media-controls.css
@@ -163,6 +163,7 @@
     font-size: x-small;
     opacity: 0.7;
     font-weight: 500;
+    font-variant-numeric: tabular-nums;
   }
 }
 


### PR DESCRIPTION
Currently Zen media controls timestamp resizes every second because it's using a variable-width font, making the progress bar re-adapt continuously to fit on a bigger/smaller space, which is visually annoying.

Applying [`tabular-nums`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric#numeric-spacing-values) we ensure numeric values are displayed with consistent spacing, without the need of a monospace font.