### PR TITLE
Fix padding when full screen by setting gap value to 0

### DIFF
--- a/src/browser/base/content/zen-styles/zen-browser-ui.css
+++ b/src/browser/base/content/zen-styles/zen-browser-ui.css
@@ -155,6 +155,9 @@
   flex-direction: row;
   position: relative;
   gap: var(--zen-element-separation);
+  :root[inDOMFullscreen] & {
+    gap: 0;
+  }
 }
 
 @media not (-moz-platform: macos) {


### PR DESCRIPTION
Somehow, gap in #tabbrowser-tabbox is still taking effect even when its child elements(sidebar and splitter) are set with `visibility:collapse`. This cause unwantted space when entering fullscreen as #7429 mentioned.