### PR TITLE
fix: remove mozilla services from app menu

### DIFF
--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -33,6 +33,12 @@
   display: none !important;
 }
 
+/* hide Mozilla services from the app menu */
+#PanelUI-fxa-menu-services,
+#PanelUI-fxa-cta-menu {
+  display: none !important;
+}
+
 body > #confetti {
   z-index: 1;
 }


### PR DESCRIPTION
This is a fix for #10854. Here's a screenshot with this fix applied:

<img width="624" height="726" alt="image" src="https://github.com/user-attachments/assets/b08811ce-4f6a-43fb-ba45-bf168a052dbc" />