### PR TITLE
feat: readded pref("browser.tabs.closeWindowWithLastTab", false);

### DIFF
--- a/src/browser/app/profile/browser.inc
+++ b/src/browser/app/profile/browser.inc
@@ -8,6 +8,7 @@ pref("browser.startup.page", 3);
 pref("browser.sessionstore.restore_pinned_tabs_on_demand", true);
 
 // Toolbars
+pref("browser.tabs.closeWindowWithLastTab", false);
 pref("browser.tabs.loadBookmarksInTabs", false);
 pref("browser.tabs.hoverPreview.enabled", false);
 pref("browser.tabs.dragdrop.moveOverThresholdPercent", 50);


### PR DESCRIPTION
I reverted a change made in commit 3da5eda (feat: Small improvements to haptic feedback…) that removed  pref("browser.tabs.closeWindowWithLastTab", false);. Without it, the browser closes on the closing of any last tab within any space, regardless of tabs being open inside other spaces.

This PR re-adds the pref to bring back the previous behavior and also resolves #9319 