### PR TITLE
fix: persist expanded glance tab after closing browser

### DIFF
--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -1415,8 +1415,9 @@
       this.overlay.classList.remove('zen-glance-overlay');
       this.#clearContainerStyles(this.browserWrapper);
       this.animatingFullOpen = false;
+      const glanceID = this.#currentGlanceID
       this.closeGlance({ noAnimation: true, skipPermitUnload: true });
-      this.#glances.delete(this.#currentGlanceID);
+      this.#glances.delete(glanceID);
     }
 
     /**

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -1415,7 +1415,7 @@
       this.overlay.classList.remove('zen-glance-overlay');
       this.#clearContainerStyles(this.browserWrapper);
       this.animatingFullOpen = false;
-      const glanceID = this.#currentGlanceID
+      const glanceID = this.#currentGlanceID;
       this.closeGlance({ noAnimation: true, skipPermitUnload: true });
       this.#glances.delete(glanceID);
     }


### PR DESCRIPTION
Fixes #7340

## Details

`closeGlance()` calls `quickCloseGlance()`, which sets `#currentGlanceID` to null, resulting in the Glance ID not being deleted from the `#glances` data structure.

## Fix

Store current glance Id in a variable, and delete it from the data structure after `closeGlance()` runs