### PR TITLE
Glance contextmenu search pref

### DIFF
--- a/src/browser/app/profile/features/glance.inc
+++ b/src/browser/app/profile/features/glance.inc
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 pref('zen.glance.enabled', true);
+pref('zen.glance.enable-contextmenu-search', true);
 pref('zen.glance.hold-duration', 300); // in ms
 pref('zen.glance.open-essential-external-links', true);
 pref('zen.glance.activation-method', 'alt'); // ctrl, alt, shift, none, hold

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -749,7 +749,7 @@
 
     onSearchSelectCommand(where) {
       // Check if glance is enabled in user preferences
-      if (!Services.prefs.getBoolPref('zen.glance.enabled', false)) {
+      if (!Services.prefs.getBoolPref('zen.glance.enable-contextmenu-search', true)) {
         return;
       }
       if (where !== 'tab') {

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -748,8 +748,11 @@
     }
 
     onSearchSelectCommand(where) {
-      // Check if glance is enabled in user preferences
-      if (!Services.prefs.getBoolPref('zen.glance.enable-contextmenu-search', true)) {
+      // Check if Glance is globally enabled and specifically enabled for contextmenu/search
+      if (
+        !Services.prefs.getBoolPref('zen.glance.enabled', false) ||
+        !Services.prefs.getBoolPref('zen.glance.enable-contextmenu-search', true)
+      ) {
         return;
       }
       if (where !== 'tab') {


### PR DESCRIPTION
This PR introduces a new preference, `zen.glance.enable-contextmenu-search,` to allow users to control whether Glance can be opened via context menu or search actions.

- The new pref is true by default.
- Glance will only activate in these cases if both `zen.glance.enabled `and `zen.glance.enable-contextmenu-search` are true.
- This gives users finer control over Glance activation, as requested in [maintainer suggestion/comment](https://github.com/zen-browser/desktop/pull/8890).

[additionally updated the docs to reflect the new config](https://github.com/zen-browser/docs/pull/201)