### PR TITLE
Fix extension settings panel failing to open from empty tabs (#7265)

### DIFF
--- a/src/toolkit/components/extensions/parent/ext-tabs-base-js.patch
+++ b/src/toolkit/components/extensions/parent/ext-tabs-base-js.patch
@@ -1,0 +1,64 @@
+diff --git a/toolkit/components/extensions/parent/ext-tabs-base.js b/toolkit/components/extensions/parent/ext-tabs-base.js
+index d3c2d62406d17a14b0288752c34b6dd4350f032a..2f970d41b8ada9a13fc18b8d2a6607b973983072 100644
+--- a/toolkit/components/extensions/parent/ext-tabs-base.js
++++ b/toolkit/components/extensions/parent/ext-tabs-base.js
+@@ -1942,6 +1942,7 @@ class TabManagerBase {
+    */
+   addActiveTabPermission(nativeTab) {
+     let tab = this.getWrapper(nativeTab);
++    if (!tab) return; // Empty tabs aren't tracked, nothing to add
+     if (
+       this.extension.hasPermission("activeTab") ||
+       (this.extension.originControls &&
+@@ -1963,7 +1964,9 @@ class TabManagerBase {
+    *        The native tab for which to revoke permissions.
+    */
+   revokeActiveTabPermission(nativeTab) {
+-    this.getWrapper(nativeTab).activeTabWindowID = null;
++    let wrapper = this.getWrapper(nativeTab);
++    if (!wrapper) return; // Empty tabs arent tracked, nothing to revoke
++    wrapper.activeTabWindowID = null;
+   }
+ 
+   /**
+@@ -1976,7 +1979,9 @@ class TabManagerBase {
+    *        True if the extension has activeTab permissions for this tab.
+    */
+   hasActiveTabPermission(nativeTab) {
+-    return this.getWrapper(nativeTab).hasActiveTabPermission;
++    let wrapper = this.getWrapper(nativeTab);
++    if (!wrapper) return false; // Empty tabs arent tracked, nothing to check
++    return wrapper.hasActiveTabPermission;
+   }
+ 
+   /**
+@@ -1987,6 +1992,7 @@ class TabManagerBase {
+    */
+   activateScripts(nativeTab) {
+     let tab = this.getWrapper(nativeTab);
++    if (!tab) return; // Empty tabs aren't tracked, nothing to activate
+     if (
+       this.extension.originControls &&
+       !tab.matchesHostPermission &&
+@@ -2019,7 +2025,9 @@ class TabManagerBase {
+    *        True if the extension has permissions for this tab.
+    */
+   hasTabPermission(nativeTab) {
+-    return this.getWrapper(nativeTab).hasTabPermission;
++    let wrapper = this.getWrapper(nativeTab);
++    if (!wrapper) return false; // Empty tabs arent tracked, nothing to check
++    return wrapper.hasTabPermission;
+   }
+ 
+   /**
+@@ -2066,7 +2074,9 @@ class TabManagerBase {
+    * @returns {object}
+    */
+   convert(nativeTab, fallbackTabSize = null) {
+-    return this.getWrapper(nativeTab).convert(fallbackTabSize);
++    let wrapper = this.getWrapper(nativeTab);
++    if (!wrapper) return null; // Empty tabs aren't tracked, can't convert
++    return wrapper.convert(fallbackTabSize);
+   }
+ 
+   /**


### PR DESCRIPTION
## Problem

When opening Zen with a blank/empty tab (no landing page), clicking on an extension button (e.g., uBlock Origin) to open its settings panel fails with a `TypeError`. The settings panel does not open unless you first open a new tab.

**Error:**
`TypeError: can't access property "activeTabWindowID", this.getWrapper(...) is undefined`


## Root Cause

Zen Browser intentionally excludes empty tabs (tabs with `zen-empty-tab` attribute) from extension tracking via `canAccessTab()` returning `false` for these tabs. This means `getWrapper()` returns `undefined` for empty tabs.

However, several methods in `ext-tabs-base.js` were accessing properties on the wrapper without checking if it exists first, causing TypeErrors when called with empty tabs:

- `revokeActiveTabPermission()` - accessed `activeTabWindowID` without null check
- `hasActiveTabPermission()` - accessed `hasActiveTabPermission` without null check
- `hasTabPermission()` - accessed `hasTabPermission` without null check
- `convert()` - called `convert()` method without null check
- `addActiveTabPermission()` - accessed `_uri` and other properties without null check
- `activateScripts()` - accessed `matchesHostPermission` and `_uri` without null check

## Solution

Added defensive null checks to all methods that call `getWrapper()` and access properties on the result. This ensures that when empty tabs are passed (which are intentionally excluded from extension tracking), the methods handle the `undefined` wrapper gracefully:

- Methods that modify state (`revokeActiveTabPermission`, `addActiveTabPermission`, `activateScripts`) return early if wrapper is undefined
- Methods that return boolean values (`hasActiveTabPermission`, `hasTabPermission`) return `false` if wrapper is undefined
- Methods that return objects (`convert`) return `null` if wrapper is undefined

This maintains Zen's design decision to exclude empty tabs from extension tracking while preventing crashes when extension code tries to interact with them.

## Changes

- Added null checks in `ext-tabs-base.js` for all methods that access wrapper properties
- Follows the same defensive programming pattern already used in `ext-tabs.js` (line 9)

## Testing

1. Open Zen with an empty tab (no landing page)
2. Click an extension button (e.g., uBlock Origin settings)
3. Verify the extension settings panel opens without errors
4. Verify no console errors appear related to `getWrapper()` being undefined

## Related

Fixes #7265