### PR TITLE
feat: improve tab switching with trackpad

### DIFF
--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -466,6 +466,10 @@ var ZenWorkspaces = new (class extends ZenMultiWindowFeature {
       this._swipeState.direction = delta > 0 ? 'left' : 'right';
     }
 
+    if (Math.abs(translateX) >= 40) {
+      return this._handleSwipeEnd(event);
+    }
+
     // Apply a translateX to the tab strip to give the user feedback on the swipe
     const currentWorkspace = this.activeWorkspace;
     this._organizeWorkspaceStripLocations({ uuid: currentWorkspace }, true, translateX);


### PR DESCRIPTION
Hi,

When switching from Arc, I directly felt an issue when switching the workspaces with the trackpad.
Most of the time, the swipe is canceled, and reverted.

This is because the `MozSwipeGesture` is not triggered until a quite big threshold.

This PR improves the behavior, by triggering the workspace switch directly from the `MozSwipeGestureUpdate`.

| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/061097b7-22c0-4e4c-b348-ea30e9826de7">  | <video src="https://github.com/user-attachments/assets/8ed76673-ed00-4e5a-b9db-cd3fddc59d92"> |

Thanks!
Mathieu.
