### PR TITLE
feat: settings -> shortcuts: show conflicting shortcut label

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -91,7 +91,7 @@ zen-settings-workspaces-hide-default-container-indicator =
     .label = Hide the default container indicator in the tab bar
 
 zen-key-unsaved = Unsaved shortcut! Please save it by clicking the "Escape" key after retyping it.
-zen-key-conflict = Conflict with another shortcut
+zen-key-conflict = Conflicts with { $group } -> { $shortcut }
 
 pane-zen-theme-title = Theme Settings
 

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1010,7 +1010,7 @@ var gZenCKSSettings = {
       this._latestValidKey = null;
       return;
     } else if (shortcut == 'Escape' && !modifiersActive) {
-      const hasConflicts = gZenKeyboardShortcutsManager.checkForConflicts(
+      const { hasConflicts, conflictShortcut } = gZenKeyboardShortcutsManager.checkForConflicts(
         this._latestValidKey ? this._latestValidKey : shortcut,
         this._latestModifier ? this._latestModifier : modifiers,
         this._currentActionID
@@ -1023,12 +1023,29 @@ var gZenCKSSettings = {
           input.classList.add(`${ZEN_CKS_INPUT_FIELD_CLASS}-invalid`);
         }
         input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-unsafed`);
-        if (hasConflicts && !input.nextElementSibling) {
-          input.after(
-            window.MozXULElement.parseXULToFragment(`
-            <label class="${ZEN_CKS_CLASS_BASE}-conflict" data-l10n-id="zen-key-conflict"></label>
-          `)
-          );
+
+        if (hasConflicts) {
+          const shortcutL10nKey =
+            zenMissingKeyboardShortcutL10n[conflictShortcut.getID()] ??
+            conflictShortcut.getL10NID();
+
+          const [group, shortcut] = await document.l10n.formatValues([
+            { id: `${ZEN_CKS_GROUP_PREFIX}-${conflictShortcut.getGroup()}` },
+            { id: shortcutL10nKey },
+          ]);
+
+          if (!input.nextElementSibling) {
+            input.after(
+              window.MozXULElement.parseXULToFragment(`
+                <label class="${ZEN_CKS_CLASS_BASE}-conflict" data-l10n-id="zen-key-conflict"></label>
+              `)
+            );
+          }
+
+          document.l10n.setAttributes(input.nextElementSibling, 'zen-key-conflict', {
+            group: group ?? '',
+            shortcut: shortcut ?? '',
+          });
         }
       } else {
         input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-editing`);

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -1358,13 +1358,13 @@ var gZenKeyboardShortcutsManager = {
         return {
           hasConflicts: true,
           conflictShortcut: targetShortcut,
-        }
+        };
       }
     }
 
     return {
       hasConflicts: false,
-    }
+    };
   },
 
   getShortcutFromCommand(command) {

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -1355,11 +1355,16 @@ var gZenKeyboardShortcutsManager = {
         targetShortcut.getModifiers().equals(modifiers) &&
         targetShortcut.getKeyNameOrCode()?.toLowerCase() == realShortcut
       ) {
-        return true;
+        return {
+          hasConflicts: true,
+          conflictShortcut: targetShortcut,
+        }
       }
     }
 
-    return false;
+    return {
+      hasConflicts: false,
+    }
   },
 
   getShortcutFromCommand(command) {


### PR DESCRIPTION
Hey,
Started using Zen recently, and I was trying to customize my shortcuts. Took a solid few minutes during the setup phase since I kept getting conflicts for almost all my overrides, and there was no way to identify the conflict except for going through the list one by one.

This PR updates the label to show the shortcut with which the conflict is occurring.

<img width="1529" height="290" alt="image" src="https://github.com/user-attachments/assets/4e68205a-6884-4183-abd8-44ccb8eda0f1" />
