### PR TITLE
feat: Add colored tab labels feature

### DIFF
--- a/locales/en-US/browser/browser/zen-tab-labels.ftl
+++ b/locales/en-US/browser/browser/zen-tab-labels.ftl
@@ -1,0 +1,23 @@
+
+# Tab Label Context Menu
+zen-tab-label-menu =
+    .label = Tab Label
+
+zen-tab-label-new =
+    .label = New Label...
+
+zen-tab-label-edit =
+    .label = Edit Label...
+
+zen-tab-label-remove =
+    .label = Remove Label
+
+# Tab Label Dialog
+zen-tab-label-dialog-new-title = Add Label
+zen-tab-label-dialog-edit-title = Edit Label
+
+zen-tab-label-input-label = Label Text
+zen-tab-label-color-label = Color
+
+zen-tab-label-cancel = Cancel
+zen-tab-label-save = Save

--- a/src/browser/base/content/zen-assets.inc.xhtml
+++ b/src/browser/base/content/zen-assets.inc.xhtml
@@ -12,6 +12,7 @@
 <link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-buttons.css" />
 <link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-toolbar.css" />
 <link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-tabs.css" />
+<link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-tab-labels.css" />
 <link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-browser-ui.css" />
 <link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-gradient-generator.css" />
 <link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-panel-ui.css" />
@@ -51,6 +52,7 @@
 <script type="text/javascript" src="chrome://browser/content/zen-components/ZenPinnedTabsStorage.mjs"></script>
 <script type="text/javascript" src="chrome://browser/content/zen-components/ZenWorkspacesStorage.mjs"></script>
 <script type="text/javascript" src="chrome://browser/content/zen-components/ZenPinnedTabManager.mjs"></script>
+<script type="text/javascript" src="chrome://browser/content/zen-components/ZenTabLabels.mjs"></script>
 <script type="text/javascript" src="chrome://browser/content/zen-components/ZenGradientGenerator.mjs"></script>
 <script type="text/javascript" src="chrome://browser/content/zen-components/ZenViewSplitter.mjs"></script>
 <script type="text/javascript" src="chrome://browser/content/zen-components/ZenGlanceManager.mjs"></script>

--- a/src/browser/base/content/zen-assets.jar.inc.mn
+++ b/src/browser/base/content/zen-assets.jar.inc.mn
@@ -53,7 +53,9 @@
 
         content/browser/zen-components/ZenPinnedTabsStorage.mjs                 (../../zen/tabs/ZenPinnedTabsStorage.mjs)
         content/browser/zen-components/ZenPinnedTabManager.mjs                  (../../zen/tabs/ZenPinnedTabManager.mjs)
+        content/browser/zen-components/ZenTabLabels.mjs                         (../../zen/tabs/ZenTabLabels.mjs)
 *       content/browser/zen-styles/zen-tabs.css                                 (../../zen/tabs/zen-tabs.css)
+        content/browser/zen-styles/zen-tab-labels.css                           (../../zen/tabs/zen-tab-labels.css)
         content/browser/zen-styles/zen-tabs/vertical-tabs.css                   (../../zen/tabs/zen-tabs/vertical-tabs.css)
 
         content/browser/zen-components/ZenGlanceManager.mjs                     (../../zen/glance/ZenGlanceManager.mjs)

--- a/src/browser/base/content/zen-panels/tab-label-dialog.inc
+++ b/src/browser/base/content/zen-panels/tab-label-dialog.inc
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+<panel id="zenTabLabelDialog"
+       type="arrow"
+       position="after_start"
+       hidden="true"
+       noautohide="true"
+       flip="both">
+  <vbox class="zen-tab-label-dialog-container" padding="16">
+    <html:div class="zen-tab-label-dialog-header">
+      <html:h3 id="zenTabLabelDialogTitle" data-l10n-id="zen-tab-label-dialog-new-title">Add Label</html:h3>
+    </html:div>
+
+    <html:div class="zen-tab-label-dialog-content">
+      <html:div class="zen-tab-label-input-group">
+        <html:label for="zenTabLabelInput" data-l10n-id="zen-tab-label-input-label">Label Text</html:label>
+        <html:input id="zenTabLabelInput"
+                    type="text"
+                    class="zen-tab-label-input"
+                    placeholder="Enter label..."
+                    data-l10n-attrs="placeholder"
+                    maxlength="50" />
+      </html:div>
+
+      <html:div class="zen-tab-label-color-group">
+        <html:label for="zenTabLabelColorPicker" data-l10n-id="zen-tab-label-color-label">Color</html:label>
+        <html:div class="zen-tab-label-color-picker-container">
+          <html:input id="zenTabLabelColorPicker"
+                      type="color"
+                      class="zen-tab-label-color-picker" />
+          <html:span class="zen-tab-label-color-preview"></html:span>
+        </html:div>
+      </html:div>
+    </html:div>
+
+    <html:div class="zen-tab-label-dialog-actions">
+      <html:button id="zenTabLabelCancel"
+                   class="zen-tab-label-button zen-tab-label-button-secondary"
+                   data-l10n-id="zen-tab-label-cancel">
+        Cancel
+      </html:button>
+      <html:button id="zenTabLabelSave"
+                   class="zen-tab-label-button zen-tab-label-button-primary"
+                   data-l10n-id="zen-tab-label-save">
+        Save
+      </html:button>
+    </html:div>
+  </vbox>
+</panel>

