### PR TITLE
Fix: Ensure download animation works properly when tabs are right

### DIFF
--- a/src/zen/downloads/ZenDownloadAnimation.mjs
+++ b/src/zen/downloads/ZenDownloadAnimation.mjs
@@ -317,7 +317,6 @@
           `;
 
         const sideProp = areTabsPositionedRight ? 'right' : 'left';
-        const startSideValue = areTabsPositionedRight ? '50px' : '-50px';
 
         const fragment = window.MozXULElement.parseXULToFragment(boxAnimationHTML);
         this.#boxAnimationElement = fragment.querySelector('.zen-download-box-animation');
@@ -325,7 +324,7 @@
         Object.assign(this.#boxAnimationElement.style, {
           bottom: '24px',
           transform: 'scale(0.8)',
-          [sideProp]: startSideValue,
+          [sideProp]: '-50px',
         });
 
         wrapper.appendChild(this.#boxAnimationElement);


### PR DESCRIPTION
## Issue:
When the download button is not visible, the animation ends with a box that should slide in from the side—as it does when the tabs are on the left—but when the tabs are on the right, the box fails to slide in correctly from the right.

https://github.com/user-attachments/assets/a055a2b8-b686-4c1c-b746-a0210302a8da

## Fix:

https://github.com/user-attachments/assets/5ebe6e80-4cca-40e2-88d2-ccfca3658fe1

