### PR TITLE
Update Firefox version to 137.0 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@
 
 ## 🖥️ Compatibility
 
-Zen is currently built using Firefox version `136.0.2`! 🚀
+Zen is currently built using Firefox version `137.0`! 🚀
 
-- [`Zen Twilight`](https://zen-browser.app/download?twilight) - Is currently built using Firefox version `RC 136.0`!
+- [`Zen Twilight`](https://zen-browser.app/download?twilight) - Is currently built using Firefox version `137.0`!
 - Check out the latest [release notes](https://zen-browser.app/release-notes)!
 - Part of our mission is to keep Zen up-to-date with the latest version of Firefox, so you can enjoy the latest features and security updates!
 


### PR DESCRIPTION
The Firefox versions listed as being used for Zen builds were outdated in the README.me, so I updated both Stable and Twilight to 137.0 which I think should be correct for both.