### PR TITLE
Fix ```:root:has()``` requirements with mods.

### DIFF
--- a/src/zen/mods/ZenMods.mjs
+++ b/src/zen/mods/ZenMods.mjs
@@ -155,7 +155,7 @@
       for (const browser of nsZenMultiWindowFeature.browsers) {
         const container = browser.document.getElementById('themes-container');
         let hasEnabledMods = false;
-        
+
         for (const { enabled, preferences, name } of modsWithPreferences) {
           const sanitizedName = this.sanitizeModName(name);
 

--- a/src/zen/mods/ZenMods.mjs
+++ b/src/zen/mods/ZenMods.mjs
@@ -189,7 +189,7 @@
                     element.style.display = 'none';
                     element.setAttribute('id', sanitizedName);
 
-                    browser.document.body.appendChild(element);
+                    browser.document.body.getElementById("zen-themes").appendChild(element);
                   }
 
                   element.setAttribute(sanitizedProperty, value);

--- a/src/zen/mods/ZenMods.mjs
+++ b/src/zen/mods/ZenMods.mjs
@@ -175,14 +175,16 @@
             }
 
             continue;
-          } else {
-            if (!hasEnabledMods && !container) {
+          }
+
+          if (!hasEnabledMods) {
+            hasEnabledMods = true;
+
+            if (!container) {
               const element = browser.document.createElement('div');
               element.setAttribute('id', 'themes-container');
               browser.document.body.appendChild(element);
             }
-            
-            hasEnabledMods = true;
           }
 
           for (const { property, type } of preferences) {

--- a/src/zen/mods/ZenMods.mjs
+++ b/src/zen/mods/ZenMods.mjs
@@ -153,6 +153,9 @@
 
     #writeToDom(modsWithPreferences) {
       for (const browser of nsZenMultiWindowFeature.browsers) {
+        const container = browser.document.getElementById('themes-container');
+        let hasEnabledMods = false;
+        
         for (const { enabled, preferences, name } of modsWithPreferences) {
           const sanitizedName = this.sanitizeModName(name);
 
@@ -172,6 +175,14 @@
             }
 
             continue;
+          } else {
+            if (!hasEnabledMods && !container) {
+              const element = browser.document.createElement('div');
+              element.setAttribute('id', 'themes-container');
+              browser.document.body.appendChild(element);
+            }
+            
+            hasEnabledMods = true;
           }
 
           for (const { property, type } of preferences) {
@@ -189,7 +200,7 @@
                     element.style.display = 'none';
                     element.setAttribute('id', sanitizedName);
 
-                    browser.document.body.getElementById("zen-themes").appendChild(element);
+                    browser.document.getElementById('themes-container').appendChild(element);
                   }
 
                   element.setAttribute(sanitizedProperty, value);
@@ -211,6 +222,10 @@
               }
             }
           }
+        }
+
+        if (!hasEnabledMods && container) {
+          container.remove();
         }
       }
     }


### PR DESCRIPTION
This pull request makes it so that mods will no longer need to have a ```:root:has()``` selector for dropdowns by injecting ```#theme-{name}``` elements into a ```#themes-container``` element, allowing mods to do this:
```css
#themes-container:has(#theme-{name}[property="value"]) ~ #element-to-style {
  property: value;
}
```
This snippet basically runs a ```:has()``` on the themes-container element, then looks for siblings of that container, and because the themes-container is at the root of the body, the mod will be able to select any element that they would be able to style and then either style it or style its child element, effectively providing the same ability that ```:root:has()``` provides currently.

Also, due to the way that this works, it is backwards-compatible with other mods, so mods that still use ```:root:has()``` will work.