### PR TITLE
fix: Update maxEssentialTabs in context menu item

### DIFF
--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -1098,7 +1098,7 @@
       const element = window.MozXULElement.parseXULToFragment(`
             <menuitem id="context_zen-add-essential"
                       data-l10n-id="tab-context-zen-add-essential"
-                      data-l10n-args='{"num": "0", "max": "12"}'
+                      data-l10n-args='{"num": "0", "max": "${this.maxEssentialTabs}"}'
                       hidden="true"
                       disabled="true"
                       command="cmd_contextZenAddToEssentials"/>


### PR DESCRIPTION
since zen browser stable release build - 1.16.4b 2025-10-08 users are able to configure the default max limit(12) of essentials in the about:config. even though the effect is working the context menu still shows hardcoded 12 value.
attached shot for reference
<img width="478" height="321" alt="Screenshot 2025-10-21 222612" src="https://github.com/user-attachments/assets/82730c68-d438-48bc-bae2-c7ef91d08bcd" />

the change is 
//before
    data-l10n-args='{"num": "0", "max": "12"}'
//after
    data-l10n-args='{"num": "0", "max": "${this.maxEssentialTabs}"}'

