### PR TITLE
fix: Fix bookmarks toolbar flickering when in sidebar-only mode

### DIFF
--- a/src/browser/base/content/browser-sets-js.patch
+++ b/src/browser/base/content/browser-sets-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/base/content/browser-sets.js b/browser/base/content/browser-sets.js
-index 9cff49a7b86f7697f70c4ef61d3c3561f058dc45..15ac9a8a79e8642b3add2f6df63ed32eb0c8bcb9 100644
+index 9cff49a7b86f7697f70c4ef61d3c3561f058dc45..64148f58b1a69872b013f636128528c2aed2f6a2 100644
 --- a/browser/base/content/browser-sets.js
 +++ b/browser/base/content/browser-sets.js
 @@ -253,7 +253,7 @@ document.addEventListener(
@@ -11,3 +11,14 @@ index 9cff49a7b86f7697f70c4ef61d3c3561f058dc45..15ac9a8a79e8642b3add2f6df63ed32e
        const SIDEBAR_REVAMP_PREF = "sidebar.revamp";
        const SIDEBAR_REVAMP_ENABLED = Services.prefs.getBoolPref(
          SIDEBAR_REVAMP_PREF,
+@@ -270,7 +270,9 @@ document.addEventListener(
+           SidebarController.toggle("viewBookmarksSidebar");
+           break;
+         case "viewBookmarksToolbarKb":
+-          BookmarkingUI.toggleBookmarksToolbar("shortcut");
++          if (!Services.prefs.getBoolPref("zen.view.use-single-toolbar", false)) {
++            BookmarkingUI.toggleBookmarksToolbar("shortcut");
++          }
+           break;
+         case "viewGenaiChatSidebarKb": {
+           const pref = "browser.ml.chat.enabled";


### PR DESCRIPTION
The bookmarks toolbar would flicker when its keybind was pressed in sidebar-only mode. This fix changes this behavior to make the toolbar not appear at all.

Fixes #11244 