### PR TITLE
feat: Preserve tab owner for back-to-close

### DIFF
--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabbrowser.js b/browser/components/tabbrowser/content/tabbrowser.js
-index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc349868d0d0 100644
+index c0eafd4faf8d57b8486c5bf8917375850ec8147e..3be730e772677a3c7aad3f1dd577b61969460dd2 100644
 --- a/browser/components/tabbrowser/content/tabbrowser.js
 +++ b/browser/components/tabbrowser/content/tabbrowser.js
 @@ -450,15 +450,64 @@
@@ -132,7 +132,25 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
  
        let browser = this.getBrowserForTab(aTab);
        browser.mIconURL = aIconURL;
-@@ -1470,6 +1533,7 @@
+@@ -1377,17 +1440,6 @@
+ 
+       let oldTab = this.selectedTab;
+ 
+-      // Preview mode should not reset the owner
+-      if (!this._previewMode && !oldTab.selected) {
+-        oldTab.owner = null;
+-      }
+-
+-      let lastRelatedTab = this._lastRelatedTabMap.get(oldTab);
+-      if (lastRelatedTab) {
+-        if (!lastRelatedTab.selected) {
+-          lastRelatedTab.owner = null;
+-        }
+-      }
+       this._lastRelatedTabMap = new WeakMap();
+ 
+       if (!gMultiProcessBrowser) {
+@@ -1470,6 +1522,7 @@
        if (!this._previewMode) {
          newTab.recordTimeFromUnloadToReload();
          newTab.updateLastAccessed();
@@ -140,7 +158,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          oldTab.updateLastAccessed();
          // if this is the foreground window, update the last-seen timestamps.
          if (this.ownerGlobal == BrowserWindowTracker.getTopWindow()) {
-@@ -1622,6 +1686,9 @@
+@@ -1622,6 +1675,9 @@
        }
  
        let activeEl = document.activeElement;
@@ -150,7 +168,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        // If focus is on the old tab, move it to the new tab.
        if (activeEl == oldTab) {
          newTab.focus();
-@@ -1945,7 +2012,8 @@
+@@ -1945,7 +2001,8 @@
      }
  
      _setTabLabel(aTab, aLabel, { beforeTabOpen, isContentTitle, isURL } = {}) {
@@ -160,7 +178,20 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          return false;
        }
  
-@@ -2053,7 +2121,7 @@
+@@ -2028,10 +2085,10 @@
+       // i.e.
+       //    Number of URLs    Load UI Links in BG       Focus Last Viewed?
+       //    == 1              false                     YES
+-      //    == 1              true                      NO
++      //    == 1              true                      YES
+       //    > 1               false/true                NO
+       var multiple = aURIs.length > 1;
+-      var owner = multiple || inBackground ? null : this.selectedTab;
++      var owner = multiple ? null : this.selectedTab;
+       var firstTabAdded = null;
+       var targetTabIndex = -1;
+ 
+@@ -2053,7 +2110,7 @@
          newIndex = this.selectedTab._tPos + 1;
        }
  
@@ -169,7 +200,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          if (this.isTabGroupLabel(targetTab)) {
            throw new Error(
              "Replacing a tab group label with a tab is not supported"
-@@ -2328,6 +2396,7 @@
+@@ -2328,6 +2385,7 @@
        uriIsAboutBlank,
        userContextId,
        skipLoad,
@@ -177,7 +208,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
      } = {}) {
        let b = document.createXULElement("browser");
        // Use the JSM global to create the permanentKey, so that if the
-@@ -2401,8 +2470,7 @@
+@@ -2401,8 +2459,7 @@
          // we use a different attribute name for this?
          b.setAttribute("name", name);
        }
@@ -187,7 +218,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          b.setAttribute("transparent", "true");
        }
  
-@@ -2567,7 +2635,7 @@
+@@ -2567,7 +2624,7 @@
  
        let panel = this.getPanel(browser);
        let uniqueId = this._generateUniquePanelID();
@@ -196,7 +227,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        aTab.linkedPanel = uniqueId;
  
        // Inject the <browser> into the DOM if necessary.
-@@ -2626,8 +2694,8 @@
+@@ -2626,8 +2683,8 @@
        // If we transitioned from one browser to two browsers, we need to set
        // hasSiblings=false on both the existing browser and the new browser.
        if (this.tabs.length == 2) {
@@ -207,7 +238,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        } else {
          aTab.linkedBrowser.browsingContext.hasSiblings = this.tabs.length > 1;
        }
