### PR TITLE
Fix: small typo

### DIFF
--- a/src/browser/base/zen-components/actors/ZenThemeMarketplaceChild.sys.mjs
+++ b/src/browser/base/zen-components/actors/ZenThemeMarketplaceChild.sys.mjs
@@ -50,7 +50,7 @@ export class ZenThemeMarketplaceChild extends JSWindowActorChild {
 
   initiateThemeMarketplace() {
     this.contentWindow.setTimeout(() => {
-      this.addIntallButtons();
+      this.addInstallButtons();
       this.injectMarkplaceAPI();
     }, 0);
   }
@@ -111,7 +111,7 @@ export class ZenThemeMarketplaceChild extends JSWindowActorChild {
     });
   }
 
-  async addIntallButtons() {
+  async addInstallButtons() {
     const actionButton = this.actionButton;
     const actionButtonUnnstall = this.actionButtonUninstall;
     const errorMessage = this.contentWindow.document.getElementById('install-theme-error');


### PR DESCRIPTION
Fix a typo in a  ZenThemeMarketplaceChild.sys.mjs in a method name: addIntallButtons -> addInstallButtons