### PR TITLE
Keep Firefox name consistent + fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To upgrade the browser to a newer version, use the embedded update functionality
 
 ## 👨‍💻 Development and Contributing
 
-Some components used by @zen-browser as an attempt to make firefox forks a better place, and for other to enjoy the beauty of OSS. You can find them [here](https://github.com/zen-browser/desktop/tree/dev/src/zen).
+Some components used by @zen-browser as an attempt to make Firefox forks a better place, and for other to enjoy the beauty of OSS. You can find them [here](https://github.com/zen-browser/desktop/tree/dev/src/zen).
 
 #### `Run Locally`
 

--- a/build/winsign/sign.ps1
+++ b/build/winsign/sign.ps1
@@ -24,7 +24,7 @@ Start-Job -Name "DownloadGitl10n" -ScriptBlock {
     cd $PWD
     $env:ZEN_L10N_CURR_DIR=[regex]::replace($PWD, "^([A-Z]):", { "/" + $args.value.Substring(0, 1).toLower() }) -replace "\\", "/"
     C:\mozilla-build\start-shell.bat $PWD\scripts\download-language-packs.sh
-    echo "Fetched l10n and firefox's one"
+    echo "Fetched l10n and Firefox's one"
 } -Verbose -ArgumentList $PWD -Debug
 
 Start-Job -Name "SurferInit" -ScriptBlock {
@@ -84,7 +84,7 @@ function DownloadArtifacts($name) {
 
     echo "Downloading artifact to $tempFile"
     DownloadFile $artifactUrl $tempFile
-    
+
     Start-Job -Name "UnzipArtifact$name" -ScriptBlock {
         param($tempFile, $outputPath)
         echo "Unzipping artifact to $outputPath"
@@ -128,13 +128,13 @@ function SignAndPackage($name) {
 
     echo "Removing old obj dir"
     rmdir engine\obj-$objName-pc-windows-msvc\ -Recurse -ErrorAction SilentlyContinue
-    
+
     echo "Creating new obj dir"
     cp windsign-temp\windows-x64-obj-$name engine\obj-$objName-pc-windows-msvc\ -Recurse
 
     echo "Copying setup.exe into obj dir"
     $env:ZEN_SETUP_EXE_PATH="$PWD\windsign-temp\windows-x64-obj-$name\browser\installer\windows\instgen\setup.exe"
-    
+
     if ($name -eq "arm64") {
         $env:WIN32_REDIST_DIR="$PWD\win-cross\vs2022\VC\Redist\MSVC\14.38.33135\arm64\Microsoft.VC143.CRT"
     } else {

--- a/docs/issue-metrics/2024_2024-11-01..2024-11-30.md
+++ b/docs/issue-metrics/2024_2024-11-01..2024-11-30.md
@@ -20,7 +20,7 @@
 | video playing windows go blank for split second | https://github.com/zen-browser/desktop/issues/3313 | None | None |
 | Light mode makes some buttons look disabled | https://github.com/zen-browser/desktop/issues/3312 | 0:40:59 | 20 days, 19:57:32 |
 | Tabs unloading with the feature disabled | https://github.com/zen-browser/desktop/issues/3311 | None | None |
-| Default browser settings changes to firefox when i close the Zen | https://github.com/zen-browser/desktop/issues/3310 | None | None |
+| Default browser settings changes to Firefox when i close the Zen | https://github.com/zen-browser/desktop/issues/3310 | None | None |
 | zen.source.tar.gz is incorrectly named, should be .tar.zst instead | https://github.com/zen-browser/desktop/issues/3308 | None | None |
 | Tab temporarely is compacted to the width of my sidebar before loading in when switching from a split-view | https://github.com/zen-browser/desktop/issues/3307 | None | None |
 | Pre-assigned url to a container, and associate a container to a workspace, but that chain is broken | https://github.com/zen-browser/desktop/issues/3306 | None | 9 days, 21:18:59 |

--- a/docs/issue-metrics/2024_2024-12-01..2024-12-31.md
+++ b/docs/issue-metrics/2024_2024-12-01..2024-12-31.md
@@ -251,7 +251,7 @@
 | "Show all tabs" keyboard shortcut not working | https://github.com/zen-browser/desktop/issues/3765 | 4:43:13 | None |
 | URL bar missing on windows of different workspaces | https://github.com/zen-browser/desktop/issues/3764 | 1 day, 12:20:03 | 9 days, 9:18:05 |
 | The tab pane shakes in compact mode when hovering on the buttons | https://github.com/zen-browser/desktop/issues/3763 | None | 9 days, 3:05:22 |
-| this last update is GARBAGE!!! why would you do that to the address bar when you click once it moves to the center. and the new logo sucks. im probably going back to firefox | https://github.com/zen-browser/desktop/issues/3762 | 2:15:10 | 17:24:07 |
+| this last update is GARBAGE!!! why would you do that to the address bar when you click once it moves to the center. and the new logo sucks. im probably going back to Firefox | https://github.com/zen-browser/desktop/issues/3762 | 2:15:10 | 17:24:07 |
 | Floating Web Panel Disappears When Clicking elsewhere on the Screen | https://github.com/zen-browser/desktop/issues/3759 | 18:57:22 | 18:57:22 |
 | Visual problems occur when playing embedded videos on websites presented in picture-in-picture mode in zen browser using it under GNU/Linux. | https://github.com/zen-browser/desktop/issues/3758 | 21:40:26 | 1 day, 0:38:06 |
 | URL Bar weird behaviour on compact mode and shortcuts | https://github.com/zen-browser/desktop/issues/3757 | 14:46:59 | 4 days, 21:05:40 |

--- a/docs/issue-metrics/2025_2025-01-01..2025-01-31.md
+++ b/docs/issue-metrics/2025_2025-01-01..2025-01-31.md
@@ -111,7 +111,7 @@
 | Compact mode won't disable after changing which toolbars are hidden | https://github.com/zen-browser/desktop/issues/4649 | 16:26:34 | None |
 | Problem with tab bar and top bar | https://github.com/zen-browser/desktop/issues/4648 | 7:28:57 | None |
 | Excessive margin between bookmark sidebar and center pane | https://github.com/zen-browser/desktop/issues/4647 | 7:37:12 | None |
-| I am not able to save my bookmarks of zen with the autoExportHTML flag, this works fine on firefox though. | https://github.com/zen-browser/desktop/issues/4646 | None | None |
+| I am not able to save my bookmarks of zen with the autoExportHTML flag, this works fine on Firefox though. | https://github.com/zen-browser/desktop/issues/4646 | None | None |
 | Dropdown input is not selected | https://github.com/zen-browser/desktop/issues/4645 | None | None |
 | Toolbar becomes big after customizing the bookmarks placement | https://github.com/zen-browser/desktop/issues/4641 | None | None |
 | Zen Mods are not properly installing | https://github.com/zen-browser/desktop/issues/4640 | None | None |
@@ -349,7 +349,7 @@
 | Page refresh | https://github.com/zen-browser/desktop/issues/4338 | 11:57:25 | None |
 | Expand Side's bar changes position of forward and backward buttons | https://github.com/zen-browser/desktop/issues/4336 | 12:19:39 | None |
 | breaks after using rectify11 and mica for everyone | https://github.com/zen-browser/desktop/issues/4335 | None | 3:03:08 |
-| Link "Zen support site" redirects to firefox support site | https://github.com/zen-browser/desktop/issues/4333 | 16:39:30 | 16:39:30 |
+| Link "Zen support site" redirects to Firefox support site | https://github.com/zen-browser/desktop/issues/4333 | 16:39:30 | 16:39:30 |
 | Opening discord keeps crashing the tab | https://github.com/zen-browser/desktop/issues/4332 | 0:24:48 | 0:24:48 |
 | space between essentials/tabs and the workspace title is different for default vs others | https://github.com/zen-browser/desktop/issues/4329 | None | 1 day, 0:42:55 |
 | Essential disappears, but it's still there | https://github.com/zen-browser/desktop/issues/4328 | 17:21:42 | 2 days, 3:52:35 |
@@ -362,7 +362,7 @@
 | Slow scrolling speed on the vertical tab bar in 1.6b | https://github.com/zen-browser/desktop/issues/4321 | 1:18:21 | 1 day, 5:19:47 |
 | browser.urlbar.suggest.topsites set to false make url cannot be edited | https://github.com/zen-browser/desktop/issues/4319 | 1 day, 3:38:03 | 2 days, 9:54:46 |
 | Tab volume icon not showing in collapsed toolbar unless tab is active | https://github.com/zen-browser/desktop/issues/4316 | None | 0:08:41 |
-| Profile avatar picture flashes and is overridden by firefox account avatar | https://github.com/zen-browser/desktop/issues/4315 | 8:16:31 | 8:16:31 |
+| Profile avatar picture flashes and is overridden by Firefox account avatar | https://github.com/zen-browser/desktop/issues/4315 | 8:16:31 | 8:16:31 |
 | Zen Browser Turn Light At Lost Focus | https://github.com/zen-browser/desktop/issues/4314 | 2 days, 4:11:22 | 5 days, 16:04:18 |
 | "Log-in to this network" modal & button not interactible | https://github.com/zen-browser/desktop/issues/4313 | None | None |
 | Sudden Crashes on Arch Linux with Multiple Tabs Opened | https://github.com/zen-browser/desktop/issues/4309 | 2:56:11 | None |

--- a/docs/issue-metrics/2025_2025-02-01..2025-02-28.md
+++ b/docs/issue-metrics/2025_2025-02-01..2025-02-28.md
@@ -516,7 +516,7 @@
 | icon is in not visible in the toolbar | https://github.com/zen-browser/desktop/issues/5215 | 4 days, 19:21:15 | None |
 | Issue: New Tab Not Opening When Searching in Korean | https://github.com/zen-browser/desktop/issues/5213 | 0:14:43 | 6 days, 13:05:20 |
 | Right-Click Context Menu: Keyboard Shortcuts Require Enter to Activate | https://github.com/zen-browser/desktop/issues/5212 | None | None |
-| Support daily.dev extension in zen browser. firefox doesn't. | https://github.com/zen-browser/desktop/issues/5211 | 0:05:56 | 0:05:56 |
+| Support daily.dev extension in zen browser. Firefox doesn't. | https://github.com/zen-browser/desktop/issues/5211 | 0:05:56 | 0:05:56 |
 | Error at the bottom right when opening a tab | https://github.com/zen-browser/desktop/issues/5210 | 0:28:59 | 0:28:59 |
 | Pen Tablet Scrolling Not Working in Sidebar | https://github.com/zen-browser/desktop/issues/5209 | None | None |
 | Essentials icons are off center | https://github.com/zen-browser/desktop/issues/5207 | 19:44:34 | 22:48:36 |

--- a/docs/issue-metrics/2025_2025-03-01..2025-03-31.md
+++ b/docs/issue-metrics/2025_2025-03-01..2025-03-31.md
@@ -83,7 +83,7 @@
 | Some browser dialogs appear off-screen | https://github.com/zen-browser/desktop/issues/7076 | 1 day, 1:32:55 | None |
 | Mouse over floating sidebar prevents hide | https://github.com/zen-browser/desktop/issues/7075 | None | None |
 | CRX Installer Not working in Zen Browser. | https://github.com/zen-browser/desktop/issues/7074 | 2 days, 23:32:33 | 3 days, 2:39:52 |
-| Cannot resize native firefox sidebar when positioned on the right after restarting the browser | https://github.com/zen-browser/desktop/issues/7073 | None | None |
+| Cannot resize native Firefox sidebar when positioned on the right after restarting the browser | https://github.com/zen-browser/desktop/issues/7073 | None | None |
 | compact mode color bug | https://github.com/zen-browser/desktop/issues/7068 | 0:19:56 | 2:12:33 |
 | Unable to assign Cmd+Z for undo | https://github.com/zen-browser/desktop/issues/7067 | None | None |
 | "change theme colors" cannot be undone and breaks other theming features | https://github.com/zen-browser/desktop/issues/7066 | None | None |
@@ -560,7 +560,7 @@
 | New tab opens black page with only search option | https://github.com/zen-browser/desktop/issues/6418 | 1:30:09 | 1 day, 20:19:37 |
 | Black text on dark theme | https://github.com/zen-browser/desktop/issues/6416 | 1 day, 0:41:57 | 16 days, 1:56:48 |
 | Login pop-ups instant crashed. | https://github.com/zen-browser/desktop/issues/6414 | None | 3 days, 11:52:50 |
-| Only last workspace tabs are synced via firefox account | https://github.com/zen-browser/desktop/issues/6413 | 3:29:46 | 16 days, 2:45:09 |
+| Only last workspace tabs are synced via Firefox account | https://github.com/zen-browser/desktop/issues/6413 | 3:29:46 | 16 days, 2:45:09 |
 | Open in split window in split window undefined behaviour | https://github.com/zen-browser/desktop/issues/6412 | 16 days, 2:55:23 | 16 days, 2:55:24 |
 | Sidebar Stucked | https://github.com/zen-browser/desktop/issues/6411 | 16 days, 3:17:38 | 16 days, 3:17:39 |
 | Keyboard shortcuts not working with non-English layouts (e.g., Turkish) | https://github.com/zen-browser/desktop/issues/6410 | 16 days, 3:27:56 | 16 days, 3:27:56 |
@@ -613,7 +613,7 @@
 | mica broke again | https://github.com/zen-browser/desktop/issues/6346 | 17 days, 16:46:21 | 17 days, 16:46:21 |
 | Search engine selector gone | https://github.com/zen-browser/desktop/issues/6345 | 4 days, 20:07:21 | 17 days, 17:17:10 |
 | PDF files open to a blank page when Zen is closed | https://github.com/zen-browser/desktop/issues/6343 | 12:43:24 | 17 days, 18:13:02 |
-| Tab peek controls overlap firefox ai chat sidebar | https://github.com/zen-browser/desktop/issues/6342 | 17 days, 18:38:25 | 17 days, 18:38:26 |
+| Tab peek controls overlap Firefox ai chat sidebar | https://github.com/zen-browser/desktop/issues/6342 | 17 days, 18:38:25 | 17 days, 18:38:26 |
 | Cant open  a link with left click. | https://github.com/zen-browser/desktop/issues/6341 | 17 days, 18:56:56 | 17 days, 18:56:57 |
 | Distorted UI during first use - fresh install | https://github.com/zen-browser/desktop/issues/6340 | 17 days, 19:04:58 | 17 days, 19:04:59 |
 | Ctrl+Tab fails to switch tabs when dragging a file | https://github.com/zen-browser/desktop/issues/6339 | 17 days, 20:59:02 | 17 days, 20:59:03 |
@@ -758,7 +758,7 @@
 | Extension icons hang off the side of the sidebar, and extension addition confirmation window hangs off the screen | https://github.com/zen-browser/desktop/issues/6135 | 18 days, 8:19:50 | 22 days, 6:38:20 |
 | Settings show zen-split-view-modifier which is unclear, I think it should be with spaces? | https://github.com/zen-browser/desktop/issues/6134 | 22 days, 7:27:49 | 22 days, 7:27:50 |
 | Grayish White Rounded Corners Visible when fullscreen in a video on youtube | https://github.com/zen-browser/desktop/issues/6132 | 8:50:42 | 22 days, 9:35:57 |
-| Zen Browser local building and running shows firefox only not zen type visual | https://github.com/zen-browser/desktop/issues/6128 | None | 3 days, 10:31:16 |
+| Zen Browser local building and running shows Firefox only not zen type visual | https://github.com/zen-browser/desktop/issues/6128 | None | 3 days, 10:31:16 |
 | Cannot download files with the flatpak version of Zen | https://github.com/zen-browser/desktop/issues/6127 | 10:53:18 | 22 days, 18:27:20 |
 | File Browser doesnt list user home directory files | https://github.com/zen-browser/desktop/issues/6126 | 22 days, 18:35:54 | 22 days, 18:35:55 |
 | Dragging sidebar moves the window | https://github.com/zen-browser/desktop/issues/6125 | 19:01:23 | 22 days, 19:16:45 |
@@ -800,7 +800,7 @@
 | YouTube not opening in theater mode | https://github.com/zen-browser/desktop/issues/6078 | 24 days, 1:55:03 | 24 days, 1:55:03 |
 | Cannot Finish Initial Config due to missing Next Button on Color / Accent Chooser | https://github.com/zen-browser/desktop/issues/6076 | 24 days, 2:23:02 | 24 days, 2:23:02 |
 | Unable to fully integrate GTK and QT themes | https://github.com/zen-browser/desktop/issues/6074 | 1 day, 4:58:09 | 24 days, 4:44:34 |
-| can not install any firefox themes | https://github.com/zen-browser/desktop/issues/6073 | 18:28:31 | 18:28:31 |
+| can not install any Firefox themes | https://github.com/zen-browser/desktop/issues/6073 | 18:28:31 | 18:28:31 |
 | No icon on windows | https://github.com/zen-browser/desktop/issues/6071 | 0:12:31 | 0:23:42 |
 | Twilight Browser: Unexpected Blur Transparency After Update | https://github.com/zen-browser/desktop/issues/6069 | 7:36:42 | 24 days, 11:03:57 |
 | New tabs open as essentials; essentials do not retain order | https://github.com/zen-browser/desktop/issues/6068 | None | 1 day, 15:21:33 |

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -16,4 +16,4 @@
 
 To save the tabs and identity them, they will contain a `zen-workspace-uuid` attribute with the workspace uuid.
 
-We will make use of firefox's builtin session restore feature to save the tabs and windows after the user closes the browser.
+We will make use of Firefox's builtin session restore feature to save the tabs and windows after the user closes the browser.

--- a/src/browser/app/profile/zen-browser.js
+++ b/src/browser/app/profile/zen-browser.js
@@ -339,7 +339,7 @@ pref("network.http.rcwn.enabled", false);
 pref("devtools.debugger.remote-enabled", false);
 pref("devtools.chrome.enabled", true);
 
-// Disable firefox's revamp
+// Disable Firefox's revamp
 pref("sidebar.revamp", false, locked);
 pref("sidebar.verticalTabs", false, locked);
 

--- a/src/firefox-patches/README.md
+++ b/src/firefox-patches/README.md
@@ -1,3 +1,3 @@
-# Temporal patches done to firefox
+# Temporal patches done to Firefox
 
-**IMPORTANT**: Once they start failing (on new firefox reelases), they should be removed as these patches are imported from future versions of firefox as termporary solutions while we wait.
+**IMPORTANT**: Once they start failing (on new Firefox releases), they should be removed as these patches are imported from future versions of Firefox as temporary solutions while we wait.

--- a/src/zen/common/styles/zen-browser-ui.css
+++ b/src/zen/common/styles/zen-browser-ui.css
@@ -104,7 +104,7 @@
 }
 
 #nav-bar {
-  /* For some reason, firefox adds a really small border to the top of the nav-bar */
+  /* For some reason, Firefox adds a really small border to the top of the nav-bar */
   border-top: none !important;
 }
 

--- a/src/zen/common/styles/zen-popup.css
+++ b/src/zen/common/styles/zen-popup.css
@@ -74,7 +74,7 @@ panel {
   padding-inline-start: calc(16px + var(--uc-arrowpanel-menuicon-margin-inline));
 }
 
-/* firefox profile avatar in appmenu */
+/* Firefox profile avatar in appmenu */
 #appMenu-fxa-label2::before {
   content: '';
   display: -moz-box;

--- a/src/zen/common/zenThemeModifier.js
+++ b/src/zen/common/zenThemeModifier.js
@@ -19,7 +19,7 @@ const kZenMaxElementSeparation = 12;
  * because we need a way to apply the accent color without having to worry about
  * shadow roots not inheriting the accent color.
  *
- * note: It must be a firefox builtin page with access to the browser's configuration
+ * note: It must be a Firefox builtin page with access to the browser's configuration
  *  and services.
  */
 var ZenThemeModifier = {

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -394,7 +394,7 @@ class KeyShortcut {
     }
     key.setAttribute('group', this.#group);
 
-    // note to "mr. macos": We add the `zen-` prefix because firefox hasnt been built with the
+    // note to "mr. macos": We add the `zen-` prefix because Firefox hasnt been built with the
     // shortcuts in mind, it will simply just override the shortcuts with whatever the default is.
     //  note that this l10n id is not used for actually translating the key's label, but rather to
     //  identify the default keybinds.


### PR DESCRIPTION
I changed `firefox` to `Firefox` to follow [Firefox's Brand Guidelines](https://mozilla.design/firefox/). Also fixed a few typos in [src/firefox-patches/README.md](https://github.com/zen-browser/desktop/blob/dev/src/firefox-patches/README.md).