### PR TITLE
fix: legacy gradients setting being ignored after opening a private window

### DIFF
--- a/src/zen/workspaces/ZenGradientGenerator.mjs
+++ b/src/zen/workspaces/ZenGradientGenerator.mjs
@@ -1448,7 +1448,11 @@
         if (dominantColor) {
           const primaryColor = this.getAccentColorForUI(dominantColor);
           browser.document.documentElement.style.setProperty('--zen-primary-color', primaryColor);
-          browser.gZenThemePicker.isLegacyVersion = this.isLegacyVersion;
+
+          // Should be set to `this.isLegacyVersion` but for some reason it is set to undefined if we open a private window,
+          // so instead get the pref value directly.
+          browser.gZenThemePicker.isLegacyVersion = Services.prefs.getIntPref('zen.theme.gradient-legacy-version', 1) === 0;
+
           let isDarkMode = isDarkModeWindow;
           if (!isDefaultTheme && !this.isLegacyVersion) {
             // Check for the primary color


### PR DESCRIPTION
Fixes theme colors becoming brighter when opening a new private window if the user has legacy gradients on. Addresses #9565.

## Technical: 
In `ZenGradientGenerator.mjs` when `isLegacyVersion` is initialized, it is set to true if `zen.theme.gradient-legacy-version` is 0, however after a new private window is opened, `isLegacyVersion` is becomes undefined, causing the theme colors to change and become brighter if the user has the legacy gradients pref enabled. This addresses the problem by instead reading directly from the pref value directly anytime a workspace change is triggered (such as when opening a private window), giving a correct value.

I plan to investigate further why `isLegacyVersion` becomes undefined when opening a private window but for now I’ve implemented this fix to resolve this UI bug that has been affecting me and others.