### PR TITLE
fix: Fix tab drag indicator orientation to horizontal on collapsed toolbar

### DIFF
--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -857,7 +857,7 @@
               const rect = targetTab.getBoundingClientRect();
               let newIndex = targetTab._tPos;
 
-              if (isVertical) {
+              if (isVertical || !this.expandedSidebarMode) {
                 const middleY = targetTab.screenY + rect.height / 2;
                 if (!isRegularTabs && event.screenY > middleY) {
                   newIndex++;

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -1046,7 +1046,7 @@
       // Calculate middle to decide 'before' or 'after'
       const rect = targetTab.getBoundingClientRect();
       let shouldPlayHapticFeedback = false;
-      if (isVertical) {
+      if (isVertical || !this.expandedSidebarMode) {
         const separation = 8;
         const middleY = targetTab.screenY + rect.height / 2;
         const indicator = this.dragIndicator;


### PR DESCRIPTION
This little change makes drag indicator always horizontal in collapsed toolbar mode, and make tab movement logic to match with drag indicator.


https://github.com/user-attachments/assets/1ef0aa59-4f47-451e-ae35-3e1d3ce11b81


https://github.com/user-attachments/assets/adfa0d50-c69e-4bff-9dec-e986961df47f

