### PR TITLE
fix(shortcuts): 🐛 remove special characters on macos

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1045,10 +1045,13 @@ var gZenCKSSettings = {
     const modifiersActive = modifiers.areAnyActive();
 
     input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-not-set`);
-
-    // This is because on some OSs (windows/macos mostly) the key is not the same as the keycode
-    // e.g. CTRL+ALT+3 may be displayed as the euro sign
-    let shortcut = event.key;
+    
+    // First, try to read the *physical* key via event.code.
+    // If event.code is like "KeyS", "KeyA", ..., strip off "Key" → "S".
+    // Otherwise, fall back to event.key (e.g. "F5", "Enter", etc.).
+    let shortcut;
+    if (event.code && event.code.startsWith("Key")) shortcut = event.code.slice(3);
+    else shortcut = event.key;
 
     shortcut = shortcut.replace(/Ctrl|Control|Shift|Alt|Option|Cmd|Meta/, ''); // Remove all modifiers
 


### PR DESCRIPTION
Hey everyone,

this aims to fix the special character input bug described in #8130. 🙌

Kind regards,
@lukas-runge