### PR TITLE
Fix toast alignment in right sidebar

### DIFF
--- a/src/zen/common/styles/zen-popup.css
+++ b/src/zen/common/styles/zen-popup.css
@@ -347,6 +347,7 @@ menuitem {
 
   :root[zen-right-side='true'] & {
     left: calc(var(--zen-element-separation) * 2);
+    align-items: start!important;
   }
 
   & .zen-toast {


### PR DESCRIPTION
This changes how the toast is aligned when sidebar is on the right.

![8585](https://github.com/user-attachments/assets/3136b78f-3456-4ecc-8660-766253701090)

Previously, it was out of view.

![35893](https://github.com/user-attachments/assets/b9d0f6b5-bc28-4e1d-a343-f79c2b86b6f5)
