### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows-profile-build.yml
+++ b/.github/workflows/windows-profile-build.yml
@@ -1,5 +1,8 @@
 name: Windows PGO Builds
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/14](https://github.com/zen-browser/desktop/security/code-scanning/14)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions granted to the `GITHUB_TOKEN` for the entire workflow. Based on the provided workflow, the minimal required permissions appear to be `contents: read`, as the workflow primarily involves downloading artifacts, setting up tools, and running commands without modifying repository contents. If additional permissions are required for specific steps, they can be added to the `permissions` block or defined at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
