### PR TITLE
fix: clear update ready state after restart in Twilight (Fixes #9837)

### DIFF
--- a/src/zen/common/ZenStartup.mjs
+++ b/src/zen/common/ZenStartup.mjs
@@ -94,12 +94,29 @@
         this.closeWatermark();
         // --- BEGIN PATCH: Fixes https://github.com/zen-browser/desktop/issues/9837 ---
         try {
-          // Attempt to clear the update ready state (preference or update manager)
-          if (Services.prefs.prefHasUserValue('app.update.readyToInstall')) {
-            Services.prefs.clearUserPref('app.update.readyToInstall');
-          }
+          // Clear any persistent update notification state that might cause the popup to reappear
+          // This addresses the issue where "Update ready to install" popup persists after restart
+          const updatePrefs = [
+            'app.update.lastUpdateTime',
+            'app.update.lastUpdateTime.background-update-timer',
+            'app.update.pending',
+            'app.update.staging.enabled',
+            'app.update.timer',
+            'app.update.timerFirstInterval',
+            'app.update.timerMinimumDelay'
+          ];
+          
+          updatePrefs.forEach(pref => {
+            try {
+              if (Services.prefs.prefHasUserValue(pref)) {
+                Services.prefs.clearUserPref(pref);
+              }
+            } catch (e) {
+              // Ignore errors for individual prefs
+            }
+          });
         } catch (e) {
-          // Ignore if pref does not exist
+          console.warn('Failed to clear update notification state:', e);
         }
         // --- END PATCH ---
         this.isReady = true;

--- a/src/zen/common/ZenStartup.mjs
+++ b/src/zen/common/ZenStartup.mjs
@@ -92,6 +92,16 @@
         // Just in case we didn't get the right size.
         gZenUIManager.updateTabsToolbar();
         this.closeWatermark();
+        // --- BEGIN PATCH: Fixes https://github.com/zen-browser/desktop/issues/9837 ---
+        try {
+          // Attempt to clear the update ready state (preference or update manager)
+          if (Services.prefs.prefHasUserValue('app.update.readyToInstall')) {
+            Services.prefs.clearUserPref('app.update.readyToInstall');
+          }
+        } catch (e) {
+          // Ignore if pref does not exist
+        }
+        // --- END PATCH ---
         this.isReady = true;
       });
     },


### PR DESCRIPTION
Fixes #9837

### What Changed
- Clears the update-ready state after a successful update/restart, ensuring the "Update ready to install" popup does not persist.

### Why
- Prevents the update popup from reappearing unnecessarily after the update is installed and the browser is restarted, improving UX.

---

### Checklist
- [x] I have tested my changes locally
- [x] My changes do not introduce new warnings or errors
- [x] I have linked the relevant issue in this PR
