### PR TITLE
Fix #7429 `Sidebar padding takes space in full screen`

### DIFF
--- a/src/browser/base/content/zen-styles/zen-browser-ui.css
+++ b/src/browser/base/content/zen-styles/zen-browser-ui.css
@@ -150,7 +150,7 @@
   }
 }
 
-#tabbrowser-tabbox {
+:root:not([inDOMFullscreen='true']) #tabbrowser-tabbox {
   display: flex;
   flex-direction: row;
   position: relative;


### PR DESCRIPTION
Limiting the presence of gap to non-fullscreen mode