### PR TITLE
fix: Hide 'Change Name' for Spaces in collapsed toolbar mode

### DIFF
--- a/src/zen/tabs/zen-tabs/vertical-tabs.css
+++ b/src/zen/tabs/zen-tabs/vertical-tabs.css
@@ -618,12 +618,6 @@
   --tab-min-width: 48px !important;
   --zen-toolbox-padding: 6px !important;
   --zen-toolbox-max-width: calc(var(--tab-min-width) + var(--zen-toolbox-padding) * 2);
-
-  /* We can't show the rename input properly in collapsed state,
-     so hide the workspace edit input */
-  #context_zenEditWorkspace {
-    display: none;
-  }
 }
 
 #navigator-toolbox:not([zen-sidebar-expanded='true']) {

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -1225,9 +1225,10 @@ var gZenWorkspaces = new (class extends nsZenMultiWindowFeature {
     };
     const workspaceName = document.getElementById('context_zenEditWorkspace');
     const themePicker = document.getElementById('context_zenChangeWorkspaceTheme');
-    workspaceName.hidden =
-      this.#contextMenuData.workspaceId &&
-      this.#contextMenuData.workspaceId !== this.activeWorkspace;
+    const isCollapsed = !Services.prefs.getBoolPref('zen.view.sidebar-expanded');
+    workspaceName.hidden = isCollapsed ||
+    (this.#contextMenuData.workspaceId &&
+      this.#contextMenuData.workspaceId !== this.activeWorkspace);
     themePicker.hidden =
       this.#contextMenuData.workspaceId &&
       this.#contextMenuData.workspaceId !== this.activeWorkspace;

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -1225,10 +1225,13 @@ var gZenWorkspaces = new (class extends nsZenMultiWindowFeature {
     };
     const workspaceName = document.getElementById('context_zenEditWorkspace');
     const themePicker = document.getElementById('context_zenChangeWorkspaceTheme');
+    /* We can't show the rename input properly in collapsed state,
+    so hide the workspace edit input */
     const isCollapsed = !Services.prefs.getBoolPref('zen.view.sidebar-expanded');
-    workspaceName.hidden = isCollapsed ||
-    (this.#contextMenuData.workspaceId &&
-      this.#contextMenuData.workspaceId !== this.activeWorkspace);
+    workspaceName.hidden =
+      isCollapsed ||
+      (this.#contextMenuData.workspaceId &&
+        this.#contextMenuData.workspaceId !== this.activeWorkspace);
     themePicker.hidden =
       this.#contextMenuData.workspaceId &&
       this.#contextMenuData.workspaceId !== this.activeWorkspace;


### PR DESCRIPTION
## Description of the Bug

In "Collapse Toolbar" mode, the "Change Name" context menu item for Spaces was incorrectly appearing **when right-clicking** on a Space icon. This item is non-functional in collapsed mode (as intended by the CSS rule in `:root:not([zen-sidebar-expanded='true'])` in `vertical-tabs.css`), but the JavaScript in `updateWorkspaceActionsMenu` was overriding the `.hidden` property.

## Description of the Fix

This PR updates the `updateWorkspaceActionsMenu` function in `gZenWorkspaces.js`.
It now checks if the sidebar is collapsed (using `!Services.prefs.getBoolPref('zen.view.sidebar-expanded')` or the DOM attribute) before setting the `workspaceName.hidden` property.

This ensures the "Change Name" item is correctly hidden in collapsed mode, aligning the JavaScript logic with the existing CSS intention.

## How to Test

1.  Enable "Collapse Toolbar" mode (in Settings > Looks & Feel).
2.  Right-click on Space icon in the sidebar.
3.  Verify that the "Change Name" option is **no longer visible** in the context menu.

## Screenshot

| Before | After |
| --- | --- |
|  <img width="557" height="720" alt="image" src="https://github.com/user-attachments/assets/389606c3-a085-4331-b424-38f47340ebce" /> | <img width="557" height="720" alt="image" src="https://github.com/user-attachments/assets/da20a258-6031-47f5-9a0a-153e284e7710" /> |
