### PR TITLE
Fix minor urlbar placeholder size changes with floating urlbar

### DIFF
--- a/src/zen/common/styles/zen-urlbar.css
+++ b/src/zen/common/styles/zen-urlbar.css
@@ -481,11 +481,14 @@ button.popup-notification-dropmarker {
   left: 50% !important;
 
   #urlbar-container:has(&) {
-    border-radius: 10px;
+    border-radius: var(--border-radius-medium);
     background: var(--toolbarbutton-hover-background);
+    height: var(--urlbar-height) !important;
+    margin-inline: 0.15rem !important;
     :root:not([zen-single-toolbar='true']) & {
       max-height: 32px !important;
-      min-height: unset;
+      min-height: unset !important;
+      margin-block: -1px !important;
     }
   }
 }


### PR DESCRIPTION
The urlbar container acting as a placeholder would differ in size as compared to the actual one by a small amount when using floating urlbar. This PR fixes that minor UI inconsistency for both single toolbar and multiple / collapsed urlbars.