### PR TITLE
fix: zen.source ignore VCS data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,7 +265,12 @@ jobs:
         run: npm run import -- --verbose
 
       - name: Compress
-        run: tar --use-compress-program=zstd -hcf zen.source.tar.zst -C engine .
+        run: |
+          tar \
+            --exclude-vcs \
+            --use-compress-program=zstd \
+            -hcf zen.source.tar.zst \
+            -C engine .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Exclude VCS data to reduce source bundle size from ~1.9GB to ~800MB while preserving all other dotfiles. This is a low–medium priority follow-up to https://github.com/zen-browser/desktop/pull/10599. I hadn't realized the engine contained .git data - a newbie mistake. On the bright side, I confirmed that other dotfiles are preserved, and I'll proceed with packaging Zen Browser for nixpkgs :slightly_smiling_face:. I verified the new command locally on the unpacked engine data, and it appears to work perfectly.