### PR TITLE
fix: hide manage themes option in customize toolbar

### DIFF
--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -24,7 +24,7 @@
 }
 
 @media -moz-pref('zen.theme.disable-lightweight') {
-  #customization-footer #customization-lwtheme-link {
+  #customization-lwtheme-link {
     display: none !important;
   }
 }

--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -23,6 +23,12 @@
   display: none !important;
 }
 
+@media -moz-pref('zen.theme.disable-lightweight') {
+  #customization-footer #customization-lwtheme-link {
+    display: none !important;
+  }
+}
+
 .private-browsing-indicator-with-label {
   display: none !important;
 }


### PR DESCRIPTION
The browser still displays the link for managing Firefox themes in Customize Toolbar so this patch fixes that. It can be shown by toggling `zen.theme.disable-lightweight` to `false` in about:config.