### PR TITLE
Live Folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,2 @@
-.dotbuild/
-engine/
-firefox-*/
-node_modules/
-.surfer/
-
-__pycache__/
-dist/
-
-windsign-temp/
-venv/
-
-!firefox-cache/
-win-cross/
-
-!firefox-patches/
+# Created by venv; see https://docs.python.org/3/library/venv.html
+*

--- a/src/zen/common/ZenUIManager.mjs
+++ b/src/zen/common/ZenUIManager.mjs
@@ -550,6 +550,7 @@ var gZenVerticalTabsManager = {
 
     gZenCompactModeManager.addEventListener(updateEvent);
     this.initRightSideOrderContextMenu();
+    this.initLiveFolderContextMenu();
 
     window.addEventListener('customizationstarting', this._preCustomize.bind(this));
     window.addEventListener('aftercustomization', this._postCustomize.bind(this));
@@ -1121,4 +1122,64 @@ var gZenVerticalTabsManager = {
 
     this._tabEdited = null;
   },
+
+  initLiveFolderContextMenu() {
+    const menuId = 'navigator-toolbox-menu'; // Primary target
+    const fallbackMenuId = 'tabContextMenu'; // Fallback target
+    let contextMenu = document.getElementById(menuId);
+
+    if (!contextMenu) {
+      contextMenu = document.getElementById(fallbackMenuId);
+    }
+
+    if (contextMenu && !document.getElementById('zen-toolbar-context-enable-github-live-folder')) {
+      const menuItem = document.createXULElement('menuitem');
+      menuItem.setAttribute('id', 'zen-toolbar-context-enable-github-live-folder');
+      // TODO: Replace with data-lazy-l10n-id for localization if this were a production feature.
+      menuItem.setAttribute('label', 'Enable GitHub PR Live Folder');
+      menuItem.setAttribute('command', 'cmd_zenEnableGitHubLiveFolder');
+
+      // Try to find a separator to insert before, or just append
+      const separator = contextMenu.querySelector('menuseparator');
+      if (separator) {
+        contextMenu.insertBefore(menuItem, separator);
+      } else {
+        contextMenu.appendChild(menuItem);
+      }
+    } else {
+      if (!contextMenu) {
+        console.warn('ZenUIManager: Could not find context menu (' + menuId + ' or ' + fallbackMenuId + ') to add Live Folder option.');
+      } else {
+        // Item might already exist, which is fine.
+      }
+    }
+  },
 };
+
+// Command handling for cmd_zenEnableGitHubLiveFolder
+// Attempt to hook into existing command infrastructure or add a listener.
+if (typeof window.goDoCommand !== 'undefined') {
+  const originalGoDoCommand = window.goDoCommand;
+  window.goDoCommand = function(aCommand) {
+    if (aCommand === 'cmd_zenEnableGitHubLiveFolder') {
+      gZenUIManager.openAndChangeToTab('chrome://browser/content/zen/livefolders/github_login.html', {
+        relatedToCurrent: false,
+        inBackground: false
+      });
+    } else {
+      originalGoDoCommand.apply(this, arguments);
+    }
+  };
+} else {
+  // Fallback if goDoCommand is not the mechanism, add a command event listener.
+  // This is a simplified approach. A more robust solution might involve <command> elements in XUL
+  // and ensuring this listener is correctly scoped and cleaned up.
+  document.addEventListener('command', function(event) {
+    if (event.target.getAttribute('command') === 'cmd_zenEnableGitHubLiveFolder' || event.command === 'cmd_zenEnableGitHubLiveFolder') {
+      gZenUIManager.openAndChangeToTab('chrome://browser/content/zen/livefolders/github_login.html', {
+        relatedToCurrent: false,
+        inBackground: false
+      });
+    }
+  });
+}

