### PR TITLE
fix: make folder search input take up full width

### DIFF
--- a/src/browser/base/content/zen-panels/folders-search.inc
+++ b/src/browser/base/content/zen-panels/folders-search.inc
@@ -8,8 +8,7 @@
     <html:input id="zen-folder-tabs-list-search" 
       data-l10n-id="zen-folders-search-placeholder" 
       data-l10n-args="{&quot;folder-name&quot;:&quot;&quot;}"
-      type="search" 
-      flex="1" />
+      type="search" />
   </hbox>
   <scrollbox class="zen-folder-tabs-list-scrollbox" flex="1">
     <vbox id="zen-folder-tabs-list"></vbox>

--- a/src/zen/folders/zen-folders.css
+++ b/src/zen/folders/zen-folders.css
@@ -392,6 +392,7 @@ zen-folder {
   background-color: transparent;
   border: none !important;
   outline: none !important;
+  flex: 1;
 }
 
 #zen-folder-tabs-list {


### PR DESCRIPTION
The folder search input doesn't seem to have flex, which makes the width differ depending on the system font of the user. This simple patch makes the input box take up the full width :)