### PR TITLE
fix: wrong security indicator in about pages

### DIFF
--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -344,6 +344,7 @@
 }
 
 #identity-popup[connection='chrome'] .identity-popup-security-connection {
+  list-style-image: url('chrome://branding/content/icon16.png') !important;
   filter: grayscale(1);
 }
 

--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -344,7 +344,7 @@
 }
 
 #identity-popup[connection='chrome'] .identity-popup-security-connection {
-  list-style-image: url('chrome://branding/content/icon16.png') !important;
+  list-style-image: url('chrome://branding/content/icon48.png') !important;
   filter: grayscale(1);
 }
 


### PR DESCRIPTION
This patch fixes the security icon displayed in the site information dialog for the about pages, it should now display the browser's icon instead of the warning symbol.

<img width="260" height="120" alt="image" src="https://github.com/user-attachments/assets/a6144370-7463-465b-bc16-ff5c507569f9" />