### PR TITLE
Fix misaligned split view favicons

### DIFF
--- a/src/zen/folders/zen-folders.css
+++ b/src/zen/folders/zen-folders.css
@@ -14,8 +14,6 @@ tab-group[split-view-group] {
   display: flex;
   flex-wrap: nowrap;
   border-radius: var(--border-radius-medium);
-  padding: 0 2px;
-  margin-inline: var(--tab-block-margin);
   margin-block: var(--tab-block-margin);
   min-height: var(--tab-min-height);
   outline: var(--tab-outline);

--- a/src/zen/folders/zen-folders.css
+++ b/src/zen/folders/zen-folders.css
@@ -14,6 +14,7 @@ tab-group[split-view-group] {
   display: flex;
   flex-wrap: nowrap;
   border-radius: var(--border-radius-medium);
+  padding: 0 2px;
   margin-block: var(--tab-block-margin);
   min-height: var(--tab-min-height);
   outline: var(--tab-outline);


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/50708082-8a7f-47b3-a24f-4e1befe9dff9)

After:
![image](https://github.com/user-attachments/assets/45210e8e-ac94-4f30-b9f4-c4b35c2dbdc1)
