### PR TITLE
feat: Close tab and switch to recent tab when going back with no history

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -57,7 +57,7 @@ zen-tabs-unloader-enabled =
     .label = Enable Tab Unloader
 
 zen-tabs-close-on-back-with-no-history =
-    .label = Close tab and switch to recent tab when going back with no history
+    .label = Close tab and switch to its owner tab (or most recently used tab) when going back with no history
 
 zen-look-and-feel-compact-toolbar-themed =
     .label = Use themed background for compact toolbar

--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -56,6 +56,9 @@ pane-settings-workspaces-title = Workspaces
 zen-tabs-unloader-enabled =
     .label = Enable Tab Unloader
 
+zen-tabs-close-on-back-with-no-history =
+    .label = Close tab and switch to recent tab when going back with no history
+
 zen-look-and-feel-compact-toolbar-themed =
     .label = Use themed background for compact toolbar
 

--- a/prefs/zen/zen.yaml
+++ b/prefs/zen/zen.yaml
@@ -34,3 +34,6 @@
 
 - name: zen.tabs.open-pinned-in-new-tab
   value: true
+
+- name: zen.tabs.close-on-back-with-no-history
+  value: true

--- a/src/browser/base/content/browser-commands-js.patch
+++ b/src/browser/base/content/browser-commands-js.patch
@@ -1,8 +1,8 @@
 diff --git a/browser/base/content/browser-commands.js b/browser/base/content/browser-commands.js
-index 939ca497b882b3f4200141ba1b6764fb5c846f45..77abad7ace109bea5392930d6e7c06568685a46b 100644
+index 939ca497b882b3f4200141ba1b6764fb5c846f45..bdf343698bdf313a519a9c8fc4645aabd21be1cf 100644
 --- a/browser/base/content/browser-commands.js
 +++ b/browser/base/content/browser-commands.js
