### PR TITLE
Fix browser-ctrlTab-js patch for Firefox 140.0 compatibility

### DIFF
--- a/src/browser/components/tabbrowser/content/browser-ctrlTab-js.patch
+++ b/src/browser/components/tabbrowser/content/browser-ctrlTab-js.patch
@@ -21,16 +21,7 @@ index 6753641cb579032306453be3f5054d7bc7661e8c..bf21f6c14f825fbe2d322900595cd344
        return;
      }
  
-@@ -483,7 +484,7 @@ var ctrlTab = {
-   },
- 
-   open: function ctrlTab_open() {
--    if (this.isOpen) {
-+    if (this.isOpen || !this.tabCount) {
-       return;
-     }
- 
-@@ -761,7 +762,7 @@ var ctrlTab = {
+@@ -764,7 +765,7 @@ var ctrlTab = {
    _initRecentlyUsedTabs() {
      this._recentlyUsedTabs = Array.prototype.filter.call(
        gBrowser.tabs,


### PR DESCRIPTION
## Summary
This PR fixes the browser-ctrlTab-js.patch file to work with Firefox 140.0, resolving the init script failure during patch application. Note that this is my first contribution to this repo so please be kind if what I did doesn't make any sense :).

## Changes Made
- Updated patch to work with Firefox 140.0 changes
- Removed obsolete open function modification (already included in Firefox 140.0)
- Updated line numbers to match current ctrlTab.js structure
- Fixes the npm run init command that was failing due to patch application errors

## Testing
- npm run init now completes successfully without patch errors
- All 166 patches apply correctly
- Language pack update works properly

## Issue
This fixes the build setup issue where the init script was failing with patch application errors. The patch was trying to modify code that had already been updated in Firefox 140.0, causing conflicts during the build setup process. This also fixes ctrl+shift+tab behavior when the "Ctrl+Tab cycles through tabs in recently used order" setting is enabled.