### PR TITLE
feat: show system notification once download is complete, canceled or failed

### DIFF
--- a/src/browser/app/profile/features.inc
+++ b/src/browser/app/profile/features.inc
@@ -140,3 +140,6 @@ pref('zen.splitView.rearrange-hover-size', 24);
 // Zen Download Animations
 pref('zen.downloads.download-animation', true);
 pref('zen.downloads.download-animation-duration', 1000); // ms
+
+// Zen Download Notifications
+pref('zen.downloads.download-notifications', true);

--- a/src/zen/downloads/ZenDownloadAnimation.mjs
+++ b/src/zen/downloads/ZenDownloadAnimation.mjs
@@ -34,6 +34,15 @@
         const list = await Downloads.getList(Downloads.ALL);
         list.addView({
           onDownloadAdded: this.#handleNewDownload.bind(this),
+          onDownloadChanged: download => {
+            if (download.succeeded) {
+              this.#handleDownloadComplete(download);
+            } else if (download.canceled) {
+              this.#handleDownloadCanceled(download);
+            } else if (download.error) {
+              this.#handleDownloadFailed(download);
+            }
+          },
         });
       } catch (error) {
         console.error(
@@ -55,6 +64,45 @@
       }
 
       this.#animateDownload(this.#lastClickPosition);
+    }
+
+    async #handleDownloadComplete(download) {
+      if (!Services.prefs.getBoolPref('zen.downloads.download-animation')) {
+        return;
+      }
+      const title = await document.l10n.formatValue('zen-download-complete') ?? 'Download Complete';
+      const body = await document.l10n.formatValue('zen-download-complete-body', { filename: download.target.path }) ?? 
+        `File "${download.target.path}" has finished downloading.`;
+      const notification = new Notification(title, {
+        body: body,
+        icon: 'chrome://browser/skin/downloads/download.svg',
+      });
+    }
+
+    async #handleDownloadCanceled(download) {
+      if (!Services.prefs.getBoolPref('zen.downloads.download-animation')) {
+        return;
+      }
+      const title = await document.l10n.formatValue('zen-download-canceled') ?? 'Download Canceled';
+      const body = await document.l10n.formatValue('zen-download-canceled-body', { filename: download.target.path }) ?? 
+        `File "${download.target.path}" download was canceled.`;
+      const notification = new Notification(title, {
+        body: body,
+        icon: 'chrome://browser/skin/downloads/download.svg',
+      });
+    }
+
+    async #handleDownloadFailed(download) {
+      if (!Services.prefs.getBoolPref('zen.downloads.download-animation')) {
+        return;
+      }
+      const title = await document.l10n.formatValue('zen-download-failed') ?? 'Download Failed';
+      const body = await document.l10n.formatValue('zen-download-failed-body', { filename: download.target.path }) ?? 
+        `Failed to download file "${download.target.path}".`;
+      const notification = new Notification(title, {
+        body: body,
+        icon: 'chrome://browser/skin/downloads/download.svg',
+      });
     }
 
     #animateDownload(startPosition) {

--- a/src/zen/downloads/ZenDownloadAnimation.mjs
+++ b/src/zen/downloads/ZenDownloadAnimation.mjs
@@ -67,7 +67,7 @@
     }
 
     async #handleDownloadComplete(download) {
-      if (!Services.prefs.getBoolPref('zen.downloads.download-animation')) {
+      if (!Services.prefs.getBoolPref('zen.downloads.download-notifications')) {
         return;
       }
       const title = await document.l10n.formatValue('zen-download-complete') ?? 'Download Complete';
@@ -80,7 +80,7 @@
     }
 
     async #handleDownloadCanceled(download) {
-      if (!Services.prefs.getBoolPref('zen.downloads.download-animation')) {
+      if (!Services.prefs.getBoolPref('zen.downloads.download-notifications')) {
         return;
       }
       const title = await document.l10n.formatValue('zen-download-canceled') ?? 'Download Canceled';
@@ -93,7 +93,7 @@
     }
 
     async #handleDownloadFailed(download) {
-      if (!Services.prefs.getBoolPref('zen.downloads.download-animation')) {
+      if (!Services.prefs.getBoolPref('zen.downloads.download-notifications')) {
         return;
       }
       const title = await document.l10n.formatValue('zen-download-failed') ?? 'Download Failed';


### PR DESCRIPTION
Added desktop notifications for download events.
The browser now shows a system notification when a download:

- completes successfully

- is canceled

- fails due to error

Each notification:

- Uses a localized title and message (document.l10n.formatValue)

- Falls back to plain strings if localization fails

- Includes the downloaded file's path

- Uses the standard download.svg icon

- Can be toggled via the zen.downloads.download-notifications preference

This enhancement improves user feedback and aligns with modern UX expectations for background downloads.

![image](https://github.com/user-attachments/assets/9272defb-a3ad-4ada-92d3-3a34d4a68d59)

Translations (l10n): https://github.com/zen-browser/l10n-packs/pull/153