### PR TITLE
Add left paading to right tab sidebar in compact mode to avoid regression of #7973

### DIFF
--- a/src/zen/compact-mode/zen-compact-mode.css
+++ b/src/zen/compact-mode/zen-compact-mode.css
@@ -107,6 +107,8 @@
       &[zen-right-side='true'] {
         & #navigator-toolbox:not([animate='true']) {
           right: calc(-1 * var(--actual-zen-sidebar-width) + var(--zen-compact-mode-offset));
+          /* Fix for https://github.com/zen-browser/desktop/issues/7973 */
+          padding-left: max(var(--zen-compact-float), var(--zen-compact-mode-offset)) !important;
         }
 
         & .browserSidebarContainer {


### PR DESCRIPTION
The added padding would be the unhided area of sidebar and is invisible since `#navigator-toolbox` has a transparent background.

Regression seen in 1.12t   20250502102900. Note the right orange line
![未命名](https://github.com/user-attachments/assets/ed2eefc6-e29e-4b34-9faa-c717acecd3fa)

