### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,6 +199,8 @@ jobs:
     name: Lint
 
   check-release:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [build-data, lint]
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/11](https://github.com/zen-browser/desktop/security/code-scanning/11)

To address the issue, we will add a `permissions` block to the `check-release` job. Based on the job's steps, it primarily involves checking out the repository, setting up Node.js, installing dependencies, and running commands. These actions typically require only `contents: read` permissions. We will explicitly set this minimal permission level to ensure the job has only the access it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
