### PR TITLE
Added transparent browser background on linux

### DIFF
--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -380,6 +380,11 @@ pref('widget.macos.titlebar-blend-mode.behind-window', true);
 pref('zen.widget.macos.window-material', 3);
 #endif
 
+// Enable transparent background for linux
+#ifdef MOZ_WIDGET_GTK
+pref('zen.widget.linux.transparency', true);
+#endif
+
 // Urlbar and autocomplete
 pref("browser.urlbar.maxRichResults", 6);
 pref("browser.urlbar.trimHttps", true);

--- a/src/browser/base/content/zen-styles/zen-theme.css
+++ b/src/browser/base/content/zen-styles/zen-theme.css
@@ -167,6 +167,11 @@
     }
   }
 
+  @media (-moz-platform: linux) and -moz-pref('zen.widget.linux.transparency'){
+    background: transparent;
+    --zen-themed-toolbar-bg-transparent: transparent;
+  }
+
   --toolbar-field-background-color: var(--zen-colors-input-bg) !important;
   --arrowpanel-background: var(--zen-dialog-background) !important;
 


### PR DESCRIPTION
1. Added the `zen.widget.linux.transparency` preference, which is enabled by default.
2. Updated zen-theme.css to properly reflect this change by applying transparent background.

Fix for issue #6965 