--- a/src/zen/livefolders/ZenLiveFolderManager.mjs
+++ b/src/zen/livefolders/ZenLiveFolderManager.mjs
@@ -1,0 +1,340 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Assuming ZenLiveFolderStorage is imported or made available globally/lazily
+// For example: const { ZenLiveFolderStorage } = ChromeUtils.importESModule('resource:///modules/ZenLiveFolderStorage.sys.mjs');
+// Or if it's on \`globalThis\` like other Zen managers.
+
+var ZenLiveFolderManager = {
+  // POLLING_INTERVAL_MS is now a getter
+  _pollingTimers: new Map(), // Store timers by folder UUID
+  _prefs: null, // For preference observer
+
+  get POLLING_INTERVAL_MS() {
+    // Lazily get the preference or use a default
+    if (!this._pollingIntervalMs) {
+        try {
+            // Default to 15 minutes (15 * 60 * 1000 ms)
+            this._pollingIntervalMs = Services.prefs.getIntPref("zen.livefolders.polling_interval_ms", 15 * 60 * 1000);
+        } catch (e) {
+            // Pref might not exist or be of wrong type, use default
+            this._pollingIntervalMs = 15 * 60 * 1000;
+        }
+    }
+    // Ensure a minimum interval to prevent abuse (e.g., 1 minute)
+    return Math.max(60 * 1000, this._pollingIntervalMs);
+  },
+
+  async init() {
+    // Ensure ZenLiveFolderStorage is initialized
+    await ZenLiveFolderStorage.promiseInitialized;
+    console.log("ZenLiveFolderManager initialized");
+    // Potentially load existing live folders and start polling
+    this.loadAndPollExistingFolders();
+    this._setupLoginListener();
+
+    // Setup preference observer for polling interval
+    if (globalThis.Services && Services.prefs) {
+        this._prefs = Services.prefs.getBranch("zen.livefolders.");
+        this._prefs.addObserver("", this); // "this" must implement observe()
+    }
+  },
+
+  _setupLoginListener() {
+    // Events from content pages might bubble up to the top-level browser window
+    // or specific elements like the tab browser.
+    // Using AppConstants.MOZ_APP_NAME to ensure this listener is only for the main app window.
+    // if (typeof window !== 'undefined' && typeof AppConstants !== 'undefined' && AppConstants.MOZ_APP_NAME === 'firefox') { // AppConstants might not be available here directly
+    if (typeof window !== 'undefined') { // Simplified check
+        // Listen on gBrowser.tabContainer for events that might bubble from tabs
+        if (globalThis.gBrowser && globalThis.gBrowser.tabContainer) {
+            globalThis.gBrowser.tabContainer.addEventListener('zen-github-username-obtained', this.handleGitHubLoginEvent.bind(this), false);
+            console.log("ZenLiveFolderManager: Added listener for zen-github-username-obtained on gBrowser.tabContainer");
+        } else {
+            console.warn("ZenLiveFolderManager: gBrowser.tabContainer not available to set up login listener. Falling back to window.");
+            // Fallback: listen on the main window.
+            window.addEventListener('zen-github-username-obtained', this.handleGitHubLoginEvent.bind(this), false);
+            console.log("ZenLiveFolderManager: Added listener for zen-github-username-obtained on window (fallback).");
+        }
+    }
+  },
+
+  async handleGitHubLoginEvent(event) {
+    if (event.detail && event.detail.username) {
+      const username = event.detail.username;
+      console.log(\`ZenLiveFolderManager: Received GitHub username: \${username}\`);
+      try {
+        const folderUuid = await this.enableGitHubPullRequestsLiveFolder(username);
+        if (folderUuid && globalThis.gZenUIManager && globalThis.gZenUIManager.showToast) {
+          globalThis.gZenUIManager.showToast('zen-livefolder-github-enabled-toast', {
+            // descriptionId: 'zen-livefolder-github-enabled-toast-description', // Example for a more specific message
+            // For now, using the main messageId as the primary display string.
+            // In a real scenario, 'zen-livefolder-github-enabled-toast' would be a generic title
+            // and descriptionId would point to "GitHub PR Live Folder for '{username}' enabled!"
+            // For simplicity here, we'll assume the main ID can convey enough.
+          });
+           // Attempt to close the login tab
+           if (event.originalTarget && event.originalTarget.ownerGlobal) {
+             const eventWindow = event.originalTarget.ownerGlobal;
+             for (const tab of globalThis.gBrowser.tabs) {
+                if (tab.linkedBrowser && tab.linkedBrowser.contentWindow === eventWindow) {
+                    if (!tab.closing) {
+                        globalThis.gBrowser.removeTab(tab);
+                    }
+                    break;
+                }
+             }
+           }
+        } else if (!folderUuid) {
+            if (globalThis.gZenUIManager && globalThis.gZenUIManager.showToast) {
+                globalThis.gZenUIManager.showToast('zen-livefolder-github-error-toast');
+            }
+        }
+      } catch (error) {
+        console.error("ZenLiveFolderManager: Error enabling GitHub Live Folder from event:", error);
+        if (globalThis.gZenUIManager && globalThis.gZenUIManager.showToast) {
+           globalThis.gZenUIManager.showToast('zen-livefolder-github-error-toast');
+        }
+      }
+    } else {
+        console.warn("ZenLiveFolderManager: Received zen-github-username-obtained event without username in detail.");
+    }
+  },
+
+  async loadAndPollExistingFolders() {
+    const folders = await ZenLiveFolderStorage.getAllLiveFolders();
+    for (const folder of folders) {
+      this.startPolling(folder.uuid);
+      // Initial fetch for each folder on startup
+      this.fetchAndStoreItems(folder.uuid);
+    }
+  },
+
+  generateUuidv4() {
+    // Assumes Services.uuid is available, similar to ZenUIManager
+    if (globalThis.Services && Services.uuid) {
+      return Services.uuid.generateUUID().toString();
+    }
+    // Fallback for environments where Services.uuid might not be available directly
+    // This is a simplified UUID v4 generator, consider a more robust one if needed.
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
+  },
+
+  _getGitHubRssUrl(username) {
+    // Updated URL format for more specific PR search and public PRs
+    return \`https://github.com/search?q=is:pr+author:\${username}+is:public&type=pulls&format=atom\`;
+  },
+
+  async enableGitHubPullRequestsLiveFolder(username) { // Ensure it's async
+    if (!username) {
+      console.error("ZenLiveFolderManager: Username is required to enable GitHub PR Live Folder.");
+      return null;
+    }
+    const folderUuid = this.generateUuidv4();
+    const rssFeedUrl = this._getGitHubRssUrl(username); // Uses the updated method
+
+    const newFolder = {
+      uuid: folderUuid,
+      type: 'github_prs',
+      title: \`Pull Requests (\${username})\`, // Dynamic title with username
+      source_username: username,
+      rss_feed_url: rssFeedUrl,
+    };
+
+    await ZenLiveFolderStorage.saveLiveFolder(newFolder);
+    console.log(\`ZenLiveFolderManager: Enabled GitHub PR Live Folder for \${username} with UUID \${folderUuid}\`);
+
+    // Initial fetch and start polling
+    await this.fetchAndStoreItems(folderUuid);
+    this.startPolling(folderUuid);
+
+    // Notify UI or other components that a new live folder has been created
+    if (globalThis.Services && globalThis.Services.obs) {
+        Services.obs.notifyObservers(null, 'zen-live-folder-created', folderUuid);
+    }
+
+    // Create a visual representation (e.g., a special pinned tab)
+    if (globalThis.gBrowser && globalThis.gBrowser.addTrustedTab && globalThis.gBrowser.pinTab) {
+        const liveFolderURL = \`chrome://browser/content/zen/livefolders/about_live_folder.xhtml?uuid=\${folderUuid}&title=\${encodeURIComponent(newFolder.title)}\`;
+
+        let liveFolderTab = globalThis.gBrowser.addTrustedTab(liveFolderURL, {
+            relatedToCurrent: false,
+            owner: null,
+        });
+        liveFolderTab.setAttribute('zen-live-folder-uuid', folderUuid);
+        liveFolderTab.setAttribute('zen-live-folder-type', newFolder.type);
+        // The title of the tab will be set by the about_live_folder.xhtml page itself from the URL query param.
+
+        globalThis.gBrowser.pinTab(liveFolderTab);
+        // Select the tab after pinning to make it active
+        globalThis.gBrowser.selectedTab = liveFolderTab;
+
+        console.log(\`ZenLiveFolderManager: Created visual tab for Live Folder \${folderUuid} at \${liveFolderURL}\`);
+    }
+
+    return folderUuid;
+  },
+
+  async fetchAndStoreItems(folderUuid) {
+    const folderData = await ZenLiveFolderStorage.getLiveFolder(folderUuid);
+    if (!folderData || !folderData.rss_feed_url) {
+      console.error(\`ZenLiveFolderManager: No folder data or RSS URL for UUID \${folderUuid}\`);
+      return;
+    }
+
+    console.log(\`ZenLiveFolderManager: Fetching items for \${folderData.title} from \${folderData.rss_feed_url}\`);
+    try {
+      const response = await fetch(folderData.rss_feed_url, { cache: "no-store" });
+      if (!response.ok) {
+        let errorMsg = \`ZenLiveFolderManager: Failed to fetch RSS feed for \${folderData.title}. Status: \${response.status} \${response.statusText}\`;
+        if (response.status === 401 || response.status === 403) {
+          errorMsg += \`. This could indicate an authentication/authorization issue if the feed were private, or an invalid username/repo for public feeds.\`;
+          // Potentially stop polling for this folder if it's a persistent auth error for a specific feed type
+          // For now, we'll let it retry as it might be a temporary issue or misconfiguration.
+        }
+        console.error(errorMsg);
+        return;
+      }
+      const feedText = await response.text();
+      const parsedItems = this._parseGitHubAtomFeed(feedText, folderUuid);
+
+      if (parsedItems.length > 0) {
+        const existingItems = await ZenLiveFolderStorage.getLiveFolderItems(folderUuid);
+        const currentFeedItemIds = new Set();
+
+        for (const item of parsedItems) {
+          await ZenLiveFolderStorage.saveLiveFolderItem(item);
+          currentFeedItemIds.add(item.item_id);
+        }
+
+        for (const existingItem of existingItems) {
+          if (!currentFeedItemIds.has(existingItem.item_id)) {
+            console.log(\`Item \${existingItem.item_id} is stale and should be removed (implementation pending).\`);
+          }
+        }
+      }
+      console.log(\`ZenLiveFolderManager: Fetched and stored \${parsedItems.length} items for \${folderData.title}.\`);
+      Services.obs.notifyObservers(null, 'zen-live-folder-updated', folderUuid);
+    } catch (error) {
+      console.error(\`ZenLiveFolderManager: Error fetching or parsing RSS feed for \${folderData.title}:\`, error);
+    }
+  },
+
+  _parseGitHubAtomFeed(feedText, folderUuid) {
+    const items = [];
+    try {
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(feedText, "application/xml");
+      const entries = xmlDoc.getElementsByTagName("entry");
+
+      for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        const title = entry.getElementsByTagName("title")[0]?.textContent || "No title";
+        const link = entry.getElementsByTagName("link")[0]?.getAttribute("href") || "";
+        const itemId = entry.getElementsByTagName("id")[0]?.textContent || link;
+        const updated = entry.getElementsByTagName("updated")[0]?.textContent || new Date().toISOString();
+
+        let status = 'open';
+        if (title.toLowerCase().includes('merged pull request')) {
+          status = 'merged';
+        } else if (title.toLowerCase().includes('closed pull request')) {
+          status = 'closed';
+        } else if (title.toLowerCase().includes('opened pull request')) {
+          status = 'open';
+        }
+
+        if (!title.toLowerCase().includes('pull request')) {
+            continue;
+        }
+
+        items.push({
+          folder_uuid: folderUuid,
+          item_id: itemId,
+          title: title.replace(/^[a-zA-Z0-9_-]+ (opened|merged|closed) pull request /, ''),
+          link: link,
+          status: status,
+          last_updated: new Date(updated).getTime(),
+        });
+      }
+    } catch (error) {
+      console.error("ZenLiveFolderManager: Error parsing Atom feed:", error);
+    }
+    return items;
+  },
+
+  startPolling(folderUuid) {
+    if (this._pollingTimers.has(folderUuid)) {
+      console.log(\`ZenLiveFolderManager: Polling already active for UUID \${folderUuid}\`);
+      return;
+    }
+
+    const intervalId = setInterval(async () => {
+      await this.fetchAndStoreItems(folderUuid);
+    }, this.POLLING_INTERVAL_MS);
+
+    this._pollingTimers.set(folderUuid, intervalId);
+    console.log(\`ZenLiveFolderManager: Started polling for UUID \${folderUuid} every \${this.POLLING_INTERVAL_MS / 1000 / 60} minutes.\`);
+  },
+
+  stopPolling(folderUuid) {
+    if (this._pollingTimers.has(folderUuid)) {
+      clearInterval(this._pollingTimers.get(folderUuid));
+      this._pollingTimers.delete(folderUuid);
+      console.log(\`ZenLiveFolderManager: Stopped polling for UUID \${folderUuid}\`);
+    }
+  },
+
+  async getLiveFoldersForDisplay() {
+    return ZenLiveFolderStorage.getAllLiveFolders();
+  },
+
+  async getLiveFolderItemsForDisplay(folderUuid) {
+    return ZenLiveFolderStorage.getLiveFolderItems(folderUuid);
+  },
+
+  async removeFolder(folderUuid) {
+    this.stopPolling(folderUuid);
+    await ZenLiveFolderStorage.removeLiveFolder(folderUuid);
+    console.log(\`ZenLiveFolderManager: Removed folder \${folderUuid}\`);
+    Services.obs.notifyObservers(null, 'zen-live-folder-removed', folderUuid);
+  },
+
+  // Preference observer implementation
+  observe(aSubject, aTopic, aData) {
+    if (aTopic === "nsPref:changed") {
+      switch (aData) {
+        case "polling_interval_ms":
+          // Clear existing interval property so it's refetched by the getter
+          delete this._pollingIntervalMs;
+          console.log("ZenLiveFolderManager: Polling interval preference changed. Updating all active polls.");
+          this.updateAllPollingIntervals();
+          break;
+      }
+    }
+  },
+
+  updateAllPollingIntervals() {
+    console.log("ZenLiveFolderManager: Updating polling intervals for all active live folders.");
+    const currentTimerKeys = Array.from(this._pollingTimers.keys()); // Iterate over a copy of keys
+    currentTimerKeys.forEach(folderUuid => {
+        this.stopPolling(folderUuid); // Clears the old timer
+        this.startPolling(folderUuid); // Starts a new one with the updated interval
+    });
+  },
+
+  // Call this on shutdown to prevent memory leaks
+  unregisterPrefObserver() {
+    if (this._prefs) {
+        this._prefs.removeObserver("", this);
+        this._prefs = null;
+    }
+  }
+};
+
+// Deferring init call to when it's explicitly called by the application startup process.
+// ZenLiveFolderManager.init(); // This should be called by the browser's startup sequence.
+// Ensure unregisterPrefObserver() is called on shutdown, e.g. via Services.obs 'quit-application' or similar.

--- a/src/zen/livefolders/ZenLiveFolderManager.mjs
+++ b/src/zen/livefolders/ZenLiveFolderManager.mjs
@@ -4,7 +4,7 @@
 
 // Assuming ZenLiveFolderStorage is imported or made available globally/lazily
 // For example: const { ZenLiveFolderStorage } = ChromeUtils.importESModule('resource:///modules/ZenLiveFolderStorage.sys.mjs');
-// Or if it's on \`globalThis\` like other Zen managers.
+// Or if it's on `globalThis` like other Zen managers.
 
 var ZenLiveFolderManager = {
   // POLLING_INTERVAL_MS is now a getter
@@ -14,13 +14,16 @@ var ZenLiveFolderManager = {
   get POLLING_INTERVAL_MS() {
     // Lazily get the preference or use a default
     if (!this._pollingIntervalMs) {
-        try {
-            // Default to 15 minutes (15 * 60 * 1000 ms)
-            this._pollingIntervalMs = Services.prefs.getIntPref("zen.livefolders.polling_interval_ms", 15 * 60 * 1000);
-        } catch (e) {
-            // Pref might not exist or be of wrong type, use default
-            this._pollingIntervalMs = 15 * 60 * 1000;
-        }
+      try {
+        // Default to 15 minutes (15 * 60 * 1000 ms)
+        this._pollingIntervalMs = Services.prefs.getIntPref(
+          'zen.livefolders.polling_interval_ms',
+          15 * 60 * 1000
+        );
+      } catch (e) {
+        // Pref might not exist or be of wrong type, use default
+        this._pollingIntervalMs = 15 * 60 * 1000;
+      }
     }
     // Ensure a minimum interval to prevent abuse (e.g., 1 minute)
     return Math.max(60 * 1000, this._pollingIntervalMs);
@@ -29,15 +32,15 @@ var ZenLiveFolderManager = {
   async init() {
     // Ensure ZenLiveFolderStorage is initialized
     await ZenLiveFolderStorage.promiseInitialized;
-    console.log("ZenLiveFolderManager initialized");
+    console.log('ZenLiveFolderManager initialized');
     // Potentially load existing live folders and start polling
     this.loadAndPollExistingFolders();
     this._setupLoginListener();
 
     // Setup preference observer for polling interval
     if (globalThis.Services && Services.prefs) {
-        this._prefs = Services.prefs.getBranch("zen.livefolders.");
-        this._prefs.addObserver("", this); // "this" must implement observe()
+      this._prefs = Services.prefs.getBranch('zen.livefolders.');
+      this._prefs.addObserver('', this); // "this" must implement observe()
     }
   },
 
@@ -46,24 +49,39 @@ var ZenLiveFolderManager = {
     // or specific elements like the tab browser.
     // Using AppConstants.MOZ_APP_NAME to ensure this listener is only for the main app window.
     // if (typeof window !== 'undefined' && typeof AppConstants !== 'undefined' && AppConstants.MOZ_APP_NAME === 'firefox') { // AppConstants might not be available here directly
-    if (typeof window !== 'undefined') { // Simplified check
-        // Listen on gBrowser.tabContainer for events that might bubble from tabs
-        if (globalThis.gBrowser && globalThis.gBrowser.tabContainer) {
-            globalThis.gBrowser.tabContainer.addEventListener('zen-github-username-obtained', this.handleGitHubLoginEvent.bind(this), false);
-            console.log("ZenLiveFolderManager: Added listener for zen-github-username-obtained on gBrowser.tabContainer");
-        } else {
-            console.warn("ZenLiveFolderManager: gBrowser.tabContainer not available to set up login listener. Falling back to window.");
-            // Fallback: listen on the main window.
-            window.addEventListener('zen-github-username-obtained', this.handleGitHubLoginEvent.bind(this), false);
-            console.log("ZenLiveFolderManager: Added listener for zen-github-username-obtained on window (fallback).");
-        }
+    if (typeof window !== 'undefined') {
+      // Simplified check
+      // Listen on gBrowser.tabContainer for events that might bubble from tabs
+      if (globalThis.gBrowser && globalThis.gBrowser.tabContainer) {
+        globalThis.gBrowser.tabContainer.addEventListener(
+          'zen-github-username-obtained',
+          this.handleGitHubLoginEvent.bind(this),
+          false
+        );
+        console.log(
+          'ZenLiveFolderManager: Added listener for zen-github-username-obtained on gBrowser.tabContainer'
+        );
+      } else {
+        console.warn(
+          'ZenLiveFolderManager: gBrowser.tabContainer not available to set up login listener. Falling back to window.'
+        );
+        // Fallback: listen on the main window.
+        window.addEventListener(
+          'zen-github-username-obtained',
+          this.handleGitHubLoginEvent.bind(this),
+          false
+        );
+        console.log(
+          'ZenLiveFolderManager: Added listener for zen-github-username-obtained on window (fallback).'
+        );
+      }
     }
   },
 
   async handleGitHubLoginEvent(event) {
     if (event.detail && event.detail.username) {
       const username = event.detail.username;
-      console.log(\`ZenLiveFolderManager: Received GitHub username: \${username}\`);
+      console.log(`ZenLiveFolderManager: Received GitHub username: ${username}`);
       try {
         const folderUuid = await this.enableGitHubPullRequestsLiveFolder(username);
         if (folderUuid && globalThis.gZenUIManager && globalThis.gZenUIManager.showToast) {
@@ -74,31 +92,33 @@ var ZenLiveFolderManager = {
             // and descriptionId would point to "GitHub PR Live Folder for '{username}' enabled!"
             // For simplicity here, we'll assume the main ID can convey enough.
           });
-           // Attempt to close the login tab
-           if (event.originalTarget && event.originalTarget.ownerGlobal) {
-             const eventWindow = event.originalTarget.ownerGlobal;
-             for (const tab of globalThis.gBrowser.tabs) {
-                if (tab.linkedBrowser && tab.linkedBrowser.contentWindow === eventWindow) {
-                    if (!tab.closing) {
-                        globalThis.gBrowser.removeTab(tab);
-                    }
-                    break;
+          // Attempt to close the login tab
+          if (event.originalTarget && event.originalTarget.ownerGlobal) {
+            const eventWindow = event.originalTarget.ownerGlobal;
+            for (const tab of globalThis.gBrowser.tabs) {
+              if (tab.linkedBrowser && tab.linkedBrowser.contentWindow === eventWindow) {
+                if (!tab.closing) {
+                  globalThis.gBrowser.removeTab(tab);
                 }
-             }
-           }
-        } else if (!folderUuid) {
-            if (globalThis.gZenUIManager && globalThis.gZenUIManager.showToast) {
-                globalThis.gZenUIManager.showToast('zen-livefolder-github-error-toast');
+                break;
+              }
             }
+          }
+        } else if (!folderUuid) {
+          if (globalThis.gZenUIManager && globalThis.gZenUIManager.showToast) {
+            globalThis.gZenUIManager.showToast('zen-livefolder-github-error-toast');
+          }
         }
       } catch (error) {
-        console.error("ZenLiveFolderManager: Error enabling GitHub Live Folder from event:", error);
+        console.error('ZenLiveFolderManager: Error enabling GitHub Live Folder from event:', error);
         if (globalThis.gZenUIManager && globalThis.gZenUIManager.showToast) {
-           globalThis.gZenUIManager.showToast('zen-livefolder-github-error-toast');
+          globalThis.gZenUIManager.showToast('zen-livefolder-github-error-toast');
         }
       }
     } else {
-        console.warn("ZenLiveFolderManager: Received zen-github-username-obtained event without username in detail.");
+      console.warn(
+        'ZenLiveFolderManager: Received zen-github-username-obtained event without username in detail.'
+      );
     }
   },
 
@@ -118,20 +138,22 @@ var ZenLiveFolderManager = {
     }
     // Fallback for environments where Services.uuid might not be available directly
     // This is a simplified UUID v4 generator, consider a more robust one if needed.
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+      var r = (Math.random() * 16) | 0,
+        v = c == 'x' ? r : (r & 0x3) | 0x8;
       return v.toString(16);
     });
   },
 
   _getGitHubRssUrl(username) {
     // Updated URL format for more specific PR search and public PRs
-    return \`https://github.com/search?q=is:pr+author:\${username}+is:public&type=pulls&format=atom\`;
+    return `https://github.com/search?q=is:pr+author:${username}+is:public&type=pulls&format=atom`;
   },
 
-  async enableGitHubPullRequestsLiveFolder(username) { // Ensure it's async
+  async enableGitHubPullRequestsLiveFolder(username) {
+    // Ensure it's async
     if (!username) {
-      console.error("ZenLiveFolderManager: Username is required to enable GitHub PR Live Folder.");
+      console.error('ZenLiveFolderManager: Username is required to enable GitHub PR Live Folder.');
       return null;
     }
     const folderUuid = this.generateUuidv4();
@@ -140,13 +162,15 @@ var ZenLiveFolderManager = {
     const newFolder = {
       uuid: folderUuid,
       type: 'github_prs',
-      title: \`Pull Requests (\${username})\`, // Dynamic title with username
+      title: `Pull Requests (${username})`, // Dynamic title with username
       source_username: username,
       rss_feed_url: rssFeedUrl,
     };
 
     await ZenLiveFolderStorage.saveLiveFolder(newFolder);
-    console.log(\`ZenLiveFolderManager: Enabled GitHub PR Live Folder for \${username} with UUID \${folderUuid}\`);
+    console.log(
+      `ZenLiveFolderManager: Enabled GitHub PR Live Folder for ${username} with UUID ${folderUuid}`
+    );
 
     // Initial fetch and start polling
     await this.fetchAndStoreItems(folderUuid);
@@ -154,26 +178,28 @@ var ZenLiveFolderManager = {
 
     // Notify UI or other components that a new live folder has been created
     if (globalThis.Services && globalThis.Services.obs) {
-        Services.obs.notifyObservers(null, 'zen-live-folder-created', folderUuid);
+      Services.obs.notifyObservers(null, 'zen-live-folder-created', folderUuid);
     }
 
     // Create a visual representation (e.g., a special pinned tab)
     if (globalThis.gBrowser && globalThis.gBrowser.addTrustedTab && globalThis.gBrowser.pinTab) {
-        const liveFolderURL = \`chrome://browser/content/zen/livefolders/about_live_folder.xhtml?uuid=\${folderUuid}&title=\${encodeURIComponent(newFolder.title)}\`;
+      const liveFolderURL = `chrome://browser/content/zen/livefolders/about_live_folder.xhtml?uuid=${folderUuid}&title=${encodeURIComponent(newFolder.title)}`;
 
-        let liveFolderTab = globalThis.gBrowser.addTrustedTab(liveFolderURL, {
-            relatedToCurrent: false,
-            owner: null,
-        });
-        liveFolderTab.setAttribute('zen-live-folder-uuid', folderUuid);
-        liveFolderTab.setAttribute('zen-live-folder-type', newFolder.type);
-        // The title of the tab will be set by the about_live_folder.xhtml page itself from the URL query param.
+      let liveFolderTab = globalThis.gBrowser.addTrustedTab(liveFolderURL, {
+        relatedToCurrent: false,
+        owner: null,
+      });
+      liveFolderTab.setAttribute('zen-live-folder-uuid', folderUuid);
+      liveFolderTab.setAttribute('zen-live-folder-type', newFolder.type);
+      // The title of the tab will be set by the about_live_folder.xhtml page itself from the URL query param.
 
-        globalThis.gBrowser.pinTab(liveFolderTab);
-        // Select the tab after pinning to make it active
-        globalThis.gBrowser.selectedTab = liveFolderTab;
+      globalThis.gBrowser.pinTab(liveFolderTab);
+      // Select the tab after pinning to make it active
+      globalThis.gBrowser.selectedTab = liveFolderTab;
 
-        console.log(\`ZenLiveFolderManager: Created visual tab for Live Folder \${folderUuid} at \${liveFolderURL}\`);
+      console.log(
+        `ZenLiveFolderManager: Created visual tab for Live Folder ${folderUuid} at ${liveFolderURL}`
+      );
     }
 
     return folderUuid;
@@ -182,17 +208,19 @@ var ZenLiveFolderManager = {
   async fetchAndStoreItems(folderUuid) {
     const folderData = await ZenLiveFolderStorage.getLiveFolder(folderUuid);
     if (!folderData || !folderData.rss_feed_url) {
-      console.error(\`ZenLiveFolderManager: No folder data or RSS URL for UUID \${folderUuid}\`);
+      console.error(`ZenLiveFolderManager: No folder data or RSS URL for UUID ${folderUuid}`);
       return;
     }
 
-    console.log(\`ZenLiveFolderManager: Fetching items for \${folderData.title} from \${folderData.rss_feed_url}\`);
+    console.log(
+      `ZenLiveFolderManager: Fetching items for ${folderData.title} from ${folderData.rss_feed_url}`
+    );
     try {
-      const response = await fetch(folderData.rss_feed_url, { cache: "no-store" });
+      const response = await fetch(folderData.rss_feed_url, { cache: 'no-store' });
       if (!response.ok) {
-        let errorMsg = \`ZenLiveFolderManager: Failed to fetch RSS feed for \${folderData.title}. Status: \${response.status} \${response.statusText}\`;
+        let errorMsg = `ZenLiveFolderManager: Failed to fetch RSS feed for ${folderData.title}. Status: ${response.status} ${response.statusText}`;
         if (response.status === 401 || response.status === 403) {
-          errorMsg += \`. This could indicate an authentication/authorization issue if the feed were private, or an invalid username/repo for public feeds.\`;
+          errorMsg += `. This could indicate an authentication/authorization issue if the feed were private, or an invalid username/repo for public feeds.`;
           // Potentially stop polling for this folder if it's a persistent auth error for a specific feed type
           // For now, we'll let it retry as it might be a temporary issue or misconfiguration.
         }
@@ -213,14 +241,21 @@ var ZenLiveFolderManager = {
 
         for (const existingItem of existingItems) {
           if (!currentFeedItemIds.has(existingItem.item_id)) {
-            console.log(\`Item \${existingItem.item_id} is stale and should be removed (implementation pending).\`);
+            console.log(
+              `Item ${existingItem.item_id} is stale and should be removed (implementation pending).`
+            );
           }
         }
       }
-      console.log(\`ZenLiveFolderManager: Fetched and stored \${parsedItems.length} items for \${folderData.title}.\`);
+      console.log(
+        `ZenLiveFolderManager: Fetched and stored ${parsedItems.length} items for ${folderData.title}.`
+      );
       Services.obs.notifyObservers(null, 'zen-live-folder-updated', folderUuid);
     } catch (error) {
-      console.error(\`ZenLiveFolderManager: Error fetching or parsing RSS feed for \${folderData.title}:\`, error);
+      console.error(
+        `ZenLiveFolderManager: Error fetching or parsing RSS feed for ${folderData.title}:`,
+        error
+      );
     }
   },
 
@@ -228,15 +263,16 @@ var ZenLiveFolderManager = {
     const items = [];
     try {
       const parser = new DOMParser();
-      const xmlDoc = parser.parseFromString(feedText, "application/xml");
-      const entries = xmlDoc.getElementsByTagName("entry");
+      const xmlDoc = parser.parseFromString(feedText, 'application/xml');
+      const entries = xmlDoc.getElementsByTagName('entry');
 
       for (let i = 0; i < entries.length; i++) {
         const entry = entries[i];
-        const title = entry.getElementsByTagName("title")[0]?.textContent || "No title";
-        const link = entry.getElementsByTagName("link")[0]?.getAttribute("href") || "";
-        const itemId = entry.getElementsByTagName("id")[0]?.textContent || link;
-        const updated = entry.getElementsByTagName("updated")[0]?.textContent || new Date().toISOString();
+        const title = entry.getElementsByTagName('title')[0]?.textContent || 'No title';
+        const link = entry.getElementsByTagName('link')[0]?.getAttribute('href') || '';
+        const itemId = entry.getElementsByTagName('id')[0]?.textContent || link;
+        const updated =
+          entry.getElementsByTagName('updated')[0]?.textContent || new Date().toISOString();
 
         let status = 'open';
         if (title.toLowerCase().includes('merged pull request')) {
@@ -248,7 +284,7 @@ var ZenLiveFolderManager = {
         }
 
         if (!title.toLowerCase().includes('pull request')) {
-            continue;
+          continue;
         }
 
         items.push({
@@ -261,14 +297,14 @@ var ZenLiveFolderManager = {
         });
       }
     } catch (error) {
-      console.error("ZenLiveFolderManager: Error parsing Atom feed:", error);
+      console.error('ZenLiveFolderManager: Error parsing Atom feed:', error);
     }
     return items;
   },
 
   startPolling(folderUuid) {
     if (this._pollingTimers.has(folderUuid)) {
-      console.log(\`ZenLiveFolderManager: Polling already active for UUID \${folderUuid}\`);
+      console.log(`ZenLiveFolderManager: Polling already active for UUID ${folderUuid}`);
       return;
     }
 
@@ -277,14 +313,16 @@ var ZenLiveFolderManager = {
     }, this.POLLING_INTERVAL_MS);
 
     this._pollingTimers.set(folderUuid, intervalId);
-    console.log(\`ZenLiveFolderManager: Started polling for UUID \${folderUuid} every \${this.POLLING_INTERVAL_MS / 1000 / 60} minutes.\`);
+    console.log(
+      `ZenLiveFolderManager: Started polling for UUID ${folderUuid} every ${this.POLLING_INTERVAL_MS / 1000 / 60} minutes.`
+    );
   },
 
   stopPolling(folderUuid) {
     if (this._pollingTimers.has(folderUuid)) {
       clearInterval(this._pollingTimers.get(folderUuid));
       this._pollingTimers.delete(folderUuid);
-      console.log(\`ZenLiveFolderManager: Stopped polling for UUID \${folderUuid}\`);
+      console.log(`ZenLiveFolderManager: Stopped polling for UUID ${folderUuid}`);
     }
   },
 
@@ -299,18 +337,20 @@ var ZenLiveFolderManager = {
   async removeFolder(folderUuid) {
     this.stopPolling(folderUuid);
     await ZenLiveFolderStorage.removeLiveFolder(folderUuid);
-    console.log(\`ZenLiveFolderManager: Removed folder \${folderUuid}\`);
+    console.log(`ZenLiveFolderManager: Removed folder ${folderUuid}`);
     Services.obs.notifyObservers(null, 'zen-live-folder-removed', folderUuid);
   },
 
   // Preference observer implementation
   observe(aSubject, aTopic, aData) {
-    if (aTopic === "nsPref:changed") {
+    if (aTopic === 'nsPref:changed') {
       switch (aData) {
-        case "polling_interval_ms":
+        case 'polling_interval_ms':
           // Clear existing interval property so it's refetched by the getter
           delete this._pollingIntervalMs;
-          console.log("ZenLiveFolderManager: Polling interval preference changed. Updating all active polls.");
+          console.log(
+            'ZenLiveFolderManager: Polling interval preference changed. Updating all active polls.'
+          );
           this.updateAllPollingIntervals();
           break;
       }
@@ -318,21 +358,21 @@ var ZenLiveFolderManager = {
   },
 
   updateAllPollingIntervals() {
-    console.log("ZenLiveFolderManager: Updating polling intervals for all active live folders.");
+    console.log('ZenLiveFolderManager: Updating polling intervals for all active live folders.');
     const currentTimerKeys = Array.from(this._pollingTimers.keys()); // Iterate over a copy of keys
-    currentTimerKeys.forEach(folderUuid => {
-        this.stopPolling(folderUuid); // Clears the old timer
-        this.startPolling(folderUuid); // Starts a new one with the updated interval
+    currentTimerKeys.forEach((folderUuid) => {
+      this.stopPolling(folderUuid); // Clears the old timer
+      this.startPolling(folderUuid); // Starts a new one with the updated interval
     });
   },
 
   // Call this on shutdown to prevent memory leaks
   unregisterPrefObserver() {
     if (this._prefs) {
-        this._prefs.removeObserver("", this);
-        this._prefs = null;
+      this._prefs.removeObserver('', this);
+      this._prefs = null;
     }
-  }
+  },
 };
 
 // Deferring init call to when it's explicitly called by the application startup process.

--- a/src/zen/livefolders/ZenLiveFolderStorage.mjs
+++ b/src/zen/livefolders/ZenLiveFolderStorage.mjs
@@ -12,7 +12,7 @@ var ZenLiveFolderStorage = {
   async _ensureTables() {
     await PlacesUtils.withConnectionWrapper('ZenLiveFolderStorage._ensureTables', async (db) => {
       // Create zen_live_folders table
-      await db.execute(\`
+      await db.execute(`
         CREATE TABLE IF NOT EXISTS zen_live_folders (
           uuid TEXT PRIMARY KEY,
           type TEXT NOT NULL, -- e.g., 'github_prs'
@@ -22,12 +22,16 @@ var ZenLiveFolderStorage = {
           created_at INTEGER NOT NULL,
           updated_at INTEGER NOT NULL
         )
-      \`);
-      await db.execute(\`CREATE INDEX IF NOT EXISTS idx_zen_live_folders_uuid ON zen_live_folders(uuid)\`);
-      await db.execute(\`CREATE INDEX IF NOT EXISTS idx_zen_live_folders_type ON zen_live_folders(type)\`);
+      `);
+      await db.execute(
+        `CREATE INDEX IF NOT EXISTS idx_zen_live_folders_uuid ON zen_live_folders(uuid)`
+      );
+      await db.execute(
+        `CREATE INDEX IF NOT EXISTS idx_zen_live_folders_type ON zen_live_folders(type)`
+      );
 
       // Create zen_live_folder_items table
-      await db.execute(\`
+      await db.execute(`
         CREATE TABLE IF NOT EXISTS zen_live_folder_items (
           id INTEGER PRIMARY KEY AUTOINCREMENT,
           folder_uuid TEXT NOT NULL,
@@ -41,18 +45,24 @@ var ZenLiveFolderStorage = {
           UNIQUE(folder_uuid, item_id),
           FOREIGN KEY (folder_uuid) REFERENCES zen_live_folders(uuid) ON DELETE CASCADE
         )
-      \`);
-      await db.execute(\`CREATE INDEX IF NOT EXISTS idx_zen_live_folder_items_folder_uuid ON zen_live_folder_items(folder_uuid)\`);
-      await db.execute(\`CREATE INDEX IF NOT EXISTS idx_zen_live_folder_items_item_id ON zen_live_folder_items(item_id)\`);
+      `);
+      await db.execute(
+        `CREATE INDEX IF NOT EXISTS idx_zen_live_folder_items_folder_uuid ON zen_live_folder_items(folder_uuid)`
+      );
+      await db.execute(
+        `CREATE INDEX IF NOT EXISTS idx_zen_live_folder_items_item_id ON zen_live_folder_items(item_id)`
+      );
 
       // Changes tracking table for live folders (optional, but good for sync)
-      await db.execute(\`
+      await db.execute(`
         CREATE TABLE IF NOT EXISTS zen_live_folders_changes (
           uuid TEXT PRIMARY KEY,
           timestamp INTEGER NOT NULL
         )
-      \`);
-      await db.execute(\`CREATE INDEX IF NOT EXISTS idx_zen_live_folders_changes_uuid ON zen_live_folders_changes(uuid)\`);
+      `);
+      await db.execute(
+        `CREATE INDEX IF NOT EXISTS idx_zen_live_folders_changes_uuid ON zen_live_folders_changes(uuid)`
+      );
     });
   },
 
@@ -60,7 +70,7 @@ var ZenLiveFolderStorage = {
     await PlacesUtils.withConnectionWrapper('ZenLiveFolderStorage.saveLiveFolder', async (db) => {
       const now = Date.now();
       await db.execute(
-        \`
+        `
         INSERT OR REPLACE INTO zen_live_folders (
           uuid, type, title, source_username, rss_feed_url, created_at, updated_at
         ) VALUES (
@@ -68,7 +78,7 @@ var ZenLiveFolderStorage = {
           COALESCE((SELECT created_at FROM zen_live_folders WHERE uuid = :uuid), :now),
           :now
         )
-      \`,
+      `,
         {
           uuid: folder.uuid,
           type: folder.type,
@@ -80,7 +90,7 @@ var ZenLiveFolderStorage = {
       );
       // Add to changes table if implementing sync
       await db.execute(
-        \`INSERT OR REPLACE INTO zen_live_folders_changes (uuid, timestamp) VALUES (:uuid, :timestamp)\`,
+        `INSERT OR REPLACE INTO zen_live_folders_changes (uuid, timestamp) VALUES (:uuid, :timestamp)`,
         { uuid: folder.uuid, timestamp: Math.floor(now / 1000) }
       );
     });
@@ -89,7 +99,7 @@ var ZenLiveFolderStorage = {
 
   async getLiveFolder(uuid) {
     const db = await PlacesUtils.promiseDBConnection();
-    const rows = await db.execute(\`SELECT * FROM zen_live_folders WHERE uuid = :uuid\`, { uuid });
+    const rows = await db.execute(`SELECT * FROM zen_live_folders WHERE uuid = :uuid`, { uuid });
     if (rows.length === 0) {
       return null;
     }
@@ -107,7 +117,7 @@ var ZenLiveFolderStorage = {
 
   async getAllLiveFolders() {
     const db = await PlacesUtils.promiseDBConnection();
-    const rows = await db.execute(\`SELECT * FROM zen_live_folders ORDER BY title ASC\`);
+    const rows = await db.execute(`SELECT * FROM zen_live_folders ORDER BY title ASC`);
     return rows.map((row) => ({
       uuid: row.getResultByName('uuid'),
       type: row.getResultByName('type'),
@@ -119,20 +129,22 @@ var ZenLiveFolderStorage = {
 
   async removeLiveFolder(uuid) {
     await PlacesUtils.withConnectionWrapper('ZenLiveFolderStorage.removeLiveFolder', async (db) => {
-      await db.execute(\`DELETE FROM zen_live_folders WHERE uuid = :uuid\`, { uuid });
+      await db.execute(`DELETE FROM zen_live_folders WHERE uuid = :uuid`, { uuid });
       // Also remove associated items
-      await db.execute(\`DELETE FROM zen_live_folder_items WHERE folder_uuid = :uuid\`, { uuid });
+      await db.execute(`DELETE FROM zen_live_folder_items WHERE folder_uuid = :uuid`, { uuid });
       // Remove from changes table
-      await db.execute(\`DELETE FROM zen_live_folders_changes WHERE uuid = :uuid\`, { uuid });
+      await db.execute(`DELETE FROM zen_live_folders_changes WHERE uuid = :uuid`, { uuid });
     });
     // Notify observers: Services.obs.notifyObservers(null, 'zen-live-folder-removed', uuid);
   },
 
   async saveLiveFolderItem(item) {
-    await PlacesUtils.withConnectionWrapper('ZenLiveFolderStorage.saveLiveFolderItem', async (db) => {
-      const now = Date.now();
-      await db.execute(
-        \`
+    await PlacesUtils.withConnectionWrapper(
+      'ZenLiveFolderStorage.saveLiveFolderItem',
+      async (db) => {
+        const now = Date.now();
+        await db.execute(
+          `
         INSERT OR REPLACE INTO zen_live_folder_items (
           folder_uuid, item_id, title, link, status, last_updated, created_at, updated_at
         ) VALUES (
@@ -140,24 +152,25 @@ var ZenLiveFolderStorage = {
           COALESCE((SELECT created_at FROM zen_live_folder_items WHERE folder_uuid = :folder_uuid AND item_id = :item_id), :now),
           :now
         )
-      \`,
-        {
-          folder_uuid: item.folder_uuid,
-          item_id: item.item_id,
-          title: item.title,
-          link: item.link,
-          status: item.status,
-          last_updated: item.last_updated,
-          now,
-        }
-      );
-    });
+      `,
+          {
+            folder_uuid: item.folder_uuid,
+            item_id: item.item_id,
+            title: item.title,
+            link: item.link,
+            status: item.status,
+            last_updated: item.last_updated,
+            now,
+          }
+        );
+      }
+    );
   },
 
   async getLiveFolderItems(folderUuid) {
     const db = await PlacesUtils.promiseDBConnection();
     const rows = await db.execute(
-      \`SELECT * FROM zen_live_folder_items WHERE folder_uuid = :folderUuid ORDER BY last_updated DESC\`,
+      `SELECT * FROM zen_live_folder_items WHERE folder_uuid = :folderUuid ORDER BY last_updated DESC`,
       { folderUuid }
     );
     return rows.map((row) => ({
@@ -172,10 +185,15 @@ var ZenLiveFolderStorage = {
   },
 
   async removeLiveFolderItems(folderUuid) {
-    await PlacesUtils.withConnectionWrapper('ZenLiveFolderStorage.removeLiveFolderItems', async (db) => {
-      await db.execute(\`DELETE FROM zen_live_folder_items WHERE folder_uuid = :folderUuid\`, { folderUuid });
-    });
-  }
+    await PlacesUtils.withConnectionWrapper(
+      'ZenLiveFolderStorage.removeLiveFolderItems',
+      async (db) => {
+        await db.execute(`DELETE FROM zen_live_folder_items WHERE folder_uuid = :folderUuid`, {
+          folderUuid,
+        });
+      }
+    );
+  },
 };
 
 ZenLiveFolderStorage.promiseInitialized = new Promise((resolve) => {
@@ -188,7 +206,9 @@ ZenLiveFolderStorage.promiseInitialized = new Promise((resolve) => {
     // If PlacesUtils is not available, wait for a global event or use a lazy loader.
     // For simplicity, we'll assume it becomes available.
     // In a real scenario, this needs careful handling of dependencies.
-    console.warn("PlacesUtils not immediately available for ZenLiveFolderStorage. Will try to initialize later.");
+    console.warn(
+      'PlacesUtils not immediately available for ZenLiveFolderStorage. Will try to initialize later.'
+    );
     // Fallback or error handling
   }
 });

--- a/src/zen/livefolders/ZenLiveFolderStorage.mjs
+++ b/src/zen/livefolders/ZenLiveFolderStorage.mjs
@@ -1,0 +1,194 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+var ZenLiveFolderStorage = {
+  async init() {
+    await this._ensureTables();
+    // Resolve a promise indicating initialization is complete
+    this._resolveInitialized();
+  },
+
+  async _ensureTables() {
+    await PlacesUtils.withConnectionWrapper('ZenLiveFolderStorage._ensureTables', async (db) => {
+      // Create zen_live_folders table
+      await db.execute(\`
+        CREATE TABLE IF NOT EXISTS zen_live_folders (
+          uuid TEXT PRIMARY KEY,
+          type TEXT NOT NULL, -- e.g., 'github_prs'
+          title TEXT NOT NULL,
+          source_username TEXT, -- e.g., GitHub username
+          rss_feed_url TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      \`);
+      await db.execute(\`CREATE INDEX IF NOT EXISTS idx_zen_live_folders_uuid ON zen_live_folders(uuid)\`);
+      await db.execute(\`CREATE INDEX IF NOT EXISTS idx_zen_live_folders_type ON zen_live_folders(type)\`);
+
+      // Create zen_live_folder_items table
+      await db.execute(\`
+        CREATE TABLE IF NOT EXISTS zen_live_folder_items (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          folder_uuid TEXT NOT NULL,
+          item_id TEXT NOT NULL, -- e.g., PR URL or unique ID from feed
+          title TEXT NOT NULL,
+          link TEXT, -- URL to the item
+          status TEXT, -- e.g., 'open', 'merged', 'closed'
+          last_updated INTEGER, -- Timestamp of when the item was last updated in the feed
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          UNIQUE(folder_uuid, item_id),
+          FOREIGN KEY (folder_uuid) REFERENCES zen_live_folders(uuid) ON DELETE CASCADE
+        )
+      \`);
+      await db.execute(\`CREATE INDEX IF NOT EXISTS idx_zen_live_folder_items_folder_uuid ON zen_live_folder_items(folder_uuid)\`);
+      await db.execute(\`CREATE INDEX IF NOT EXISTS idx_zen_live_folder_items_item_id ON zen_live_folder_items(item_id)\`);
+
+      // Changes tracking table for live folders (optional, but good for sync)
+      await db.execute(\`
+        CREATE TABLE IF NOT EXISTS zen_live_folders_changes (
+          uuid TEXT PRIMARY KEY,
+          timestamp INTEGER NOT NULL
+        )
+      \`);
+      await db.execute(\`CREATE INDEX IF NOT EXISTS idx_zen_live_folders_changes_uuid ON zen_live_folders_changes(uuid)\`);
+    });
+  },
+
+  async saveLiveFolder(folder) {
+    await PlacesUtils.withConnectionWrapper('ZenLiveFolderStorage.saveLiveFolder', async (db) => {
+      const now = Date.now();
+      await db.execute(
+        \`
+        INSERT OR REPLACE INTO zen_live_folders (
+          uuid, type, title, source_username, rss_feed_url, created_at, updated_at
+        ) VALUES (
+          :uuid, :type, :title, :source_username, :rss_feed_url,
+          COALESCE((SELECT created_at FROM zen_live_folders WHERE uuid = :uuid), :now),
+          :now
+        )
+      \`,
+        {
+          uuid: folder.uuid,
+          type: folder.type,
+          title: folder.title,
+          source_username: folder.source_username,
+          rss_feed_url: folder.rss_feed_url,
+          now,
+        }
+      );
+      // Add to changes table if implementing sync
+      await db.execute(
+        \`INSERT OR REPLACE INTO zen_live_folders_changes (uuid, timestamp) VALUES (:uuid, :timestamp)\`,
+        { uuid: folder.uuid, timestamp: Math.floor(now / 1000) }
+      );
+    });
+    // Notify observers if necessary: Services.obs.notifyObservers(null, 'zen-live-folder-updated', folder.uuid);
+  },
+
+  async getLiveFolder(uuid) {
+    const db = await PlacesUtils.promiseDBConnection();
+    const rows = await db.execute(\`SELECT * FROM zen_live_folders WHERE uuid = :uuid\`, { uuid });
+    if (rows.length === 0) {
+      return null;
+    }
+    const row = rows[0];
+    return {
+      uuid: row.getResultByName('uuid'),
+      type: row.getResultByName('type'),
+      title: row.getResultByName('title'),
+      source_username: row.getResultByName('source_username'),
+      rss_feed_url: row.getResultByName('rss_feed_url'),
+      created_at: row.getResultByName('created_at'),
+      updated_at: row.getResultByName('updated_at'),
+    };
+  },
+
+  async getAllLiveFolders() {
+    const db = await PlacesUtils.promiseDBConnection();
+    const rows = await db.execute(\`SELECT * FROM zen_live_folders ORDER BY title ASC\`);
+    return rows.map((row) => ({
+      uuid: row.getResultByName('uuid'),
+      type: row.getResultByName('type'),
+      title: row.getResultByName('title'),
+      source_username: row.getResultByName('source_username'),
+      rss_feed_url: row.getResultByName('rss_feed_url'),
+    }));
+  },
+
+  async removeLiveFolder(uuid) {
+    await PlacesUtils.withConnectionWrapper('ZenLiveFolderStorage.removeLiveFolder', async (db) => {
+      await db.execute(\`DELETE FROM zen_live_folders WHERE uuid = :uuid\`, { uuid });
+      // Also remove associated items
+      await db.execute(\`DELETE FROM zen_live_folder_items WHERE folder_uuid = :uuid\`, { uuid });
+      // Remove from changes table
+      await db.execute(\`DELETE FROM zen_live_folders_changes WHERE uuid = :uuid\`, { uuid });
+    });
+    // Notify observers: Services.obs.notifyObservers(null, 'zen-live-folder-removed', uuid);
+  },
+
+  async saveLiveFolderItem(item) {
+    await PlacesUtils.withConnectionWrapper('ZenLiveFolderStorage.saveLiveFolderItem', async (db) => {
+      const now = Date.now();
+      await db.execute(
+        \`
+        INSERT OR REPLACE INTO zen_live_folder_items (
+          folder_uuid, item_id, title, link, status, last_updated, created_at, updated_at
+        ) VALUES (
+          :folder_uuid, :item_id, :title, :link, :status, :last_updated,
+          COALESCE((SELECT created_at FROM zen_live_folder_items WHERE folder_uuid = :folder_uuid AND item_id = :item_id), :now),
+          :now
+        )
+      \`,
+        {
+          folder_uuid: item.folder_uuid,
+          item_id: item.item_id,
+          title: item.title,
+          link: item.link,
+          status: item.status,
+          last_updated: item.last_updated,
+          now,
+        }
+      );
+    });
+  },
+
+  async getLiveFolderItems(folderUuid) {
+    const db = await PlacesUtils.promiseDBConnection();
+    const rows = await db.execute(
+      \`SELECT * FROM zen_live_folder_items WHERE folder_uuid = :folderUuid ORDER BY last_updated DESC\`,
+      { folderUuid }
+    );
+    return rows.map((row) => ({
+      id: row.getResultByName('id'),
+      folder_uuid: row.getResultByName('folder_uuid'),
+      item_id: row.getResultByName('item_id'),
+      title: row.getResultByName('title'),
+      link: row.getResultByName('link'),
+      status: row.getResultByName('status'),
+      last_updated: row.getResultByName('last_updated'),
+    }));
+  },
+
+  async removeLiveFolderItems(folderUuid) {
+    await PlacesUtils.withConnectionWrapper('ZenLiveFolderStorage.removeLiveFolderItems', async (db) => {
+      await db.execute(\`DELETE FROM zen_live_folder_items WHERE folder_uuid = :folderUuid\`, { folderUuid });
+    });
+  }
+};
+
+ZenLiveFolderStorage.promiseInitialized = new Promise((resolve) => {
+  ZenLiveFolderStorage._resolveInitialized = resolve;
+  // We need PlacesUtils to be available. Assuming it's loaded similarly to other storage files.
+  // A more robust way would be to ensure PlacesUtils is loaded before calling init.
+  if (globalThis.PlacesUtils) {
+    ZenLiveFolderStorage.init();
+  } else {
+    // If PlacesUtils is not available, wait for a global event or use a lazy loader.
+    // For simplicity, we'll assume it becomes available.
+    // In a real scenario, this needs careful handling of dependencies.
+    console.warn("PlacesUtils not immediately available for ZenLiveFolderStorage. Will try to initialize later.");
+    // Fallback or error handling
+  }
+});

--- a/src/zen/livefolders/about_live_folder.xhtml
+++ b/src/zen/livefolders/about_live_folder.xhtml
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8"/>
+  <title>Live Folder</title>
+  <!-- The stylesheet will be created in the next step -->
+  <link rel="stylesheet" href="chrome://browser/content/zen/livefolders/live-folder-styles.css"/>
+  <script type="module">
+    // Accessing chrome resources like gZenLiveFolderManager from a chrome:// page's content script.
+    // This typically works because they share the same chrome privileges.
+    const ZLFM = window.opener?.gZenLiveFolderManager || window.parent?.gZenLiveFolderManager || (typeof gZenLiveFolderManager !== 'undefined' ? gZenLiveFolderManager : null);
+
+    const params = new URLSearchParams(window.location.search);
+    const folderUuid = params.get('uuid');
+    const folderTitle = params.get('title') || 'Live Folder Items';
+    document.title = folderTitle;
+
+    const itemContainer = document.getElementById('itemContainer');
+    const folderHeader = document.getElementById('folderHeader');
+    // Ensure elements exist before setting textContent
+    if (folderHeader) folderHeader.textContent = folderTitle;
+
+    function getStatusIndicatorClass(status) {
+        switch (status ? status.toLowerCase() : '') {
+            case 'open': return 'status-open';
+            case 'merged': return 'status-merged';
+            case 'closed': return 'status-closed';
+            default: return 'status-unknown';
+        }
+    }
+
+    async function renderItems() {
+      if (!itemContainer) return; // Ensure container exists
+
+      if (!ZLFM) {
+        itemContainer.innerHTML = '<p>Error: Live Folder Manager not accessible. Ensure gZenLiveFolderManager is global or passed correctly.</p>';
+        return;
+      }
+      if (!folderUuid) {
+        itemContainer.innerHTML = '<p>Error: Folder UUID not provided in URL.</p>';
+        return;
+      }
+
+      itemContainer.innerHTML = '<p>Loading items...</p>';
+      try {
+        const items = await ZLFM.getLiveFolderItemsForDisplay(folderUuid);
+        itemContainer.innerHTML = ''; // Clear loading message
+
+        if (!items || items.length === 0) {
+          itemContainer.innerHTML = '<p>No items to display.</p>';
+          return;
+        }
+
+        const ul = document.createElement('ul');
+        items.forEach(item => {
+          const li = document.createElement('li');
+          li.className = 'live-folder-item';
+
+          const indicator = document.createElement('span');
+          indicator.className = \`status-indicator \${getStatusIndicatorClass(item.status)}\`;
+          li.appendChild(indicator);
+
+          const titleLink = document.createElement('a');
+          titleLink.href = item.link;
+          titleLink.textContent = item.title;
+          titleLink.target = '_blank';
+
+          // Correctly open links in a new browser tab from chrome context
+          titleLink.addEventListener('click', (e) => {
+            e.preventDefault(); // Prevent default navigation within the about page
+            if (window.opener && window.opener.gBrowser && window.opener.gBrowser.addTrustedTab) {
+                window.opener.gBrowser.addTrustedTab(item.link, { relatedToCurrent: true });
+            } else if (globalThis.gBrowser && globalThis.gBrowser.addTrustedTab) {
+                globalThis.gBrowser.addTrustedTab(item.link, { relatedToCurrent: true });
+            } else {
+                // Fallback if gBrowser is not accessible
+                console.warn("Could not open tab via gBrowser. Standard link behavior will apply.");
+                window.open(item.link, '_blank');
+            }
+          });
+          li.appendChild(titleLink);
+          ul.appendChild(li);
+        });
+        itemContainer.appendChild(ul);
+      } catch (e) {
+        itemContainer.innerHTML = \`<p>Error loading items: \${e.message}</p>\`;
+        console.error("Error rendering live folder items:", e);
+      }
+    }
+
+    function handleLiveFolderUpdate(subject, topic, data) {
+        // Note: Observer function signature is (subject, topic, data)
+        // The 'subject' here is the nsISupportsString containing the UUID.
+        const updatedUuid = subject.data ? subject.data : subject; // subject can be nsISupportsString or string
+        if (updatedUuid === folderUuid) {
+            console.log(\`Live folder \${folderUuid} updated (event received), refreshing display.\`);
+            renderItems();
+        }
+    }
+
+    // Wait for the DOM to be fully loaded before trying to access elements
+    document.addEventListener('DOMContentLoaded', () => {
+        // Re-assign elements in case script runs before DOM is ready
+        const currentItemContainer = document.getElementById('itemContainer');
+        const currentFolderHeader = document.getElementById('folderHeader');
+        if (currentFolderHeader) currentFolderHeader.textContent = folderTitle; // Set title once DOM is ready
+
+        if (ZLFM && folderUuid && currentItemContainer) {
+          renderItems();
+          // Observer setup
+          const obs = window.opener?.Services?.obs || globalThis.Services?.obs;
+          if (obs) {
+              obs.addObserver(handleLiveFolderUpdate, 'zen-live-folder-updated');
+              window.addEventListener('pagehide', () => {
+                  obs.removeObserver(handleLiveFolderUpdate, 'zen-live-folder-updated');
+              }, {once: true});
+              console.log(\`Observer for 'zen-live-folder-updated' on \${folderUuid} added.\`);
+          } else {
+              console.warn("Services.obs not available. Cannot listen for live folder updates.");
+              if (currentItemContainer) currentItemContainer.innerHTML += "<p><em>Warning: Real-time updates may not work.</em></p>";
+          }
+        } else {
+            if (currentItemContainer) {
+                let errorMsg = "Initialization error: ";
+                if (!ZLFM) errorMsg += "Live Folder Manager not found. ";
+                if (!folderUuid) errorMsg += "Folder UUID missing from URL. ";
+                currentItemContainer.textContent = errorMsg;
+            }
+        }
+    });
+  </script>
+</head>
+<body>
+  <h1 id="folderHeader">Live Folder</h1>
+  <div id="itemContainer">
+    <p>Loading...</p>
+  </div>
+</body>
+</html>

--- a/src/zen/livefolders/github_login.html
+++ b/src/zen/livefolders/github_login.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>GitHub Login for Live Folder</title>
+  <style>
+    body { font-family: sans-serif; display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100vh; margin: 0; }
+    input { margin-bottom: 10px; padding: 8px; }
+    button { padding: 10px 15px; }
+  </style>
+</head>
+<body>
+  <h1>Link GitHub Account for Live Folder</h1>
+  <p>Please enter your GitHub username. In a real implementation, this would be a GitHub OAuth flow.</p>
+  <input type="text" id="githubUsername" placeholder="GitHub Username">
+  <button id="submitUsername">Link Account</button>
+  <script>
+    document.getElementById('submitUsername').addEventListener('click', () => {
+      const username = document.getElementById('githubUsername').value;
+      if (username && window.opener && window.opener.gZenLiveFolderManager) {
+        // In a real scenario, postMessage would be more secure and robust
+        // For now, directly calling if possible or using a custom event.
+        // Let's use a custom event that the chrome script will listen for on the window.
+        // This is simpler than cross-origin postMessage for now as they are same-origin.
+        const event = new CustomEvent('zen-github-username-obtained', {
+          detail: { username: username },
+          bubbles: true,
+          composed: true
+        });
+        window.dispatchEvent(event); // Dispatch on the current window
+
+        // For now, we'll also try to notify the opener directly if in the same process,
+        // as message managers can be complex.
+         if (window.opener.gBrowser && window.opener.gBrowser.getTabForBrowser) {
+            let openerTab = null;
+            for (const win of Services.wm.getEnumerator('navigator:browser')) {
+                const browser = win.gBrowser.selectedBrowser;
+                if (browser.contentWindow === window.opener) {
+                     openerTab = win.gBrowser.selectedTab;
+                     break;
+                }
+            }
+            if(openerTab) {
+                openerTab.dispatchEvent(new CustomEvent('zen-github-username-obtained', {
+                    detail: { username: username }
+                }));
+            }
+        }
+        // A more robust method would be via messageManager to the parent process.
+        // Example: window.parent.postMessage({ type: 'githubUsername', username: username }, '*');
+
+        window.close(); // Close the tab after sending
+      } else {
+        if (!username) alert('Please enter a username.');
+        else alert('Could not communicate with the main window. Ensure this tab was opened by the Zen browser.');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/src/zen/livefolders/live-folder-styles.css
+++ b/src/zen/livefolders/live-folder-styles.css
@@ -1,0 +1,48 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  margin: 0;
+  padding: 15px;
+  background-color: var(--lwt-accent-color, #f0f0f0); /* Example using LWT variable */
+  color: var(--lwt-text-color, #111); /* Example using LWT variable */
+}
+#folderHeader {
+  margin-top: 0;
+  font-size: 1.4em; /* Slightly smaller */
+  color: var(--lwt-tab-text-color, var(--lwt-text-color, #000)); /* Use tab text color or fallback */
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--lwt-toolbar-field-border-color, #ccc);
+  margin-bottom: 10px;
+}
+#itemContainer ul {
+    padding-left: 0;
+}
+.live-folder-item {
+  list-style: none;
+  padding: 10px 5px; /* Increased padding */
+  border-bottom: 1px solid var(--lwt-toolbar-field-border-color, #ddd); /* LWT variable */
+  display: flex;
+  align-items: center;
+  cursor: default;
+}
+.live-folder-item:last-child {
+  border-bottom: none;
+}
+.live-folder-item a {
+  text-decoration: none;
+  color: var(--lwt-toolbarbutton-icon-fill-attention, #0060df); /* LWT variable for links */
+  margin-left: 5px; /* Space between indicator and text */
+}
+.live-folder-item a:hover {
+  text-decoration: underline;
+}
+.status-indicator {
+  width: 8px; /* Smaller indicator */
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+.status-open { background-color: #28a745; } /* Bootstrap success green */
+.status-merged { background-color: #6f42c1; } /* Bootstrap purple */
+.status-closed { background-color: #dc3545; } /* Bootstrap danger red */
+.status-unknown { background-color: #6c757d; } /* Bootstrap secondary grey */

--- a/src/zen/livefolders/moz.build
+++ b/src/zen/livefolders/moz.build
@@ -2,13 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-JS_MODULES += [
+EXTRA_JS_MODULES += [
     "ZenLiveFolderManager.mjs",
     "ZenLiveFolderStorage.mjs",
 ]
 
-BROWSER_CHROME_FILES += [
+FINAL_TARGET_FILES += [
     "about_live_folder.xhtml",
-    "live-folder-styles.css",
     "github_login.html",
+    "live-folder-styles.css",
 ]

--- a/src/zen/livefolders/moz.build
+++ b/src/zen/livefolders/moz.build
@@ -1,12 +1,14 @@
-#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-DIRS += [
-    "glance",
-    "livefolders",
-    "mods",
-    "tests",
-    "toolkit",
+JS_MODULES += [
+    "ZenLiveFolderManager.mjs",
+    "ZenLiveFolderStorage.mjs",
+]
+
+BROWSER_CHROME_FILES += [
+    "about_live_folder.xhtml",
+    "live-folder-styles.css",
+    "github_login.html",
 ]

--- a/src/zen/tests/livefolders/head.js
+++ b/src/zen/tests/livefolders/head.js
@@ -1,0 +1,19 @@
+// src/zen/tests/livefolders/head.js
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Import common services
+var { Services } = ChromeUtils.importESModule("resource://gre/modules/Services.sys.mjs");
+var { PlacesUtils } = ChromeUtils.importESModule("resource://gre/modules/PlacesUtils.sys.mjs");
+var { XPCOMUtils } = ChromeUtils.importESModule("resource://gre/modules/XPCOMUtils.sys.mjs");
+var { FileUtils } = ChromeUtils.importESModule("resource://gre/modules/FileUtils.sys.mjs");
+
+// Ensure profile directory is set up for PlacesUtils
+do_get_profile();
+
+// Globally available mocks or stubs if needed across tests
+globalThis.mockGZenUIManager = {
+  showToast: (messageId, options) => {
+    console.log(\`Mock Toast: \${messageId}, Options: \${JSON.stringify(options)}\`);
+  }
+};

--- a/src/zen/tests/livefolders/moz.build
+++ b/src/zen/tests/livefolders/moz.build
@@ -1,0 +1,4 @@
+# src/zen/tests/livefolders/moz.build
+XPCSHELL_TESTS_MANIFESTS += [
+    "xpcshell.ini",
+]

--- a/src/zen/tests/livefolders/test_ZenLiveFolderManager.sys.mjs
+++ b/src/zen/tests/livefolders/test_ZenLiveFolderManager.sys.mjs
@@ -1,0 +1,241 @@
+// src/zen/tests/livefolders/test_ZenLiveFolderManager.sys.mjs
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+const { ZenLiveFolderManager } = ChromeUtils.importESModule(
+  "resource:///chrome/zen/livefolders/ZenLiveFolderManager.mjs"
+);
+const { ZenLiveFolderStorage } = ChromeUtils.importESModule(
+  "resource:///chrome/zen/livefolders/ZenLiveFolderStorage.mjs"
+);
+
+// Mock global gZenUIManager if not already available from head.js
+if (typeof globalThis.gZenUIManager === 'undefined' && typeof globalThis.mockGZenUIManager !== 'undefined') {
+    globalThis.gZenUIManager = globalThis.mockGZenUIManager;
+} else if (typeof globalThis.gZenUIManager === 'undefined') {
+    globalThis.gZenUIManager = { // Fallback mock if head.js didn't provide it
+      showToast: (messageId, options) => {
+        console.log(\`(Fallback Mock) Toast: \${messageId}, Options: \${JSON.stringify(options)}\`);
+      }
+    };
+}
+
+// Mock Services and other globals needed by ZenLiveFolderManager
+let observedNotifications = [];
+if (!globalThis.Services) globalThis.Services = {};
+
+globalThis.Services.obs = globalThis.Services.obs || {
+    notifyObservers: (subject, topic, data) => {
+        observedNotifications.push({ subject, topic, data });
+    },
+    addObserver: () => {},
+    removeObserver: () => {},
+};
+
+// Minimal prefs mock for polling interval
+let mockPollingInterval = 15 * 60 * 1000;
+const mockPrefsBranch = {
+    _observers: [],
+    addObserver: function(domain, obs) { this._observers.push(obs); },
+    removeObserver: function(domain, obs) { this._observers = this._observers.filter(o => o !== obs); },
+    getIntPref: function(prefName, defaultValue) {
+        if (prefName === "polling_interval_ms") return mockPollingInterval;
+        return defaultValue;
+    },
+    // Simulate pref change notification
+    _notifyPrefChange(prefName) {
+        this._observers.forEach(obs => {
+            if (typeof obs.observe === 'function') {
+                obs.observe(null, "nsPref:changed", prefName);
+            }
+        });
+    }
+};
+globalThis.Services.prefs = globalThis.Services.prefs || {
+    getIntPref: (prefKey, defaultValue) => {
+        if (prefKey === "zen.livefolders.polling_interval_ms") return mockPollingInterval;
+        return defaultValue;
+    },
+    getBranch: (branchName) => {
+        if (branchName === "zen.livefolders.") return mockPrefsBranch;
+        // Fallback for other branches if necessary
+        return { addObserver: () => {}, removeObserver: () => {}, getIntPref: (k,d) => d };
+    },
+};
+
+globalThis.Services.uuid = globalThis.Services.uuid || {
+    generateUUID: () => \`test-uuid-\${Math.random().toString(36).substring(2, 15)}\`
+};
+
+// Mock for gBrowser and tab operations (very basic)
+globalThis.gBrowser = globalThis.gBrowser || {
+    addTrustedTab: (url, options) => {
+        console.log(\`Mock gBrowser.addTrustedTab: \${url}\`);
+        const mockTab = {
+            setAttribute: (attr, val) => { mockTab[attr] = val; },
+            linkedBrowser: { contentWindow: {} }, // Mock contentWindow for event dispatch checks
+        };
+        return mockTab;
+    },
+    pinTab: (tab) => { console.log('Mock gBrowser.pinTab'); },
+    removeTab: (tab) => { console.log('Mock gBrowser.removeTab'); },
+    selectedTab: null,
+    tabs: [],
+    tabContainer: {
+        addEventListener: () => {},
+        removeEventListener: () => {},
+    }
+};
+
+
+add_task(async function setup() {
+  await ZenLiveFolderStorage.promiseInitialized; // Manager depends on storage
+  // Manually ensure _pollingIntervalMs is reset if tests change mockPollingInterval directly
+  delete ZenLiveFolderManager._pollingIntervalMs;
+  await ZenLiveFolderManager.init();
+  observedNotifications = [];
+
+  await PlacesUtils.withConnectionWrapper("test_manager_setup_cleanup", async (db) => {
+    await db.execute("DELETE FROM zen_live_folder_items");
+    await db.execute("DELETE FROM zen_live_folders");
+    await db.execute("DELETE FROM zen_live_folders_changes");
+  });
+});
+
+add_task(async function test_enable_github_prs_live_folder() {
+  const username = "testghuser";
+
+  let saveFolderCalledWith = null;
+  const originalSaveLiveFolder = ZenLiveFolderStorage.saveLiveFolder;
+  ZenLiveFolderStorage.saveLiveFolder = async (folder) => {
+    saveFolderCalledWith = folder;
+    return originalSaveLiveFolder.call(ZenLiveFolderStorage, folder);
+  };
+
+  const originalFetch = globalThis.fetch;
+  let fetchCallCount = 0;
+  globalThis.fetch = async (url) => {
+    fetchCallCount++;
+    Assert.ok(url.includes(username), "Fetch URL should include username");
+    Assert.ok(url.includes("is:pr"), "Fetch URL should query for 'is:pr'");
+    Assert.ok(url.includes("author:" + username), "Fetch URL should include 'author:username'");
+    return {
+      ok: true,
+      text: async () => \`<?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <entry>
+            <id>tag:github.com,2008:PullRequestEvent/123</id>
+            <title>\${username} opened pull request myrepo#42 Awesome Feature</title>
+            <link href="http://example.com/pull/42"/>
+            <updated>2023-01-01T10:00:00Z</updated>
+          </entry>
+        </feed>\`,
+    };
+  };
+
+  const folderUuid = await ZenLiveFolderManager.enableGitHubPullRequestsLiveFolder(username);
+  Assert.ok(folderUuid, "Should return a folder UUID");
+  Assert.ok(saveFolderCalledWith, "saveLiveFolder should have been called");
+  Assert.equal(saveFolderCalledWith.source_username, username, "Username should match");
+  Assert.equal(saveFolderCalledWith.type, "github_prs", "Type should be github_prs");
+  Assert.ok(saveFolderCalledWith.title.includes(username), "Folder title should include username");
+
+  const items = await ZenLiveFolderStorage.getLiveFolderItems(folderUuid);
+  Assert.equal(items.length, 1, "Should have fetched and stored one item");
+  Assert.equal(items[0].title, "myrepo#42 Awesome Feature", "Item title should be parsed correctly");
+  Assert.equal(fetchCallCount, 1, "Fetch should be called once during initial enablement.");
+
+  const creationNotification = observedNotifications.find(obs => obs.topic === 'zen-live-folder-created');
+  Assert.ok(creationNotification, "zen-live-folder-created should be observed");
+  Assert.equal(creationNotification.data, folderUuid, "Notification data should be the folder UUID");
+
+  ZenLiveFolderStorage.saveLiveFolder = originalSaveLiveFolder;
+  globalThis.fetch = originalFetch;
+});
+
+add_task(async function test_parse_github_atom_feed() {
+  const feedText = \`<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <entry><id>pr1</id><title>user1 opened pull request repo/project#1 Test PR 1</title><link href="http://example.com/pr/1"/><updated>2023-01-01T12:00:00Z</updated></entry>
+      <entry><id>pr2</id><title>user1 merged pull request repo/project#2 Test PR 2</title><link href="http://example.com/pr/2"/><updated>2023-01-02T12:00:00Z</updated></entry>
+      <entry><id>pr3</id><title>user1 closed pull request repo/project#3 Test PR 3</title><link href="http://example.com/pr/3"/><updated>2023-01-03T12:00:00Z</updated></entry>
+      <entry><id>issue1</id><title>user1 opened issue repo/project#4 An Issue</title><link href="http://example.com/issue/4"/><updated>2023-01-04T12:00:00Z</updated></entry>
+    </feed>\`;
+  const folderUuid = "parse-test-uuid";
+  const items = ZenLiveFolderManager._parseGitHubAtomFeed(feedText, folderUuid);
+
+  Assert.equal(items.length, 3, "Should parse 3 PR items, skipping the issue");
+  const pr1 = items.find(item => item.link === "http://example.com/pr/1");
+  Assert.equal(pr1.status, "open");
+  Assert.equal(pr1.title, "repo/project#1 Test PR 1");
+});
+
+add_task(async function test_polling_config_and_start_stop() {
+  mockPollingInterval = 30 * 60 * 1000; // 30 minutes
+  delete ZenLiveFolderManager._pollingIntervalMs; // Clear cached value
+  Assert.equal(ZenLiveFolderManager.POLLING_INTERVAL_MS, 30 * 60 * 1000, "Polling interval should be 30 mins from mock pref");
+
+  mockPollingInterval = 30 * 1000; // 30 seconds (below minimum)
+  delete ZenLiveFolderManager._pollingIntervalMs;
+  Assert.equal(ZenLiveFolderManager.POLLING_INTERVAL_MS, 60 * 1000, "Polling interval should be forced to 1 min if pref is too low");
+
+  const folderUuid = "polling-test-uuid";
+  // Need to save a folder for polling to make sense, as fetchAndStoreItems requires folderData
+  await ZenLiveFolderStorage.saveLiveFolder({uuid: folderUuid, type: "github_prs", title: "PollTest", rss_feed_url: "http://example.com/polltest"});
+
+  ZenLiveFolderManager.startPolling(folderUuid);
+  Assert.ok(ZenLiveFolderManager._pollingTimers.has(folderUuid), "Should have a timer for the folder");
+
+  // Simulate pref change to update interval
+  mockPollingInterval = 2 * 60 * 1000; // 2 minutes
+  mockPrefsBranch._notifyPrefChange("polling_interval_ms"); // Notify observers
+  // Check if timer was restarted (hard to check directly without more spies, but _pollingIntervalMs should be cleared)
+  Assert.ok(ZenLiveFolderManager._pollingTimers.has(folderUuid), "Timer should still exist after pref change.");
+  // At this point, the old timer is cleared, and a new one started.
+  // We can verify the new interval will be used by checking the POLLING_INTERVAL_MS getter again.
+  Assert.equal(ZenLiveFolderManager.POLLING_INTERVAL_MS, 2 * 60 * 1000, "Getter should reflect new pref value for next cycle.");
+
+
+  ZenLiveFolderManager.stopPolling(folderUuid);
+  Assert.ok(!ZenLiveFolderManager._pollingTimers.has(folderUuid), "Timer should be cleared after stopping");
+
+  // Cleanup
+  await ZenLiveFolderStorage.removeLiveFolder(folderUuid);
+  mockPollingInterval = 15 * 60 * 1000; // Reset to default for other tests
+  delete ZenLiveFolderManager._pollingIntervalMs;
+});
+
+add_task(async function test_fetch_error_handling() {
+    const username = "fetcherroruser";
+    const originalFetch = globalThis.fetch;
+    let errorLogged = false;
+    const originalConsoleError = console.error;
+    console.error = (msg) => {
+        if (msg.includes("Failed to fetch RSS feed")) errorLogged = true;
+        originalConsoleError.call(console, msg);
+    };
+
+    globalThis.fetch = async (url) => ({ ok: false, status: 500, statusText: "Server Error" });
+
+    const folderUuid = await ZenLiveFolderManager.enableGitHubPullRequestsLiveFolder(username);
+    Assert.ok(folderUuid, "Folder should still be created even if initial fetch fails");
+    Assert.ok(errorLogged, "Error should have been logged for failed fetch");
+
+    const items = await ZenLiveFolderStorage.getLiveFolderItems(folderUuid);
+    Assert.equal(items.length, 0, "No items should be stored after failed fetch");
+
+    globalThis.fetch = originalFetch;
+    console.error = originalConsoleError;
+    await ZenLiveFolderStorage.removeLiveFolder(folderUuid);
+});
+
+// Teardown method to unregister observers if manager has shutdown logic
+add_task(async function teardown() {
+    if (typeof ZenLiveFolderManager.unregisterPrefObserver === "function") {
+        ZenLiveFolderManager.unregisterPrefObserver();
+    }
+    // Clear any remaining timers
+    ZenLiveFolderManager._pollingTimers.forEach((timerId, uuid) => {
+        ZenLiveFolderManager.stopPolling(uuid);
+    });
+});

--- a/src/zen/tests/livefolders/test_ZenLiveFolderStorage.sys.mjs
+++ b/src/zen/tests/livefolders/test_ZenLiveFolderStorage.sys.mjs
@@ -1,0 +1,142 @@
+// src/zen/tests/livefolders/test_ZenLiveFolderStorage.sys.mjs
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+const { ZenLiveFolderStorage } = ChromeUtils.importESModule(
+  "resource:///chrome/zen/livefolders/ZenLiveFolderStorage.mjs"
+);
+
+add_task(async function setup() {
+  // Ensure the tables are created by initializing storage
+  await ZenLiveFolderStorage.promiseInitialized;
+  // Clean up before running tests
+  await PlacesUtils.withConnectionWrapper("test_setup_cleanup", async (db) => {
+    await db.execute("DELETE FROM zen_live_folder_items");
+    await db.execute("DELETE FROM zen_live_folders");
+    await db.execute("DELETE FROM zen_live_folders_changes"); // Also clear this table
+  });
+});
+
+add_task(async function test_save_get_remove_live_folder() {
+  const folder1 = {
+    uuid: "test-uuid-1",
+    type: "github_prs",
+    title: "Test PRs 1",
+    source_username: "testuser1",
+    rss_feed_url: "http://example.com/feed1.rss",
+  };
+  await ZenLiveFolderStorage.saveLiveFolder(folder1);
+
+  let retrievedFolder = await ZenLiveFolderStorage.getLiveFolder(folder1.uuid);
+  Assert.notEqual(retrievedFolder, null, "Folder 1 should be retrieved");
+  Assert.equal(retrievedFolder.title, folder1.title, "Folder 1 title should match");
+  Assert.ok(retrievedFolder.created_at, "Folder 1 should have created_at timestamp");
+  Assert.ok(retrievedFolder.updated_at, "Folder 1 should have updated_at timestamp");
+  const initialUpdatedAt = retrievedFolder.updated_at;
+
+  const folder2 = {
+    uuid: "test-uuid-2",
+    type: "gitlab_mrs",
+    title: "Test MRs 2",
+    source_username: "testuser2",
+    rss_feed_url: "http://example.com/feed2.rss",
+  };
+  await ZenLiveFolderStorage.saveLiveFolder(folder2);
+
+  let allFolders = await ZenLiveFolderStorage.getAllLiveFolders();
+  Assert.equal(allFolders.length, 2, "Should retrieve two folders");
+
+  // Test saving again (update)
+  folder1.title = "Test PRs 1 Updated";
+  // Ensure a delay to check if updated_at changes
+  await new Promise(resolve => setTimeout(resolve, 10));
+  await ZenLiveFolderStorage.saveLiveFolder(folder1);
+  retrievedFolder = await ZenLiveFolderStorage.getLiveFolder(folder1.uuid);
+  Assert.equal(retrievedFolder.title, folder1.title, "Folder 1 updated title should match");
+  Assert.ok(retrievedFolder.updated_at > initialUpdatedAt, "Folder 1 updated_at should be greater after update");
+
+
+  await ZenLiveFolderStorage.removeLiveFolder(folder1.uuid);
+  retrievedFolder = await ZenLiveFolderStorage.getLiveFolder(folder1.uuid);
+  Assert.equal(retrievedFolder, null, "Folder 1 should be null after removal");
+
+  // Check changes table
+  const db = await PlacesUtils.promiseDBConnection();
+  let rows = await db.execute("SELECT * FROM zen_live_folders_changes WHERE uuid = ?", [folder1.uuid]);
+  Assert.equal(rows.length, 0, "Folder 1 should be removed from changes table");
+
+
+  allFolders = await ZenLiveFolderStorage.getAllLiveFolders();
+  Assert.equal(allFolders.length, 1, "Should have one folder left");
+  Assert.equal(allFolders[0].uuid, folder2.uuid, "Remaining folder should be folder 2");
+
+  await ZenLiveFolderStorage.removeLiveFolder(folder2.uuid);
+  allFolders = await ZenLiveFolderStorage.getAllLiveFolders();
+  Assert.equal(allFolders.length, 0, "Should have no folders left");
+});
+
+add_task(async function test_save_get_remove_live_folder_items() {
+  const folder = {
+    uuid: "item-test-folder-uuid",
+    type: "github_prs",
+    title: "Item Test Folder",
+    source_username: "itemuser",
+    rss_feed_url: "http://example.com/itemfeed.rss",
+  };
+  await ZenLiveFolderStorage.saveLiveFolder(folder);
+
+  const item1 = {
+    folder_uuid: folder.uuid,
+    item_id: "pr-1",
+    title: "Pull Request 1",
+    link: "http://example.com/pr/1",
+    status: "open",
+    last_updated: Date.now(),
+  };
+  await ZenLiveFolderStorage.saveLiveFolderItem(item1);
+  const item1CreatedAt = (await ZenLiveFolderStorage.getLiveFolderItems(folder.uuid)).find(i=>i.item_id === "pr-1").created_at;
+
+
+  const item2 = {
+    folder_uuid: folder.uuid,
+    item_id: "pr-2",
+    title: "Pull Request 2",
+    link: "http://example.com/pr/2",
+    status: "merged",
+    last_updated: Date.now() - 1000, // Older
+  };
+  await ZenLiveFolderStorage.saveLiveFolderItem(item2);
+
+  let items = await ZenLiveFolderStorage.getLiveFolderItems(folder.uuid);
+  Assert.equal(items.length, 2, "Should retrieve two items for the folder");
+  // Items are ordered by last_updated DESC
+  Assert.equal(items[0].item_id, "pr-1", "First item should be pr-1 due to newer timestamp");
+
+  // Test update
+  item1.status = "closed";
+  const item1OriginalLastUpdated = item1.last_updated;
+  item1.last_updated = Date.now(); // Ensure updated_at for item changes
+  await new Promise(resolve => setTimeout(resolve, 10)); // ensure time passes
+  await ZenLiveFolderStorage.saveLiveFolderItem(item1);
+
+  items = await ZenLiveFolderStorage.getLiveFolderItems(folder.uuid);
+  const updatedItem1 = items.find(i => i.item_id === "pr-1");
+  Assert.equal(updatedItem1.status, "closed", "Item 1 status should be updated to closed");
+  Assert.ok(updatedItem1.updated_at > item1CreatedAt, "Item 1 updated_at should be greater after update");
+  Assert.equal(updatedItem1.created_at, item1CreatedAt, "Item 1 created_at should not change on update");
+  Assert.ok(updatedItem1.last_updated > item1OriginalLastUpdated, "Item 1 last_updated from feed should be updated");
+
+  // Test removing all items for a folder
+  await ZenLiveFolderStorage.removeLiveFolderItems(folder.uuid);
+  items = await ZenLiveFolderStorage.getLiveFolderItems(folder.uuid);
+  Assert.equal(items.length, 0, "Items should be empty after removeLiveFolderItems");
+
+  // Test that removing folder also removes items (CASCADE)
+  await ZenLiveFolderStorage.saveLiveFolderItem(item1); // Add an item back
+  items = await ZenLiveFolderStorage.getLiveFolderItems(folder.uuid);
+  Assert.equal(items.length, 1, "Should have one item before folder removal");
+
+  await ZenLiveFolderStorage.removeLiveFolder(folder.uuid);
+  items = await ZenLiveFolderStorage.getLiveFolderItems(folder.uuid);
+  Assert.equal(items.length, 0, "Items should be empty after folder removal due to CASCADE");
+});

--- a/src/zen/tests/livefolders/xpcshell.ini
+++ b/src/zen/tests/livefolders/xpcshell.ini
@@ -1,0 +1,5 @@
+# src/zen/tests/livefolders/xpcshell.ini
+[DEFAULT]
+head = head.js
+[test_ZenLiveFolderStorage.sys.mjs]
+[test_ZenLiveFolderManager.sys.mjs]

--- a/src/zen/tests/moz.build
+++ b/src/zen/tests/moz.build
@@ -10,3 +10,7 @@ BROWSER_CHROME_MANIFESTS += [
     "urlbar/browser.toml",
     "workspaces/browser.toml",
 ]
+
+DIRS += [
+    "livefolders",
+]


### PR DESCRIPTION
This update introduces "Live Folders," starting with support for GitHub Pull Requests.

Here's what it does:

1.  **Core Logic & Storage:**
    *   I've added components to manage live folder operations, including fetching and parsing RSS feeds.
    *   I've also set up a system to store live folder data and items in an SQLite database.
    *   The GitHub PR RSS feed URL is used to get public pull requests for a specified user.

2.  **UI Integration:**
    *   You'll find a new context menu item "Enable GitHub PR Live Folder" (currently accessible via main toolbar/tab context menus).
    *   Selecting this option will open a page where you can input a GitHub username.
    *   Once you submit a username, a new "Live Folder" (e.g., "Pull Requests (username)") will be created.
    *   Live Folders appear as pinned tabs and display a content page that dynamically shows the fetched pull requests with status indicators (open, merged, closed) and links to the PRs.
    *   The display page listens for updates and refreshes content automatically.

3.  **Configuration & Error Handling:**
    *   You can configure the polling interval for checking RSS feed updates (default is 15 minutes, minimum 1 minute).
    *   You can update this polling interval dynamically without a browser restart.
    *   I've included basic error handling for feed fetching and parsing, with logs for diagnostics.

4.  **Unit Tests:**
    *   I've added unit tests for the new live folder management and storage components.
    *   These tests cover data persistence, feed parsing logic, folder creation, polling configuration, and error handling, using mocks for external dependencies.

This feature allows you to create dynamic folders that stay updated with information from external sources, beginning with GitHub Pull Requests.