### PR TITLE
Improve animation triggering when moving tabs across the separator (fix #10295)

### DIFF
--- a/src/browser/components/tabbrowser/content/tabs-js.patch
+++ b/src/browser/components/tabbrowser/content/tabs-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabs.js b/browser/components/tabbrowser/content/tabs.js
-index c7557dad38db9ef02b981c46de9595df77cb67db..4192dc797d5f07ece57e7e9ecb0cd0698e189659 100644
+index c7557dad38db9ef02b981c46de9595df77cb67db..4b49d647f2d780cefe23a8fcd7b76d84c2156a1d 100644
 --- a/browser/components/tabbrowser/content/tabs.js
 +++ b/browser/components/tabbrowser/content/tabs.js
 @@ -44,6 +44,9 @@
@@ -471,7 +471,7 @@ index c7557dad38db9ef02b981c46de9595df77cb67db..4192dc797d5f07ece57e7e9ecb0cd069
  
        let dropElement = getOverlappedElement();
 +      if (dropElement?.hasAttribute("split-view-group")) dropElement = dropElement.labelElement;
-+      gZenPinnedTabManager.animateSeparatorMove(movingTabs, dropElement, isPinned, event);
++      gZenPinnedTabManager.animateSeparatorMove(movingTabs, isPinned, event);
  
        let newDropElementIndex;
        if (dropElement) {

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -1294,12 +1294,19 @@
       const draggingTabHeight = movingTabs.reduce((acc, item) => {
         return acc + window.windowUtils.getBoundsWithoutFlushing(item).height;
       }, 0);
-      let topToNormalTabs = itemsToCheck[0].screenY;
-      if (!isPinned) {
-        topToNormalTabs += draggedTab.getBoundingClientRect().height;
+      const draggedTabHeight = draggedTab.getBoundingClientRect().height;
+      const separatorStyle = window.getComputedStyle(itemsToCheck[0]);
+      let boundaryY = itemsToCheck[0].screenY;
+      if (isPinned) {
+        boundaryY -= parseInt(separatorStyle.marginTop) + draggedTabHeight / 2;
+      } else {
+        boundaryY += parseInt(separatorStyle.marginBottom) + draggedTabHeight / 2;
+        if (Services.prefs.getBoolPref('zen.view.show-newtab-button-top')) {
+          boundaryY += itemsToCheck[1].getBoundingClientRect().height;
+        }
       }
       const isGoingToPinnedTabs =
-        translate < topToNormalTabs && gBrowser.pinnedTabCount - gBrowser._numZenEssentials > 0;
+        translate < boundaryY && gBrowser.pinnedTabCount - gBrowser._numZenEssentials > 0;
       const multiplier = isGoingToPinnedTabs !== isPinned ? (isGoingToPinnedTabs ? 1 : -1) : 0;
       this._isGoingToPinnedTabs = isGoingToPinnedTabs;
       itemsToCheck.forEach((item) => {

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -1280,7 +1280,7 @@
         : [separator];
     }
 
-    animateSeparatorMove(movingTabs, dropElement, isPinned, event) {
+    animateSeparatorMove(movingTabs, isPinned, event) {
       let draggedTab = movingTabs[0];
       if (gBrowser.isTabGroupLabel(draggedTab) && draggedTab.group.isZenFolder) {
         this._isGoingToPinnedTabs = true;
@@ -1302,11 +1302,9 @@
         translate < topToNormalTabs && gBrowser.pinnedTabCount - gBrowser._numZenEssentials > 0;
       const multiplier = isGoingToPinnedTabs !== isPinned ? (isGoingToPinnedTabs ? 1 : -1) : 0;
       this._isGoingToPinnedTabs = isGoingToPinnedTabs;
-      if (!dropElement) {
-        itemsToCheck.forEach((item) => {
-          item.style.transform = `translateY(${draggingTabHeight * multiplier}px)`;
-        });
-      }
+      itemsToCheck.forEach((item) => {
+        item.style.transform = `translateY(${draggingTabHeight * multiplier}px)`;
+      });
     }
 
     getLastTabBound(lastBound, lastTab, isDraggingFolder = false) {


### PR DESCRIPTION
## Summary

Changed the behavior of the separator animation when dragging and dropping tabs between pinned tabs and normal tabs.
- Made the animation occur even when there are overlapping elements.
- Added thickness to the boundary that triggers the animation when crossing the separator, improving the usability of dropping tabs directly before or after the separator.

## Related Issue
fix #10295

## Changes
- [5913396](https://github.com/zen-browser/desktop/pull/10508/commits/59133962ee60cd7cfa791c1bebff41c4a7f0afaf): Remove the condition that triggers the animation only when dropElement is absent
  - When the New tab button is positioned at the bottom of the tabs, and you attempt to move a pinned tab to the normal tabs area, the target tab overlaps with the topmost normal tab at the exact moment it slightly exceeds the separator. Therefore, if there is a condition that triggers the animation only when dropElement is absent, there is a problem where the animation does not execute even after crossing the separator.
  - The animation is controlled to occur only when the tab moves to a different area using multiplier, so the condition is unnecessary.
- [8fd5afd](https://github.com/zen-browser/desktop/pull/10508/commits/8fd5afd013a9cb25340d4593d6e1f55a76f820ef): Change to add thickness to the boundary that triggers the animation
  - Modified to trigger a separator movement animation when the dragged tab overlaps with the boundary. The boundary has a thickness from the separator's Y-position: margin + half the tab height. This accounts for users typically clicking near the tab's center when dragging, so we add half the tab height to the boundary.
  - This prevents the issue where the tab accidentally straddles an existing tab immediately before or after the separator, causing it to be placed beyond that tab instead of directly before or after the separator.

## Verification

- [x] Confirmed that the build passes locally
- [x] Verified functionality in actual usage scenarios  
  | `New tab` Button Position | Video |
  | --- | --- |
  | Top | <video src="https://github.com/user-attachments/assets/4fd8d6e0-a667-483c-bfee-589af4ac02da"> |
  | Bottom | <video src="https://github.com/user-attachments/assets/fd3dd353-3383-4665-8945-f9fc483fe3e2"> |



