### PR TITLE
Added workspace color bg to search mode indicators

### DIFF
--- a/src/zen/common/styles/zen-urlbar.css
+++ b/src/zen/common/styles/zen-urlbar.css
@@ -507,6 +507,10 @@ button.popup-notification-dropmarker {
   }
 }
 
+#urlbar-search-mode-indicator {
+  background-color: color-mix(in srgb, var(--zen-primary-color) 50%, transparent 50%) !important;
+}
+
 /* Code ~~stolen~~ taken inspiration from https://github.com/greeeen-dev/zen-arc-cmd-bar
  *
  * MIT License


### PR DESCRIPTION
Added a background color for search mode indicators:
![image](https://github.com/user-attachments/assets/8ff29c97-96b5-4101-8b78-3d3ac5b95b90)
