### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-candidate-release.yml
+++ b/.github/workflows/check-candidate-release.yml
@@ -5,6 +5,9 @@ on:
     - cron: '59 4 * * 2'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check_candidates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/1](https://github.com/zen-browser/desktop/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's functionality, it only needs to read the repository contents. Therefore, we will set `contents: read` as the permission. This change will ensure that the `GITHUB_TOKEN` used in the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
