### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/macos-release-build.yml
+++ b/.github/workflows/macos-release-build.yml
@@ -1,4 +1,6 @@
 name: macOS Release Build
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/8](https://github.com/zen-browser/desktop/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's steps, the `contents: read` permission is sufficient for most actions, such as checking out the repository and uploading artifacts. No write permissions are necessary unless explicitly required by a step, which is not evident in this workflow.

The `permissions` block will be added at the top level of the workflow, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
