### PR TITLE
Feature: previous/next tab shortcuts

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -350,3 +350,5 @@ zen-devtools-toggle-storage-shortcut = Toggle Storage
 zen-devtools-toggle-dom-shortcut = Toggle DOM
 zen-devtools-toggle-accessibility-shortcut = Toggle Accessibility
 zen-close-all-unpinned-tabs-shortcut = Close All Unpinned Tabs
+zen-tab-next-shortcut = Next Tab
+zen-tab-previous-shortcut = Previous Tab

--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -352,3 +352,5 @@ zen-devtools-toggle-accessibility-shortcut = Toggle Accessibility
 zen-close-all-unpinned-tabs-shortcut = Close All Unpinned Tabs
 zen-tab-next-shortcut = Next Tab
 zen-tab-previous-shortcut = Previous Tab
+zen-move-tab-forward-shortcut = Move Tab Forward
+zen-move-tab-backward-shortcut = Move Tab Backward

--- a/src/browser/base/content/zen-commands.inc.xhtml
+++ b/src/browser/base/content/zen-commands.inc.xhtml
@@ -64,4 +64,6 @@
 
   <command id="cmd_zenTabNext" />
   <command id="cmd_zenTabPrevious" />
+  <command id="cmd_zenMoveTabForward" />
+  <command id="cmd_zenMoveTabBackward" />
 </commandset>

--- a/src/browser/base/content/zen-commands.inc.xhtml
+++ b/src/browser/base/content/zen-commands.inc.xhtml
@@ -61,4 +61,7 @@
 
   <command id="cmd_zenTogglePinTab" />
   <command id="cmd_zenCloseUnpinnedTabs" />
+
+  <command id="cmd_zenTabNext" />
+  <command id="cmd_zenTabPrevious" />
 </commandset>

--- a/src/zen/common/zen-sets.js
+++ b/src/zen/common/zen-sets.js
@@ -129,6 +129,12 @@ document.addEventListener(
             gZenWorkspaces.unloadWorkspace();
             break;
           }
