### PR TITLE
fix: Fix copy button not working in calc and unit conversion results

### DIFF
--- a/src/zen/common/ZenUIManager.mjs
+++ b/src/zen/common/ZenUIManager.mjs
@@ -398,17 +398,19 @@ var gZenUIManager = {
       }
 
       if (gURLBar.focused) {
-        gURLBar.view.close({ elementPicked: onSwitch });
-        gURLBar.updateTextOverflow();
+        setTimeout(() => {
+          gURLBar.view.close({ elementPicked: onSwitch });
+          gURLBar.updateTextOverflow();
 
-        // Ensure tab and browser are valid before updating state
-        const selectedTab = gBrowser.selectedTab;
-        if (selectedTab && selectedTab.linkedBrowser && !selectedTab.closing && onSwitch) {
-          const browserState = gURLBar.getBrowserState(selectedTab.linkedBrowser);
-          if (browserState) {
-            browserState.urlbarFocused = false;
+          // Ensure tab and browser are valid before updating state
+          const selectedTab = gBrowser.selectedTab;
+          if (selectedTab && selectedTab.linkedBrowser && !selectedTab.closing && onSwitch) {
+            const browserState = gURLBar.getBrowserState(selectedTab.linkedBrowser);
+            if (browserState) {
+              browserState.urlbarFocused = false;
+            }
           }
-        }
+        }, 0);
       }
     });
   },


### PR DESCRIPTION
Resolves race condition where urlbar view close was interrupting engagement events, preventing onEngagement from being called.

Add `setTimeout(..., 0)` to resolve race condition

Fixes https://github.com/zen-browser/desktop/issues/9519