### PR TITLE
Add “Open Link in Glance” option to context menu

### DIFF
--- a/locales/en-US/browser/browser/zen-general.ftl
+++ b/locales/en-US/browser/browser/zen-general.ftl
@@ -116,3 +116,8 @@ zen-site-data-setting-site-protection = Tracking Protection
 
 zen-site-data-panel-feature-callout-title = A new home for add-ons, permissions, and more
 zen-site-data-panel-feature-callout-subtitle = Click the icon to manage site settings, view security info, access extensions, and perform common actions.
+
+
+zen-open-link-in-glance =
+    .label = Open Link in Glance
+    .accesskey = G

--- a/locales/en-US/browser/browser/zen-general.ftl
+++ b/locales/en-US/browser/browser/zen-general.ftl
@@ -117,7 +117,6 @@ zen-site-data-setting-site-protection = Tracking Protection
 zen-site-data-panel-feature-callout-title = A new home for add-ons, permissions, and more
 zen-site-data-panel-feature-callout-subtitle = Click the icon to manage site settings, view security info, access extensions, and perform common actions.
 
-
 zen-open-link-in-glance =
     .label = Open Link in Glance
     .accesskey = G

--- a/src/browser/base/content/nsContextMenu-sys-mjs.patch
+++ b/src/browser/base/content/nsContextMenu-sys-mjs.patch
@@ -1,16 +1,13 @@
 diff --git a/browser/base/content/nsContextMenu.sys.mjs b/browser/base/content/nsContextMenu.sys.mjs
-index 259b440375c7e84d373a134fea20cdbc1c1bae4b..f54d4e18e2ab11b3bc21d3b5b4de32df3d832e23 100644
+index 259b440375c7e84d373a134fea20cdbc1c1bae4b..c4a251f0169d22186c2766992ab40366d53582f1 100644
 --- a/browser/base/content/nsContextMenu.sys.mjs
 +++ b/browser/base/content/nsContextMenu.sys.mjs
