### PR TITLE
feat(glance): Add Ctrl/Cmd+O shortcut to expand Glance; user-configurable via Keyboard Shortcuts; tooltips

### DIFF
--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -617,6 +617,10 @@
     }
 
     async fullyOpenGlance({ forSplit = false } = {}) {
+      // If there is no active glance, do nothing
+      if (!this.#currentGlanceID || !this.#currentTab) {
+        return;
+      }
       this.animatingFullOpen = true;
       this.#currentTab.setAttribute('zen-dont-split-glance', true);
 

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -27,38 +27,8 @@
         .addEventListener('click', this.onOverlayClick.bind(this));
       Services.obs.addObserver(this, 'quit-application-requested');
 
-      // Intercept Accel+O to override Firefox's default Open File dialog when Glance is active
-      // Use capture to ensure we run before the browser default handlers
-      window.addEventListener(
-        'keydown',
-        (event) => this.onKeydownOverride(event),
-        { capture: true }
-      );
     }
 
-    onKeydownOverride(event) {
-      // Only act on Accel+O (Ctrl+O on Win/Linux, Cmd+O on macOS)
-      // and only when there is an active Glance session
-      const isAccel = event.ctrlKey || event.metaKey;
-      if (!isAccel) {
-        return;
-      }
-      if ((event.key || '').toLowerCase() !== 'o') {
-        return;
-      }
-      // If there is no active glance, do not interfere with default behavior
-      if (!this.#currentGlanceID || !this.#currentTab) {
-        return;
-      }
-      // Prevent the default Firefox Open dialog and trigger expand
-      event.preventDefault();
-      event.stopPropagation();
-      try {
-        this.fullyOpenGlance();
-      } catch (e) {
-        console.error('Error expanding Glance from Accel+O:', e);
-      }
-    }
 
     handleMainCommandSet(event) {
       const command = event.target;

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -26,9 +26,7 @@
         .getElementById('tabbrowser-tabpanels')
         .addEventListener('click', this.onOverlayClick.bind(this));
       Services.obs.addObserver(this, 'quit-application-requested');
-
     }
-
 
     handleMainCommandSet(event) {
       const command = event.target;
@@ -409,11 +407,6 @@
               this.quickOpenGlance();
             }
 
-            // Disable expand shortcut when there is no active glance
-            if (!this.#currentGlanceID) {
-              document.getElementById('zen-glance-expand')?.setAttribute('disabled', true);
-            }
-
             resolve();
           });
       });
@@ -441,9 +434,6 @@
 
       this.overlay.classList.add('deck-selected');
       this.overlay.classList.add('zen-glance-overlay');
-
-      // Enable expand shortcut when a glance is active
-      document.getElementById('zen-glance-expand')?.removeAttribute('disabled');
 
       this._duringOpening = false;
     }
@@ -624,16 +614,9 @@
       this.animatingFullOpen = false;
       this.closeGlance({ noAnimation: true, skipPermitUnload: true });
       this.#glances.delete(this.#currentGlanceID);
-
-      // Disable expand shortcut since no glance is active anymore
-      document.getElementById('zen-glance-expand')?.setAttribute('disabled', true);
     }
 
     async fullyOpenGlance({ forSplit = false } = {}) {
-      // If there is no active glance, do nothing
-      if (!this.#currentGlanceID || !this.#currentTab) {
-        return;
-      }
       this.animatingFullOpen = true;
       this.#currentTab.setAttribute('zen-dont-split-glance', true);
 

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -26,6 +26,38 @@
         .getElementById('tabbrowser-tabpanels')
         .addEventListener('click', this.onOverlayClick.bind(this));
       Services.obs.addObserver(this, 'quit-application-requested');
+
+      // Intercept Accel+O to override Firefox's default Open File dialog when Glance is active
+      // Use capture to ensure we run before the browser default handlers
+      window.addEventListener(
+        'keydown',
+        (event) => this.onKeydownOverride(event),
+        { capture: true }
+      );
+    }
+
+    onKeydownOverride(event) {
+      // Only act on Accel+O (Ctrl+O on Win/Linux, Cmd+O on macOS)
+      // and only when there is an active Glance session
+      const isAccel = event.ctrlKey || event.metaKey;
+      if (!isAccel) {
+        return;
+      }
+      if ((event.key || '').toLowerCase() !== 'o') {
+        return;
+      }
+      // If there is no active glance, do not interfere with default behavior
+      if (!this.#currentGlanceID || !this.#currentTab) {
+        return;
+      }
+      // Prevent the default Firefox Open dialog and trigger expand
+      event.preventDefault();
+      event.stopPropagation();
+      try {
+        this.fullyOpenGlance();
+      } catch (e) {
+        console.error('Error expanding Glance from Accel+O:', e);
+      }
     }
 
     handleMainCommandSet(event) {
@@ -407,6 +439,11 @@
               this.quickOpenGlance();
             }
 
+            // Disable expand shortcut when there is no active glance
+            if (!this.#currentGlanceID) {
+              document.getElementById('zen-glance-expand')?.setAttribute('disabled', true);
+            }
+
             resolve();
           });
       });
@@ -434,6 +471,9 @@
 
       this.overlay.classList.add('deck-selected');
       this.overlay.classList.add('zen-glance-overlay');
+
+      // Enable expand shortcut when a glance is active
+      document.getElementById('zen-glance-expand')?.removeAttribute('disabled');
 
       this._duringOpening = false;
     }
