### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -1,4 +1,7 @@
 name: Monthly issue metrics
+permissions:
+  contents: write
+  issues: read
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/5](https://github.com/zen-browser/desktop/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required. Based on the workflow's operations:
1. The `contents: write` permission is needed for committing changes to the repository.
2. The `issues: read` permission is required for the `issue-metrics` tool to query issues.
3. All other permissions will be omitted to minimize access.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
