### PR TITLE
feat: Add "Max amount of Essential Tabs" setting to the Preferences UI

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -350,3 +350,4 @@ zen-devtools-toggle-storage-shortcut = Toggle Storage
 zen-devtools-toggle-dom-shortcut = Toggle DOM
 zen-devtools-toggle-accessibility-shortcut = Toggle Accessibility
 zen-close-all-unpinned-tabs-shortcut = Close All Unpinned Tabs
+zen-tabs-max-essential-tabs = Max amount of Essential Tabs

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1182,6 +1182,11 @@ Preferences.addAll([
     type: 'bool',
     default: false,
   },
+  {
+    id: 'zen.tabs.essentials.max',
+    type: 'int',
+    default: 12
+  }
 ]);
 
 Preferences.addSetting({

--- a/src/browser/components/preferences/zenTabsManagement.inc.xhtml
+++ b/src/browser/components/preferences/zenTabsManagement.inc.xhtml
@@ -37,6 +37,18 @@
             class="description-deemphasized"
             data-l10n-id="zen-tabs-cycle-by-attribute-warning"
             hidden="true"/>
+      <hbox align="center" flex="1">
+            <label control="zenMaxEssentialsTabs"
+                  data-l10n-id="zen-tabs-max-essential-tabs"
+                  flex="1" />
+            <html:input id="zenMaxEssentialsTabs"
+                  preference="zen.tabs.essentials.max"
+                  type="number"
+                  style="width: 6em"
+                  align="right"
+                  min="1" />
+      </hbox>
+
 </groupbox>
 
 <hbox id="zenTabsUnloadCategory"


### PR DESCRIPTION
# Summary

- Adds a UI representation of the `zen.tabs.essentials.max` preference added in https://github.com/zen-browser/desktop/pull/10731:
<img width="744" height="428" alt="image" src="https://github.com/user-attachments/assets/e380d8a6-4f40-40bb-a950-38ed8cb9f9b9" />

# Notes
It was requested in this discussion thread: https://github.com/zen-browser/desktop/discussions/10379

I wasn't sure where exactly to put the setting, so I put it in "Tab Management -> Workspaces". If requested, I'l move it.

