### PR TITLE
fix: Shift navbar down when accesing it on macOS in fullscreen (#8757)

### DIFF
--- a/src/browser/base/content/browser-fullScreenAndPointerLock-js.patch
+++ b/src/browser/base/content/browser-fullScreenAndPointerLock-js.patch
@@ -2,18 +2,18 @@ diff --git a/browser/base/content/browser-fullScreenAndPointerLock.js b/browser/
 index bef746dc594ad974c91075cf3657c199f8f8830f..bb671341b6715c42df76f7298ba55e1fac73f33b 100644
 --- a/browser/base/content/browser-fullScreenAndPointerLock.js
 +++ b/browser/base/content/browser-fullScreenAndPointerLock.js
-@@ -424,10 +424,10 @@ var FullScreen = {
+@@ -423,10 +423,10 @@ var FullScreen = {
+     shiftSize = shiftSize.toFixed(2);
      gNavToolbox.classList.toggle("fullscreen-with-menubar", shiftSize > 0);
  
-     let transform = shiftSize > 0 ? `translateY(${shiftSize}px)` : "";
+-    let transform = shiftSize > 0 ? `translateY(${shiftSize}px)` : "";
 -    gNavToolbox.style.transform = transform;
 -    gURLBar.textbox.style.transform = gURLBar.textbox.hasAttribute("breakout")
 -      ? transform
--      : "";
-+    //gNavToolbox.style.transform = transform;
-+    //gURLBar.textbox.style.transform = gURLBar.textbox.hasAttribute("breakout")
-+    //  ? transform
-+    //  : "";
++    const padding = shiftSize > 0 ? `${shiftSize}px` : "";
++    const appContentNavbarWrapper = document.getElementById('zen-appcontent-navbar-wrapper');
++    appContentNavbarWrapper.style.paddingTop = gURLBar.textbox.hasAttribute("breakout")
++      ? padding
+       : "";
      if (shiftSize > 0) {
        // If the mouse tracking missed our fullScreenToggler, then the toolbox
-       // might not have been shown before the menubar is animated down. Make

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -715,6 +715,15 @@ window.gZenCompactModeManager = {
           if (event.target.matches(':hover')) {
             return;
           }
+          if (AppConstants.platform == 'macosx' && FullScreen._currentToolbarShift > 0) {
+            this.flashElement(
+              target,
+              this.hideAfterHoverDuration,
+              'has-hover' + target.id,
+              'zen-has-hover'
+            );
+            return;
+          }
 
           if (
             event.explicitOriginalTarget?.closest?.('#urlbar[zen-floating-urlbar]') ||
@@ -764,12 +773,20 @@ window.gZenCompactModeManager = {
           }
           window.cancelAnimationFrame(this._removeHoverFrames[target.id]);
 
-          this.flashElement(
-            target,
-            this.hideAfterHoverDuration,
-            'has-hover' + target.id,
-            'zen-has-hover'
-          );
+          if (
+            AppConstants.platform == 'macosx' &&
+            window.fullScreen &&
+            entry.screenEdge === 'top'
+          ) {
+            target.setAttribute('zen-has-hover', 'true');
+          } else {
+            this.flashElement(
+              target,
+              this.hideAfterHoverDuration,
+              'has-hover' + target.id,
+              'zen-has-hover'
+            );
+          }
           document.addEventListener(
             'mousemove',
             () => {


### PR DESCRIPTION
Shift nav bar down when accessing it on macOS while in fullscreen, allowing it to be shown when the macOS top bar appears.
I tried to keep this PR simple, but the nav bar kept auto hiding when the macOS top bar appears making it difficult to access. The changes made in `ZenCompactMode.mjs` fixes that.

Fixes https://github.com/zen-browser/desktop/issues/8757

EDIT: This is how it currently works
https://github.com/user-attachments/assets/5ad31673-366a-4c65-b6ba-2d2b2a2036ff

