### PR TITLE
fix: closes #7274 - Fixed mouses simulating swipes with Forward and B…

### DIFF
--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -472,19 +472,15 @@ var ZenWorkspaces = new (class extends ZenMultiWindowFeature {
   }
 
   async _handleSwipeEnd(event) {
-    if (!this.workspaceEnabled || !this._swipeState?.isGestureActive) return;
+    if (!this.workspaceEnabled) return;
     event.preventDefault();
     event.stopPropagation();
     const isRTL = document.documentElement.matches(':-moz-locale-dir(rtl)');
-    const moveForward = (this._swipeState.direction === 'right') !== isRTL;
+    const moveForward = (event.direction === SimpleGestureEvent.DIRECTION_RIGHT) !== isRTL;
 
-    let rawDirection = moveForward ? 1 : -1;
-    if (this._swipeState.direction) {
-      let direction = this.naturalScroll ? -1 : 1;
-      this.changeWorkspaceShortcut(rawDirection * direction, true);
-    } else {
-      this._cancelSwipeAnimation();
-    }
+    const rawDirection = moveForward ? 1 : -1;
+    const direction = this.naturalScroll ? -1 : 1;
+    this.changeWorkspaceShortcut(rawDirection * direction, true);
 
     // Reset swipe state
     this._swipeState = {


### PR DESCRIPTION
Hi, 

Firstly, thanks for this amazing work! This browser is a 💎, and it's an honour to contribute to such a project!

On several mouses, and mouses customization softwares (like Logitech Option +, or Better Mouse), the Back and Forward event are emulated by sending a Left or Right SwipeEvent.

This blocks the usage of these buttons to switch workspace due to the way the events were previously handled. 

This PR fixes the issue.

Tested with a Logitech MX Vertical, and a MacBookPro Trackpad.

Thanks!

fix #7274