### PR TITLE
Feature: Add checks for sound before auto toggling PiP

### DIFF
--- a/src/toolkit/actors/PictureInPictureChild-sys-mjs.patch
+++ b/src/toolkit/actors/PictureInPictureChild-sys-mjs.patch
@@ -1,0 +1,12 @@
+diff --git a/toolkit/actors/PictureInPictureChild.sys.mjs b/toolkit/actors/PictureInPictureChild.sys.mjs
+index 7ae1aa58bbaeab7a1835a3ea8328735d4f4ecfb1..9d0679dde3c031c2459c09ffbc157f32bc7d003a 100644
+--- a/toolkit/actors/PictureInPictureChild.sys.mjs
++++ b/toolkit/actors/PictureInPictureChild.sys.mjs
+@@ -291,6 +291,7 @@ export class PictureInPictureLauncherChild extends JSWindowActorChild {
+       if (
+         video &&
+         PictureInPictureChild.videoIsPlaying(video) &&
++        !video.muted &&
+         PictureInPictureChild.videoIsPiPEligible(video)
+       ) {
+         this.togglePictureInPicture({ video, reason: "AutoPip" }, false);

--- a/src/toolkit/components/pictureinpicture/PictureInPicture-sys-mjs.patch
+++ b/src/toolkit/components/pictureinpicture/PictureInPicture-sys-mjs.patch
@@ -1,8 +1,18 @@
 diff --git a/toolkit/components/pictureinpicture/PictureInPicture.sys.mjs b/toolkit/components/pictureinpicture/PictureInPicture.sys.mjs
-index 5da0404b2672ba8cce7bcf808bf2373474776654..3b93217b38f25f54d7ef44d151e314bc1c5e5ce3 100644
+index 5da0404b2672ba8cce7bcf808bf2373474776654..6a22fce1212bd6ac6bdd4962b8247c3db956f0eb 100644
 --- a/toolkit/components/pictureinpicture/PictureInPicture.sys.mjs
 +++ b/toolkit/components/pictureinpicture/PictureInPicture.sys.mjs
-@@ -494,7 +494,7 @@ export var PictureInPicture = {
+@@ -126,6 +126,9 @@ export class PictureInPictureToggleParent extends JSWindowActorParent {
+         if (browser.ownerGlobal.gBrowser.selectedBrowser == browser) {
+           break;
+         }
++        if (browser.ownerGlobal.gBrowser.getTabForBrowser(browser).muted) {
++          break;
++        }
+         let actor = browsingContext.currentWindowGlobal.getActor(
+           "PictureInPictureLauncher"
+         );
+@@ -494,7 +497,7 @@ export var PictureInPicture = {
      // focus the tab's window
      tab.ownerGlobal.focus();
  

--- a/src/toolkit/components/pictureinpicture/PictureInPicture-sys-mjs.patch
+++ b/src/toolkit/components/pictureinpicture/PictureInPicture-sys-mjs.patch
@@ -6,7 +6,7 @@ index 5da0404b2672ba8cce7bcf808bf2373474776654..6a22fce1212bd6ac6bdd4962b8247c3d
          if (browser.ownerGlobal.gBrowser.selectedBrowser == browser) {
            break;
          }
-+        if (browser.ownerGlobal.gBrowser.getTabForBrowser(browser).muted) {
++        if (browser.audioMuted) {
 +          break;
 +        }
          let actor = browsingContext.currentWindowGlobal.getActor(


### PR DESCRIPTION
Coming from Arc, I really liked using auto PiP. Enabling it in Zen has been a bit annoying because even muted videos on web pages (such as the muted stream on twitch's home page) are activating auto PiP when you change tabs. 

I've added a simple patch in the `actors/PictureInPictureChild.sys.mjs` file that checks if the video player itself is muted and if it is it does not activate PiP when you switch away from that tab.

I then added another small patch in `components/PictureInPicture.sys.mjs` which checks whether the tab itself is muted and prevents auto PiP if it is in fact muted. 

Maybe this behavior should be behind a preference?