### PR TITLE
Fix: Resolve shortcut conflict for forwarding workspace 

### DIFF
--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -668,7 +668,7 @@ class nsZenKeyboardShortcutsLoader {
     newShortcutList.push(
       new KeyShortcut(
         'zen-workspace-forward',
-        'E',
+        'A',
         '',
         ZEN_WORKSPACE_SHORTCUTS_GROUP,
         nsKeyShortcutModifiers.fromObject({ accel: true, alt: true }),


### PR DESCRIPTION
I changed the modifier key from 'E' to 'A' as in issue #9746 there was the same default key for dev network tool and forward workspace shortcuts.