### PR TITLE
ci: Use the default github.token if secrets.DEPLOY_KEY is not available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Check if correct branch
         if: ${{ inputs.create_release }}
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -195,7 +195,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -237,7 +237,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -363,7 +363,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -409,7 +409,7 @@ jobs:
 
           echo "AppDir: $APPDIR"
           ls -al
-          find .
+          find . 
           ls -al "$APPDIR"
           ./appimagetool-x86_64.AppImage -u "$UPINFO" "$APPDIR" zen-"$ARCH".AppImage --runtime-file ./uruntime-appimage-squashfs-lite-"$ARCH"
           mkdir dist
@@ -469,7 +469,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -482,7 +482,7 @@ jobs:
         with:
           repository: zen-browser/updates-server
           path: updates-server
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Download object files
         if: ${{ inputs.update_branch == 'release' }}
@@ -548,7 +548,7 @@ jobs:
           draft: false
           generate_release_notes: false
           prerelease: true
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
           fail_on_unmatched_files: false
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -557,7 +557,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: ${{ inputs.update_branch == 'release' }}
         with:
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
           tag_name: ${{ needs.build-data.outputs.version }}
           prerelease: false
           fail_on_unmatched_files: false
@@ -595,7 +595,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: zen-browser/release-utils
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Install dependencies
         run: |
@@ -619,7 +619,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: zen-browser/flatpak
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
           path: flatpak
 
       - name: Move releases.xml
@@ -654,7 +654,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: flathub/app.zen_browser.zen
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Download Linux x86_64 build
         uses: actions/download-artifact@v4
@@ -670,7 +670,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: zen-browser
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Download Flatpak archive
         run: |
@@ -716,7 +716,7 @@ jobs:
           GIT_TRACE: 1
           GIT_CURL_VERBOSE: 1
         with:
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
           commit-message: 🚀 Update to version ${{ needs.build-data.outputs.version }}
           title: 🚀 Update to version ${{ needs.build-data.outputs.version }}
           body: |
@@ -725,5 +725,5 @@ jobs:
             @${{ github.actor }} please review and merge this PR.
           branch: update-to-${{ needs.build-data.outputs.version }}
           base: master
-          git-token: ${{ secrets.DEPLOY_KEY }}
+          git-token: ${{ secrets.DEPLOY_KEY || github.token }}
           delete-branch: true

--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Get dates for last month
         shell: bash
@@ -41,7 +41,7 @@ jobs:
       - name: Run issue-metrics tool
         uses: github/issue-metrics@v2
         env:
-          GH_TOKEN: ${{ secrets.DEPLOY_KEY }}
+          GH_TOKEN: ${{ secrets.DEPLOY_KEY || github.token }}
           HIDE_AUTHOR: true
           HIDE_TIME_TO_ANSWER: true
           SEARCH_QUERY: 'repo:zen-browser/desktop is:issue created:${{ env.last_month }}'

--- a/.github/workflows/linux-release-build.yml
+++ b/.github/workflows/linux-release-build.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/macos-release-build.yml
+++ b/.github/workflows/macos-release-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/macos-universal-release-build.yml
+++ b/.github/workflows/macos-universal-release-build.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/windows-release-build.yml
+++ b/.github/workflows/windows-release-build.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.DEPLOY_KEY || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
In github actions, `github.token` is available by default. By using this as a fallback, people will be able to generate twilight builds from their forks without needing to set up any extra secrets.

Just a little convenience update for people developing in their forks since it can be a lot set up a dev enviornment. It's a lot easier to just kick off a build and check on it when it is done.