--- a/src/browser/base/content/zen-popupset.inc.xhtml
+++ b/src/browser/base/content/zen-popupset.inc.xhtml
@@ -6,5 +6,6 @@
 #include zen-panels/emojis-picker.inc
 #include zen-panels/folders-search.inc
 #include zen-panels/site-data.inc
+#include zen-panels/tab-label-dialog.inc
 
 #include zen-panels/popups.inc

--- a/src/browser/components/sessionstore/TabState-sys-mjs.patch
+++ b/src/browser/components/sessionstore/TabState-sys-mjs.patch
@@ -2,7 +2,7 @@ diff --git a/browser/components/sessionstore/TabState.sys.mjs b/browser/componen
 index 82721356d191055bec0d4b0ca49e481221988801..1ea5c394c704da295149443d7794961a12f2060b 100644
 --- a/browser/components/sessionstore/TabState.sys.mjs
 +++ b/browser/components/sessionstore/TabState.sys.mjs
-@@ -85,7 +85,22 @@ class _TabState {
+@@ -85,7 +85,25 @@ class _TabState {
        tabData.groupId = tab.group.id;
      }
  
@@ -15,6 +15,9 @@ index 82721356d191055bec0d4b0ca49e481221988801..1ea5c394c704da295149443d7794961a
 +    tabData.zenPinnedIcon = tab.getAttribute("zen-pinned-icon");
 +    tabData.zenIsEmpty = tab.hasAttribute("zen-empty-tab");
 +    tabData.zenHasStaticLabel = tab.hasAttribute("zen-has-static-label");
++    tabData.zenTabLabelId = tab.getAttribute("zen-tab-label-id");
++    tabData.zenTabLabelText = tab.getAttribute("zen-tab-label-text");
++    tabData.zenTabLabelColor = tab.getAttribute("zen-tab-label-color");
 +    tabData.zenGlanceId = tab.getAttribute("glance-id");
 +    tabData.zenIsGlance = tab.hasAttribute("zen-glance-tab");
 +

--- a/src/zen/common/ZenSessionStore.mjs
+++ b/src/zen/common/ZenSessionStore.mjs
@@ -30,6 +30,20 @@
       if (tabData.zenPinnedEntry) {
         tab.setAttribute('zen-pinned-entry', tabData.zenPinnedEntry);
       }
+      // Restore tab label data
+      if (tabData.zenTabLabelId) {
+        tab.setAttribute('zen-tab-label-id', tabData.zenTabLabelId);
+      }
+      if (tabData.zenTabLabelText) {
+        tab.setAttribute('zen-tab-label-text', tabData.zenTabLabelText);
+      }
+      if (tabData.zenTabLabelColor) {
+        tab.setAttribute('zen-tab-label-color', tabData.zenTabLabelColor);
+      }
+      // Trigger label restoration in ZenTabLabels
+      if (tabData.zenTabLabelId && window.gZenTabLabels) {
+        window.gZenTabLabels.restoreTabLabel(tab);
+      }
     }
 
     async #waitAndCleanup() {

