### PR TITLE
Respect glance enabled preference before opening Glance on search

### DIFF
--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -747,6 +747,10 @@
     }
 
     onSearchSelectCommand(where) {
+      // Check if glance is enabled in user preferences
+      if (!Services.prefs.getBoolPref('zen.glance.enabled', false)) {
+        return;
+      }
       if (where !== 'tab') {
         return;
       }


### PR DESCRIPTION
This pull request addresses #8863   where opening a new tab via the Vimium extension would always trigger the Glance popup view, even when Glance was disabled in preferences.

The fix was to update the onSearchSelectCommand function to check the zen.glance.enabled user preference before attempting to open Glance.