### PR TITLE
Allow ctrl+n/p to navigate urlbar entries

### DIFF
--- a/src/browser/components/urlbar/UrlbarController-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarController-sys-mjs.patch
@@ -1,8 +1,16 @@
 diff --git a/browser/components/urlbar/UrlbarController.sys.mjs b/browser/components/urlbar/UrlbarController.sys.mjs
-index a1faf7e4278c66865f267283515f22052769928d..d76d19da5a3d4b9739faf3a673bb3ad693765ada 100644
+index a1faf7e4278c66865f267283515f22052769928d..297391205ab3cd96bed2e5a3e36a181c6da90098 100644
 --- a/browser/components/urlbar/UrlbarController.sys.mjs
 +++ b/browser/components/urlbar/UrlbarController.sys.mjs
-@@ -441,6 +441,8 @@ export class UrlbarController {
+@@ -297,7 +297,6 @@ export class UrlbarController {
+     const isMac = AppConstants.platform == "macosx";
+     // Handle readline/emacs-style navigation bindings on Mac.
+     if (
+-      isMac &&
+       this.view.isOpen &&
+       event.ctrlKey &&
+       (event.key == "n" || event.key == "p")
+@@ -441,6 +440,8 @@ export class UrlbarController {
              });
            }
            event.preventDefault();


### PR DESCRIPTION
This somewhat addresses this feature request: #1936.

An ideal solution would be to implement a custom keybind for this, but I'm nowhere near competent enough to do that, so I changed the code to allow using ctrl+n/p, which already worked for macos, to work anywhere. I feel like this change is fine, since it's not intrusive and simple.