### PR TITLE
Fixed typo (markplace) in child actor and replaced it with marketplace.

### DIFF
--- a/src/zen/mods/actors/ZenThemeMarketplaceChild.sys.mjs
+++ b/src/zen/mods/actors/ZenThemeMarketplaceChild.sys.mjs
@@ -51,7 +51,7 @@ export class ZenThemeMarketplaceChild extends JSWindowActorChild {
   initiateThemeMarketplace() {
     this.contentWindow.setTimeout(() => {
       this.addInstallButtons();
-      this.injectMarkplaceAPI();
+      this.injectMarketplaceAPI();
     }, 0);
   }
 
@@ -105,7 +105,7 @@ export class ZenThemeMarketplaceChild extends JSWindowActorChild {
     }
   }
 
-  injectMarkplaceAPI() {
+  injectMarketplaceAPI() {
     Cu.exportFunction(this.installTheme.bind(this), this.contentWindow, {
       defineAs: 'ZenInstallTheme',
     });


### PR DESCRIPTION
There is a function inside of the child actor file for Zen Themes. This function was named ```injectMarkplaceAPI``` which is probably a typo so I replaced it with ```injectMarketplaceAPI```.

EDIT: I did also notice an ```actionButtonUnnstall``` variable but I left it alone because there was another function called ```actionButtonUninstall```. (So it was probably intentional)