### PR TITLE
Make `Move sidebar to right` works in 1.12t

### DIFF
--- a/src/zen/common/styles/zen-sidebar.css
+++ b/src/zen/common/styles/zen-sidebar.css
@@ -15,18 +15,23 @@
     border-radius: var(--zen-native-inner-radius);
     box-shadow: var(--zen-big-shadow);
     overflow: hidden;
-    &[positionend=''] {
-      order: 6;
-      & ~ #sidebar-splitter {
-        order: 5;
-      }
-    }
+    
     :root:not([zen-right-side='true']) &[positionend='true'] {
       margin-right: var(--zen-element-separation);
     }
 
     :root[zen-right-side='true'] & {
       margin-left: var(--zen-element-separation);
+    }
+  }
+
+  & #tabbrowser-tabbox[sidebar-positionend] {
+    & #sidebar-box {
+      order: 7 !important;
+    }
+    
+    & #sidebar-splitter {
+      order: 6 !important;
     }
   }
 }


### PR DESCRIPTION
in 1.12t, attribute for _move sidebar to right_ changes from `positionend` to `sidebar-positionend`
modify CSS accordingly to make it work again