### PR TITLE
feat(downloads): add pref to control download popup position independently

### DIFF
--- a/prefs/zen/downloads.yaml
+++ b/prefs/zen/downloads.yaml
@@ -7,3 +7,6 @@
 
 - name: zen.downloads.download-animation-duration
   value: 1000 # ms
+
+- name: zen.downloads.icon-popup-position
+  value: "follow-tabs"

--- a/prefs/zen/downloads.yaml
+++ b/prefs/zen/downloads.yaml
@@ -9,4 +9,7 @@
   value: 1000 # ms
 
 - name: zen.downloads.icon-popup-position
-  value: "follow-tabs"
+  # 0: Follow tab's position
+  # 1: Left side always
+  # 2: Right side always
+  value: 0

--- a/src/zen/downloads/ZenDownloadAnimation.mjs
+++ b/src/zen/downloads/ZenDownloadAnimation.mjs
@@ -131,6 +131,9 @@ class nsZenDownloadAnimationElement extends HTMLElement {
   }
 
   #areTabsOnRightSide() {
+    const position = Services.prefs.getStringPref('zen.downloads.icon-popup-position', 'follow-tabs');
+    if (position === 'left') return false;
+    if (position === 'right') return true;
     return Services.prefs.getBoolPref('zen.tabs.vertical.right-side');
   }
 

--- a/src/zen/downloads/ZenDownloadAnimation.mjs
+++ b/src/zen/downloads/ZenDownloadAnimation.mjs
@@ -131,9 +131,9 @@ class nsZenDownloadAnimationElement extends HTMLElement {
   }
 
   #areTabsOnRightSide() {
-    const position = Services.prefs.getStringPref('zen.downloads.icon-popup-position', 'follow-tabs');
-    if (position === 'left') return false;
-    if (position === 'right') return true;
+    const position = Services.prefs.getIntPref('zen.downloads.icon-popup-position', 0);
+    if (position === 1) return false;
+    if (position === 2) return true;
     return Services.prefs.getBoolPref('zen.tabs.vertical.right-side');
   }
 


### PR DESCRIPTION
## Summary

Adds `zen.downloads.icon-popup-position` preference that allows users to control the download popup/indicator position independently from the vertical tabs position.

**Valid values:**
- `"follow-tabs"` (default): popup appears on same side as vertical tabs (current behavior)
- `"left"`: popup always appears on the left
- `"right"`: popup always appears on the right

## Use Case

This is useful for users who have vertical tabs on the right (`zen.tabs.vertical.right-side = true`) but prefer the download indicator to appear on the left side of the screen.

## Changes

- Added new preference `zen.downloads.icon-popup-position` in `prefs/zen/downloads.yaml`
- Modified `#areTabsOnRightSide()` in `ZenDownloadAnimation.mjs` to check the new pref first, falling back to tab position when set to `"follow-tabs"`

## Testing

1. Set `zen.tabs.vertical.right-side` to `true` in `about:config`
2. Set `zen.downloads.icon-popup-position` to `"left"` in `about:config`
3. Download a file
4. Verify the download popup appears on the left side despite tabs being on the right