### PR TITLE
docs: add local development setup guidelines

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -17,6 +17,10 @@ The `dev` branch is the main branch of the repository, and it is the default bra
 
 The `stable` branch may have hotfixes directly from the `stable` branch, and the `twilight` branch may have feature branches branched off from the `twilight` branch. This is done so that we can apply hotfixes like security patches directly to the `stable` branch without having to merge the changes from the `twilight` branch.
 
+# Local Development Setup
+
+Before you set up your local development environment, **read our [Building Guidelines](https://docs.zen-browser.app/guides/building)**. Skipping them can lead to avoidable build errors.
+
 # Code Of Conduct
 
 Please read our [Code of Conduct](../CODE_OF_CONDUCT.md) before contributing.


### PR DESCRIPTION
Hi there!

I’ve seen a few developers (#8723)—myself included—struggle to set up the project locally. I think there are 2 main reasons:
1. **Missing setup instructions in this repo.** There's no explicit instruction on how to set up the local environment in this repo. If people want to look for some help in `contribute.md`, they will find nothing.
2. **Building guidelines buried in the wrong section.** That's why I overlooked it until I found AI referenced it.😅 I have opened another [PR](https://github.com/zen-browser/docs/pull/204) in `docs` repo to move it to where it should be.
<img width="287" alt="image" src="https://github.com/user-attachments/assets/692e2c3b-0c5d-4fb9-b6eb-a0b29f926459" />

For this PR, let’s simply add a reference link to `contribute.md` as a quick redirect. That way we avoid maintaining duplicate setup instructions, and future developers can easily find the authoritative guide. Win-win~✌🏼