-@@ -2814,7 +2882,6 @@
+@@ -2814,7 +2871,6 @@
              this.selectedTab = this.addTrustedTab(BROWSER_NEW_TAB_URL, {
                tabIndex: tab._tPos + 1,
                userContextId: tab.userContextId,
@@ -215,7 +246,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
                focusUrlBar: true,
              });
              resolve(this.selectedBrowser);
-@@ -2923,6 +2990,8 @@
+@@ -2923,6 +2979,8 @@
          schemelessInput,
          hasValidUserGestureActivation = false,
          textDirectiveUserActivation = false,
@@ -224,7 +255,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        } = {}
      ) {
        // all callers of addTab that pass a params object need to pass
-@@ -2933,6 +3002,12 @@
+@@ -2933,17 +2991,17 @@
          );
        }
  
@@ -237,7 +268,19 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        if (!UserInteraction.running("browser.tabs.opening", window)) {
          UserInteraction.start("browser.tabs.opening", "initting", window);
        }
-@@ -2996,6 +3071,19 @@
+ 
+-      // If we're opening a foreground tab, set the owner by default.
+-      ownerTab ??= inBackground ? null : this.selectedTab;
+-
+-      // if we're adding tabs, we're past interrupt mode, ditch the owner
+-      if (this.selectedTab.owner) {
+-        this.selectedTab.owner = null;
+-      }
++      ownerTab ??= this.selectedTab;
+ 
+       // Find the tab that opened this one, if any. This is used for
+       // determining positioning, and inherited attributes such as the
+@@ -2996,6 +3054,19 @@
            noInitialLabel,
            skipBackgroundNotify,
          });
@@ -257,7 +300,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          if (insertTab) {
            // Insert the tab into the tab container in the correct position.
            this.#insertTabAtIndex(t, {
-@@ -3004,6 +3092,7 @@
+@@ -3004,6 +3075,7 @@
              ownerTab,
              openerTab,
              pinned,
@@ -265,7 +308,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
              bulkOrderedOpen,
              tabGroup: tabGroup ?? openerTab?.group,
            });
-@@ -3022,6 +3111,7 @@
+@@ -3022,6 +3094,7 @@
            openWindowInfo,
            skipLoad,
            triggeringRemoteType,
@@ -273,7 +316,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          }));
  
          if (focusUrlBar) {
-@@ -3146,6 +3236,12 @@
+@@ -3146,6 +3219,12 @@
          }
        }
  
@@ -286,7 +329,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        // Additionally send pinned tab events
        if (pinned) {
          this.#notifyPinnedStatus(t);
-@@ -3330,10 +3426,10 @@
+@@ -3330,10 +3409,10 @@
          isAdoptingGroup = false,
          isUserTriggered = false,
          telemetryUserCreateSource = "unknown",
@@ -298,7 +341,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        }
  
        if (!color) {
-@@ -3354,9 +3450,14 @@
+@@ -3354,9 +3433,14 @@
          label,
          isAdoptingGroup
        );
@@ -315,7 +358,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        );
        group.addTabs(tabs);
  
-@@ -3477,7 +3578,7 @@
+@@ -3477,7 +3561,7 @@
        }
  
        this.#handleTabMove(tab, () =>
@@ -324,7 +367,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        );
      }
  
-@@ -3679,6 +3780,7 @@
+@@ -3679,6 +3763,7 @@
          openWindowInfo,
          skipLoad,
          triggeringRemoteType,
@@ -332,7 +375,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        }
      ) {
        // If we don't have a preferred remote type (or it is `NOT_REMOTE`), and
-@@ -3748,6 +3850,7 @@
+@@ -3748,6 +3833,7 @@
            openWindowInfo,
            name,
            skipLoad,
@@ -340,7 +383,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          });
        }
  
-@@ -3935,7 +4038,7 @@
+@@ -3935,7 +4021,7 @@
          // Add a new tab if needed.
          if (!tab) {
            let createLazyBrowser =
@@ -349,7 +392,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
  
            let url = "about:blank";
            if (tabData.entries?.length) {
-@@ -3972,8 +4075,10 @@
+@@ -3972,8 +4058,10 @@
              insertTab: false,
              skipLoad: true,
              preferredRemoteType,
@@ -361,7 +404,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
            if (select) {
              tabToSelect = tab;
            }
-@@ -3985,7 +4090,8 @@
+@@ -3985,7 +4073,8 @@
            this.pinTab(tab);
            // Then ensure all the tab open/pinning information is sent.
            this._fireTabOpen(tab, {});
@@ -371,7 +414,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
            let { groupId } = tabData;
            const tabGroup = tabGroupWorkingData.get(groupId);
            // if a tab refers to a tab group we don't know, skip any group
-@@ -3999,7 +4105,10 @@
+@@ -3999,7 +4088,10 @@
                  tabGroup.stateData.id,
                  tabGroup.stateData.color,
                  tabGroup.stateData.collapsed,
@@ -383,7 +426,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
                );
                tabsFragment.appendChild(tabGroup.node);
              }
