### PR TITLE
Enable workspace horizontal scrolling compatibility for Logitech mice

### DIFF
--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -616,30 +616,42 @@ var gZenWorkspaces = new (class extends nsZenMultiWindowFeature {
           }
         }
 
-        const isVerticalScroll = event.deltaY && !event.deltaX;
+        const absX = Math.abs(event.deltaX || 0);
+        const absY = Math.abs(event.deltaY || 0);
 
-        //if the scroll is vertical this checks that a modifier key is used before proceeding
-        if (isVerticalScroll) {
-          const activationKeyMap = {
-            ctrl: event.ctrlKey,
-            alt: event.altKey,
-            shift: event.shiftKey,
-            meta: event.metaKey,
-          };
+        const isVerticalScroll = absY > absX * 2;
+        const isHorizontalScroll = absX > absY * 2;
 
-          if (
-            this.activationMethod in activationKeyMap &&
-            !activationKeyMap[this.activationMethod]
-          ) {
-            return;
-          }
+        const activationKeyMap = {
+          ctrl: event.ctrlKey,
+          alt: event.altKey,
+          shift: event.shiftKey,
+          meta: event.metaKey,
+        };
+        const modifierActive =
+          this.activationMethod in activationKeyMap && activationKeyMap[this.activationMethod];
+
+        let delta;
+        let shouldProceed = false;
+
+        if (isVerticalScroll && modifierActive) {
+          // scroll is vertical + modifier key
+          delta = event.deltaY;
+          shouldProceed = true;
+        } else if (isHorizontalScroll) {
+          // clear horizontal scrolling
+          delta = event.deltaX;
+          shouldProceed = true;
+        } else {
+          // diagonal scrolling or unclear direction, ignore
+          return;
         }
+
+        if (!shouldProceed) return;
 
         const currentTime = Date.now();
         if (currentTime - this._lastScrollTime < scrollCooldown) return;
 
-        //this decides which delta to use
-        const delta = isVerticalScroll ? event.deltaY : event.deltaX;
         if (Math.abs(delta) < scrollThreshold) return;
 
         // Determine scroll direction

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -602,8 +602,8 @@ var gZenWorkspaces = new (class extends nsZenMultiWindowFeature {
       async (event) => {
         if (this.privateWindowOrDisabled) return;
 
-        // Only process non-gesture scrolls
-        if (event.deltaMode !== 1) return;
+        // Allow DOM_DELTA_LINE (1) and DOM_DELTA_PIXEL (0) events
+        if (event.deltaMode > 1) return;
 
         const isVerticalScroll = event.deltaY && !event.deltaX;
 

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -605,6 +605,17 @@ var gZenWorkspaces = new (class extends nsZenMultiWindowFeature {
         // Allow DOM_DELTA_LINE (1) and DOM_DELTA_PIXEL (0) events
         if (event.deltaMode > 1) return;
 
+        // Add cooling to consecutive DOM_DELTA_PIXEL events, which are usually from touchpads
+        if (event.deltaMode === 0) {
+          const now = Date.now();
+          const timeSinceLastDeltaMode0 = now - (this._lastDeltaMode0Time || 0);
+          this._lastDeltaMode0Time = now;
+
+          if (Math.abs(event.deltaY || 0) === 0 && timeSinceLastDeltaMode0 < 200) {
+            return;
+          }
+        }
+
         const isVerticalScroll = event.deltaY && !event.deltaX;
 
         //if the scroll is vertical this checks that a modifier key is used before proceeding

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -596,6 +596,7 @@ var gZenWorkspaces = new (class extends nsZenMultiWindowFeature {
 
     const scrollCooldown = 200; // Milliseconds to wait before allowing another scroll
     const scrollThreshold = 2; // Minimum scroll delta to trigger workspace change
+    const scrollDeltaMode0Cooldown = 200; // Cooldown for consecutive DOM_DELTA_PIXEL events
 
     toolbox.addEventListener(
       'wheel',
@@ -611,7 +612,10 @@ var gZenWorkspaces = new (class extends nsZenMultiWindowFeature {
           const timeSinceLastDeltaMode0 = now - (this._lastDeltaMode0Time || 0);
           this._lastDeltaMode0Time = now;
 
-          if (Math.abs(event.deltaY || 0) === 0 && timeSinceLastDeltaMode0 < 200) {
+          if (
+            Math.abs(event.deltaY || 0) === 0 &&
+            timeSinceLastDeltaMode0 < scrollDeltaMode0Cooldown
+          ) {
             return;
           }
         }


### PR DESCRIPTION
## Problem Description

Fixes #8649

Logitech mice horizontal scroll wheels don't work for workspace navigation on macOS.

## Root Cause Analysis

The original `deltaMode !== 1` check was **intentionally designed** to prevent macOS trackpad momentum scrolling issues:

### Trackpad Momentum Scrolling Problem
- When users swipe once on Mac trackpads, the system generates dozens of continuous `deltaMode=0` events
- These events continue for several hundred milliseconds after the user stops touching the trackpad
- Without filtering, this causes unintended multiple workspace switches from a single gesture

However, Logitech horizontal scroll wheels also send `deltaMode=0` events instead of the expected `deltaMode=1`, causing them to be filtered out along with trackpad momentum events.

## Solution Approach

### Implementation
This implements a targeted compatibility layer that:

1. **Expands accepted `deltaMode` values**: Changes from `deltaMode !== 1` to `deltaMode > 1`
2. **Adds momentum scrolling detection**: Filters consecutive `deltaY: 0` events based on timing
3. **Improves direction detection**: Uses proportional thresholds to prevent accidental diagonal scrolling

### Event Pattern Recognition
- **Logitech mice**: Send discrete `deltaY: 0` events with sufficient time gaps (>200ms) → Allowed
- **Mac trackpad momentum**: Sends rapid consecutive `deltaY: 0` events (<200ms apart) → Filtered out
- **Diagonal trackpad gestures**: Only clear directional intent (2:1 ratio) triggers workspace switching

## Future Considerations

### Long-term Solution
A more elegant approach would follow Arc browser's progressive scroll handling with gradual, responsive workspace transitions. This would require significant animation system refactoring.

![Workplace behavior on Arc](https://github.com/user-attachments/assets/fd1063b7-b539-4023-8dfa-40783322e819)

### Standards Progress
The W3C has proposed adding an `isInertialScrolling` property to `WheelEvent` [W3C UI Events Issue w3c/pointerevents#587](https://github.com/w3c/pointerevents/issues/587), which would provide a native way to distinguish user-initiated vs. momentum scrolling events.

## Testing

Tested with Logitech MX Master on macOS and MacBook trackpad. Not test on Windows/Linux devices.