### PR TITLE
fix: use default zen accent color and revert changes related to accent color

### DIFF
--- a/prefs/theme.yaml
+++ b/prefs/theme.yaml
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 - name: zen.theme.accent-color
-  value: 'AccentColor'
+  value: '#ffb787'
 
 - name: zen.theme.content-element-separation
   value: 8

--- a/prefs/theme.yaml
+++ b/prefs/theme.yaml
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 - name: zen.theme.accent-color
-  value: 'system'
+  value: 'AccentColor'
 
 - name: zen.theme.content-element-separation
   value: 8

--- a/src/zen/common/styles/zen-browser-ui.css
+++ b/src/zen/common/styles/zen-browser-ui.css
@@ -48,13 +48,6 @@
   isolation: isolate;
   background: var(--zen-themed-toolbar-bg-transparent);
 
-  /*
-   *  Important: We set the color to `AccentColor` so we can
-   *  Compute the stylings and get the native accent color.
-   *  Please, do not remove this.
-   */
-  color: AccentColor;
-
   &::after,
   &::before {
     content: '';

--- a/src/zen/common/zenThemeModifier.js
+++ b/src/zen/common/zenThemeModifier.js
@@ -97,10 +97,7 @@ var ZenThemeModifier = {
    * Update the accent color.
    */
   updateAccentColor() {
-    let accentColor = Services.prefs.getStringPref('zen.theme.accent-color');
-    if (accentColor.startsWith('system:')) {
-      accentColor = accentColor.replace('system:', '').trim();
-    }
+    const accentColor = Services.prefs.getStringPref('zen.theme.accent-color');
     document.documentElement.style.setProperty('--zen-primary-color', accentColor);
   },
 };

--- a/src/zen/workspaces/ZenGradientGenerator.mjs
+++ b/src/zen/workspaces/ZenGradientGenerator.mjs
@@ -1501,16 +1501,7 @@
 
     getNativeAccentColor() {
       const accentColor = Services.prefs.getStringPref('zen.theme.accent-color');
-      let rgb;
-      if (accentColor.startsWith('system')) {
-        const rawRgb = window.getComputedStyle(document.getElementById('zen-browser-background'))[
-          'color'
-        ];
-        Services.prefs.setStringPref('zen.theme.accent-color', `system:${rawRgb}`);
-        rgb = rawRgb.match(/\d+/g).map(Number);
-      } else {
-        rgb = this.hexToRgb(accentColor);
-      }
+      const rgb = this.hexToRgb(accentColor);
       if (this.isDarkMode) {
         // If the theme is dark, we want to use a lighter color
         return this.blendColors(rgb, [0, 0, 0], 40);


### PR DESCRIPTION
Uses AccentColor as the default variable for the preference `zen.theme.accent-color` and reverts some changes as requested.