### PR TITLE
Updated confusing tracking protection setting

### DIFF
--- a/locales/ar/browser/browser/zen-general.ftl
+++ b/locales/ar/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/cy/browser/browser/zen-general.ftl
+++ b/locales/cy/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/el/browser/browser/zen-general.ftl
+++ b/locales/el/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/en-GB/browser/browser/zen-general.ftl
+++ b/locales/en-GB/browser/browser/zen-general.ftl
@@ -55,8 +55,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/en-US/browser/browser/zen-general.ftl
+++ b/locales/en-US/browser/browser/zen-general.ftl
@@ -75,8 +75,8 @@ zen-generic-more = More
 zen-generic-next = Next
 
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension =
     .label = Extension

--- a/locales/fa/browser/browser/zen-general.ftl
+++ b/locales/fa/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/fi/browser/browser/zen-general.ftl
+++ b/locales/fi/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/is/browser/browser/zen-general.ftl
+++ b/locales/is/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/ja/browser/browser/zen-general.ftl
+++ b/locales/ja/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/nl/browser/browser/zen-general.ftl
+++ b/locales/nl/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/nn-NO/browser/browser/zen-general.ftl
+++ b/locales/nn-NO/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/pl/browser/browser/zen-general.ftl
+++ b/locales/pl/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/sv-SE/browser/browser/zen-general.ftl
+++ b/locales/sv-SE/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/th/browser/browser/zen-general.ftl
+++ b/locales/th/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/tr/browser/browser/zen-general.ftl
+++ b/locales/tr/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/vi/browser/browser/zen-general.ftl
+++ b/locales/vi/browser/browser/zen-general.ftl
@@ -57,8 +57,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/zh-CN/browser/browser/zen-general.ftl
+++ b/locales/zh-CN/browser/browser/zen-general.ftl
@@ -55,8 +55,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension

--- a/locales/zh-TW/browser/browser/zen-general.ftl
+++ b/locales/zh-TW/browser/browser/zen-general.ftl
@@ -55,8 +55,8 @@ zen-generic-manage = Manage
 zen-generic-more = More
 zen-generic-next = Next
 # These labels will be used for the site data panel settings
-zen-site-data-setting-allow = Allowed
-zen-site-data-setting-block = Blocked
+zen-site-data-setting-allow = Enabled
+zen-site-data-setting-block = Disabled
 zen-site-data-setting-cross-site = Cross-Site cookie
 zen-site-data-security-info-extension = 
     .label = Extension


### PR DESCRIPTION
The wording on the Tracking Protection setting in the new Control Center is confusing.

Currently, there are two options:
- Tracking Protection: Allowed
- Tracking Protection: Blocked

It's likely to be confusing to many users, since Tracking Protection is a feature that **blocks** tracking when enabled. I myself was wondering if _Allowed_ meant that requests are allowed to pass through it or if TP is allowed to work on that site.

Changing the wording to _Enabled_ and _Disabled_ makes it much more clear what the switch does.