### PR TITLE
Deploy  dependencies in AppImage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,40 +419,40 @@ jobs:
 
           # deploy deps so that the appimage can work on musl systems as well as super old distros: 
           SYSLIBS="/usr/lib/$ARCH-linux-gnu"
-          cd $APPDIR && (
-            wget "https://github.com/VHSgunzo/sharun/releases/latest/download/sharun-$ARCH-aio" -O ./sharun-aio
-            chmod +x ./sharun-aio
-            ./sharun-aio l -p -v -s -k            \
-              ./bin/zen*                          \
-              ./bin/glxtest                       \
-              ./bin/vaapitest                     \
-              ./bin/pingsender                    \
-              ./bin/lib*                          \
-              "$SYSLIBS"/lib*GL*                  \
-              "$SYSLIBS"/dri/*                    \
-              "$SYSLIBS"/libpci.so*               \
-              "$SYSLIBS"/libxcb-*                 \
-              "$SYSLIBS"/libXcursor.so*           \
-              "$SYSLIBS"/libXinerama*             \
-              "$SYSLIBS"/libwayland*              \
-              "$SYSLIBS"/libnss*                  \
-              "$SYSLIBS"/libsoftokn3.so           \
-              "$SYSLIBS"/libfreeblpriv3.so        \
-              "$SYSLIBS"/libgtk*                  \
-              "$SYSLIBS"/libgdk*                  \
-              "$SYSLIBS"/libcanberra*             \
-              "$SYSLIBS"/gdk-pixbuf-*/*/loaders/* \
-              "$SYSLIBS"/libcloudproviders*       \
-              "$SYSLIBS"/gconv/*                  \
-              "$SYSLIBS"/pkcs11/*                 \
-              "$SYSLIBS"/gvfs/*                   \
-              "$SYSLIBS"/libcanberra*/*           \
-              "$SYSLIBS"/gio/modules/*            \
-              "$SYSLIBS"/pulseaudio/*             \
-              "$SYSLIBS"/alsa-lib/*
-            rm -f ./sharun-aio
-            ./sharun -g
-          )
+          cd $APPDIR
+          wget "https://github.com/VHSgunzo/sharun/releases/latest/download/sharun-$ARCH-aio" -O ./sharun-aio
+          chmod +x ./sharun-aio
+          ./sharun-aio l -p -v -s -k            \
+            ./bin/zen*                          \
+            ./bin/glxtest                       \
+            ./bin/vaapitest                     \
+            ./bin/pingsender                    \
+            ./bin/lib*                          \
+            "$SYSLIBS"/lib*GL*                  \
+            "$SYSLIBS"/dri/*                    \
+            "$SYSLIBS"/libpci.so*               \
+            "$SYSLIBS"/libxcb-*                 \
+            "$SYSLIBS"/libXcursor.so*           \
+            "$SYSLIBS"/libXinerama*             \
+            "$SYSLIBS"/libwayland*              \
+            "$SYSLIBS"/libnss*                  \
+            "$SYSLIBS"/libsoftokn3.so           \
+            "$SYSLIBS"/libfreeblpriv3.so        \
+            "$SYSLIBS"/libgtk*                  \
+            "$SYSLIBS"/libgdk*                  \
+            "$SYSLIBS"/libcanberra*             \
+            "$SYSLIBS"/gdk-pixbuf-*/*/loaders/* \
+            "$SYSLIBS"/libcloudproviders*       \
+            "$SYSLIBS"/gconv/*                  \
+            "$SYSLIBS"/pkcs11/*                 \
+            "$SYSLIBS"/gvfs/*                   \
+            "$SYSLIBS"/libcanberra*/*           \
+            "$SYSLIBS"/gio/modules/*            \
+            "$SYSLIBS"/pulseaudio/*             \
+            "$SYSLIBS"/alsa-lib/*
+          rm -f ./sharun-aio
+          ./sharun -g
+          cd -
 
           wget "https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH" -O ./uruntime
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,6 +452,8 @@ jobs:
             "$SYSLIBS"/alsa-lib/*
           rm -f ./sharun-aio
           ./sharun -g
+          # It seems Zen has built in code to load shared libs that bypasses --library-path, this fixes it
+          ln -sr ./lib/lib* ./bin || true
           cd -
 
           wget "https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH" -O ./uruntime

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -478,6 +478,10 @@ jobs:
             --header uruntime                    \
             -i "$APPDIR" -o zen-"$ARCH".AppImage
 
+          # make zsync file
+          echo "Generating zsync file..."
+          zsyncmake ./zen-"$ARCH".AppImage -u ./zen-"$ARCH".AppImage
+
           mkdir dist
           mv zen*AppImage* dist/.
           unset ARCH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,7 +389,9 @@ jobs:
         run: |
           npm install
           sudo apt-get update
-          sudo apt-get -y install libfuse2 desktop-file-utils appstream
+          sudo apt-get -y install wget ffmpeg dconf-gsettings-backend p11-kit-modules libgtk-3-0t64 \
+            libgdk-pixbuf-2.0-0 libasound2t64 libasound2-plugins libegl1 libpulse0 libegl-mesa0 tar \
+            libxcb-dri3-0 libxcb-dri2-0 libxcursor1 libxinerama1 libxcb-glx0 libxcb-icccm4 libpci3 zsync 
 
       - name: Download Linux build
         uses: actions/download-artifact@v4
@@ -412,21 +414,70 @@ jobs:
 
           APPDIR=build/AppDir
           tar -xvf *.tar.* && rm -rf *.tar.*
-          mv zen/* $APPDIR/
-          wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
-          wget "https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-squashfs-lite-$ARCH"
-          chmod +x *.AppImage
-          chmod +x ./uruntime-appimage-squashfs-lite-"$ARCH"
+          mkdir -p $APPDIR/bin
+          mv zen/* $APPDIR/bin
+
+          # deploy deps so that the appimage can work on musl systems as well as super old distros: 
+          SYSLIBS="/usr/lib/$ARCH-linux-gnu"
+          cd $APPDIR && (
+            wget "https://github.com/VHSgunzo/sharun/releases/latest/download/sharun-$ARCH-aio" -O ./sharun-aio
+            chmod +x ./sharun-aio
+            ./sharun-aio l -p -v -s -k            \
+              ./bin/zen*                          \
+              ./bin/glxtest                       \
+              ./bin/vaapitest                     \
+              ./bin/pingsender                    \
+              ./bin/lib*                          \
+              "$SYSLIBS"/lib*GL*                  \
+              "$SYSLIBS"/dri/*                    \
+              "$SYSLIBS"/libpci.so*               \
+              "$SYSLIBS"/libxcb-*                 \
+              "$SYSLIBS"/libXcursor.so*           \
+              "$SYSLIBS"/libXinerama*             \
+              "$SYSLIBS"/libwayland*              \
+              "$SYSLIBS"/libnss*                  \
+              "$SYSLIBS"/libsoftokn3.so           \
+              "$SYSLIBS"/libfreeblpriv3.so        \
+              "$SYSLIBS"/libgtk*                  \
+              "$SYSLIBS"/libgdk*                  \
+              "$SYSLIBS"/libcanberra*             \
+              "$SYSLIBS"/gdk-pixbuf-*/*/loaders/* \
+              "$SYSLIBS"/libcloudproviders*       \
+              "$SYSLIBS"/gconv/*                  \
+              "$SYSLIBS"/pkcs11/*                 \
+              "$SYSLIBS"/gvfs/*                   \
+              "$SYSLIBS"/libcanberra*/*           \
+              "$SYSLIBS"/gio/modules/*            \
+              "$SYSLIBS"/pulseaudio/*             \
+              "$SYSLIBS"/alsa-lib/*
+            rm -f ./sharun-aio
+            ./sharun -g
+          )
+
+          wget "https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH" -O ./uruntime
+
+          chmod +x ./uruntime
           chmod +x ./build/AppDir/AppRun
 
           # keep the uruntime mountpoint (massively speeds up launch time)
-          sed -i 's|URUNTIME_MOUNT=[0-9]|URUNTIME_MOUNT=0|' ./uruntime-appimage-squashfs-lite-"$ARCH"
+          sed -i 's|URUNTIME_MOUNT=[0-9]|URUNTIME_MOUNT=0|' ./uruntime
+
+          # add zsync delta update info
+          ./uruntime --appimage-addupdinfo "$UPINFO"
 
           echo "AppDir: $APPDIR"
           ls -al
           find .
           ls -al "$APPDIR"
-          ./appimagetool-x86_64.AppImage -u "$UPINFO" "$APPDIR" zen-"$ARCH".AppImage --runtime-file ./uruntime-appimage-squashfs-lite-"$ARCH"
+
+          echo "Generating AppImage..."
+          ./uruntime --appimage-mkdwarfs -f      \
+            --set-owner 0 --set-group 0          \
+            --no-history --no-create-timestamp   \
+            --compression zstd:level=22 -S26 -B8 \
+            --header uruntime                    \
+            -i "$APPDIR" -o zen-"$ARCH".AppImage
+
           mkdir dist
           mv zen*AppImage* dist/.
           unset ARCH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,7 +391,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install wget ffmpeg dconf-gsettings-backend p11-kit-modules libgtk-3-0t64 \
             libgdk-pixbuf-2.0-0 libasound2t64 libasound2-plugins libegl1 libpulse0 libegl-mesa0 tar \
-            libxcb-dri3-0 libxcb-dri2-0 libxcursor1 libxinerama1 libxcb-glx0 libxcb-icccm4 libpci3 zsync 
+            libxcb-dri3-0 libxcb-dri2-0 libxcursor1 libxinerama1 libxcb-glx0 libxcb-icccm4 libpci3 zsync
 
       - name: Download Linux build
         uses: actions/download-artifact@v4

--- a/build/AppDir/AppRun
+++ b/build/AppDir/AppRun
@@ -1,6 +1,5 @@
 #!/bin/sh
 CURRENTDIR="$(dirname "$(readlink -f "$0")")"
-export PATH="${CURRENTDIR}:${PATH}"
 export MOZ_LEGACY_PROFILES=1          # Prevent per installation profiles
 export MOZ_APP_LAUNCHER="${APPIMAGE}" # Allows setting as default browser
-exec "${CURRENTDIR}/zen" "$@"
+exec "${CURRENTDIR}/bin/zen" "$@"


### PR DESCRIPTION
fixes #7967 and likely other similar issues. 

So far Zen has just used the portable tarball build repacked as an AppImage, while this is usually good enough™ It means that the AppImage can't really work everywhere since the portable tar build depends on the host glibc.

These changes add the needed dependencies to guaranteed operation anywhere, such as musl distros and distros as old as ubuntu 14.04. 

--------------------------------------------------------------------

Considerations: 

This change will break integration with appimaged and appimagelauncher since I switched the AppImage to dwarfs to reduce the final size (now 180 MiB). I could go back to squashfs but that makes the AppImage **+250 MiB** and I don't think it is worth it 👀

Note that this is unrelated to the [infamous execv error](https://github.com/zen-browser/desktop/issues/2911) people will still be able to launch it even on appimagelauncher, just that integration is broken due to it not being able to read dwarfs.

AM, dbin, Gearlever, soar, etc already support dwarfs so it is not an issue there.

**Note** I'm not able to figure out how the CI works, so I'm not sure if I made a mistake in the steps. 😅 I did testing [here](https://github.com/Samueru-sama/zen-appimage-test) instead by using the tarball directly.
