### PR TITLE
remove --cask flag from mac install instructions as it isn't necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ winget install --id Zen-Team.Zen-Browser
 You can also install Zen using Homebrew:
 
 ```
-brew install --cask zen-browser
+brew install zen-browser
 ```
 
 #### Linux


### PR DESCRIPTION
the --cask flag isn't necessary for installing the zen-browser via brew.