### PR TITLE
fix: prevent new window when shift-clicking links in split view glance

### DIFF
--- a/src/zen/glance/actors/ZenGlanceChild.sys.mjs
+++ b/src/zen/glance/actors/ZenGlanceChild.sys.mjs
@@ -82,14 +82,14 @@ export class ZenGlanceChild extends JSWindowActorChild {
     } else if (activationMethod === 'meta' && !event.metaKey) {
       return;
     }
+    event.preventDefault();
+    event.stopPropagation();
     this.#glanceTarget = target;
     this.contentWindow.addEventListener('mousemove', this.mousemoveCallback, { once: true });
   }
 
-  on_mouseup(event) {
+  on_mouseup() {
     if (this.#glanceTarget) {
-      event.preventDefault();
-      event.stopPropagation();
       this.#openGlance(this.#glanceTarget);
       this.#glanceTarget = null;
     }


### PR DESCRIPTION
Move event.preventDefault() from mouseup to mousedown handler to block Firefox's default shift-click behavior before it executes.

Fixes https://github.com/zen-browser/desktop/issues/11409

@nihalxkumar I've created this PR for you, mind if we use it?

