### PR TITLE
fix: #9997 New container tab popup menu displayed incorrectly

### DIFF
--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -609,3 +609,13 @@ body > #confetti {
 #widget-overflow-list {
   flex-direction: column-reverse;
 }
+
+/* Contextual new tab popup menu */
+#tabs-newtab-button > .new-tab-popup > menuitem {
+  & > :is(.menu-highlightable-text, .menu-accel) {
+    display: none !important;
+  }
+  & > label {
+    opacity: 1 !important;
+  }
+}


### PR DESCRIPTION
Fix #9997 
As stated in the issue, the context menu to create a new tab with a specific container (opened via holding the new tab button) is displayed differently than the right click's context menu on the new tab button.

# Image of the issue

<img width="483" height="453" alt="image" src="https://github.com/user-attachments/assets/494f019f-d8c2-4d6b-9fee-11571a2ebd98" />

# Image after the fix

<img width="254" height="342" alt="image" src="https://github.com/user-attachments/assets/ec1e65a6-6f6e-4896-9c12-b36b97552d66" />
