### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Zen Release builds
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -77,6 +80,9 @@ jobs:
           echo "bid=${bdat}" >> $GITHUB_OUTPUT
 
   start-self-host:
+    permissions:
+      contents: read
+      secrets: read
     runs-on: ubuntu-latest
     needs: debug-inputs
     steps:
@@ -102,6 +108,8 @@ jobs:
           rm start.sh || true
 
   check-build-is-correct:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [debug-inputs]
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/desktop/security/code-scanning/6](https://github.com/zen-browser/desktop/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for the `GITHUB_TOKEN`. Based on the workflow's operations, the following permissions are necessary:
- `contents: read` for accessing repository contents during the `actions/checkout@v4` step.
- `contents: write` if the workflow modifies repository contents (e.g., creating releases or updating branches).
- Additional permissions (e.g., `actions: write`, `pull-requests: write`) if specific steps require them.

We will analyze the workflow and assign the least privileges required for each job. If a job does not require elevated permissions, it will inherit the root-level permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
