### PR TITLE
Fixed sidebar split screen error. Fix #6972

### DIFF
--- a/src/browser/base/content/browser-box-inc-xhtml.patch
+++ b/src/browser/base/content/browser-box-inc-xhtml.patch
@@ -1,20 +1,21 @@
 diff --git a/browser/base/content/browser-box.inc.xhtml b/browser/base/content/browser-box.inc.xhtml
-index afa7f8e7dd74173bf2c696bd96f7e86e8b0126bc..4847c24923f673e91eb7fb65ea6b037f38062405 100644
+index 7d7e8697f0..281ed7774c 100644
 --- a/browser/base/content/browser-box.inc.xhtml
 +++ b/browser/base/content/browser-box.inc.xhtml
-@@ -25,7 +25,15 @@
-     </stack>
+@@ -23,7 +23,13 @@
+     <browser id="sidebar" autoscroll="false" disablehistory="true" disablefullscreen="true" tooltip="aHTMLTooltip"/>
    </vbox>
    <splitter id="sidebar-splitter" class="chromeclass-extrachrome sidebar-splitter" resizebefore="sibling" resizeafter="none" hidden="true"/>
-+<vbox flex="1" id="zen-appcontent-wrapper">
-+  <html:div id="zen-appcontent-navbar-wrapper">
+-  <tabbox id="tabbrowser-tabbox" flex="1" tabcontainer="tabbrowser-tabs">
+-    <tabpanels id="tabbrowser-tabpanels" flex="1" selectedIndex="0"/>
+-  </tabbox>
++  <vbox flex="1" id="zen-appcontent-wrapper">
 +    <html:div id="zen-appcontent-navbar-container"></html:div>
-+  </html:div>
-+  <hbox id="zen-tabbox-wrapper" flex="1">
-   <tabbox id="tabbrowser-tabbox" flex="1" tabcontainer="tabbrowser-tabs">
-+#include zen-tabbrowser-elements.inc.xhtml
-     <tabpanels id="tabbrowser-tabpanels" flex="1" selectedIndex="0"/>
-   </tabbox>
++    <hbox id="zen-tabbox-wrapper" flex="1" tabcontainer="tabbrowser-tabs">
++      <tabbox id="tabbrowser-tabbox" flex="1" tabcontainer="tabbrowser-tabs">
++        #include zen-tabbrowser-elements.inc.xhtml
++        <tabpanels id="tabbrowser-tabpanels" flex="1" selectedIndex="0"/>
++      </tabbox>
++    </hbox>
++  </vbox>
  </hbox>
-+</vbox>
-+</hbox>

--- a/src/zen/common/ZenStartup.mjs
+++ b/src/zen/common/ZenStartup.mjs
@@ -144,7 +144,7 @@
       const browser = document.getElementById('browser');
       browser.prepend(gNavToolbox);
 
-      const sidebarPanelWrapper = document.getElementById('tabbrowser-tabbox');
+      const sidebarPanelWrapper = document.getElementById('zen-tabbox-wrapper');
       for (let id of kElementsToAppend) {
         const elem = document.getElementById(id);
         if (elem) {

--- a/src/zen/common/styles/zen-sidebar.css
+++ b/src/zen/common/styles/zen-sidebar.css
@@ -29,7 +29,7 @@
     order: 8 !important;
   }
 
-  #sidebar-box[sidebar-positionend]+#sidebar-splitter {
+  #sidebar-box[sidebar-positionend] + #sidebar-splitter {
     order: 7 !important;
   }
 }

--- a/src/zen/common/styles/zen-sidebar.css
+++ b/src/zen/common/styles/zen-sidebar.css
@@ -8,7 +8,7 @@
 #zen-tabbox-wrapper {
   & #sidebar-splitter {
     opacity: 0;
-    margin: 0 calc(-1 * var(--zen-element-separation) + 2px);
+    margin: 0 calc(-1 * var(--zen-element-separation) + 8px);
   }
 
   & #sidebar-box {
@@ -17,22 +17,20 @@
     overflow: hidden;
 
     :root:not([zen-right-side='true']) &[positionend='true'] {
-      margin-right: var(--zen-element-separation);
+      margin-right: 0;
     }
 
     :root[zen-right-side='true'] & {
-      margin-left: var(--zen-element-separation);
+      margin-left: 0;
     }
   }
 
-  & #tabbrowser-tabbox[sidebar-positionend] {
-    & #sidebar-box {
-      order: 8 !important;
-    }
+  & #sidebar-box[sidebar-positionend] {
+    order: 8 !important;
+  }
 
-    & #sidebar-splitter {
-      order: 7 !important;
-    }
+  #sidebar-box[sidebar-positionend]+#sidebar-splitter {
+    order: 7 !important;
   }
 }
 


### PR DESCRIPTION
This uses the same solution as previously  #8322
To fix #6972

I programmed this with no AI assistance, however here is a change log written by claude :)

1. [browser-box.inc.xhtml](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (via patch)
Refactored the tabbox structure:
Wrapped the tabbox in a new <vbox id="zen-appcontent-wrapper">.
Added <html:div id="zen-appcontent-navbar-container"></html:div> for navbar items.
Introduced <hbox id="zen-tabbox-wrapper"> to contain the tabbox.
Included zen-tabbrowser-elements.inc.xhtml inside the tabbox.
2. [ZenStartup.mjs](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated sidebar relocation logic:
Changed the target for appending sidebar elements from tabbrowser-tabbox to zen-tabbox-wrapper to match the new structure.
3. [zen-sidebar.css](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Adjusted sidebar styling:
Increased the margin for #sidebar-splitter.
Set margin-right and margin-left to 0 for sidebar box depending on side.
Changed ordering logic for sidebar elements to target #sidebar-box[sidebar-positionend] and its adjacent splitter, instead of nested selectors.
Summary:
You restructured the browser tabbox layout to use new wrapper elements, updated the startup logic to match this structure, and refined sidebar CSS for improved layout and compatibility with the new DOM hierarchy.