+          case 'cmd_zenTabNext':
+            gBrowser.tabContainer.advanceSelectedTab(1, true);
+            break;
+          case 'cmd_zenTabPrevious':
+            gBrowser.tabContainer.advanceSelectedTab(-1, true);
+            break;
           default:
             gZenGlanceManager.handleMainCommandSet(event);
             if (event.target.id.startsWith('cmd_zenWorkspaceSwitch')) {

--- a/src/zen/common/zen-sets.js
+++ b/src/zen/common/zen-sets.js
@@ -135,6 +135,12 @@ document.addEventListener(
           case 'cmd_zenTabPrevious':
             gBrowser.tabContainer.advanceSelectedTab(-1, true);
             break;
+          case 'cmd_zenMoveTabForward':
+            gBrowser.moveTabForward();
+            break;
+          case 'cmd_zenMoveTabBackward':
+            gBrowser.moveTabBackward();
+            break;
           default:
             gZenGlanceManager.handleMainCommandSet(event);
             if (event.target.id.startsWith('cmd_zenWorkspaceSwitch')) {

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -54,6 +54,8 @@ const defaultKeyboardGroups = {
     'zen-close-shortcut',
     'zen-tab-next-shortcut',
     'zen-tab-previous-shortcut',
+    'zen-move-tab-forward-shortcut',
+    'zen-move-tab-backward-shortcut',
     'id:key_selectTab1',
     'id:key_selectTab2',
     'id:key_selectTab3',
@@ -1100,33 +1102,51 @@ class nsZenKeyboardShortcutsVersioner {
 
     if (version < 14) {
       // Migrate from version 13 to 14
-      // Add customizable tab navigation shortcuts (Next Tab and Previous Tab)
-      if (!data.find(s => s.id === 'zen-tab-next')) {
-        data.push(
-          new KeyShortcut(
-            'zen-tab-next',
-            '',
-            'VK_TAB',
-            'windowAndTabManagement',
-            nsKeyShortcutModifiers.fromObject({ accel: true }),
-            'cmd_zenTabNext',
-            'zen-tab-next-shortcut'
-          )
-        );
-      }
-      if (!data.find(s => s.id === 'zen-tab-previous')) {
-        data.push(
-          new KeyShortcut(
-            'zen-tab-previous',
-            '',
-            'VK_TAB',
-            'windowAndTabManagement',
-            nsKeyShortcutModifiers.fromObject({ accel: true, shift: true }),
-            'cmd_zenTabPrevious',
-            'zen-tab-previous-shortcut'
-          )
-        );
-      }
+      // Add customizable tab navigation and move tab shortcuts
+      data.push(
+        new KeyShortcut(
+          'zen-tab-next',
+          '',
+          'VK_TAB',
+          'windowAndTabManagement',
+          nsKeyShortcutModifiers.fromObject({ accel: true }),
+          'cmd_zenTabNext',
+          'zen-tab-next-shortcut'
+        )
+      );
+      data.push(
+        new KeyShortcut(
+          'zen-tab-previous',
+          '',
+          'VK_TAB',
+          'windowAndTabManagement',
+          nsKeyShortcutModifiers.fromObject({ accel: true, shift: true }),
+          'cmd_zenTabPrevious',
+          'zen-tab-previous-shortcut'
+        )
+      );
+      data.push(
+        new KeyShortcut(
+          'zen-move-tab-forward',
+          '',
+          '',
+          'windowAndTabManagement',
+          nsKeyShortcutModifiers.fromObject({}),
+          'cmd_zenMoveTabForward',
+          'zen-move-tab-forward-shortcut'
+        )
+      );
+      data.push(
+        new KeyShortcut(
+          'zen-move-tab-backward',
+          '',
+          '',
+          'windowAndTabManagement',
+          nsKeyShortcutModifiers.fromObject({}),
+          'cmd_zenMoveTabBackward',
+          'zen-move-tab-backward-shortcut'
+        )
+      );
     }
 
     return data;

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -52,6 +52,8 @@ const defaultKeyboardGroups = {
     'zen-close-all-unpinned-tabs-shortcut',
     'zen-close-tab-shortcut',
     'zen-close-shortcut',
+    'zen-tab-next-shortcut',
+    'zen-tab-previous-shortcut',
     'id:key_selectTab1',
     'id:key_selectTab2',
     'id:key_selectTab3',
@@ -800,7 +802,7 @@ class nsZenKeyboardShortcutsLoader {
 }
 
 class nsZenKeyboardShortcutsVersioner {
-  static LATEST_KBS_VERSION = 13;
+  static LATEST_KBS_VERSION = 14;
 
   constructor() {}
 
@@ -1094,6 +1096,37 @@ class nsZenKeyboardShortcutsVersioner {
           'zen-close-all-unpinned-tabs-shortcut'
         )
       );
+    }
+
+    if (version < 14) {
+      // Migrate from version 13 to 14
+      // Add customizable tab navigation shortcuts (Next Tab and Previous Tab)
+      if (!data.find(s => s.id === 'zen-tab-next')) {
+        data.push(
+          new KeyShortcut(
+            'zen-tab-next',
+            '',
+            'VK_TAB',
+            'windowAndTabManagement',
+            nsKeyShortcutModifiers.fromObject({ accel: true }),
+            'cmd_zenTabNext',
+            'zen-tab-next-shortcut'
+          )
+        );
+      }
+      if (!data.find(s => s.id === 'zen-tab-previous')) {
+        data.push(
+          new KeyShortcut(
+            'zen-tab-previous',
+            '',
+            'VK_TAB',
+            'windowAndTabManagement',
+            nsKeyShortcutModifiers.fromObject({ accel: true, shift: true }),
+            'cmd_zenTabPrevious',
+            'zen-tab-previous-shortcut'
+          )
+        );
+      }
     }
 
     return data;


### PR DESCRIPTION
Added shortcut options for Previous / Next tab navigation and Move tab Forward / backwards.

removing the default Firefox ctrl+tab tab cycling however would require a patch and more maintenance, so i just added the option for "extra" shortcuts.