### PR TITLE
fix(split-view): left-align close buttons in split view tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -65,7 +64,6 @@
       "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -108,7 +106,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -149,7 +146,6 @@
       "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.26.8",
         "@babel/helper-validator-option": "^7.25.9",
@@ -167,7 +163,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -341,7 +336,6 @@
       "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/template": "^7.27.0",
         "@babel/types": "^7.27.0"
@@ -1173,6 +1167,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1846,8 +1841,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0",
-      "peer": true
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2034,8 +2028,7 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/core-js-pure": {
       "version": "3.41.0",
@@ -2355,8 +2348,7 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.139.tgz",
       "integrity": "sha512-GGnRYOTdN5LYpwbIr0rwP/ZHOQSvAF6TG0LSzp28uCBb9JiXHJGmaaKw29qjNJc5bGnnp6kXJqRnGMQoELwi5w==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2592,7 +2584,6 @@
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2616,6 +2607,7 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3463,7 +3455,6 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4461,7 +4452,6 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -4896,7 +4886,6 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -5111,8 +5100,7 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5568,6 +5556,7 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6982,7 +6971,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -7264,8 +7252,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.7.0",

--- a/src/zen/split-view/zen-split-group.inc.css
+++ b/src/zen/split-view/zen-split-group.inc.css
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-tab-group[split-view-group] {
+ tab-group[split-view-group] {
   display: block;
 
   @media (prefers-reduced-motion: no-preference) {
@@ -173,9 +173,37 @@ tab-group[split-view-group] .tab-group-label-container {
   margin: 2px 0 0 0 !important;
 }
 
-tab-group[split-view-group] .tab-close-button {
-  display: block;
-  visibility: visible;
+/* Split view tab close button positioning
+   Position close buttons on the left edge to prevent accidental closes when clicking
+   the center area to switch tabs. This ensures all tabs (including the last) have
+   consistent left-edge positioning. */
+tab-group[split-view-group] .tab-group-container > .tabbrowser-tab {
+  position: relative;
+}
+
+tab-group[split-view-group] .tab-group-container > .tabbrowser-tab .tab-close-button {
+  display: block !important;
+  visibility: visible !important;
+  position: absolute !important;
+  left: 4px !important;
+  right: auto !important;
+  margin-inline-start: 0 !important;
+  margin-inline-end: auto !important;
+  margin-left: 0 !important;
+  margin-right: auto !important;
+  z-index: 10;
+  transform: none !important;
+  order: -1 !important;
+}
+
+tab-group[split-view-group] .tab-group-container > .tabbrowser-tab:last-child .tab-close-button {
+  left: 4px !important;
+  right: auto !important;
+}
+
+tab-group[split-view-group] .tab-group-container > .tabbrowser-tab .tab-content {
+  padding-inline-start: 28px !important;
+  justify-content: flex-start !important;
 }
 
 tab-group[split-view-group] .tab-group-line {


### PR DESCRIPTION
## Problem Statement

When switching from a normal tab to a split view tab group in the vertical tab bar, users often click the center area of the split view group. However, with multiple tabs (3-4) in split view, the close buttons (X) appear in the center area where users naturally click, leading to accidental tab closes.

I personally faced this problem while having a split view group for my reading session across multiple tabs. I accidentally closed the tabs multiple times while switching.

**User Impact:**

- Accidental tab closes when clicking center to switch tabs
- Poor UX especially with 3-4 tabs in split view

## Proposed Solution

Position all close buttons on the **left edge** of each tab in split view groups, instead of right/center positioning. This minimal change:

- Prevents accidental closes when clicking center area
- Maintains close button accessibility
- Zero breaking changes. It's just repositioning for better UX.

## Changes

- Modified `src/zen/split-view/zen-split-group.inc.css` to position close buttons on left edge
- Added padding to tab content to accommodate left-positioned buttons

## Testing

Tested with:
- 2 tabs in split view
- 3-4 tabs in split view (most problematic case)
- Switching from normal tabs to split view groups

## Screenshots

<img width="1624" height="971" alt="Screenshot 2025-11-11 at 1 22 20 PM" src="https://github.com/user-attachments/assets/63fced04-7aec-40c6-bdf4-a93b298929ac" />
