### PR TITLE
feat: Bootstrapping of zen.source in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,6 +264,12 @@ jobs:
       - name: Import
         run: npm run import -- --verbose
 
+      - name: Bootstrap
+        run: npm run bootstrap
+
+      - name: Update Language Packs
+        run: python3 ./scripts/update_en_US_packs.py
+
       - name: Compress
         run: |
           tar \


### PR DESCRIPTION
Hello again!

https://github.com/zen-browser/desktop/pull/10606:

> Well, I'm giving it a try and will see what happens. I'll post updates here if I find or learn anything interesting.

This is my follow up. So I built the browser successfully but it's clear that it's missing the custom mozconfig ([you mentioned](https://github.com/zen-browser/desktop/pull/10606#issuecomment-3343846893)) that apparently is done via surfer bootstrap. The engine without it is pretty much unusable. The current zen.source does not contain necessary data so I figured out the best way forward would be to finish the bootstrapping of sources within the pipeline, so the produced zen.source is ready for build. I followed the instructions from: https://docs.zen-browser.app/contribute/desktop/building

But:

1. I was not able to test the changes locally due to:
   `NotImplementedError: Bootstrap support for this Linux distro not yet available: nixos`
3. I am not 100% sure whether *Update Language Packs* step is necessary but I think it is.
4. I am hoping that python3 is pre-installed in the runner image (I see you are using something custom).

Please kindly review my PR and see if my idea is correct! :rocket: 