### PR TITLE
fix: targeting new container tab context menu with a higher specificity and removing opacity rule

### DIFF
--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -611,11 +611,8 @@ body > #confetti {
 }
 
 /* Contextual new tab popup menu */
-#tabs-newtab-button > .new-tab-popup > menuitem {
+#navigator-toolbox #titlebar #TabsToolbar #tabs-newtab-button > .new-tab-popup > menuitem {
   & > :is(.menu-highlightable-text, .menu-accel) {
-    display: none !important;
-  }
-  & > label {
-    opacity: 1 !important;
+    display: none;
   }
 }


### PR DESCRIPTION
I assumed that you want both of `!important` to be removed.

If I assumed wrong, let me know!