### PR TITLE
Fix TypeError: can't access property "pinned", group is undefined

### DIFF
--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -17,7 +17,7 @@
     }
 
     #onTabGrouped(event) {
-      const tab = event.target;
+      const tab = event.detail;
       const group = tab.group;
       group.pinned = tab.pinned;
 
@@ -30,8 +30,8 @@
     }
 
     #onTabUngrouped(event) {
-      const tab = event.target;
-      const group = event.detail;
+      const tab = event.detail;
+      const group = event.target;
       if (group.hasAttribute('split-view-group') && tab.hasAttribute('had-zen-pinned-changed')) {
         tab.setAttribute('zen-pinned-changed', true);
         tab.removeAttribute('had-zen-pinned-changed');


### PR DESCRIPTION
small fix for an annoying err msg. In 140 `event.target` in `TabUngrouped`, `TabGrouped` events started to return a group instead of a tab.