### PR TITLE
Add min width to split-view vertical splitter

### DIFF
--- a/src/browser/base/content/zen-styles/zen-browser-ui.css
+++ b/src/browser/base/content/zen-styles/zen-browser-ui.css
@@ -207,6 +207,7 @@
   &:is(.zen-split-view-splitter[orient='vertical']) {
     /* Bit of a hacky solution, but it works */
     width: var(--zen-split-row-gap);
+    min-width: 1px;
     margin-left: calc(var(--zen-element-separation) * -1 - 1px);
     height: unset;
     cursor: ew-resize;


### PR DESCRIPTION
Currently , the width of split-view vertical splitter is defined by:
```
width: var(--zen-split-row-gap);
--zen-split-row-gap: var(--zen-element-separation);
```

The width of splitter becomes 0 and is not accessible when `--zen-element-separation` is manually set to 0 in `about:config`
A minimal width of 1 px is given in this pr to avoid the above condition.

===
Note: 
In comparision, the height of horizontal splitter is `calc(var(--zen-element-separation) + 1px)`, which also avoids the aforementioned condition.
I chose to add min-width because I believe that has least overall impact.
