### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-linter.yml
+++ b/.github/workflows/code-linter.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/2](https://github.com/zen-browser/desktop/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the least privileges required for the workflow to function. Since the workflow only checks out the repository and runs linting commands, it only needs `contents: read` permissions. This change will ensure that the workflow does not have unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
