### PR TITLE
fix: remove css rule blocking psuedo-classes from showing in Settings page

### DIFF
--- a/src/browser/themes/shared/preferences/zen-preferences.css
+++ b/src/browser/themes/shared/preferences/zen-preferences.css
@@ -91,8 +91,8 @@ groupbox button {
 
 groupbox button,
 groupbox menulist {
-  background-color: light-dark(#f1f1f1, #363636) !important;
-  color: light-dark(black, white) !important;
+  background-color: light-dark(#f1f1f1, #363636);
+  color: light-dark(black, white);
 }
 
 groupbox h2 {


### PR DESCRIPTION
Fixes #11178 

## Details
using `!important` was preventing psuedo-classes (such as `:hover`) from showing. This 2 line change removes the rule so that visual indicators for buttons are visible on mouse hover. 

This change does not seem to affect other styles in the settings page when visually checking through.