-@@ -1104,6 +1104,10 @@ export class nsContextMenu {
+@@ -1103,6 +1103,8 @@ export class nsContextMenu {
+         !this.onMozExtLink &&
          !this.isSecureAboutPage()
      );
- 
-+    // Show Zen Split View link option
 +    this.showItem("context-zenSplitLink", this.onLink && !this.onMailtoLink && !this.onTelLink);
-+
-+    // Show Open Link in Glance option
 +    this.showItem("context-zenOpenLinkInGlance", this.onLink && !this.onMailtoLink && !this.onTelLink);
-+
+ 
      let canNotStrip =
        lazy.STRIP_ON_SHARE_CAN_DISABLE && !this.#canStripParams();

--- a/src/browser/base/content/nsContextMenu-sys-mjs.patch
+++ b/src/browser/base/content/nsContextMenu-sys-mjs.patch
@@ -1,13 +1,16 @@
 diff --git a/browser/base/content/nsContextMenu.sys.mjs b/browser/base/content/nsContextMenu.sys.mjs
-index 259b440375c7e84d373a134fea20cdbc1c1bae4b..a9ce22a2391b4ec0bf82ceedd35f4c9d9626bb28 100644
+index 259b440375c7e84d373a134fea20cdbc1c1bae4b..f54d4e18e2ab11b3bc21d3b5b4de32df3d832e23 100644
 --- a/browser/base/content/nsContextMenu.sys.mjs
 +++ b/browser/base/content/nsContextMenu.sys.mjs
-@@ -1104,6 +1104,8 @@ export class nsContextMenu {
+@@ -1104,6 +1104,10 @@ export class nsContextMenu {
          !this.isSecureAboutPage()
      );
  
++    // Show Zen Split View link option
 +    this.showItem("context-zenSplitLink", this.onLink && !this.onMailtoLink && !this.onTelLink);
++
++    // Show Open Link in Glance option
++    this.showItem("context-zenOpenLinkInGlance", this.onLink && !this.onMailtoLink && !this.onTelLink);
 +
      let canNotStrip =
        lazy.STRIP_ON_SHARE_CAN_DISABLE && !this.#canStripParams();
- 

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -66,23 +66,16 @@
     }
 
     #insertIntoContextMenu() {
-      const sibling = document.getElementById("context-sep-open");
-      if (!sibling) return;
-  
       const menuitem = document.createXULElement("menuitem");
       menuitem.setAttribute("id", "context-zenOpenLinkInGlance");
       menuitem.setAttribute("hidden", "true");
       menuitem.setAttribute("data-l10n-id", "zen-open-link-in-glance");
   
-      // Bind directly to this.openLinkInGlance (no separate command)
-      menuitem.addEventListener("command", this.openLinkInGlance.bind(this));
-  
-      sibling.insertAdjacentElement("beforebegin", menuitem);
-    }
-
-    openLinkInGlance() {
-      const url = gContextMenu.linkURL || gContextMenu.target.ownerDocument.location.href;
-      this.openGlance({ url });
+      menuitem.addEventListener("command", () => this.openGlance({ url: gContextMenu.linkURL }));
+    
+      document
+        .getElementById("context-sep-open")
+        .insertAdjacentElement("beforebegin", menuitem);
     }
 
     /**

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -40,6 +40,7 @@
       this.#setupEventListeners();
       this.#setupPreferences();
       this.#setupObservers();
+      this.#insertIntoContextMenu();
     }
 
     #setupEventListeners() {
@@ -62,6 +63,26 @@
 
     #setupObservers() {
       Services.obs.addObserver(this, 'quit-application-requested');
+    }
+
+    #insertIntoContextMenu() {
+      const sibling = document.getElementById("context-sep-open");
+      if (!sibling) return;
+  
+      const menuitem = document.createXULElement("menuitem");
+      menuitem.setAttribute("id", "context-zenOpenLinkInGlance");
+      menuitem.setAttribute("hidden", "true");
+      menuitem.setAttribute("data-l10n-id", "zen-open-link-in-glance");
+  
+      // Bind directly to this.openLinkInGlance (no separate command)
+      menuitem.addEventListener("command", this.openLinkInGlance.bind(this));
+  
+      sibling.insertAdjacentElement("beforebegin", menuitem);
+    }
+
+    openLinkInGlance() {
+      const url = gContextMenu.linkURL || gContextMenu.target.ownerDocument.location.href;
+      this.openGlance({ url });
     }
 
     /**

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -66,16 +66,14 @@
     }
 
     #insertIntoContextMenu() {
-      const menuitem = document.createXULElement("menuitem");
-      menuitem.setAttribute("id", "context-zenOpenLinkInGlance");
-      menuitem.setAttribute("hidden", "true");
-      menuitem.setAttribute("data-l10n-id", "zen-open-link-in-glance");
-  
-      menuitem.addEventListener("command", () => this.openGlance({ url: gContextMenu.linkURL }));
-    
-      document
-        .getElementById("context-sep-open")
-        .insertAdjacentElement("beforebegin", menuitem);
+      const menuitem = document.createXULElement('menuitem');
+      menuitem.setAttribute('id', 'context-zenOpenLinkInGlance');
+      menuitem.setAttribute('hidden', 'true');
+      menuitem.setAttribute('data-l10n-id', 'zen-open-link-in-glance');
+
+      menuitem.addEventListener('command', () => this.openGlance({ url: gContextMenu.linkURL }));
+
+      document.getElementById('context-sep-open').insertAdjacentElement('beforebegin', menuitem);
     }
 
     /**


### PR DESCRIPTION
Introduces a new context menu option that allows users to open links directly in Zen Glance.

Made directly in github, didn't want to download the whole repo, so forgive my poor commits, instead I'll give a summary here.

- **`ZenGlanceManager.mjs`**
  - Inserts a new context menu item before `context-sep-open`

- **`nsContextMenu.sys.mjs`**
  - Shows the new `context-zenOpenLinkInGlance` item when right-clicking a standard link (non-mailto, non-tel)

- **`zen-general.ftl`**
  - Added localized strings:
    ```ftl
    zen-open-link-in-glance =
        .label = Open Link in Glance
        .accesskey = G
    ```