### PR TITLE
Fix: Wrong dialog width in compact view

### DIFF
--- a/src/browser/base/content/zen-styles/zen-panels/dialog.css
+++ b/src/browser/base/content/zen-styles/zen-panels/dialog.css
@@ -7,5 +7,6 @@
 @media (prefers-color-scheme: dark) {
   .dialogBox:not(.spotlightBox) {
     border: 1px solid var(--zen-colors-border);
+    min-width: min(80vw, 376px);
   }
 }

--- a/src/browser/base/content/zen-styles/zen-panels/dialog.css
+++ b/src/browser/base/content/zen-styles/zen-panels/dialog.css
@@ -3,10 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-/* Zen Welcome idalog override */
+/* Zen Welcome dialog override */
 @media (prefers-color-scheme: dark) {
   .dialogBox:not(.spotlightBox) {
     border: 1px solid var(--zen-colors-border);
-    min-width: min(80vw, 376px);
   }
+}
+.dialogBox:not(.spotlightBox) {
+  min-width: min(80vw, 376px);
 }


### PR DESCRIPTION
## Description
When a new tab is opened in compact view mode, clicking on a link that is configured to open an external application displays a dialog with an incorrect width. This issue causes the dialog content to be improperly aligned and, in some cases, partially cut off.

>Note: This is my first contribution to an open source project, so any feedback is welcome. 😊

### Bug demonstration:

https://github.com/user-attachments/assets/e989520e-1021-4701-8374-ca096067bfed

### Fixed:

https://github.com/user-attachments/assets/3901a1f7-7762-4a9c-8fd5-a5ab8593a8dc


Let me know if any improvements are needed