### PR TITLE
fix: repeating right sidebar gradient in compact mode

### DIFF
--- a/src/zen/compact-mode/zen-compact-mode.css
+++ b/src/zen/compact-mode/zen-compact-mode.css
@@ -361,7 +361,7 @@
           @media -moz-pref('zen.view.compact.color-toolbar') {
             background-attachment: fixed;
             background: var(--zen-main-browser-background-toolbar);
-            background-size: 100% 100vw;
+            background-size: 100% 100vh;
           }
         }
       }

--- a/src/zen/compact-mode/zen-compact-mode.css
+++ b/src/zen/compact-mode/zen-compact-mode.css
@@ -160,7 +160,7 @@
             outline: 1px solid rgba(255, 255, 255, .15);
             outline-offset: -1px;
             background-attachment: fixed !important;
-            background-size: 2000px !important;
+            background-size: 100vw !important;
           }
 
           &,
@@ -361,7 +361,7 @@
           @media -moz-pref('zen.view.compact.color-toolbar') {
             background-attachment: fixed;
             background: var(--zen-main-browser-background-toolbar);
-            background-size: 100% 2000px;
+            background-size: 100% 100vw;
           }
         }
       }


### PR DESCRIPTION
Fixes the repeating gradient on the right sidebar in compact mode in displays wider than >2000 pixels

Replaces the hardcoded `2000px` value with `100vw` which adapts to the window width ^^

Before and after:
<img width="554" height="223" alt="image" src="https://github.com/user-attachments/assets/c2108038-b4b2-4ed0-8b42-8dd3c0361b7d" />