### PR TITLE
Fix sidebar always stays left

### DIFF
--- a/src/browser/base/content/zen-styles/zen-sidebar.css
+++ b/src/browser/base/content/zen-styles/zen-sidebar.css
@@ -49,11 +49,11 @@
     border-radius: var(--zen-native-inner-radius);
     box-shadow: var(--zen-big-shadow);
     overflow: hidden;
-    &[positionend=""] {
+    &[positionend=''] {
       order: 6;
-	  & ~ #sidebar-splitter {
-  		order: 5;
-    }
+      & ~ #sidebar-splitter {
+        order: 5;
+      }
     }
     :root:not([zen-right-side='true']) &[positionend='true'] {
       margin-right: var(--zen-element-separation);

--- a/src/browser/base/content/zen-styles/zen-sidebar.css
+++ b/src/browser/base/content/zen-styles/zen-sidebar.css
@@ -49,7 +49,12 @@
     border-radius: var(--zen-native-inner-radius);
     box-shadow: var(--zen-big-shadow);
     overflow: hidden;
-
+    &[positionend=""] {
+      order: 6;
+	  & ~ #sidebar-splitter {
+  		order: 5;
+    }
+    }
     :root:not([zen-right-side='true']) &[positionend='true'] {
       margin-right: var(--zen-element-separation);
     }


### PR DESCRIPTION
change the order to honor `positionend` attribute in #sidebar-box while maintaining dragable by splitter
fix for #7260 