-@@ -4044,9 +4153,23 @@
+@@ -4044,9 +4136,23 @@
        // to remove the old selected tab.
        if (tabToSelect) {
          let leftoverTab = this.selectedTab;
@@ -407,7 +450,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
  
        if (tabs.length > 1 || !tabs[0].selected) {
          this._updateTabsAfterInsert();
-@@ -4237,11 +4360,14 @@
+@@ -4237,11 +4343,14 @@
        if (ownerTab) {
          tab.owner = ownerTab;
        }
@@ -423,7 +466,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          if (
            !bulkOrderedOpen &&
            ((openerTab &&
-@@ -4253,7 +4379,7 @@
+@@ -4253,7 +4362,7 @@
            let lastRelatedTab =
              openerTab && this._lastRelatedTabMap.get(openerTab);
            let previousTab = lastRelatedTab || openerTab || this.selectedTab;
@@ -432,7 +475,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
              tabGroup = previousTab.group;
            }
            if (
-@@ -4264,7 +4390,7 @@
+@@ -4264,14 +4373,12 @@
            ) {
              elementIndex = Infinity;
            } else if (previousTab.visible) {
@@ -441,7 +484,15 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
            } else if (previousTab == FirefoxViewHandler.tab) {
              elementIndex = 0;
            }
-@@ -4292,14 +4418,14 @@
+ 
+-          if (lastRelatedTab) {
+-            lastRelatedTab.owner = null;
+-          } else if (openerTab) {
++          if (openerTab && !tab.owner) {
+             tab.owner = openerTab;
+           }
+           // Always set related map if opener exists.
+@@ -4292,14 +4399,14 @@
        }
        // Ensure index is within bounds.
        if (tab.pinned) {
@@ -460,7 +511,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
  
        if (pinned && !itemAfter?.pinned) {
          itemAfter = null;
-@@ -4310,7 +4436,7 @@
+@@ -4310,7 +4417,7 @@
  
        this.tabContainer._invalidateCachedTabs();
  
@@ -469,7 +520,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          if (this.isTab(itemAfter) && itemAfter.group == tabGroup) {
            // Place at the front of, or between tabs in, the same tab group
            this.tabContainer.insertBefore(tab, itemAfter);
-@@ -4346,6 +4472,7 @@
+@@ -4346,6 +4453,7 @@
        if (pinned) {
          this._updateTabBarForPinnedTabs();
        }
@@ -477,7 +528,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
  
        TabBarVisibility.update();
      }
-@@ -4635,6 +4762,9 @@
+@@ -4635,6 +4743,9 @@
          return;
        }
  
@@ -487,7 +538,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        this.removeTabs(selectedTabs, { isUserTriggered, telemetrySource });
      }
  
-@@ -4896,6 +5026,7 @@
+@@ -4896,6 +5007,7 @@
          telemetrySource,
        } = {}
      ) {
@@ -495,7 +546,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        // When 'closeWindowWithLastTab' pref is enabled, closing all tabs
        // can be considered equivalent to closing the window.
        if (
-@@ -4985,6 +5116,7 @@
+@@ -4985,6 +5097,7 @@
          if (lastToClose) {
            this.removeTab(lastToClose, aParams);
          }
@@ -503,7 +554,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        } catch (e) {
          console.error(e);
        }
-@@ -5023,6 +5155,12 @@
+@@ -5023,6 +5136,12 @@
          aTab._closeTimeNoAnimTimerId = Glean.browserTabclose.timeNoAnim.start();
        }
  
@@ -516,7 +567,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        // Handle requests for synchronously removing an already
        // asynchronously closing tab.
        if (!animate && aTab.closing) {
-@@ -5037,6 +5175,9 @@
+@@ -5037,6 +5156,9 @@
        // state).
        let tabWidth = window.windowUtils.getBoundsWithoutFlushing(aTab).width;
        let isLastTab = this.#isLastTabInWindow(aTab);
@@ -526,7 +577,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        if (
          !this._beginRemoveTab(aTab, {
            closeWindowFastpath: true,
-@@ -5085,7 +5226,13 @@
+@@ -5085,7 +5207,13 @@
          // We're not animating, so we can cancel the animation stopwatch.
          Glean.browserTabclose.timeAnim.cancel(aTab._closeTimeAnimTimerId);
          aTab._closeTimeAnimTimerId = null;
@@ -541,7 +592,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          return;
        }
  
-@@ -5219,7 +5366,7 @@
+@@ -5219,7 +5347,7 @@
            closeWindowWithLastTab != null
              ? closeWindowWithLastTab
              : !window.toolbar.visible ||
@@ -550,7 +601,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
  
          if (closeWindow) {
            // We've already called beforeunload on all the relevant tabs if we get here,
-@@ -5243,6 +5390,7 @@
+@@ -5243,6 +5371,7 @@
  
          newTab = true;
        }
@@ -558,7 +609,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        aTab._endRemoveArgs = [closeWindow, newTab];
  
        // swapBrowsersAndCloseOther will take care of closing the window without animation.
-@@ -5283,13 +5431,7 @@
+@@ -5283,13 +5412,7 @@
        aTab._mouseleave();
  
        if (newTab) {
@@ -573,7 +624,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        } else {
          TabBarVisibility.update();
        }
-@@ -5422,6 +5564,7 @@
+@@ -5422,6 +5545,7 @@
          this.tabs[i]._tPos = i;
        }
  
@@ -581,7 +632,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        if (!this._windowIsClosing) {
          // update tab close buttons state
          this.tabContainer._updateCloseButtons();
-@@ -5643,6 +5786,7 @@
+@@ -5643,6 +5767,7 @@
        }
  
        let excludeTabs = new Set(aExcludeTabs);
@@ -589,7 +640,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
  
        // If this tab has a successor, it should be selectable, since
        // hiding or closing a tab removes that tab as a successor.
-@@ -5655,13 +5799,13 @@
+@@ -5655,13 +5780,13 @@
          !excludeTabs.has(aTab.owner) &&
          Services.prefs.getBoolPref("browser.tabs.selectOwnerOnClose")
        ) {
@@ -605,7 +656,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        );
  
        let tab = this.tabContainer.findNextTab(aTab, {
-@@ -5677,7 +5821,7 @@
+@@ -5677,7 +5802,7 @@
        }
  
        if (tab) {
@@ -614,7 +665,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        }
  
        // If no qualifying visible tab was found, see if there is a tab in
-@@ -5698,7 +5842,7 @@
+@@ -5698,7 +5823,7 @@
          });
        }
  
@@ -623,7 +674,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
      }
  
      _blurTab(aTab) {
-@@ -6104,10 +6248,10 @@
+@@ -6104,10 +6229,10 @@
        SessionStore.deleteCustomTabValue(aTab, "hiddenBy");
      }
  
