### PR TITLE
Disable restoring pinned tabs on demand by default

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -318,7 +318,7 @@ pref("mousewheel.default.delta_multiplier_y", 200);
   pref("dom.ipc.processPriorityManager.backgroundUsesEcoQoS", false);
 #endif
 
-pref('browser.sessionstore.restore_pinned_tabs_on_demand', true);
+pref('browser.sessionstore.restore_pinned_tabs_on_demand', false);
 pref('browser.newtabpage.activity-stream.system.showWeather', true);
 
 // Enable experimental settings page (Used for Zen Labs)


### PR DESCRIPTION
Currently, Essentials are not loaded when the browser starts. The issue has already been reported: https://github.com/zen-browser/desktop/issues/5022

I think that not loading Essentials on startup is not what we want when we use such a feature. I personally have my email client in those tabs and I expect it to be loaded when I open my browser.