### PR TITLE
fix: align with Firefox UI styles & improve accessibility

### DIFF
--- a/src/zen/common/styles/zen-theme.css
+++ b/src/zen/common/styles/zen-theme.css
@@ -84,7 +84,7 @@
   --button-bgcolor: var(--in-content-button-background) !important;
   --button-hover-bgcolor: var(--in-content-button-background-hover) !important;
   --button-hover-color: var(--in-content-button-text-color-hover) !important;
-  --focus-outline-color: var(--button-bgcolor) !important;
+  --focus-outline-color: var(--color-accent-primary) !important;
 
   --toolbarbutton-icon-fill-attention: var(--zen-primary-color) !important;
   --toolbarbutton-icon-fill: currentColor !important;


### PR DESCRIPTION
## Description
This PR aims to solve the issue (#9220) I raised in the community. I discovered this bug about two weeks ago but hadn’t had time to fix it. Since it’s still unresolved, I decided to take a look.

## Root Cause
Apparently, Zen Browser insert the custom CSS theme into the `common-shared.css`.
```diff
@@ -5,6 +5,8 @@
 @import url("chrome://global/skin/design-system/tokens-brand.css");
 @import url("chrome://global/skin/design-system/text-and-typography.css");
 
+@import url("chrome://browser/content/zen-styles/zen-theme.css");
```
And there's one thing in `zen-theme.css` caught my eye:
```css
/* This is like the secondary button */
--in-content-button-background: transparent !important;
--button-bgcolor: var(--in-content-button-background) !important;
--focus-outline-color: var(--button-bgcolor) !important; // <-- Here! Why make focus outline transparent? 🤔
```
So I inspected the Firefox implementation:
<img width="1361" alt="image" src="https://github.com/user-attachments/assets/fcbf272c-5db1-4884-86b9-aa06a4bb53b5" />
And also look into what `--in-content-focus-outline` stands for:
<img width="339" alt="image" src="https://github.com/user-attachments/assets/f3452916-7d5d-4236-8736-aa857675fa9a" />
<img width="338" alt="image" src="https://github.com/user-attachments/assets/87200840-c1e8-4827-bafc-e6ef20dabd4e" />

Firefox’s approach seems more reasonable for a broader range of users. I adopted it with Zen’s custom theme accordingly—the UI now looks great.

## Demo

https://github.com/user-attachments/assets/50de01ff-3fd0-4297-b9d1-13aebf8f7e6e