### PR TITLE
fix: allow selection within link

### DIFF
--- a/src/zen/common/sys/ZenActorsManager.sys.mjs
+++ b/src/zen/common/sys/ZenActorsManager.sys.mjs
@@ -45,6 +45,12 @@ let JSWINDOWACTORS = {
         mousedown: {
           capture: true,
         },
+        mouseup: {
+          capture: true,
+        },
+        mousemove: {
+          capture: true,
+        },
         keydown: {
           capture: true,
         },

--- a/src/zen/common/sys/ZenActorsManager.sys.mjs
+++ b/src/zen/common/sys/ZenActorsManager.sys.mjs
@@ -48,9 +48,6 @@ let JSWINDOWACTORS = {
         mouseup: {
           capture: true,
         },
-        mousemove: {
-          capture: true,
-        },
         keydown: {
           capture: true,
         },

--- a/src/zen/glance/actors/ZenGlanceChild.sys.mjs
+++ b/src/zen/glance/actors/ZenGlanceChild.sys.mjs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 export class ZenGlanceChild extends JSWindowActorChild {
   #activationMethod;
+  #glanceTarget = null;
 
   constructor() {
     super();
@@ -81,10 +82,22 @@ export class ZenGlanceChild extends JSWindowActorChild {
       return;
     }
     if (target) {
+      this.#glanceTarget = target;
+    }
+  }
+
+  on_mouseup(event) {
+    if (this.#glanceTarget) {
       event.preventDefault();
       event.stopPropagation();
+      this.#openGlance(this.#glanceTarget);
+      this.#glanceTarget = null;
+    }
+  }
 
-      this.#openGlance(target);
+  on_mousemove() {
+    if (this.#glanceTarget) {
+      this.#glanceTarget = null;
     }
   }
 
@@ -99,5 +112,8 @@ export class ZenGlanceChild extends JSWindowActorChild {
 
   async on_DOMContentLoaded() {
     await this.#initActivationMethod();
+    this.contentWindow.addEventListener('mousedown', this, true);
+    this.contentWindow.addEventListener('mouseup', this, true);
+    this.contentWindow.addEventListener('mousemove', this, true);
   }
 }

--- a/src/zen/glance/actors/ZenGlanceChild.sys.mjs
+++ b/src/zen/glance/actors/ZenGlanceChild.sys.mjs
@@ -110,8 +110,5 @@ export class ZenGlanceChild extends JSWindowActorChild {
 
   async on_DOMContentLoaded() {
     await this.#initActivationMethod();
-    this.contentWindow.addEventListener('mousedown', this, true);
-    this.contentWindow.addEventListener('mouseup', this, true);
-    this.contentWindow.addEventListener('mousemove', this, true);
   }
 }

--- a/src/zen/glance/actors/ZenGlanceChild.sys.mjs
+++ b/src/zen/glance/actors/ZenGlanceChild.sys.mjs
@@ -81,9 +81,7 @@ export class ZenGlanceChild extends JSWindowActorChild {
     } else if (activationMethod === 'meta' && !event.metaKey) {
       return;
     }
-    if (target) {
-      this.#glanceTarget = target;
-    }
+    this.#glanceTarget = target;
   }
 
   on_mouseup(event) {

--- a/src/zen/glance/actors/ZenGlanceChild.sys.mjs
+++ b/src/zen/glance/actors/ZenGlanceChild.sys.mjs
@@ -7,6 +7,7 @@ export class ZenGlanceChild extends JSWindowActorChild {
 
   constructor() {
     super();
+    this.mousemoveCallback = this.mousemoveCallback.bind(this);
   }
 
   async handleEvent(event) {
@@ -82,6 +83,7 @@ export class ZenGlanceChild extends JSWindowActorChild {
       return;
     }
     this.#glanceTarget = target;
+    window.addEventListener('mousemove', this.mousemoveCallback, { once: true });
   }
 
   on_mouseup(event) {
@@ -90,10 +92,11 @@ export class ZenGlanceChild extends JSWindowActorChild {
       event.stopPropagation();
       this.#openGlance(this.#glanceTarget);
       this.#glanceTarget = null;
+      window.removeEventListener('mousemove', this.mousemoveCallback);
     }
   }
 
-  on_mousemove() {
+  mousemoveCallback() {
     if (this.#glanceTarget) {
       this.#glanceTarget = null;
     }


### PR DESCRIPTION
fixes: #8391

The glance feature was clashing with the possibility to select text within a link. To avoid the conflict, glance will only open upon mouseup and only if the mouse hasn't moved since the mouse was pressed. That's just like a normal link click works as well, so I think it makes sense for glance to behave like this too.

https://github.com/user-attachments/assets/c4c52bbe-4e41-41bb-a2c2-ced0c2488d5d

