### PR TITLE
Remove overwritten font size in Zen Toast styling.

### DIFF
--- a/src/zen/common/styles/zen-popup.css
+++ b/src/zen/common/styles/zen-popup.css
@@ -380,7 +380,6 @@ menuseparator {
     font-weight: 600;
     align-items: center;
     width: max-content;
-    font-size: small;
     position: absolute;
     transform-origin: top center;
     max-height: var(--zen-toast-max-height);


### PR DESCRIPTION
This pull request removes an overwritten font size in the Zen Toast styling.