### PR TITLE
fix: notification popup icons are not centered in multiple toolbars layout

### DIFF
--- a/src/zen/common/styles/zen-omnibox.css
+++ b/src/zen/common/styles/zen-omnibox.css
@@ -346,6 +346,7 @@
   #notification-popup-box {
     margin: 0 4px 0 0 !important;
     justify-content: center;
+    height: unset !important;
     gap: 8px;
     background: transparent;
 


### PR DESCRIPTION
# Issue

In multiple toolbars layout, the icons that appear with notification popups are not centered in the URL bar. 

The height set for the box is lesser than expected.

<img width="392" height="113" alt="image" src="https://github.com/user-attachments/assets/ef12bf54-84b6-4b52-9a93-e96478dc8c07" />

# About the fix

As same as in [single toolbar layout](https://github.com/zen-browser/desktop/blob/7e35ed749123be328fb7ba5343373dbaf61d0232/src/zen/common/styles/zen-omnibox.css#L326), the height is `unset`.

