### PR TITLE
urlbar.yaml: Fix network.IDN_show_punycode to show international characters as designed

### DIFF
--- a/prefs/urlbar.yaml
+++ b/prefs/urlbar.yaml
@@ -54,7 +54,7 @@
   value: false
 
 - name: network.IDN_show_punycode
-  value: true
+  value: false
 
 - name: browser.urlbar.suggest.topsites
   value: true

--- a/prefs/urlbar.yaml
+++ b/prefs/urlbar.yaml
@@ -53,9 +53,6 @@
 - name: browser.formfill.enable
   value: false
 
-- name: network.IDN_show_punycode
-  value: false
-
 - name: browser.urlbar.suggest.topsites
   value: true
   locked: true


### PR DESCRIPTION
All web browsers that support IDN (international domain names) should not show the ASCII punycode for IDN, but the actual international characters.

As the bug reports say, this is fixed by setting `network.IDN_show_punycode` to `false`.

Fixes: #4527, #5119, #7253:
- Punycode instead of special characters shown in urlbar by default