### PR TITLE
Fix extension button icon

### DIFF
--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -165,6 +165,7 @@
 
 #add-ons-button,
 #appMenu-extensions-themes-button,
+#appMenu-unified-extensions-button,
 #unified-extensions-button {
   list-style-image: url('extension.svg') !important;
 }


### PR DESCRIPTION
Fixed extension icon display if the extension button was hidden from the toolbar
![image](https://github.com/user-attachments/assets/757a130c-a8da-4e4d-85d7-a727512bb2ab)
![image](https://github.com/user-attachments/assets/bda41e0c-a6b6-4eb1-8a34-872effdddce4)
