### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/macos-universal-release-build.yml
+++ b/.github/workflows/macos-universal-release-build.yml
@@ -1,5 +1,11 @@
 name: macOS Release Build
 
+permissions:
+  contents: read
+  actions: read
+  packages: read
+  id-token: write
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/9](https://github.com/zen-browser/desktop/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required. Based on the operations in the workflow, the following permissions are necessary:
- `contents: read` for accessing the repository contents.
- `actions: read` for downloading artifacts from other workflows.
- `packages: read` for accessing packages if needed.
- `id-token: write` for authentication with external services if required.

We will add this block at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific `permissions` blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
