### PR TITLE
fix: use list-style rather than menu for appMenu items

### DIFF
--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -967,23 +967,23 @@ menuitem[id='placesContext_showAllBookmarks'],
 }
 
 #appMenuRecentlyClosedTabs {
-  --menu-image: url('container-tab.svg');
+  list-style-image: url('container-tab.svg');
 }
 
 #appMenuClearRecentHistory {
-  --menu-image: url('edit-delete.svg');
+  list-style-image: url('edit-delete.svg');
 }
 
 #appMenuRecentlyClosedWindows {
-  --menu-image: url('window.svg');
+  list-style-image: url('window.svg');
 }
 
 #appMenuSearchHistory {
-  --menu-image: url('search-glass.svg');
+  list-style-image: url('search-glass.svg');
 }
 
 #PanelUI-historyMore {
-  --menu-image: url('manage.svg');
+  list-style-image: url('manage.svg');
 }
 
 menuitem[id='placesContext_new:bookmark'],

--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -967,23 +967,23 @@ menuitem[id='placesContext_showAllBookmarks'],
 }
 
 #appMenuRecentlyClosedTabs {
-  list-style-image: url('container-tab.svg');
+  list-style-image: url('container-tab.svg') !important;
 }
 
 #appMenuClearRecentHistory {
-  list-style-image: url('edit-delete.svg');
+  list-style-image: url('edit-delete.svg') !important;
 }
 
 #appMenuRecentlyClosedWindows {
-  list-style-image: url('window.svg');
+  list-style-image: url('window.svg') !important;
 }
 
 #appMenuSearchHistory {
-  list-style-image: url('search-glass.svg');
+  list-style-image: url('search-glass.svg') !important;
 }
 
 #PanelUI-historyMore {
-  list-style-image: url('manage.svg');
+  list-style-image: url('manage.svg') !important;
 }
 
 menuitem[id='placesContext_new:bookmark'],


### PR DESCRIPTION
When using `--menu-image` the list appeared cluttered.
Before:
![image](https://github.com/user-attachments/assets/ffe39446-63cb-4a53-8026-bcb89983f64f)
