### PR TITLE
Potential fix for code scanning alert no. 19: Overly permissive regular expression range

### DIFF
--- a/src/zen/mods/ZenThemesImporter.mjs
+++ b/src/zen/mods/ZenThemesImporter.mjs
@@ -249,7 +249,7 @@ var gZenThemesImporter = new (class {
   writeToDom(themesWithPreferences) {
     for (const browser of ZenMultiWindowFeature.browsers) {
       for (const { enabled, preferences, name } of themesWithPreferences) {
-        const sanitizedName = `theme-${name?.replaceAll(/\s/g, '-')?.replaceAll(/[^A-z_-]+/g, '')}`;
+        const sanitizedName = `theme-${name?.replaceAll(/\s/g, '-')?.replaceAll(/[^A-Za-z_-]+/g, '')}`;
 
         if (enabled !== undefined && !enabled) {
           const element = browser.document.getElementById(sanitizedName);


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/19](https://github.com/zen-browser/desktop/security/code-scanning/19)

To fix the issue, the overly permissive range `A-z` in the regular expression should be replaced with `A-Za-z`, which explicitly matches only uppercase and lowercase letters. This change ensures that the sanitization process removes all unintended characters while preserving valid alphabetic characters, underscores, and hyphens.

The specific change is in the `replaceAll` method on line 252, where the regular expression `/[^A-z_-]+/g` should be updated to `/[^A-Za-z_-]+/g`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