--- a/src/zen/tabs/ZenTabLabels.mjs
+++ b/src/zen/tabs/ZenTabLabels.mjs
@@ -1,0 +1,427 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/**
+ * ZenTabLabels - Manages colored labels for tabs
+ *
+ * Features:
+ * - Add colored labels to tabs via context menu
+ * - Labels appear under the tab title with a color indicator
+ * - Quick selection of previously created labels
+ * - Session persistence of labels
+ */
+{
+  const LABEL_COLORS = [
+    '#FF6B6B', // Red
+    '#4ECDC4', // Teal
+    '#45B7D1', // Blue
+    '#96CEB4', // Green
+    '#FFEAA7', // Yellow
+    '#DDA15E', // Orange
+    '#BC6C25', // Brown
+    '#B19CD9', // Purple
+    '#FF85A2', // Pink
+    '#95E1D3', // Mint
+  ];
+
+  class ZenTabLabels extends nsZenDOMOperatedFeature {
+    constructor() {
+      super();
+      // Store label definitions: { id: { text: string, color: string } }
+      this._labels = new Map();
+      // Store tab->label mappings: { tabId: labelId }
+      this._tabLabels = new Map();
+      // Counter for generating unique label IDs
+      this._labelIdCounter = 0;
+
+      this._currentEditingTab = null;
+    }
+
+  init() {
+    this._initContextMenu();
+    this._initEventListeners();
+    this._initDialog();
+  }
+
+  _initContextMenu() {
+    // Add "Add Label" menu item to tab context menu
+    const contextMenuItems = window.MozXULElement.parseXULToFragment(`
+      <menu id="zen-context-menu-tab-label" data-l10n-id="zen-tab-label-menu">
+        <menupopup id="zen-tab-label-popup">
+          <menuitem id="zen-context-menu-new-label" data-l10n-id="zen-tab-label-new" class="menuitem-iconic" />
+          <menuseparator id="zen-tab-label-separator" hidden="true"/>
+          <menuitem id="zen-context-menu-edit-label" data-l10n-id="zen-tab-label-edit" hidden="true"/>
+          <menuitem id="zen-context-menu-remove-label" data-l10n-id="zen-tab-label-remove" hidden="true"/>
+        </menupopup>
+      </menu>
+    `);
+
+    // Insert after "Reload Tab" in context menu
+    const reloadTab = document.getElementById('context_reloadTab');
+    if (reloadTab) {
+      reloadTab.after(contextMenuItems);
+    }
+
+    // Listen for context menu opening to populate quick labels
+    const labelPopup = document.getElementById('zen-tab-label-popup');
+    if (labelPopup) {
+      labelPopup.addEventListener('popupshowing', this._onLabelMenuShowing.bind(this));
+    }
+  }
+
+  _initEventListeners() {
+    // New label menu item
+    const newLabelItem = document.getElementById('zen-context-menu-new-label');
+    if (newLabelItem) {
+      newLabelItem.addEventListener('command', () => {
+        this._openLabelDialog();
+      });
+    }
+
+    // Edit label menu item
+    const editLabelItem = document.getElementById('zen-context-menu-edit-label');
+    if (editLabelItem) {
+      editLabelItem.addEventListener('command', () => {
+        this._openLabelDialog(true);
+      });
+    }
+
+    // Remove label menu item
+    const removeLabelItem = document.getElementById('zen-context-menu-remove-label');
+    if (removeLabelItem) {
+      removeLabelItem.addEventListener('command', () => {
+        this._removeTabLabel(TabContextMenu.contextTab);
+      });
+    }
+
+    // Listen for tab close to clean up labels
+    window.addEventListener('TabClose', (event) => {
+      this._onTabClose(event.detail.adoptedBy ? null : event.target);
+    });
+  }
+
+  _initDialog() {
+    // Save button
+    const saveButton = document.getElementById('zenTabLabelSave');
+    if (saveButton) {
+      saveButton.addEventListener('click', () => {
+        this._saveLabel();
+      });
+    }
+
+    // Cancel button
+    const cancelButton = document.getElementById('zenTabLabelCancel');
+    if (cancelButton) {
+      cancelButton.addEventListener('click', () => {
+        this._closeDialog();
+      });
+    }
+
+    // Enter key to save
+    const input = document.getElementById('zenTabLabelInput');
+    if (input) {
+      input.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          this._saveLabel();
+        } else if (event.key === 'Escape') {
+          this._closeDialog();
+        }
+      });
+    }
+
+    // Color picker preview
+    const colorPicker = document.getElementById('zenTabLabelColorPicker');
+    const colorPreview = document.querySelector('.zen-tab-label-color-preview');
+    if (colorPicker && colorPreview) {
+      colorPicker.addEventListener('input', (event) => {
+        colorPreview.style.backgroundColor = event.target.value;
+      });
+    }
+  }
+
+  _onLabelMenuShowing(event) {
+    const tab = TabContextMenu.contextTab;
+    if (!tab) return;
+
+    const popup = event.target;
+    const separator = document.getElementById('zen-tab-label-separator');
+    const editItem = document.getElementById('zen-context-menu-edit-label');
+    const removeItem = document.getElementById('zen-context-menu-remove-label');
+
+    // Remove existing quick label items
+    const existingItems = popup.querySelectorAll('.zen-quick-label-item');
+    existingItems.forEach(item => item.remove());
+
+    // Check if tab has a label
+    const tabId = this._getTabId(tab);
+    const hasLabel = this._tabLabels.has(tabId);
+
+    // Show/hide edit and remove items
+    if (hasLabel) {
+      editItem.hidden = false;
+      removeItem.hidden = false;
+    } else {
+      editItem.hidden = true;
+      removeItem.hidden = true;
+    }
+
+    // Add quick selection items for existing labels
+    if (this._labels.size > 0) {
+      separator.hidden = false;
+
+      const currentLabelId = this._tabLabels.get(tabId);
+
+      for (const [labelId, label] of this._labels) {
+        const item = document.createXULElement('menuitem');
+        item.classList.add('zen-quick-label-item', 'menuitem-iconic');
+        item.setAttribute('label', label.text);
+        item.style.setProperty('--label-color', label.color);
+
+        if (currentLabelId === labelId) {
+          item.setAttribute('checked', 'true');
+          item.setAttribute('type', 'checkbox');
+        }
+
+        item.addEventListener('command', () => {
+          if (currentLabelId === labelId) {
+            this._removeTabLabel(tab);
+          } else {
+            this._applyLabelToTab(tab, labelId);
+          }
+        });
+
+        separator.after(item);
+      }
+    } else {
+      separator.hidden = true;
+    }
+  }
+
+  _openLabelDialog(isEdit = false) {
+    const tab = TabContextMenu.contextTab;
+    if (!tab) return;
+
+    this._currentEditingTab = tab;
+    const dialog = document.getElementById('zenTabLabelDialog');
+    const input = document.getElementById('zenTabLabelInput');
+    const colorPicker = document.getElementById('zenTabLabelColorPicker');
+    const colorPreview = document.querySelector('.zen-tab-label-color-preview');
+    const title = document.getElementById('zenTabLabelDialogTitle');
+
+    if (isEdit) {
+      const tabId = this._getTabId(tab);
+      const labelId = this._tabLabels.get(tabId);
+      const label = this._labels.get(labelId);
+
+      if (label) {
+        input.value = label.text;
+        colorPicker.value = label.color;
+        if (colorPreview) {
+          colorPreview.style.backgroundColor = label.color;
+        }
+        title.setAttribute('data-l10n-id', 'zen-tab-label-dialog-edit-title');
+      }
+    } else {
+      input.value = '';
+      const randomColor = this._getRandomColor();
+      colorPicker.value = randomColor;
+      if (colorPreview) {
+        colorPreview.style.backgroundColor = randomColor;
+      }
+      title.setAttribute('data-l10n-id', 'zen-tab-label-dialog-new-title');
+    }
+
+    // Open dialog as popup anchored to the tab
+    dialog.openPopup(tab, 'after_start', 0, 0, false, false);
+
+    // Focus input after a short delay to ensure dialog is rendered
+    setTimeout(() => {
+      input.focus();
+      input.select();
+    }, 100);
+  }
+
+  _closeDialog() {
+    const dialog = document.getElementById('zenTabLabelDialog');
+    if (dialog.state === 'open') {
+      dialog.hidePopup();
+    }
+    this._currentEditingTab = null;
+  }
+
+  _saveLabel() {
+    const input = document.getElementById('zenTabLabelInput');
+    const colorPicker = document.getElementById('zenTabLabelColorPicker');
+    const labelText = input.value.trim();
+
+    if (!labelText || !this._currentEditingTab) {
+      this._closeDialog();
+      return;
+    }
+
+    const tab = this._currentEditingTab;
+    const tabId = this._getTabId(tab);
+    const existingLabelId = this._tabLabels.get(tabId);
+
+    let labelId;
+    if (existingLabelId) {
+      // Update existing label
+      labelId = existingLabelId;
+      this._labels.set(labelId, {
+        text: labelText,
+        color: colorPicker.value
+      });
+    } else {
+      // Create new label
+      labelId = `label-${this._labelIdCounter++}`;
+      this._labels.set(labelId, {
+        text: labelText,
+        color: colorPicker.value
+      });
+    }
+
+    this._applyLabelToTab(tab, labelId);
+    this._closeDialog();
+  }
+
+  _applyLabelToTab(tab, labelId) {
+    const tabId = this._getTabId(tab);
+    const label = this._labels.get(labelId);
+
+    if (!label) return;
+
+    this._tabLabels.set(tabId, labelId);
+
+    // Set attributes on tab for session storage
+    tab.setAttribute('zen-tab-label-id', labelId);
+    tab.setAttribute('zen-tab-label-text', label.text);
+    tab.setAttribute('zen-tab-label-color', label.color);
+
+    // Update UI
+    this._updateTabLabelUI(tab, label);
+  }
+
+  _removeTabLabel(tab) {
+    const tabId = this._getTabId(tab);
+    this._tabLabels.delete(tabId);
+
+    // Remove attributes
+    tab.removeAttribute('zen-tab-label-id');
+    tab.removeAttribute('zen-tab-label-text');
+    tab.removeAttribute('zen-tab-label-color');
+
+    // Update UI
+    this._updateTabLabelUI(tab, null);
+  }
+
+  _updateTabLabelUI(tab, label) {
+    let labelContainer = tab.querySelector('.zen-tab-label-display');
+
+    if (!label) {
+      // Remove label display
+      if (labelContainer) {
+        labelContainer.remove();
+      }
+      return;
+    }
+
+    if (!labelContainer) {
+      // Create label display element
+      const tabLabelContainer = tab.querySelector('.tab-label-container');
+      if (tabLabelContainer) {
+        labelContainer = document.createXULElement('hbox');
+        labelContainer.classList.add('zen-tab-label-display');
+        tabLabelContainer.after(labelContainer);
+      }
+    }
+
+    if (labelContainer) {
+      labelContainer.innerHTML = '';
+
+      const colorDot = document.createXULElement('box');
+      colorDot.classList.add('zen-tab-label-color');
+      colorDot.style.backgroundColor = label.color;
+
+      const labelText = document.createXULElement('label');
+      labelText.classList.add('zen-tab-label-text');
+      labelText.textContent = label.text;
+
+      labelContainer.appendChild(colorDot);
+      labelContainer.appendChild(labelText);
+    }
+  }
+
+  _onTabClose(tab) {
+    if (!tab) return;
+
+    const tabId = this._getTabId(tab);
+    this._tabLabels.delete(tabId);
+
+    // Clean up unused labels (not associated with any tab)
+    this._cleanupUnusedLabels();
+  }
+
+  _cleanupUnusedLabels() {
+    const usedLabelIds = new Set(this._tabLabels.values());
+
+    for (const labelId of this._labels.keys()) {
+      if (!usedLabelIds.has(labelId)) {
+        this._labels.delete(labelId);
+      }
+    }
+  }
+
+  _getTabId(tab) {
+    // Use tab's linkedPanel as unique ID
+    return tab.linkedPanel || tab.getAttribute('linkedpanel');
+  }
+
+  _getRandomColor() {
+    return LABEL_COLORS[Math.floor(Math.random() * LABEL_COLORS.length)];
+  }
+
+  /**
+   * Restore label data from session storage
+   */
+  restoreTabLabel(tab) {
+    const labelId = tab.getAttribute('zen-tab-label-id');
+    const labelText = tab.getAttribute('zen-tab-label-text');
+    const labelColor = tab.getAttribute('zen-tab-label-color');
+
+    if (labelId && labelText && labelColor) {
+      const tabId = this._getTabId(tab);
+
+      // Restore label definition if not exists
+      if (!this._labels.has(labelId)) {
+        this._labels.set(labelId, { text: labelText, color: labelColor });
+      }
+
+      // Restore tab-label mapping
+      this._tabLabels.set(tabId, labelId);
+
+      // Update UI
+      this._updateTabLabelUI(tab, { text: labelText, color: labelColor });
+
+      // Update counter to avoid ID collisions
+      const numericId = parseInt(labelId.replace('label-', ''));
+      if (!isNaN(numericId) && numericId >= this._labelIdCounter) {
+        this._labelIdCounter = numericId + 1;
+      }
+    }
+  }
+
+    /**
+     * Restore all tab labels for the current session
+     */
+    restoreAllTabLabels() {
+      const tabs = gBrowser.tabs;
+      for (const tab of tabs) {
+        this.restoreTabLabel(tab);
+      }
+    }
+  }
+
+  // Create global instance
+  window.gZenTabLabels = new ZenTabLabels();
+}

