### PR TITLE
fix: remove extra spaces between words when renaming a tab/folder

### DIFF
--- a/src/zen/common/ZenUIManager.mjs
+++ b/src/zen/common/ZenUIManager.mjs
@@ -1105,7 +1105,7 @@ var gZenVerticalTabsManager = {
         ? this._tabEdited.querySelector('.tab-label-container-editing')
         : this._tabEdited;
       let input = document.getElementById('tab-label-input');
-      let newName = input.value.trim();
+      let newName = input.value.replace(/\s+/g, ' ').trim();
 
       document.documentElement.removeAttribute('zen-renaming-tab');
       input.remove();


### PR DESCRIPTION
Fixes the issue where the rename value like `foo     bar` preserves spaces between words, but is visually shown as `foo bar` upon saving. Then, editing said tab/folder again shows `foo     bar`.

`trim()` removes leading and trailing whitespaces but not spaces between words so I added the `replace()` method next to it to address this issue.