### PR TITLE
Add a unique id to the checkbox for auto-updating Zen Mods on startup.

### DIFF
--- a/src/browser/components/preferences/zenMarketplace.inc.xhtml
+++ b/src/browser/components/preferences/zenMarketplace.inc.xhtml
@@ -20,7 +20,7 @@
             <button id="zenThemeMarketplaceCheckForUpdates" data-l10n-id="zen-theme-marketplace-check-for-updates-button" />
       </hbox>
 
-      <checkbox id="zenWorkspacesForceContainerTabsToWorkspace"
+      <checkbox id="zenThemeMarketplaceEnableAutoUpdate"
             data-l10n-id="zen-themes-auto-update"
             preference="zen.mods.auto-update"/>
 

--- a/src/browser/components/preferences/zenMarketplace.inc.xhtml
+++ b/src/browser/components/preferences/zenMarketplace.inc.xhtml
@@ -20,7 +20,7 @@
             <button id="zenThemeMarketplaceCheckForUpdates" data-l10n-id="zen-theme-marketplace-check-for-updates-button" />
       </hbox>
 
-      <checkbox id="zenThemeMarketplaceEnableAutoUpdate"
+      <checkbox id="zenThemeMarketplaceAutoUpdate"
             data-l10n-id="zen-themes-auto-update"
             preference="zen.mods.auto-update"/>
 


### PR DESCRIPTION
The recent pr that changed the Zen Mods structure uses a preexisting id for the auto-updating checkbox and this pr fixes that by replacing it with ```zenThemeMarketplaceAutoUpdate```.