### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -449,6 +449,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [windows-step-3, linux]
     if: always()
+    permissions:
+      contents: read
     steps:
       - name: Download aws-cli
         if: ${{ inputs.create_release && inputs.update_branch == 'release' }}


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/16](https://github.com/zen-browser/desktop/security/code-scanning/16)

To fix the issue, we will add a `permissions` block to the `stop-self-hosted` job. Since the job does not appear to require any write permissions, we will set the permissions to `contents: read`, which is the minimal permission required for most workflows. This ensures that the job has only the permissions it needs and does not inherit potentially excessive permissions from the repository or workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
