### PR TITLE
Fix cursor height in "Create Space" input field.

### DIFF
--- a/src/zen/workspaces/create-workspace-form.css
+++ b/src/zen/workspaces/create-workspace-form.css
@@ -109,6 +109,7 @@ zen-workspace-creation {
           padding: 0 !important;
           width: 100%;
           outline: none;
+          border-radius: 0;
         }
       }
 


### PR DESCRIPTION
Currently if you put your cursor in the space of the first character in the input field of the "Create Space" form, it will have less height than if you put it after a character. This is due to the border radius of the text field which is invisible so I have removed it to fix this issue.

(first screenshot shows the issue, second shows what it should look like)
<img width="150" height="43" alt="Screenshot 2025-10-24 220702" src="https://github.com/user-attachments/assets/bada6b0d-d6e7-4a9c-a26c-23acae98f14d" />
<img width="61" height="32" alt="Screenshot 2025-10-24 220747" src="https://github.com/user-attachments/assets/b2790725-439c-4d71-bc93-0d36b5b6f370" />
