### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,8 @@ jobs:
           commit_user_email: zen-browser-auto@users.noreply.github.com
 
   lint:
+    permissions:
+      contents: read
     uses: ./.github/workflows/code-linter.yml
     needs: [build-data]
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/20](https://github.com/zen-browser/desktop/security/code-scanning/20)

To fix the issue, we will add a `permissions` block to the `lint` job in the workflow. Since the `lint` job is likely only reading the repository contents to perform linting, we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to complete the task.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
