### PR TITLE
fix: always show HTTP warning icon in single toolbar

### DIFF
--- a/src/browser/themes/shared/identity-block/identity-block-css.patch
+++ b/src/browser/themes/shared/identity-block/identity-block-css.patch
@@ -7,7 +7,7 @@ index 13b1659ed5a3b9bb0342b601998d0fd5c9760e22..4f13c401f23f51962986fe8caf197aa5
  #identity-box[pageproxystate="valid"]:is(.notSecureText, .chromeUI, .extensionPage) > .identity-box-button,
  #urlbar-label-box {
 -  background-color: var(--urlbar-box-bgcolor);
-+  background-color: light-dark(#cecece, rgb(66, 65, 77));
++  background-color: transparent;
    color: var(--urlbar-box-text-color);
    padding-inline: 8px;
    border-radius: var(--urlbar-icon-border-radius);

--- a/src/zen/common/styles/zen-urlbar.css
+++ b/src/zen/common/styles/zen-urlbar.css
@@ -201,7 +201,7 @@
     display: none;
   }
 
-  #identity-box:not([pageproxystate='invalid']) #identity-icon-box:not([open]) {
+  #identity-box:not([pageproxystate='invalid']):not(.notSecure) #identity-icon-box:not([open]) {
     margin-inline-start: calc(-8px - 2 * var(--urlbar-icon-padding));
     transform: translateX(100%);
     opacity: 0;
@@ -376,7 +376,7 @@ button.popup-notification-dropmarker {
   #identity-box:is(:not(.chromeUI), [pageproxystate='invalid'])
   #identity-icon-box {
   border-radius: var(--urlbar-icon-border-radius) !important;
-  min-width: 30px;
+  min-width: 28px;
 }
 
 /* Notification Stack */


### PR DESCRIPTION
While it does display the `http://` part in the address bar, I think it's important to always make the warning symbol always show on HTTP sites in single toolbar mode. Not everybody knows what it means.

Also changed the icon container width to `28px` to center the icon and removed the hardcoded background color as well.

<img width="327" height="93" alt="Screenshot 2025-09-04 180111" src="https://github.com/user-attachments/assets/997d4713-d20d-41a0-a1b9-118678168cc4" />