@@ -636,7 +687,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          aTab.selected ||
          aTab.closing ||
          // Tabs that are sharing the screen, microphone or camera cannot be hidden.
-@@ -6166,6 +6310,7 @@
+@@ -6166,6 +6291,7 @@
       * @param {MozTabbrowserTab|MozTabbrowserTabGroup|MozTabbrowserTabGroup.labelElement} aTab
       */
      replaceTabWithWindow(aTab, aOptions) {
@@ -644,7 +695,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        if (this.tabs.length == 1) {
          return null;
        }
-@@ -6299,7 +6444,7 @@
+@@ -6299,7 +6425,7 @@
       *   `true` if element is a `<tab-group>`
       */
      isTabGroup(element) {
@@ -653,7 +704,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
      }
  
      /**
-@@ -6375,8 +6520,8 @@
+@@ -6375,8 +6501,8 @@
        }
  
        // Don't allow mixing pinned and unpinned tabs.
@@ -664,7 +715,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        } else {
          tabIndex = Math.max(tabIndex, this.pinnedTabCount);
        }
-@@ -6402,10 +6547,16 @@
+@@ -6402,10 +6528,16 @@
        this.#handleTabMove(
          element,
          () => {
@@ -683,7 +734,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
            if (neighbor && this.isTab(element) && tabIndex > element._tPos) {
              neighbor.after(element);
            } else {
-@@ -6463,23 +6614,28 @@
+@@ -6463,23 +6595,28 @@
      #moveTabNextTo(element, targetElement, moveBefore = false, metricsContext) {
        if (this.isTabGroupLabel(targetElement)) {
          targetElement = targetElement.group;
@@ -718,7 +769,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        } else if (!element.pinned && targetElement && targetElement.pinned) {
          // If the caller asks to move an unpinned element next to a pinned
          // tab, move the unpinned element to be the first unpinned element
-@@ -6492,14 +6648,34 @@
+@@ -6492,14 +6629,34 @@
          //    move the tab group right before the first unpinned tab.
          // 4. Moving a tab group and the first unpinned tab is grouped:
          //    move the tab group right before the first unpinned tab's tab group.
@@ -754,7 +805,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          element.pinned
            ? this.tabContainer.pinnedTabsContainer
            : this.tabContainer;
-@@ -6508,7 +6684,7 @@
+@@ -6508,7 +6665,7 @@
          element,
          () => {
            if (moveBefore) {
@@ -763,7 +814,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
            } else if (targetElement) {
              targetElement.after(element);
            } else {
-@@ -6580,10 +6756,10 @@
+@@ -6580,10 +6737,10 @@
       * @param {TabMetricsContext} [metricsContext]
       */
      moveTabToGroup(aTab, aGroup, metricsContext) {
@@ -776,7 +827,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          return;
        }
        if (aTab.group && aTab.group.id === aGroup.id) {
-@@ -6613,6 +6789,7 @@
+@@ -6613,6 +6770,7 @@
  
        let state = {
          tabIndex: tab._tPos,
@@ -784,7 +835,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        };
        if (tab.visible) {
          state.elementIndex = tab.elementIndex;
-@@ -6639,7 +6816,7 @@
+@@ -6639,7 +6797,7 @@
        let changedTabGroup =
          previousTabState.tabGroupId != currentTabState.tabGroupId;
  
@@ -793,7 +844,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
          tab.dispatchEvent(
            new CustomEvent("TabMove", {
              bubbles: true,
-@@ -6676,6 +6853,10 @@
+@@ -6676,6 +6834,10 @@
  
        moveActionCallback();
  
@@ -804,7 +855,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
        // Clear tabs cache after moving nodes because the order of tabs may have
        // changed.
        this.tabContainer._invalidateCachedTabs();
-@@ -7576,7 +7757,7 @@
+@@ -7576,7 +7738,7 @@
              // preventDefault(). It will still raise the window if appropriate.
              break;
            }
@@ -813,7 +864,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
            window.focus();
            aEvent.preventDefault();
            break;
-@@ -7593,7 +7774,6 @@
+@@ -7593,7 +7755,6 @@
          }
          case "TabGroupCollapse":
            aEvent.target.tabs.forEach(tab => {
@@ -821,7 +872,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
            });
            break;
          case "TabGroupCreateByUser":
-@@ -8542,6 +8722,7 @@
+@@ -8542,6 +8703,7 @@
              aWebProgress.isTopLevel
            ) {
              this.mTab.setAttribute("busy", "true");
@@ -829,7 +880,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
              gBrowser._tabAttrModified(this.mTab, ["busy"]);
              this.mTab._notselectedsinceload = !this.mTab.selected;
            }
-@@ -9543,7 +9724,7 @@ var TabContextMenu = {
+@@ -9543,7 +9705,7 @@ var TabContextMenu = {
      );
      contextUnpinSelectedTabs.hidden =
        !this.contextTab.pinned || !this.multiselected;
@@ -838,7 +889,7 @@ index c0eafd4faf8d57b8486c5bf8917375850ec8147e..326bf96d9346aba7096d518fbf63cc34
      // Build Ask Chat items
      TabContextMenu.GenAI.buildTabMenu(
        document.getElementById("context_askChat"),
-@@ -9863,6 +10044,7 @@ var TabContextMenu = {
+@@ -9863,6 +10025,7 @@ var TabContextMenu = {
          )
        );
      } else {


### PR DESCRIPTION
I was testing on Twilight and Firefox is aggressively removing tab owners in some cases. These changes attempt to maintain persistent tab owner relationships to enable consistent back-to-close behavior similar to Arc Browser.

## Changes

**Modified `tabbrowser.js` in 3 places:**

1. **Background tabs now set owner** - Ctrl+Click and middle-click tabs maintain owner relationship
    - It seems like this was usually happening anyway despite what this part of the code would suggest. I'm fine with removing this if you think it's unnecessary
2. **Switching tabs preserves owner** - Owner no longer cleared when changing tabs
    - If you spawned a new tab then switch tabs around, the owner is lost and back-to-close no longer works. 
3. **Related tab chains keep owner** - Multiple tabs opened from same source all maintain owner

## Testing

1. **Ctrl+Click**: Click link with Ctrl → switch to tab → press back → returns to original tab
2. **Multiple tabs**: Open several from one page → all can return to that page
3. **Tab switching**: Switch tabs multiple times → back still works

b=no-bug, c=tabs