### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/twilight-release-schedule.yml
+++ b/.github/workflows/twilight-release-schedule.yml
@@ -27,6 +27,8 @@ jobs:
     name: Post Build
     runs-on: ubuntu-latest
     needs: twilight-release-schedule
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/13](https://github.com/zen-browser/desktop/security/code-scanning/13)

To fix the issue, we will add an explicit `permissions` block to the `Post Build` job. Since the job only performs read operations (e.g., checking out the repository), we will set the permissions to `contents: read`. This ensures that the job has the minimal permissions required to function correctly.

The changes will be made to the `.github/workflows/twilight-release-schedule.yml` file, specifically within the `Post Build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
