### PR TITLE
Removes repetition of a pre-existing function from the marketplace manager.

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -131,6 +131,11 @@ var gZenMarketplaceManager = {
     return this._modsList;
   },
 
+  _triggerBuildUpdateWithoutRebuild() {
+    this._doNotRebuildModsList = true;
+    gZenMods.triggerModsUpdate();
+  },
+
   async removeMod(modId) {
     await gZenMods.removeMod(modId);
 
@@ -140,20 +145,13 @@ var gZenMarketplaceManager = {
   async disableMod(modId) {
     await gZenMods.disableMod(modId);
 
-    this._doNotRebuildModsList = true;
-    gZenMods.triggerModsUpdate();
+    this._triggerBuildUpdateWithoutRebuild();
   },
 
   async enableMod(modId) {
     await gZenMods.enableMod(modId);
 
-    this._doNotRebuildModsList = true;
-    gZenMods.triggerModsUpdate();
-  },
-
-  _triggerBuildUpdateWithoutRebuild() {
-    this._doNotRebuildModsList = true;
-    gZenMods.triggerModsUpdate();
+    this._triggerBuildUpdateWithoutRebuild();
   },
 
   async _importThemes() {


### PR DESCRIPTION
I have removed the unnecessary repetition of what ```gZenMarketplaceManager._triggerBuildUpdateWithoutRebuild``` already does and replaced those situations with calls to that actual function.

I have also rearranged that function to before the functions that call it so the flow makes more sense.