### PR TITLE
Change icon for 'Copy Current URL' action

### DIFF
--- a/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
+++ b/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
@@ -30,7 +30,7 @@ const globalActionsTemplate = [
   {
     label: 'Copy Current URL',
     command: 'cmd_zenCopyCurrentURL',
-    icon: 'chrome://browser/skin/zen-icons/edit-copy.svg',
+    icon: 'chrome://browser/skin/zen-icons/link.svg',
   },
   {
     label: 'Settings',


### PR DESCRIPTION
This PR simply changes the icon of 'Copy Current URL' action to match the one used in the new 'Copy URL' button in the URL Bar.

I noticed that the 'Toggle Compact Mode' icon needs also to be changed depending on the side of the sidebar, but my knowledge of coding stops there, sorry...