### PR TITLE
fix: make scrolling in folder popup more apparent

### DIFF
--- a/src/zen/folders/zen-folders.css
+++ b/src/zen/folders/zen-folders.css
@@ -378,7 +378,7 @@ zen-folder {
 
 #zen-folder-tabs-list {
   padding: 0 4px;
-  max-height: 248px;
+  max-height: 263px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
I did this because the scrollbar hides when you open the popup so there is no solid indication of being able to scroll through it, this makes it so tab 6 is partially visible in the popup.

Small change, feel free to not approve