### PR TITLE
Add fix for #7810

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -981,8 +981,11 @@ var gZenCKSSettings = {
             sibling.remove();
           }
         }
+        if (target.classList.contains(`${ZEN_CKS_INPUT_FIELD_CLASS}-not-set`)) {
+          target.label = 'Not set';
+        }
       });
-
+      
       const groupElem = wrapper.querySelector(`[data-group="${ZEN_CKS_GROUP_PREFIX}-${group}"]`);
       groupElem.after(fragment);
     }
@@ -1038,6 +1041,7 @@ var gZenCKSSettings = {
     shortcut = shortcut.replace(/Ctrl|Control|Shift|Alt|Option|Cmd|Meta/, ''); // Remove all modifiers
 
     if (shortcut == 'Tab' && !modifiersActive) {
+      input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-not-set`);
       input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-editing`);
       this._latestValidKey = null;
       return;
@@ -1065,6 +1069,9 @@ var gZenCKSSettings = {
         input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-editing`);
 
         this._editDone(this._latestValidKey, this._latestModifier);
+        if (this.name == 'Not set') {
+          input.classList.add(`${ZEN_CKS_INPUT_FIELD_CLASS}-not-set`);
+        } 
         this._latestValidKey = null;
         this._latestModifier = null;
         input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-invalid`);
@@ -1086,6 +1093,10 @@ var gZenCKSSettings = {
       this._latestValidKey = null;
       this._latestModifier = null;
       this._hasSafed = true;
+      const sibling = input.nextElementSibling;
+      if (sibling && sibling.classList.contains(`${ZEN_CKS_CLASS_BASE}-conflict`)) {
+        sibling.remove();
+      }
       return;
     }
 

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -985,7 +985,7 @@ var gZenCKSSettings = {
           target.label = 'Not set';
         }
       });
-      
+
       const groupElem = wrapper.querySelector(`[data-group="${ZEN_CKS_GROUP_PREFIX}-${group}"]`);
       groupElem.after(fragment);
     }
@@ -1071,7 +1071,7 @@ var gZenCKSSettings = {
         this._editDone(this._latestValidKey, this._latestModifier);
         if (this.name == 'Not set') {
           input.classList.add(`${ZEN_CKS_INPUT_FIELD_CLASS}-not-set`);
-        } 
+        }
         this._latestValidKey = null;
         this._latestModifier = null;
         input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-invalid`);


### PR DESCRIPTION
To fix this, I just had to add a small line of code which takes care of removing the error message when the user deletes the key binding.

I also added some fixes to small visual bugs, for example, when clicking escape on anything, even when not changed from unset, it would give the impression that it has changed. I also changed it so that when you close and reopen, if the shortcut has not been set, it will have the name 'Not set' as before; it would have the unset changed name in grey if that makes sense.