### PR TITLE
fix: Fix bookmark toolbar flickering when in sidebar-only mode

### DIFF
--- a/src/zen/tabs/zen-tabs.css
+++ b/src/zen/tabs/zen-tabs.css
@@ -34,10 +34,12 @@
 
     /* Include styles for the top bar under certain conditions:
       * - Bookmarks toolbar is visible OR
-      * - The container is explicitly marked to hide controls (e.g., on Linux with reversed controls)
+      * - The container is explicitly marked to hide controls (e.g., on Linux with reversed controls) OR
+      * - Sidebar is on the left (to prevent flash when toggling bookmarks)
       */
     :root[zen-has-bookmarks] &,
-    &[should-hide='true'] {
+    &[should-hide='true'],
+    :root:not([zen-right-side='true']) & {
 %include zen-tabs/vertical-tabs-topbar.inc.css
     }
 
@@ -49,6 +51,7 @@
       pointer-events: none !important;
     }
   }
+
 }
 
 

--- a/src/zen/tabs/zen-tabs/vertical-tabs-topbar.inc.css
+++ b/src/zen/tabs/zen-tabs/vertical-tabs-topbar.inc.css
@@ -9,6 +9,10 @@
 height: var(--zen-toolbar-height);
 z-index: 1;
 
+& .zen-toolbar-background {
+  display: flex;
+}
+
 #zen-appcontent-navbar-container {
   display: flex;
   min-height: var(--zen-toolbar-height);
@@ -22,7 +26,8 @@ z-index: 1;
 
 %include ../../compact-mode/windows-captions-fix-active.inc.css
 
-  &:not([zen-has-hover='true']):not([has-popup-menu]):not([zen-compact-mode-active]) {
+  &:not([zen-has-hover='true']):not([has-popup-menu]):not([zen-compact-mode-active]),
+  :root:not([zen-right-side='true']):not([zen-has-bookmarks]) & {
     height: var(--zen-element-separation);
     opacity: 0;
     & #zen-appcontent-navbar-container {
@@ -39,5 +44,19 @@ z-index: 1;
       opacity: 0 !important;
       pointer-events: none !important;
     }
+  }
+}
+
+/* When sidebar is on left, position contents absolutely to overlay on hover */
+:root:not([zen-right-side='true']) & {
+  /* Keep wrapper in flow to reserve space, but position contents absolutely */
+  position: relative;
+
+  & #zen-appcontent-navbar-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
   }
 }


### PR DESCRIPTION
These changes fix the behavior of the bookmark toolbar's icons and text flickering upon being toggled via keybind while in sidebar-only mode. This was happening only while the sidebar was left-aligned due to inconsistent styling application.

Fixes #11244