### PR TITLE
Update lch to oklch (changed gradients to a better colorspace)

### DIFF
--- a/src/zen/workspaces/ZenGradientGenerator.mjs
+++ b/src/zen/workspaces/ZenGradientGenerator.mjs
@@ -909,12 +909,12 @@
       } else if (themedColors.length === 1) {
         return this.getSingleRGBColor(themedColors[0], forToolbar);
       } else if (themedColors.length !== 3) {
-        return `linear-gradient(in lch ${this.currentRotation}deg, ${themedColors.map((color) => this.getSingleRGBColor(color, forToolbar)).join(', ')})`;
+        return `linear-gradient(in oklch ${this.currentRotation}deg, ${themedColors.map((color) => this.getSingleRGBColor(color, forToolbar)).join(', ')})`;
       } else {
         let color1 = this.getSingleRGBColor(themedColors[2], forToolbar);
         let color2 = this.getSingleRGBColor(themedColors[0], forToolbar);
         let color3 = this.getSingleRGBColor(themedColors[1], forToolbar);
-        return `linear-gradient(in lch ${this.currentRotation}deg, ${color1}, ${color2}, ${color3})`;
+        return `linear-gradient(in oklch ${this.currentRotation}deg, ${color1}, ${color2}, ${color3})`;
       }
     }
 


### PR DESCRIPTION
I replaced the lch color space with oklch for generating gradients. The oklch color space is based on a more perceptually uniform model (Oklab), which means the colors will look more consistent and natural, especially when it comes to lightness. It also improves how colors appear across different screens, making the gradients more accurate and visually pleasing. I would ideally change it to oklab but that might need more adjustments