### PR TITLE
Fix: Unexpected Spelling in Theme Configuration Page

### DIFF
--- a/prefs/theme.yaml
+++ b/prefs/theme.yaml
@@ -26,7 +26,7 @@
 - name: zen.theme.disable-lightweight
   value: true
 
-- name: zen.theme.use-sysyem-colors
+- name: zen.theme.use-system-colors
   value: false
 
 - name: zen.theme.hide-tab-throbber

--- a/src/zen/common/ZenUIMigration.sys.mjs
+++ b/src/zen/common/ZenUIMigration.sys.mjs
@@ -6,7 +6,7 @@ const { AppConstants } = ChromeUtils.importESModule('resource://gre/modules/AppC
 
 class nsZenUIMigration {
   PREF_NAME = 'zen.ui.migration.version';
-  MIGRATION_VERSION = 3;
+  MIGRATION_VERSION = 4;
 
   init(isNewProfile) {
     if (!isNewProfile) {
@@ -76,6 +76,14 @@ class nsZenUIMigration {
     if (Services.prefs.getStringPref('zen.theme.accent-color', '').startsWith('system')) {
       Services.prefs.setStringPref('zen.theme.accent-color', '#ffb787');
     }
+  }
+
+  _migrateV4() {
+    // Fix spelling mistake in preference name
+    Services.prefs.setBoolPref(
+      'zen.theme.use-system-colors',
+      Services.prefs.getBoolPref('zen.theme.use-sysyem-colors', false)
+    );
   }
 }
 

--- a/src/zen/workspaces/ZenGradientGenerator.mjs
+++ b/src/zen/workspaces/ZenGradientGenerator.mjs
@@ -1192,7 +1192,7 @@
     }
 
     shouldBeDarkMode(accentColor) {
-      if (Services.prefs.getBoolPref('zen.theme.use-sysyem-colors')) {
+      if (Services.prefs.getBoolPref('zen.theme.use-system-colors')) {
         return this.isDarkMode;
       }
 


### PR DESCRIPTION
sys**t**em <- sys**y**em

<img width="844" height="992" alt="zen-unexpected-spelling-screenshot" src="https://github.com/user-attachments/assets/a4664bfc-7f7e-44a9-8d10-a078cbe7af16" />
