### PR TITLE
Fix split view gap when in compact view and sidebar is on right

### DIFF
--- a/src/zen/compact-mode/sidebar.inc.css
+++ b/src/zen/compact-mode/sidebar.inc.css
@@ -106,7 +106,7 @@
       right: calc(-1 * var(--actual-zen-sidebar-width) + var(--zen-element-separation) / 2 + 1px);
     }
 
-    & .browserSidebarContainer {
+    & .browserSidebarContainer:not([is-zen-split='true']) {
       margin-left: 0 !important;
       margin-right: 0 !important;
     }


### PR DESCRIPTION
Issue was caused by a specific css rule in `sidebar.inc.css` targeting `[zen-right-side='true']`. It was forcing margin: 0 !important on the `.browserSidebarContainer`, which overrode the specific gaps defined for split views in `zen-decks.css`.

I updated the selector to exclude split views, this works smoothly now.


https://github.com/user-attachments/assets/72d9efd3-d217-48d4-9f1f-98c6d7700e0b


Fixes https://github.com/zen-browser/desktop/issues/11269