### PR TITLE
Glance: reduce Windows scroll lag by skipping blur and adding compositor hints

### DIFF
--- a/src/zen/glance/zen-glance.css
+++ b/src/zen/glance/zen-glance.css
@@ -108,6 +108,8 @@
   box-shadow: none !important;
   visibility: inherit;
   z-index: 1;
+  /* Hint compositor to optimize animations and scrolling */
+  will-change: transform, opacity, filter;
 
   :root[zen-no-padding='true'] & {
     --zen-native-inner-radius: 0px;
@@ -120,6 +122,8 @@
     top: 0;
     left: 0;
     flex: unset !important;
+    /* Promote to its own layer during transitions to reduce jank */
+    will-change: transform, opacity, top, left, width, height;
 
     &[has-finished-animation='true'] {
       position: relative !important;


### PR DESCRIPTION
## Summary fixes #10382
This PR addresses high scroll lag in the Glance preview on Windows when using an external mouse. When the preview is expanded to a full tab, the lag disappears; the issue is isolated to the Glance overlay.

## What changed
- Windows-only: Skip `backdrop-filter: blur(...)` during Glance open/close background animations to avoid main-thread painting that degrades async scrolling (APZ) and causes wheel jank.
- Non-Windows: Keep the existing blur effect and visuals unchanged.
- Add CSS `will-change` hints to the overlay and browser containers to promote layers and smooth compositor-driven animations.

## Why this fixes the issue
Backdrop blur on Windows is expensive and can force synchronous painting during scroll, disrupting APZ paths. Removing blur for the Glance background on Windows preserves async scrolling so the preview’s scroll responsiveness matches the base page.

## Verification steps
1. Windows x64 laptop/desktop with an external mouse.
2. Open a site (e.g., The Atlantic).
3. Trigger Glance (e.g., Alt-click the main article).
4. Scroll rapidly with the mouse wheel.

Expected: Glance scroll responsiveness is similar to the base page; the brief “stuck at top” pause disappears or is greatly reduced. Expanding Glance to a new tab remains unchanged.

## Visual impact
- Windows: Background dimming uses opacity (no blur) while Glance is open; a subtle scale is preserved for depth. If stronger dimming is desired, we can tweak the opacity.
- macOS/Linux: No change.

## Files changed
- `src/zen/glance/ZenGlanceManager.mjs`
- `src/zen/glance/zen-glance.css`

## Risks and mitigations
- Visual parity on Windows: Blur is replaced with opacity dimming. If it’s too light or dark on some setups, we can adjust values or make it configurable.

## Follow-ups (optional)
- Add a pref (e.g., `zen.glance.windows.blur`) to let users opt back into blur on Windows.
- Consider GPU/driver-based gating if specific hardware still shows lag.
