### PR TITLE
Potential fix for code scanning alert no. 17: Overly permissive regular expression range

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -275,7 +275,7 @@ var gZenMarketplaceManager = {
     const themeList = document.createElement('div');
 
     for (const theme of Object.values(themes).sort((a, b) => a.name.localeCompare(b.name))) {
-      const sanitizedName = `theme-${theme.name?.replaceAll(/\s/g, '-')?.replaceAll(/[^A-z_-]+/g, '')}`;
+      const sanitizedName = `theme-${theme.name?.replaceAll(/\s/g, '-')?.replaceAll(/[^A-Za-z_-]+/g, '')}`;
       const isThemeEnabled = theme.enabled === undefined || theme.enabled;
       const fragment = window.MozXULElement.parseXULToFragment(`
         <vbox class="zenThemeMarketplaceItem">


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/17](https://github.com/zen-browser/desktop/security/code-scanning/17)

To fix the issue, the overly permissive range `A-z` should be replaced with a more precise range that matches only uppercase and lowercase alphabetic characters. Specifically, the range should be updated to `A-Za-z`. This ensures that only valid alphabetic characters are included, while excluding unintended characters like `[`, `\`, `]`, `^`, `_`, and `` ` ``.

The updated regular expression will look like `/[^A-Za-z_-]+/g`, which matches any character that is not an uppercase or lowercase letter, an underscore, or a hyphen. This change ensures that the sanitization process works as intended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
