### PR TITLE
Smooth transition from fullscreen in compact mode

### DIFF
--- a/src/zen/compact-mode/zen-compact-mode.css
+++ b/src/zen/compact-mode/zen-compact-mode.css
@@ -384,3 +384,20 @@
     }
   }
 }
+
+:root[zen-compact-mode='true']:not([customizing])[inDOMFullscreen='true'] {
+  @media -moz-pref('zen.view.compact.hide-tabbar') or -moz-pref('zen.view.use-single-toolbar') {
+    &:not([zen-compact-animating]) {
+      #navigator-toolbox {
+        opacity: 0;
+      }
+    }
+  }
+  @media -moz-pref('zen.view.compact.hide-toolbar') {
+    &:not([zen-single-toolbar='true']) {
+      & #zen-appcontent-navbar-container {
+        opacity: 0;
+      }
+    }
+  }
+}

--- a/src/zen/compact-mode/zen-compact-mode.css
+++ b/src/zen/compact-mode/zen-compact-mode.css
@@ -385,6 +385,7 @@
   }
 }
 
+/* Fix for https://github.com/zen-browser/desktop/issues/7615 */
 :root[zen-compact-mode='true']:not([customizing])[inDOMFullscreen='true'] {
   @media -moz-pref('zen.view.compact.hide-tabbar') or -moz-pref('zen.view.use-single-toolbar') {
     &:not([zen-compact-animating]) {


### PR DESCRIPTION
Fix for #7615 
This PR adds `opacity: 0` to tab sidebar and top bar when fullscreen at compact mode.
Both tab sidebar and topbar are already `visibility:collapse` when fullscreen, so this change is not going to affect the layout of fullscreen but only makes transition animation between fullscreen and non-fullscreen less intrusive visually.