### PR TITLE
fix: zen.source exclude-vcs breaks submodules checksums

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,7 +267,7 @@ jobs:
       - name: Compress
         run: |
           tar \
-            --exclude-vcs \
+            --exclude='./.git' \
             --use-compress-program=zstd \
             -hcf zen.source.tar.zst \
             -C engine .


### PR DESCRIPTION
It turns out that Cargo (or a related tool) checksums VCS metadata (e.g., .gitignore files) in the installed modules. Using the previously applied --exclude-vcs option (which acts globally) caused some of these files to be missing, leading to errors such as:

```
zen-browser-unwrapped> error: failed to calculate checksum of: /build/third_party/rust/mp4parse/link-u-avif-sample-images/.gitignore
zen-browser-unwrapped> 
zen-browser-unwrapped> Caused by:
zen-browser-unwrapped>   failed to open file `/build/third_party/rust/mp4parse/link-u-avif-sample-images/.gitignore`
zen-browser-unwrapped> 
zen-browser-unwrapped> Caused by:
zen-browser-unwrapped>   No such file or directory (os error 2)
zen-browser-unwrapped> make[3]: *** [/build/config/makefiles/rust.mk:528: force-cargo-library-build] Error 101
zen-browser-unwrapped> make[3]: Leaving directory '/build/objdir/toolkit/library/rust'
zen-browser-unwrapped> make[2]: *** [/build/config/recurse.mk:72: toolkit/library/rust/target-objects] Error 2
```

This fix excludes only the root .git directory, while leaving all other VCS metadata untouched. I verified the command locally, and as expected only .git is ignored.

Sorry for opening yet another PR! I wasn't aware of this behavior and didn't expect files like .gitignore to be part of internal checksums. On the bright side, the build now progresses further and is compiling successfully.