### PR TITLE
fix: Prevent sites from hijacking keyboard shortcuts by default

### DIFF
--- a/prefs/firefox/permissions.yaml
+++ b/prefs/firefox/permissions.yaml
@@ -1,0 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file contains configuration values for site permissions
+
+# Disables site shortcuts by default.
+# To allow site shortcuts they have to be explicitly enabled per site
+- name: permissions.default.shortcuts
+  value: 2


### PR DESCRIPTION
Fix to address https://github.com/zen-browser/desktop/issues/8894

As mentioned in this issue, there are websites that can hijack the keyboard shortcuts set by Zen for a site feature. By default this behaviour is disabled on Arc and I believe it also makes sense to have it disabled on Zen.

Enabling site shortcuts is still possible on a per-site basis in the site settings window.