### PR TITLE
fix: replace incorrect team name for Mozilla services

### DIFF
--- a/locales/en-US/browser/browser/zen-override.ftl
+++ b/locales/en-US/browser/browser/zen-override.ftl
@@ -1,0 +1,1 @@
+zen-appmenu-other-protection-header = Try other protection tools from Mozilla:

--- a/src/browser/base/content/appmenu-viewcache-inc-xhtml.patch
+++ b/src/browser/base/content/appmenu-viewcache-inc-xhtml.patch
@@ -1,0 +1,13 @@
+diff --git a/browser/base/content/appmenu-viewcache.inc.xhtml b/browser/base/content/appmenu-viewcache.inc.xhtml
+index 9f15f0a7aa5087b707497a042ab9843e914e7384..a85371615cf08dff19ea4669578247fc0b67810d 100644
+--- a/browser/base/content/appmenu-viewcache.inc.xhtml
++++ b/browser/base/content/appmenu-viewcache.inc.xhtml
+@@ -686,7 +686,7 @@
+       <!-- updateCTAPanel will control if we show this panel -->
+       <vbox id="PanelUI-fxa-cta-menu" hidden="true">
+         <toolbarseparator id="PanelUI-products-separator" />
+-        <label id="fxa-menu-other-protection-tools-header" crop="end" class="PanelUI-fxa-menu-section-title" data-l10n-id="appmenu-other-protection-header" />
++        <label id="fxa-menu-other-protection-tools-header" crop="end" class="PanelUI-fxa-menu-section-title" data-l10n-id="zen-appmenu-other-protection-header" />
+         <toolbarbutton id="PanelUI-fxa-menu-monitor-button" class="fxa-cta-button subviewbutton subviewbutton-iconic">
+           <vbox flex="1">
+             <hbox align="center">

--- a/src/browser/base/content/zen-locales.inc.xhtml
+++ b/src/browser/base/content/zen-locales.inc.xhtml
@@ -8,4 +8,5 @@
 <link rel="localization" href="browser/zen-general.ftl"/>
 <link rel="localization" href="browser/zen-vertical-tabs.ftl"/>
 <link rel="localization" href="browser/zen-folders.ftl"/>
+<link rel="localization" href="browser/zen-override.ftl"/>
 </linkset>


### PR DESCRIPTION
This is a fix for #10854. This PR replaces The `appmenu-other-protection-header` FTL string with a custom one, so that it no longer refers to `-vendor-short-name`, but use the hardcoded "Mozilla".

A screenshot with this fix applied: 
<img width="328" height="332" alt="image" src="https://github.com/user-attachments/assets/9f555ac9-9d26-4b14-93ac-5db01b18dc22" />
