### PR TITLE
fix: add requests to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ packaging==24.2
 pathspec==0.12.1
 platformdirs==4.3.6
 pycodestyle==2.12.1
+requests==2.32.5


### PR DESCRIPTION
When I tried to run `npm run update-ff`, it failed with `No module named 'requests'`. Before that I installed pyenv, python 3.11, and ran `python3 -m pip install -r requirements.txt`. Adding the missing library to requirements.txt should solve this problem.

Info about python setup is very much missing from the docs, which might confuse newcomers (e.g., me).