### PR TITLE
fix: sidebar flickering during drag operations in compact mode

### DIFF
--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -32,6 +32,8 @@ var gZenCompactModeManager = {
   _flashTimeouts: {},
   _eventListeners: [],
   _removeHoverFrames: {},
+  _isDragging: false,
+  _dragDebounceTimer: null,
 
   // Delay to avoid flickering when hovering over the sidebar
   HOVER_HACK_DELAY: Services.prefs.getIntPref('zen.view.compact.hover-hack-delay', 0),
@@ -670,6 +672,10 @@ var gZenCompactModeManager = {
         setTimeout(() => {
           if (event.type === 'mouseenter' && !event.target.matches(':hover')) return;
           if (event.target.closest('panel')) return;
+          if (event.type === 'dragover') {
+            this._isDragging = true;
+            clearTimeout(this._dragDebouceTimer);
+          }
           // Dont register the hover if the urlbar is floating and we are hovering over it
           this.clearFlashTimeout('has-hover' + target.id);
           window.requestAnimationFrame(() => {
@@ -687,6 +693,13 @@ var gZenCompactModeManager = {
       };
 
       const onLeave = (event) => {
+        if (event.type === 'dragleave' && this._isDragging) {
+          clearTimeout(this._dragDebounceTimer);
+          this._dragDebounceTimer = setTimeout(() => {
+            this._isDragging = false;
+          }, 150);
+          return;
+        }
         if (AppConstants.platform == 'macosx') {
           const buttonRect = gZenVerticalTabsManager.actualWindowButtons.getBoundingClientRect();
           const MAC_WINDOW_BUTTONS_X_BORDER = buttonRect.width + buttonRect.x;
@@ -740,6 +753,16 @@ var gZenCompactModeManager = {
 
       target.addEventListener('mouseleave', onLeave);
       target.addEventListener('dragleave', onLeave);
+
+      // Clean up drag state when drag operation completes
+      target.addEventListener('drop', () => {
+        this._isDragging = false;
+        clearTimeout(this._dragDebounceTimer);
+      });
+      target.addEventListener('dragend', () => {
+        this._isDragging = false;
+        clearTimeout(this._dragDebounceTimer);
+      });
     }
 
     document.documentElement.addEventListener('mouseleave', (event) => {


### PR DESCRIPTION
## Description
Fixes #10942 - Resolves sidebar flickering when dragging content to window edge in compact mode.

## Problem
When dragging text/URLs near the window edge in compact mode, the sidebar rapidly flickered between visible and hidden states, making drag-and-drop functionality unusable.

## Root Cause
The sidebar's expansion during `dragover` changed DOM boundaries, triggering spurious `dragleave` events. This created a feedback loop:
`dragover` → expand → `dragleave` → collapse → repeat

## Solution
Implemented a debouncing mechanism specifically for drag operations:
- Added `_isDragging` flag to track active drag state
- `dragleave` events during active drags are debounced with 150ms delay
- State is cleaned up on `drop`/`dragend` events
- Normal hover behavior remains unaffected

## Changes
- Modified `src/browser/base/content/ZenCompactMode.mjs`:
  - Added drag state tracking properties
  - Modified `onEnter` handler to detect drag operations
  - Modified `onLeave` handler to debounce dragleave events
  - Added `drop` and `dragend` cleanup listeners

## Testing
- [x] Drag text to sidebar edge - sidebar stays visible without flickering
- [x] Normal hover behavior works correctly
- [x] Drop operations complete successfully
- [x] Canceling drag (ESC) properly resets state
- [x] No regressions in non-compact mode

## Screenshots/Video
[Screencast from 2025-10-25 17-26-16.webm](https://github.com/user-attachments/assets/fa3db7b7-e7e4-4409-abad-ce83746c85e8)

## Checklist
- [x] Code follows project style guidelines
- [x] Tested on Ubuntu 24.04.3 LTS
- [x] No console errors introduced
- [x] Minimal code changes (debounce approach)