### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows-release-build.yml
+++ b/.github/workflows/windows-release-build.yml
@@ -1,5 +1,8 @@
 name: Windows Release Build
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/15](https://github.com/zen-browser/desktop/security/code-scanning/15)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the `GITHUB_TOKEN` to the minimal required permissions. Based on the workflow's operations, the `contents: read` permission is sufficient for most steps, as they primarily involve reading repository contents and caching artifacts. If any step requires additional permissions, they can be added at the job level.

The `permissions` block will be added at the root of the workflow file, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
