### PR TITLE
add open button to background tab toast

### DIFF
--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -163,7 +163,8 @@
   list-style-image: url('search-page.svg') !important;
 }
 
-#open-button {
+#open-file-button,
+#zen-open-background-tab-button {
   list-style-image: url('open.svg') !important;
 }
 

--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -163,7 +163,7 @@
   list-style-image: url('search-page.svg') !important;
 }
 
-#open-file-button {
+#open-button {
   list-style-image: url('open.svg') !important;
 }
 

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -689,7 +689,15 @@ var gZenCompactModeManager = {
       !this._nextTimeWillBeActive &&
       this.canHideSidebar
     ) {
-      gZenUIManager.showToast('zen-background-tab-opened-toast');
+      gZenUIManager.showToast('zen-background-tab-opened-toast', {
+        button: {
+          id: 'open-button',
+          command: () => {
+            const targetWindow = window.ownerGlobal.parent || window;
+            targetWindow.gBrowser.selectedTab = tab;
+          },
+        },
+      });
     }
     delete this._nextTimeWillBeActive;
   },

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -691,7 +691,7 @@ var gZenCompactModeManager = {
     ) {
       gZenUIManager.showToast('zen-background-tab-opened-toast', {
         button: {
-          id: 'open-button',
+          id: 'zen-open-background-tab-button',
           command: () => {
             const targetWindow = window.ownerGlobal.parent || window;
             targetWindow.gBrowser.selectedTab = tab;


### PR DESCRIPTION
## Problem

The new background tab toast is not interactive. It would be nice if you could click on it to open the newly opened tab.

<img width="236" height="58" alt="image" src="https://github.com/user-attachments/assets/ae7b2662-e6c7-447e-a346-b32b3153d79e" />

This has also been requested by some other users: https://github.com/zen-browser/desktop/discussions/9295

## Solution

Add a button that opens the new tab.

https://github.com/user-attachments/assets/6ace4d32-4427-45d3-8256-b8caa978d396