--- a/src/zen/tabs/zen-tab-labels.css
+++ b/src/zen/tabs/zen-tab-labels.css
@@ -1,0 +1,178 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* Tab Label Display */
+.zen-tab-label-display {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  padding: 2px 0;
+  font-size: 11px;
+  opacity: 0.85;
+}
+
+.zen-tab-label-color {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.zen-tab-label-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Context menu quick label items */
+.zen-quick-label-item {
+  position: relative;
+  padding-inline-start: 24px !important;
+}
+
+.zen-quick-label-item::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--label-color, #999);
+}
+
+/* Tab Label Dialog */
+#zenTabLabelDialog {
+  --dialog-bg: var(--zen-dialog-background, var(--arrowpanel-background));
+  --dialog-border: var(--zen-dialog-border, var(--arrowpanel-border-color));
+  --input-bg: var(--zen-input-background, Field);
+  --input-border: var(--zen-input-border, var(--input-border-color));
+  --input-text: var(--zen-input-text, FieldText);
+  --button-primary-bg: var(--zen-primary-color, var(--button-primary-bgcolor));
+  --button-primary-text: var(--zen-primary-text-color, var(--button-primary-color));
+  --button-secondary-bg: var(--zen-secondary-color, var(--button-bgcolor));
+  --button-secondary-text: var(--zen-text-color, var(--button-color));
+}
+
+.zen-tab-label-dialog-container {
+  background: var(--dialog-bg);
+  border: 1px solid var(--dialog-border);
+  border-radius: 8px;
+  min-width: 280px;
+  max-width: 320px;
+}
+
+.zen-tab-label-dialog-header h3 {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--input-text);
+}
+
+.zen-tab-label-dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.zen-tab-label-input-group,
+.zen-tab-label-color-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.zen-tab-label-input-group label,
+.zen-tab-label-color-group label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--input-text);
+}
+
+.zen-tab-label-input {
+  padding: 8px 10px;
+  border: 1px solid var(--input-border);
+  border-radius: 4px;
+  background: var(--input-bg);
+  color: var(--input-text);
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.zen-tab-label-input:focus {
+  outline: 2px solid var(--button-primary-bg);
+  outline-offset: -1px;
+}
+
+.zen-tab-label-color-picker-container {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.zen-tab-label-color-picker {
+  width: 50px;
+  height: 32px;
+  border: 1px solid var(--input-border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.zen-tab-label-color-preview {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid var(--input-border);
+}
+
+.zen-tab-label-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.zen-tab-label-button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  transition: opacity 0.15s ease;
+}
+
+.zen-tab-label-button:hover {
+  opacity: 0.85;
+}
+
+.zen-tab-label-button:active {
+  opacity: 0.7;
+}
+
+.zen-tab-label-button-primary {
+  background: var(--button-primary-bg);
+  color: var(--button-primary-text);
+}
+
+.zen-tab-label-button-secondary {
+  background: var(--button-secondary-bg);
+  color: var(--button-secondary-text);
+  border: 1px solid var(--input-border);
+}
+
+/* Hide label display on pinned tabs to save space */
+.tabbrowser-tab[pinned] .zen-tab-label-display {
+  display: none;
+}
+
+/* Ensure label is visible in vertical tabs */
+#tabbrowser-tabs[orient="vertical"] .zen-tab-label-display {
+  display: flex;
+}


### PR DESCRIPTION
Implements a comprehensive tab labeling system with the following features:

Core Functionality:
- Add custom colored labels to tabs via context menu
- Labels appear below tab title with color-coded circle indicator
- Quick label selection from previously created labels in current session
- Edit and remove label options in context menu
- Random color assignment with manual color picker override

Implementation Details:
- ZenTabLabels.mjs: Main module managing label data and UI interactions
- Popup dialog for creating/editing labels with text input and color picker
- Session storage integration for label persistence across restarts
- Automatic label restoration on browser startup
- Context menu integration with "Tab Label" submenu
- Quick selection of existing labels for easy reuse

UI Components:
- zen-tab-labels.css: Styling for label display and dialog
- tab-label-dialog.inc: XUL dialog panel structure
- Colored circle indicator next to label text
- Clean, minimalist design matching Zen's aesthetic

Session Management:
- Labels stored in SessionStore via TabState attributes
- Three attributes per labeled tab: id, text, and color
- Automatic restoration via ZenSessionStore.restoreInitialTabData()
- Label cleanup when tabs are closed

Localization:
- English strings in zen-tab-labels.ftl
- Ready for translation to other languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)