### PR TITLE
chore: remove notification talk name

### DIFF
--- a/build/flatpak/app.zen_browser.zen.yml.template
+++ b/build/flatpak/app.zen_browser.zen.yml.template
@@ -32,7 +32,6 @@ finish-args:
   - --system-talk-name=org.freedesktop.NetworkManager
   - --talk-name=org.a11y.Bus
   - --talk-name=org.gtk.vfs.*
-  - --talk-name=org.freedesktop.Notifications
   - --own-name=org.mpris.MediaPlayer2.firefox.*
   - --own-name=org.mozilla.zen.*
 cleanup:


### PR DESCRIPTION
> org.mozilla.firefox.BaseApp has libnotify which uses the portal for notifications. Direct access to org.freedesktop.Notifications should not be needed anymore.

See https://github.com/flathub/app.zen_browser.zen/issues/106