### PR TITLE
Potential fix for code scanning alert no. 18: Overly permissive regular expression range

### DIFF
--- a/src/zen/mods/ZenThemesCommon.mjs
+++ b/src/zen/mods/ZenThemesCommon.mjs
@@ -76,7 +76,7 @@ var ZenThemesCommon = {
 
       for (let [entry, label] of Object.entries(preferences)) {
         const [_, negation = '', os = '', property] =
-          /(!?)(?:(macos|windows|linux):)?([A-z0-9-_.]+)/g.exec(entry);
+          /(!?)(?:(macos|windows|linux):)?([A-Za-z0-9-_.]+)/g.exec(entry);
         const isNegation = negation === '!';
 
         if (


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/18](https://github.com/zen-browser/desktop/security/code-scanning/18)

To fix the issue, the overly permissive range `A-z` should be replaced with a more precise range that matches only uppercase and lowercase letters (`A-Z` and `a-z`). The corrected regular expression will explicitly include the intended characters: uppercase letters, lowercase letters, digits (`0-9`), and the symbols `-`, `_`, and `.`.

The specific change is to replace `/[A-z0-9-_.]+/` with `/[A-Za-z0-9-_.]+/`. This ensures that the regular expression matches only the intended characters without introducing unintended matches.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