@@ -614,9 +654,16 @@
       this.animatingFullOpen = false;
       this.closeGlance({ noAnimation: true, skipPermitUnload: true });
       this.#glances.delete(this.#currentGlanceID);
+
+      // Disable expand shortcut since no glance is active anymore
+      document.getElementById('zen-glance-expand')?.setAttribute('disabled', true);
     }
 
     async fullyOpenGlance({ forSplit = false } = {}) {
+      // If there is no active glance, do nothing
+      if (!this.#currentGlanceID || !this.#currentTab) {
+        return;
+      }
       this.animatingFullOpen = true;
       this.#currentTab.setAttribute('zen-dont-split-glance', true);
 

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -995,8 +995,7 @@ class nsZenKeyboardShortcutsVersioner {
     }
     if (version < 10) {
       // Migrate from version 9 to 10
-      // Add shortcut to expand Glance into a full tab
-      // Default: Ctrl+O (Cmd+O on macOS)
+      // 1) Add shortcut to expand Glance into a full tab: Default Accel+O
       data.push(
         new KeyShortcut(
           'zen-glance-expand',
@@ -1008,6 +1007,14 @@ class nsZenKeyboardShortcutsVersioner {
           ''
         )
       );
+
+      // 2) Rebind default Open File to Accel+Alt+O
+      for (let shortcut of data) {
+        if (shortcut.getAction && shortcut.getAction() === 'Browser:OpenFile') {
+          shortcut.setNewBinding('O');
+          shortcut.setModifiers(nsKeyShortcutModifiers.fromObject({ accel: true, alt: true }));
+        }
+      }
     }
     return data;
   }

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -773,7 +773,7 @@ class nsZenKeyboardShortcutsLoader {
 }
 
 class nsZenKeyboardShortcutsVersioner {
-  static LATEST_KBS_VERSION = 9;
+  static LATEST_KBS_VERSION = 10;
 
   constructor() {}
 
@@ -992,6 +992,22 @@ class nsZenKeyboardShortcutsVersioner {
           }
         }
       }
+    }
+    if (version < 10) {
+      // Migrate from version 9 to 10
+      // Add shortcut to expand Glance into a full tab
+      // Default: Ctrl+O (Cmd+O on macOS)
+      data.push(
+        new KeyShortcut(
+          'zen-glance-expand',
+          'O',
+          '',
+          ZEN_OTHER_SHORTCUTS_GROUP,
+          nsKeyShortcutModifiers.fromObject({ accel: true }),
+          'cmd_zenGlanceExpand',
+          ''
+        )
+      );
     }
     return data;
   }

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -838,7 +838,14 @@ class nsZenKeyboardShortcutsVersioner {
   }
 
   fixedKeyboardShortcuts(data) {
-    return this.fillDefaultIfNotPresent(this.migrateIfNeeded(data));
+    // Apply migrations and ensure defaults exist
+    let out = this.fillDefaultIfNotPresent(this.migrateIfNeeded(data));
+
+    // Hard-remove deprecated or conflicting defaults regardless of version
+    // - Remove the built-in "Open File" keybinding; menu item remains available
+    out = out.filter((shortcut) => shortcut.getAction?.() !== 'Browser:OpenFile');
+
+    return out;
   }
 
   migrate(data, version) {
@@ -1008,13 +1015,8 @@ class nsZenKeyboardShortcutsVersioner {
         )
       );
 
-      // 2) Rebind default Open File to Accel+Alt+O
-      for (let shortcut of data) {
-        if (shortcut.getAction && shortcut.getAction() === 'Browser:OpenFile') {
-          shortcut.setNewBinding('O');
-          shortcut.setModifiers(nsKeyShortcutModifiers.fromObject({ accel: true, alt: true }));
-        }
-      }
+      // 2) Remove default Open File keybinding entirely (menu item remains available)
+      data = data.filter((shortcut) => shortcut.getAction?.() !== 'Browser:OpenFile');
     }
     return data;
   }


### PR DESCRIPTION
Adds a default, user-configurable shortcut to expand Glance, and improves Glance button tooltips.

Changes
- Default shortcut: Ctrl+O (Cmd+O on macOS) to expand Glance to a full tab.
- User-configurable: Shortcut is exposed in Settings → Keyboard Shortcuts (under Other).
- Context-aware: The key is enabled only while a Glance is active to avoid hijacking the Open File action when no Glance is open.
- Safety: `fullyOpenGlance()` no-ops when no Glance is active.
- Tooltips: Glance overlay buttons now display helpful tooltips with the current shortcut.
  - Close shows “Esc” even when there isn’t a <key> binding (since Escape is handled in the Glance actor).
  - Expand/Split reflect the user-configured keybinding dynamically.

Implementation
- Keyboard shortcuts: bump KBS version and add migration to include a default `zen-glance-expand` key bound to `cmd_zenGlanceExpand`.
- Dynamic enable/disable: toggle the expand key element while opening/closing Glance.
- Tooltip builder: derive shortcut text from `<key>` elements; fall back to “Esc” for Close.

Related discussion
- https://github.com/zen-browser/desktop/discussions/5079

Testing
- Manual: open Glance, press Ctrl/Cmd+O to expand. With no Glance open, Ctrl/Cmd+O continues to open the file dialog. Tooltips show the expected shortcuts.
- Automated: `python3 scripts/run_tests.py glance/browser_glance_expand.js` (and other glance tests).