### PR TITLE
fix: remove unwanted margin on `#sidebar-box`

### DIFF
--- a/src/zen/common/styles/zen-sidebar.css
+++ b/src/zen/common/styles/zen-sidebar.css
@@ -15,14 +15,6 @@
     border-radius: var(--zen-native-inner-radius);
     box-shadow: var(--zen-big-shadow);
     overflow: hidden;
-
-    :root:not([zen-right-side='true']) &[positionend='true'] {
-      margin-right: var(--zen-element-separation);
-    }
-
-    :root[zen-right-side='true'] & {
-      margin-left: var(--zen-element-separation);
-    }
   }
 
   & #tabbrowser-tabbox[sidebar-positionend] {


### PR DESCRIPTION
Fixes #10415

Removes redundant rules on `#sidebar-box` one of which added an ugly margin, and the other did nothing.

Likely remainders from an older version of zen that were forgotten.