-@@ -14,6 +14,19 @@ var BrowserCommands = {
+@@ -14,6 +14,17 @@ var BrowserCommands = {
      const where = BrowserUtils.whereToOpenLink(aEvent, false, true);
  
      if (where == "current") {
@@ -10,11 +10,9 @@ index 939ca497b882b3f4200141ba1b6764fb5c846f45..77abad7ace109bea5392930d6e7c0656
 +      const canGoBack = gBrowser.webNavigation?.canGoBack;
 +
 +      if (!canGoBack) {
-+        const currentTab = gBrowser.selectedTab;
-+
-+        if (gZenCommonActions.shouldCloseTabOnBack(currentTab)) {
++        if (gZenCommonActions.shouldCloseTabOnBack()) {
 +          // removeTab handles tab selection (owner or most recent)
-+          gBrowser.removeTab(currentTab);
++          gBrowser.removeTab(gBrowser.selectedTab);
 +          return;
 +        }
 +      }
@@ -22,7 +20,7 @@ index 939ca497b882b3f4200141ba1b6764fb5c846f45..77abad7ace109bea5392930d6e7c0656
        try {
          gBrowser.goBack();
        } catch (ex) {}
-@@ -315,6 +328,10 @@ var BrowserCommands = {
+@@ -315,6 +326,10 @@ var BrowserCommands = {
        }
      }
  
@@ -33,7 +31,7 @@ index 939ca497b882b3f4200141ba1b6764fb5c846f45..77abad7ace109bea5392930d6e7c0656
      // A notification intended to be useful for modular peformance tracking
      // starting as close as is reasonably possible to the time when the user
      // expressed the intent to open a new tab.  Since there are a lot of
-@@ -399,6 +416,11 @@ var BrowserCommands = {
+@@ -399,6 +414,11 @@ var BrowserCommands = {
        return;
      }
  
@@ -45,7 +43,7 @@ index 939ca497b882b3f4200141ba1b6764fb5c846f45..77abad7ace109bea5392930d6e7c0656
      // Keyboard shortcuts that would close a tab that is pinned select the first
      // unpinned tab instead.
      if (
-@@ -406,8 +428,8 @@ var BrowserCommands = {
+@@ -406,8 +426,8 @@ var BrowserCommands = {
        (event.ctrlKey || event.metaKey || event.altKey) &&
        gBrowser.selectedTab.pinned
      ) {

--- a/src/browser/base/content/browser-commands-js.patch
+++ b/src/browser/base/content/browser-commands-js.patch
@@ -1,8 +1,28 @@
 diff --git a/browser/base/content/browser-commands.js b/browser/base/content/browser-commands.js
-index 939ca497b882b3f4200141ba1b6764fb5c846f45..36c830a503b004c0a332340f686c86cad68e9381 100644
+index 939ca497b882b3f4200141ba1b6764fb5c846f45..77abad7ace109bea5392930d6e7c06568685a46b 100644
 --- a/browser/base/content/browser-commands.js
 +++ b/browser/base/content/browser-commands.js
-@@ -315,6 +315,10 @@ var BrowserCommands = {
+@@ -14,6 +14,19 @@ var BrowserCommands = {
+     const where = BrowserUtils.whereToOpenLink(aEvent, false, true);
+ 
+     if (where == "current") {
++      // Check if we can go back in history
++      const canGoBack = gBrowser.webNavigation?.canGoBack;
++
++      if (!canGoBack) {
++        const currentTab = gBrowser.selectedTab;
++
++        if (gZenCommonActions.shouldCloseTabOnBack(currentTab)) {
++          // removeTab handles tab selection (owner or most recent)
++          gBrowser.removeTab(currentTab);
++          return;
++        }
++      }
++
+       try {
+         gBrowser.goBack();
+       } catch (ex) {}
+@@ -315,6 +328,10 @@ var BrowserCommands = {
        }
      }
  
@@ -13,7 +33,7 @@ index 939ca497b882b3f4200141ba1b6764fb5c846f45..36c830a503b004c0a332340f686c86ca
      // A notification intended to be useful for modular peformance tracking
      // starting as close as is reasonably possible to the time when the user
      // expressed the intent to open a new tab.  Since there are a lot of
-@@ -399,6 +403,11 @@ var BrowserCommands = {
+@@ -399,6 +416,11 @@ var BrowserCommands = {
        return;
      }
  
@@ -25,7 +45,7 @@ index 939ca497b882b3f4200141ba1b6764fb5c846f45..36c830a503b004c0a332340f686c86ca
      // Keyboard shortcuts that would close a tab that is pinned select the first
      // unpinned tab instead.
      if (
-@@ -406,8 +415,8 @@ var BrowserCommands = {
+@@ -406,8 +428,8 @@ var BrowserCommands = {
        (event.ctrlKey || event.metaKey || event.altKey) &&
        gBrowser.selectedTab.pinned
      ) {

--- a/src/browser/base/content/browser-commands-js.patch
+++ b/src/browser/base/content/browser-commands-js.patch
@@ -1,26 +1,19 @@
 diff --git a/browser/base/content/browser-commands.js b/browser/base/content/browser-commands.js
-index 939ca497b882b3f4200141ba1b6764fb5c846f45..bdf343698bdf313a519a9c8fc4645aabd21be1cf 100644
+index 939ca497b882b3f4200141ba1b6764fb5c846f45..779cba5ff3df856a246321a36caa3725c054a314 100644
 --- a/browser/base/content/browser-commands.js
 +++ b/browser/base/content/browser-commands.js
-@@ -14,6 +14,17 @@ var BrowserCommands = {
+@@ -14,6 +14,10 @@ var BrowserCommands = {
      const where = BrowserUtils.whereToOpenLink(aEvent, false, true);
  
      if (where == "current") {
-+      // Check if we can go back in history
-+      const canGoBack = gBrowser.webNavigation?.canGoBack;
-+
-+      if (!canGoBack) {
-+        if (gZenCommonActions.shouldCloseTabOnBack()) {
-+          // removeTab handles tab selection (owner or most recent)
-+          gBrowser.removeTab(gBrowser.selectedTab);
-+          return;
-+        }
++      if (!gBrowser.webNavigation.canGoBack && gZenCommonActions.shouldCloseTabOnBack()) {
++        gBrowser.removeTab(gBrowser.selectedTab);
++        return;
 +      }
-+
        try {
          gBrowser.goBack();
        } catch (ex) {}
-@@ -315,6 +326,10 @@ var BrowserCommands = {
+@@ -315,6 +319,10 @@ var BrowserCommands = {
        }
      }
  
@@ -31,7 +24,7 @@ index 939ca497b882b3f4200141ba1b6764fb5c846f45..bdf343698bdf313a519a9c8fc4645aab
      // A notification intended to be useful for modular peformance tracking
      // starting as close as is reasonably possible to the time when the user
      // expressed the intent to open a new tab.  Since there are a lot of
-@@ -399,6 +414,11 @@ var BrowserCommands = {
+@@ -399,6 +407,11 @@ var BrowserCommands = {
        return;
      }
  
@@ -43,7 +36,7 @@ index 939ca497b882b3f4200141ba1b6764fb5c846f45..bdf343698bdf313a519a9c8fc4645aab
      // Keyboard shortcuts that would close a tab that is pinned select the first
      // unpinned tab instead.
      if (
-@@ -406,8 +426,8 @@ var BrowserCommands = {
+@@ -406,8 +419,8 @@ var BrowserCommands = {
        (event.ctrlKey || event.metaKey || event.altKey) &&
        gBrowser.selectedTab.pinned
      ) {

--- a/src/browser/base/content/browser-gestureSupport-js.patch
+++ b/src/browser/base/content/browser-gestureSupport-js.patch
@@ -1,18 +1,13 @@
 diff --git a/browser/base/content/browser-gestureSupport.js b/browser/base/content/browser-gestureSupport.js
-index a28d54bf72c0e6495b9586f220d1859aac794936..740905f1689b65591b02bebf92932b0a414a660e 100644
+index a28d54bf72c0e6495b9586f220d1859aac794936..66154668b9f85ffbaacea1e8351370659260227b 100644
 --- a/browser/base/content/browser-gestureSupport.js
 +++ b/browser/base/content/browser-gestureSupport.js
-@@ -832,7 +832,12 @@ var gHistorySwipeAnimation = {
+@@ -832,7 +832,7 @@ var gHistorySwipeAnimation = {
     * @return true if there is a previous page in history, false otherwise.
     */
    canGoBack: function HSA_canGoBack() {
 -    return gBrowser.webNavigation.canGoBack;
-+    if (gBrowser.webNavigation.canGoBack) {
-+      return true;
-+    }
-+    
-+    // Allow swipe back gesture for regular unpinned tabs (to close them)
-+    return gZenCommonActions.shouldCloseTabOnBack(gBrowser?.selectedTab);
++    return gBrowser.webNavigation.canGoBack || gZenCommonActions.shouldCloseTabOnBack();
    },
  
    /**

--- a/src/browser/base/content/browser-gestureSupport-js.patch
+++ b/src/browser/base/content/browser-gestureSupport-js.patch
@@ -1,0 +1,18 @@
+diff --git a/browser/base/content/browser-gestureSupport.js b/browser/base/content/browser-gestureSupport.js
+index a28d54bf72c0e6495b9586f220d1859aac794936..740905f1689b65591b02bebf92932b0a414a660e 100644
+--- a/browser/base/content/browser-gestureSupport.js
++++ b/browser/base/content/browser-gestureSupport.js
+@@ -832,7 +832,12 @@ var gHistorySwipeAnimation = {
+    * @return true if there is a previous page in history, false otherwise.
+    */
+   canGoBack: function HSA_canGoBack() {
+-    return gBrowser.webNavigation.canGoBack;
++    if (gBrowser.webNavigation.canGoBack) {
++      return true;
++    }
++    
++    // Allow swipe back gesture for regular unpinned tabs (to close them)
++    return gZenCommonActions.shouldCloseTabOnBack(gBrowser?.selectedTab);
+   },
+ 
+   /**

--- a/src/browser/base/content/browser-js.patch
+++ b/src/browser/base/content/browser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/base/content/browser.js b/browser/base/content/browser.js
-index b4b79e7fb3228ba91bd8afa08659be0d88883725..633952ecae7be210324caef29429c97e928d6014 100644
+index b4b79e7fb3228ba91bd8afa08659be0d88883725..b4801e2a3076139622d58f81943e61cd61ee1828 100644
 --- a/browser/base/content/browser.js
 +++ b/browser/base/content/browser.js
 @@ -31,6 +31,7 @@ ChromeUtils.defineESModuleGetters(this, {
@@ -10,18 +10,21 @@ index b4b79e7fb3228ba91bd8afa08659be0d88883725..633952ecae7be210324caef29429c97e
    DevToolsSocketStatus:
      "resource://devtools/shared/security/DevToolsSocketStatus.sys.mjs",
    DownloadUtils: "resource://gre/modules/DownloadUtils.sys.mjs",
-@@ -822,7 +823,9 @@ function UpdateBackForwardCommands(aWebNavigation) {
+@@ -822,7 +823,12 @@ function UpdateBackForwardCommands(aWebNavigation) {
  
    var backDisabled = backCommand.hasAttribute("disabled");
    var forwardDisabled = forwardCommand.hasAttribute("disabled");
 -  if (backDisabled == aWebNavigation.canGoBack) {
++  var canGoBack = aWebNavigation.canGoBack;
++  if (!canGoBack) {
++    canGoBack = gZenCommonActions.shouldCloseTabOnBack();
++  }
 +  
-+  // Check if we can go back OR if we can close tab and go back to owner
-+  if (backDisabled == (aWebNavigation.canGoBack || gZenCommonActions.shouldCloseTabOnBack(gBrowser?.selectedTab))) {
++  if (backDisabled == canGoBack) {
      if (backDisabled) {
        backCommand.removeAttribute("disabled");
      } else {
-@@ -2298,6 +2301,8 @@ var XULBrowserWindow = {
+@@ -2298,6 +2304,8 @@ var XULBrowserWindow = {
      AboutReaderParent.updateReaderButton(gBrowser.selectedBrowser);
      TranslationsParent.onLocationChange(gBrowser.selectedBrowser);
  
@@ -30,7 +33,7 @@ index b4b79e7fb3228ba91bd8afa08659be0d88883725..633952ecae7be210324caef29429c97e
      PictureInPicture.updateUrlbarToggle(gBrowser.selectedBrowser);
  
      if (!gMultiProcessBrowser) {
-@@ -3809,7 +3814,7 @@ function warnAboutClosingWindow() {
+@@ -3809,7 +3817,7 @@ function warnAboutClosingWindow() {
  
    if (!isPBWindow && !toolbar.visible) {
      return gBrowser.warnAboutClosingTabs(
@@ -39,7 +42,7 @@ index b4b79e7fb3228ba91bd8afa08659be0d88883725..633952ecae7be210324caef29429c97e
        gBrowser.closingTabsEnum.ALL
      );
    }
-@@ -3849,7 +3854,7 @@ function warnAboutClosingWindow() {
+@@ -3849,7 +3857,7 @@ function warnAboutClosingWindow() {
      return (
        isPBWindow ||
        gBrowser.warnAboutClosingTabs(
@@ -48,7 +51,7 @@ index b4b79e7fb3228ba91bd8afa08659be0d88883725..633952ecae7be210324caef29429c97e
          gBrowser.closingTabsEnum.ALL
        )
      );
-@@ -3874,7 +3879,7 @@ function warnAboutClosingWindow() {
+@@ -3874,7 +3882,7 @@ function warnAboutClosingWindow() {
      AppConstants.platform != "macosx" ||
      isPBWindow ||
      gBrowser.warnAboutClosingTabs(
@@ -57,7 +60,7 @@ index b4b79e7fb3228ba91bd8afa08659be0d88883725..633952ecae7be210324caef29429c97e
        gBrowser.closingTabsEnum.ALL
      )
    );
-@@ -4796,6 +4801,9 @@ var ConfirmationHint = {
+@@ -4796,6 +4804,9 @@ var ConfirmationHint = {
      MozXULElement.insertFTLIfNeeded("toolkit/branding/brandings.ftl");
      MozXULElement.insertFTLIfNeeded("browser/confirmationHints.ftl");
      document.l10n.setAttributes(this._message, messageId, options.l10nArgs);

--- a/src/browser/base/content/browser-js.patch
+++ b/src/browser/base/content/browser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/base/content/browser.js b/browser/base/content/browser.js
-index b4b79e7fb3228ba91bd8afa08659be0d88883725..9e1d59b6a736107e55bda73686a4a627e4c0ba7c 100644
+index b4b79e7fb3228ba91bd8afa08659be0d88883725..633952ecae7be210324caef29429c97e928d6014 100644
 --- a/browser/base/content/browser.js
 +++ b/browser/base/content/browser.js
 @@ -31,6 +31,7 @@ ChromeUtils.defineESModuleGetters(this, {
@@ -10,7 +10,18 @@ index b4b79e7fb3228ba91bd8afa08659be0d88883725..9e1d59b6a736107e55bda73686a4a627
    DevToolsSocketStatus:
      "resource://devtools/shared/security/DevToolsSocketStatus.sys.mjs",
    DownloadUtils: "resource://gre/modules/DownloadUtils.sys.mjs",
-@@ -2298,6 +2299,8 @@ var XULBrowserWindow = {
+@@ -822,7 +823,9 @@ function UpdateBackForwardCommands(aWebNavigation) {
+ 
+   var backDisabled = backCommand.hasAttribute("disabled");
+   var forwardDisabled = forwardCommand.hasAttribute("disabled");
+-  if (backDisabled == aWebNavigation.canGoBack) {
++  
++  // Check if we can go back OR if we can close tab and go back to owner
++  if (backDisabled == (aWebNavigation.canGoBack || gZenCommonActions.shouldCloseTabOnBack(gBrowser?.selectedTab))) {
+     if (backDisabled) {
+       backCommand.removeAttribute("disabled");
+     } else {
+@@ -2298,6 +2301,8 @@ var XULBrowserWindow = {
      AboutReaderParent.updateReaderButton(gBrowser.selectedBrowser);
      TranslationsParent.onLocationChange(gBrowser.selectedBrowser);
  
@@ -19,7 +30,7 @@ index b4b79e7fb3228ba91bd8afa08659be0d88883725..9e1d59b6a736107e55bda73686a4a627
      PictureInPicture.updateUrlbarToggle(gBrowser.selectedBrowser);
  
      if (!gMultiProcessBrowser) {
-@@ -3809,7 +3812,7 @@ function warnAboutClosingWindow() {
+@@ -3809,7 +3814,7 @@ function warnAboutClosingWindow() {
  
    if (!isPBWindow && !toolbar.visible) {
      return gBrowser.warnAboutClosingTabs(
@@ -28,7 +39,7 @@ index b4b79e7fb3228ba91bd8afa08659be0d88883725..9e1d59b6a736107e55bda73686a4a627
        gBrowser.closingTabsEnum.ALL
      );
    }
-@@ -3849,7 +3852,7 @@ function warnAboutClosingWindow() {
+@@ -3849,7 +3854,7 @@ function warnAboutClosingWindow() {
      return (
        isPBWindow ||
        gBrowser.warnAboutClosingTabs(
@@ -37,7 +48,7 @@ index b4b79e7fb3228ba91bd8afa08659be0d88883725..9e1d59b6a736107e55bda73686a4a627
          gBrowser.closingTabsEnum.ALL
        )
      );
-@@ -3874,7 +3877,7 @@ function warnAboutClosingWindow() {
+@@ -3874,7 +3879,7 @@ function warnAboutClosingWindow() {
      AppConstants.platform != "macosx" ||
      isPBWindow ||
      gBrowser.warnAboutClosingTabs(
@@ -46,7 +57,7 @@ index b4b79e7fb3228ba91bd8afa08659be0d88883725..9e1d59b6a736107e55bda73686a4a627
        gBrowser.closingTabsEnum.ALL
      )
    );
-@@ -4796,6 +4799,9 @@ var ConfirmationHint = {
+@@ -4796,6 +4801,9 @@ var ConfirmationHint = {
      MozXULElement.insertFTLIfNeeded("toolkit/branding/brandings.ftl");
      MozXULElement.insertFTLIfNeeded("browser/confirmationHints.ftl");
      document.l10n.setAttributes(this._message, messageId, options.l10nArgs);

--- a/src/browser/components/preferences/zenTabsManagement.inc.xhtml
+++ b/src/browser/components/preferences/zenTabsManagement.inc.xhtml
@@ -26,6 +26,9 @@
       <checkbox id="zenWorkspacesForceContainerTabsToWorkspace"
             data-l10n-id="zen-settings-workspaces-force-container-tabs-to-workspace"
             preference="zen.workspaces.force-container-workspace"/>
+      <checkbox id="zenTabsCloseOnBackWithNoHistory"
+            data-l10n-id="zen-tabs-close-on-back-with-no-history"
+            preference="zen.tabs.close-on-back-with-no-history"/>
 </groupbox>
 
 <hbox id="zenTabsUnloadCategory"

--- a/src/zen/common/ZenCommonUtils.mjs
+++ b/src/zen/common/ZenCommonUtils.mjs
@@ -110,7 +110,7 @@ var gZenCommonActions = {
 
   /**
    * Determines if a tab should be closed when navigating back with no history.
-   * Only regular unpinned tabs (not pinned, not empty) are eligible.
+   * Only tabs with an owner that are not pinned and not empty are eligible.
    * Respects the user preference zen.tabs.close-on-back-with-no-history.
    *
    * @return {boolean} True if the tab should be closed on back

--- a/src/zen/common/ZenCommonUtils.mjs
+++ b/src/zen/common/ZenCommonUtils.mjs
@@ -113,13 +113,13 @@ var gZenCommonActions = {
    * Only regular unpinned tabs (not pinned, not empty) are eligible.
    * Respects the user preference zen.tabs.close-on-back-with-no-history.
    *
-   * @param {Tab} tab - The tab to check
    * @return {boolean} True if the tab should be closed on back
    */
-  shouldCloseTabOnBack(tab) {
+  shouldCloseTabOnBack() {
     if (!Services.prefs.getBoolPref('zen.tabs.close-on-back-with-no-history', true)) {
       return false;
     }
-    return tab && !tab.pinned && !tab.hasAttribute('zen-empty-tab');
+    const tab = gBrowser.selectedTab;
+    return Boolean(tab.owner && !tab.pinned && !tab.hasAttribute('zen-empty-tab'));
   },
 };

--- a/src/zen/common/ZenCommonUtils.mjs
+++ b/src/zen/common/ZenCommonUtils.mjs
@@ -107,4 +107,19 @@ var gZenCommonActions = {
       timer = setTimeout(() => f.apply(this, args), delay);
     };
   },
+
+  /**
+   * Determines if a tab should be closed when navigating back with no history.
+   * Only regular unpinned tabs (not pinned, not empty) are eligible.
+   * Respects the user preference zen.tabs.close-on-back-with-no-history.
+   *
+   * @param {Tab} tab - The tab to check
+   * @return {boolean} True if the tab should be closed on back
+   */
+  shouldCloseTabOnBack(tab) {
+    if (!Services.prefs.getBoolPref('zen.tabs.close-on-back-with-no-history', true)) {
+      return false;
+    }
+    return tab && !tab.pinned && !tab.hasAttribute('zen-empty-tab');
+  },
 };


### PR DESCRIPTION
## Description

This PR implements a feature where navigating back on a regular unpinned tab with no browser history will close the tab and switch to the most recently visited tab, providing a more intuitive browsing experience similar to other modern browsers.

## Changes

- **Back navigation with no history now closes regular unpinned tabs**
- Automatically switches to the most recently visited tab
- Works with all input methods:
  - Back button click
  - Keyboard shortcuts (Alt+Left, Cmd+Left)
  - Trackpad swipe gestures

## Implementation Details

### Files Modified

1. **browser/base/content/browser-commands.js**
   - Added logic to check if back navigation is possible
   - If not, close the tab and switch to most recently visited tab
   - Only applies to regular unpinned tabs

2. **browser/base/content/browser.js**
   - Modified `UpdateBackForwardCommands` to keep back button enabled
   - Ensures back button is clickable even with no history for closeable tabs

3. **browser/base/content/browser-gestureSupport.js**
   - Modified `canGoBack` to allow swipe gestures
   - Enables trackpad gestures to trigger tab close

## Tab Types Excluded

The feature only affects regular unpinned tabs and excludes:
- Pinned tabs
- Essential tabs
- Empty tabs (zen-empty-tab)

## Testing

Tested with:
- ✅ Back button click
- ✅ Keyboard shortcuts
- ✅ Trackpad swipe gestures
- ✅ Verified exclusions (pinned, essential tabs)
- ✅ Tab history switching works correctly

b=no-bug, c=tabs, common, gestures