### PR TITLE
fix: zen.source builds missing dotfiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,10 +265,7 @@ jobs:
         run: npm run import -- --verbose
 
       - name: Compress
-        run: |
-          cd engine
-          tar --use-compress-program=zstd -hcf ../zen.source.tar.zst *
-          cd ..
+        run: tar --use-compress-program=zstd -hcf zen.source.tar.zst -C engine .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The existing compression skips over dotfiles (such as .cargo/config.toml.in) which contain crucial configuration for the build process, requiring additional patching to zen.source before a build can be made.

For reference, I'm trying to package Zen Browser for nixpkgs, building it from source. And because of missing dotfiles, the build fails with:

```
zen-browser-unwrapped>  0:20.86(B Creating config.status(B(B
zen-browser-unwrapped>  0:21.32(B Reticulating splines...(B(B
zen-browser-unwrapped>  0:21.34(B Traceback (most recent call last):(B(B
zen-browser-unwrapped>  0:21.34(B   File "/build/configure.py", line 329, in <module>(B(B
zen-browser-unwrapped>  0:21.34(B     sys.exit(main(sys.argv))(B(B
zen-browser-unwrapped>  0:21.34(B              ~~~~^^^^^^^^^^(B(B
zen-browser-unwrapped>  0:21.34(B   File "/build/configure.py", line 160, in main(B(B
zen-browser-unwrapped>  0:21.34(B     return config_status(config)(B(B
zen-browser-unwrapped>  0:21.34(B   File "/build/configure.py", line 278, in config_status(B(B
zen-browser-unwrapped>  0:21.34(B     return config_status(args=[], **sanitized_config)(B(B
zen-browser-unwrapped>  0:21.34(B   File "/build/python/mozbuild/mozbuild/config_status.py", line 201, in config_status(B(B
zen-browser-unwrapped>  0:21.34(B     pool = BackendPool(definitions, processes=processes)(B(B
zen-browser-unwrapped>  0:21.34(B   File "/build/python/mozbuild/mozbuild/config_status.py", line 54, in __init__(B(B
zen-browser-unwrapped>  0:21.34(B     definitions = list(definitions)(B(B
zen-browser-unwrapped>  0:21.34(B   File "/build/python/mozbuild/mozbuild/frontend/emitter.py", line 156, in emit(B(B
zen-browser-unwrapped>  0:21.34(B     objs = list(emitfn(out))(B(B
zen-browser-unwrapped>  0:21.34(B   File "/build/python/mozbuild/mozbuild/frontend/emitter.py", line 1528, in emit_from_context(B(B
zen-browser-unwrapped>  0:21.34(B     raise SandboxValidationError((B(B
zen-browser-unwrapped>  0:21.34(B     ...<2 lines>...(B(B
zen-browser-unwrapped>  0:21.34(B     )(B(B
zen-browser-unwrapped>  0:21.34(B mozbuild.frontend.reader.SandboxValidationError:(B(B
zen-browser-unwrapped>  0:21.34(B ==============================(B(B
zen-browser-unwrapped>  0:21.34(B FATAL ERROR PROCESSING MOZBUILD FILE(B(B
zen-browser-unwrapped>  0:21.34(B ==============================(B(B
zen-browser-unwrapped>  0:21.34(B (B(B
zen-browser-unwrapped>  0:21.34(B The error occurred while processing the following file or one of the files it includes:(B(B
zen-browser-unwrapped>  0:21.34(B (B(B
zen-browser-unwrapped>  0:21.34(B     /build/moz.build(B(B
zen-browser-unwrapped>  0:21.34(B (B(B
zen-browser-unwrapped>  0:21.34(B The error occurred when validating the result of the execution. The reported error is:(B(B
zen-browser-unwrapped>  0:21.34(B (B(B
zen-browser-unwrapped>  0:21.34(B     File listed in OBJDIR_PP_FILES does not exist: /build/.cargo/config.toml.in(B(B
zen-browser-unwrapped>  0:21.34(B (B(B
zen-browser-unwrapped>  0:21.34(B (B(B
zen-browser-unwrapped> *** Fix above errors and then restart with "./mach build"
```

I then confirmed that `zen.source.tar.zst` was missing dotfiles and found the subtle compression bug where `*` does not match dotfiles in `tar --use-compress-program=zstd -hcf ../zen.source.tar.zst *`.