### PR TITLE
feat: Add color picker for workspace SVG icons

### DIFF
--- a/src/browser/base/content/zen-panels/emojis-picker.inc
+++ b/src/browser/base/content/zen-panels/emojis-picker.inc
@@ -18,6 +18,9 @@
       </hbox>
       <hbox id="PanelUI-zen-emojis-picker-list" />
     </vbox>
-    <hbox svgs="true" id="PanelUI-zen-emojis-picker-svgs" />
+    <vbox svgs="true">
+      <hbox id="PanelUI-zen-emojis-picker-colors" />
+      <hbox id="PanelUI-zen-emojis-picker-svgs" />
+    </vbox>
   </hbox>
 </panel>

--- a/src/zen/common/emojis/ZenEmojiPicker.mjs
+++ b/src/zen/common/emojis/ZenEmojiPicker.mjs
@@ -6,29 +6,46 @@ import { nsZenDOMOperatedFeature } from 'chrome://browser/content/zen-components
 
 // prettier-ignore
 const SVG_ICONS = [
-    "airplane.svg", "american-football.svg", "baseball.svg", "basket.svg", 
-    "bed.svg", "bell.svg", "bookmark.svg", "book.svg", 
-    "briefcase.svg", "brush.svg", "bug.svg", "build.svg", 
-    "cafe.svg", "call.svg", "card.svg", "chat.svg", 
-    "checkbox.svg", "circle.svg", "cloud.svg", "code.svg", 
-    "coins.svg", "construct.svg", "cutlery.svg", "egg.svg", 
-    "extension-puzzle.svg", "eye.svg", "fast-food.svg", "fish.svg", 
-    "flag.svg", "flame.svg", "flask.svg", "folder.svg", 
-    "game-controller.svg", "globe-1.svg", "globe.svg", "grid-2x2.svg", 
-    "grid-3x3.svg", "heart.svg", "ice-cream.svg", "image.svg", 
-    "inbox.svg", "key.svg", "layers.svg", "leaf.svg", 
-    "lightning.svg", "location.svg", "lock-closed.svg", "logo-rss.svg", 
-    "logo-usd.svg", "mail.svg", "map.svg", "megaphone.svg", 
-    "moon.svg", "music.svg", "navigate.svg", "nuclear.svg", 
-    "page.svg", "palette.svg", "paw.svg", "people.svg", 
-    "pizza.svg", "planet.svg", "present.svg", "rocket.svg", 
-    "school.svg", "shapes.svg", "shirt.svg", "skull.svg", 
-    "squares.svg", "square.svg", "star-1.svg", "star.svg", 
-    "stats-chart.svg", "sun.svg", "tada.svg", "terminal.svg", 
-    "ticket.svg", "time.svg", "trash.svg", "triangle.svg", 
-    "video.svg", "volume-high.svg", "wallet.svg", "warning.svg", 
-    "water.svg", "weight.svg", 
+    "airplane.svg", "american-football.svg", "baseball.svg", "basket.svg",
+    "bed.svg", "bell.svg", "bookmark.svg", "book.svg",
+    "briefcase.svg", "brush.svg", "bug.svg", "build.svg",
+    "cafe.svg", "call.svg", "card.svg", "chat.svg",
+    "checkbox.svg", "circle.svg", "cloud.svg", "code.svg",
+    "coins.svg", "construct.svg", "cutlery.svg", "egg.svg",
+    "extension-puzzle.svg", "eye.svg", "fast-food.svg", "fish.svg",
+    "flag.svg", "flame.svg", "flask.svg", "folder.svg",
+    "game-controller.svg", "globe-1.svg", "globe.svg", "grid-2x2.svg",
+    "grid-3x3.svg", "heart.svg", "ice-cream.svg", "image.svg",
+    "inbox.svg", "key.svg", "layers.svg", "leaf.svg",
+    "lightning.svg", "location.svg", "lock-closed.svg", "logo-rss.svg",
+    "logo-usd.svg", "mail.svg", "map.svg", "megaphone.svg",
+    "moon.svg", "music.svg", "navigate.svg", "nuclear.svg",
+    "page.svg", "palette.svg", "paw.svg", "people.svg",
+    "pizza.svg", "planet.svg", "present.svg", "rocket.svg",
+    "school.svg", "shapes.svg", "shirt.svg", "skull.svg",
+    "squares.svg", "square.svg", "star-1.svg", "star.svg",
+    "stats-chart.svg", "sun.svg", "tada.svg", "terminal.svg",
+    "ticket.svg", "time.svg", "trash.svg", "triangle.svg",
+    "video.svg", "volume-high.svg", "wallet.svg", "warning.svg",
+    "water.svg", "weight.svg",
   ];
+
+// Icon colors for SVG icons
+const ICON_COLORS = [
+  { name: 'default', value: null },
+  { name: 'red', value: '#ef4444' },
+  { name: 'orange', value: '#f97316' },
+  { name: 'amber', value: '#f59e0b' },
+  { name: 'yellow', value: '#eab308' },
+  { name: 'lime', value: '#84cc16' },
+  { name: 'green', value: '#22c55e' },
+  { name: 'teal', value: '#14b8a6' },
+  { name: 'cyan', value: '#06b6d4' },
+  { name: 'blue', value: '#3b82f6' },
+  { name: 'indigo', value: '#6366f1' },
+  { name: 'purple', value: '#a855f7' },
+  { name: 'pink', value: '#ec4899' },
+];
 
 class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
   #panel;
@@ -38,6 +55,9 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
   #currentPromise = null;
   #currentPromiseResolve = null;
   #currentPromiseReject = null;
+
+  #selectedColor = null;
+  #initialColor = null;
 
   init() {
     this.#panel = document.getElementById('PanelUI-zen-emojis-picker');
@@ -91,6 +111,10 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     return document.getElementById('PanelUI-zen-emojis-picker-svgs');
   }
 
+  get colorList() {
+    return document.getElementById('PanelUI-zen-emojis-picker-colors');
+  }
+
   get searchInput() {
     return document.getElementById('PanelUI-zen-emojis-picker-search');
   }
@@ -139,10 +163,74 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     }
   }
 
+  #createColorButtons() {
+    const colorList = this.colorList;
+    colorList.innerHTML = '';
+
+    for (const color of ICON_COLORS) {
+      const item = document.createElement('div');
+      item.className = 'zen-emojis-picker-color';
+      item.setAttribute('data-color', color.value || 'default');
+      item.setAttribute('title', color.name);
+
+      if (color.value) {
+        item.style.backgroundColor = color.value;
+      } else {
+        // Default color - use a gradient to indicate "no color"
+        item.style.background = 'linear-gradient(135deg, #888 50%, #ccc 50%)';
+      }
+
+      // Mark initially selected color
+      if (this.#selectedColor === color.value) {
+        item.setAttribute('selected', 'true');
+      }
+
+      item.addEventListener('click', () => {
+        this.#selectColor(color.value);
+      });
+
+      colorList.appendChild(item);
+    }
+  }
+
+  #selectColor(color) {
+    this.#selectedColor = color;
+    // Update UI to show selected color
+    const colorButtons = this.colorList.querySelectorAll('.zen-emojis-picker-color');
+    for (const btn of colorButtons) {
+      const btnColor = btn.getAttribute('data-color');
+      if ((btnColor === 'default' && color === null) || btnColor === color) {
+        btn.setAttribute('selected', 'true');
+      } else {
+        btn.removeAttribute('selected');
+      }
+    }
+
+    // Update SVG icons preview with the selected color
+    this.#updateSvgIconsColor();
+  }
+
+  #updateSvgIconsColor() {
+    const svgButtons = this.svgList.querySelectorAll('.zen-emojis-picker-svg');
+    for (const btn of svgButtons) {
+      if (this.#selectedColor) {
+        btn.style.setProperty('--zen-icon-color', this.#selectedColor);
+        btn.setAttribute('has-color', 'true');
+      } else {
+        btn.style.removeProperty('--zen-icon-color');
+        btn.removeAttribute('has-color');
+      }
+    }
+  }
+
   // note: It's async on purpose so we can render the popup before processing the emojis
   async #onPopupShowing(event) {
     if (event.target !== this.#panel) return;
     this.searchInput.value = '';
+
+    // Initialize selected color
+    this.#selectedColor = this.#initialColor;
+
     const allowEmojis = !this.#panel.hasAttribute('only-svg-icons');
     if (allowEmojis) {
       const emojiList = this.emojiList;
@@ -160,6 +248,10 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
         this.searchInput.focus();
       }, 500);
     }
+
+    // Create color buttons
+    this.#createColorButtons();
+
     const svgList = this.svgList;
     for (const icon of SVG_ICONS) {
       const item = document.createXULElement('toolbarbutton');
@@ -173,6 +265,9 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
       });
       svgList.appendChild(item);
     }
+
+    // Apply initial color to SVG icons
+    this.#updateSvgIconsColor();
   }
 
   #onPopupHidden(event) {
@@ -185,6 +280,7 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     emojiList.innerHTML = '';
 
     this.svgList.innerHTML = '';
+    this.colorList.innerHTML = '';
 
     if (this.#currentPromiseReject) {
       this.#currentPromiseReject(new Error('Emoji picker closed without selection'));
@@ -193,17 +289,25 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     this.#currentPromise = null;
     this.#currentPromiseResolve = null;
     this.#currentPromiseReject = null;
+    this.#selectedColor = null;
+    this.#initialColor = null;
 
     this.#anchor.removeAttribute('zen-emoji-open');
     this.#anchor = null;
   }
 
   #selectEmoji(emoji) {
-    this.#currentPromiseResolve?.(emoji);
+    // Return an object with emoji and color for SVG icons, or just the emoji for regular emojis
+    const isSvg = emoji && emoji.endsWith('.svg');
+    const result = {
+      icon: emoji,
+      iconColor: isSvg ? this.#selectedColor : null,
+    };
+    this.#currentPromiseResolve?.(result);
     this.#panel.hidePopup();
   }
 
-  open(anchor, { onlySvgIcons = false } = {}) {
+  open(anchor, { onlySvgIcons = false, initialColor = null } = {}) {
     if (this.#currentPromise) {
       return null;
     }
@@ -212,6 +316,7 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
       this.#currentPromiseReject = reject;
     });
     this.#anchor = anchor;
+    this.#initialColor = initialColor;
     this.#anchor.setAttribute('zen-emoji-open', 'true');
     if (onlySvgIcons) {
       this.#panel.setAttribute('only-svg-icons', 'true');

--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -128,6 +128,31 @@ body > #confetti {
     }
   }
 
+  #PanelUI-zen-emojis-picker-colors {
+    padding: 8px 10px;
+    gap: 6px;
+    justify-content: center;
+    border-bottom: 1px solid light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));
+
+    & .zen-emojis-picker-color {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      cursor: pointer;
+      border: 2px solid transparent;
+      transition: transform 0.1s, border-color 0.1s;
+      box-sizing: border-box;
+
+      &:hover {
+        transform: scale(1.15);
+      }
+
+      &[selected='true'] {
+        border-color: light-dark(rgba(0, 0, 0, 0.5), rgba(255, 255, 255, 0.7));
+      }
+    }
+  }
+
   #PanelUI-zen-emojis-picker-list,
   #PanelUI-zen-emojis-picker-svgs {
     overflow-y: auto;
@@ -151,12 +176,19 @@ body > #confetti {
 
     .zen-emojis-picker-svg {
       padding: 4px !important;
+      -moz-context-properties: fill, fill-opacity;
+      fill: currentColor;
+
       & label {
         display: none;
       }
 
       & .toolbarbutton-icon {
         width: 22px;
+      }
+
+      &[has-color='true'] {
+        fill: var(--zen-icon-color);
       }
     }
   }

--- a/src/zen/workspaces/ZenWorkspaceCreation.mjs
+++ b/src/zen/workspaces/ZenWorkspaceCreation.mjs
@@ -202,6 +202,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
     const workspace = await gZenWorkspaces.getActiveWorkspace();
     workspace.name = this.inputName.value.trim();
     workspace.icon = this.inputIcon.image || this.inputIcon.label || undefined;
+    workspace.iconColor = this._iconColor || undefined;
     workspace.containerTabId = this.currentProfile;
     await gZenWorkspaces.saveWorkspace(workspace);
 
@@ -219,17 +220,27 @@ class nsZenWorkspaceCreation extends MozXULElement {
 
   onIconCommand(event) {
     gZenEmojiPicker
-      .open(event.target)
-      .then(async (emoji) => {
-        const isSvg = emoji && emoji.endsWith('.svg');
+      .open(event.target, { initialColor: this._iconColor })
+      .then(async (result) => {
+        const icon = result?.icon;
+        const iconColor = result?.iconColor;
+        const isSvg = icon && icon.endsWith('.svg');
         if (isSvg) {
           this.inputIcon.label = '';
-          this.inputIcon.image = emoji;
+          this.inputIcon.image = icon;
           this.inputIcon.setAttribute('has-svg-icon', 'true');
+          this._iconColor = iconColor;
+          if (iconColor) {
+            this.inputIcon.style.setProperty('--zen-workspace-icon-color', iconColor);
+          } else {
+            this.inputIcon.style.removeProperty('--zen-workspace-icon-color');
+          }
         } else {
           this.inputIcon.image = '';
-          this.inputIcon.label = emoji || '';
+          this.inputIcon.label = icon || '';
           this.inputIcon.removeAttribute('has-svg-icon');
+          this._iconColor = null;
+          this.inputIcon.style.removeProperty('--zen-workspace-icon-color');
         }
       })
       .catch((error) => {

--- a/src/zen/workspaces/ZenWorkspaceIcons.mjs
+++ b/src/zen/workspaces/ZenWorkspaceIcons.mjs
@@ -111,6 +111,12 @@ class nsZenWorkspaceIcons extends MozXULElement {
         const image = document.createElement('img');
         image.src = workspace.icon;
         image.classList.add('zen-workspace-icon');
+        // Apply icon color if set
+        if (workspace.iconColor) {
+          image.style.setProperty('--zen-workspace-icon-color', workspace.iconColor);
+          image.style.setProperty('--zen-workspace-icon-src', `url('${workspace.icon}')`);
+          image.setAttribute('has-color', 'true');
+        }
         button.appendChild(image);
       } else {
         icon.textContent = workspace.icon;

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -1086,20 +1086,21 @@ class nsZenWorkspaces extends nsZenMultiWindowFeature {
     if (!anchor) {
       return;
     }
+    const workspace = this.getWorkspaceFromId(workspaceId);
     const hasNoIcon = anchor.hasAttribute('no-icon');
     anchor.removeAttribute('no-icon');
     if (hasNoIcon) {
       anchor.textContent = '';
     }
     gZenEmojiPicker
-      .open(anchor)
-      .then(async (emoji) => {
-        const workspace = this.getWorkspaceFromId(workspaceId);
+      .open(anchor, { initialColor: workspace?.iconColor })
+      .then(async (result) => {
         if (!workspace) {
           console.warn('No active workspace found to change icon');
           return;
         }
-        workspace.icon = emoji;
+        workspace.icon = result?.icon;
+        workspace.iconColor = result?.iconColor || null;
         await this.saveWorkspace(workspace);
       })
       .catch((error) => {
@@ -1887,6 +1888,12 @@ class nsZenWorkspaces extends nsZenMultiWindowFeature {
     if (icon?.endsWith('.svg')) {
       const img = document.createElement('img');
       img.src = icon;
+      // Apply icon color if set
+      if (currentWorkspace.iconColor) {
+        img.style.setProperty('--zen-workspace-icon-color', currentWorkspace.iconColor);
+        img.style.setProperty('--zen-workspace-icon-src', `url('${icon}')`);
+        img.setAttribute('has-color', 'true');
+      }
       indicatorIcon.appendChild(img);
     } else {
       indicatorIcon.textContent = icon;

--- a/src/zen/workspaces/ZenWorkspacesStorage.mjs
+++ b/src/zen/workspaces/ZenWorkspacesStorage.mjs
@@ -53,6 +53,7 @@ window.ZenWorkspacesStorage = {
         await addColumnIfNotExists('theme_opacity', 'REAL');
         await addColumnIfNotExists('theme_rotation', 'INTEGER');
         await addColumnIfNotExists('theme_texture', 'REAL');
+        await addColumnIfNotExists('icon_color', 'TEXT');
 
         // Create an index on the uuid column
         await db.execute(`
@@ -140,13 +141,13 @@ window.ZenWorkspacesStorage = {
             `
           INSERT OR REPLACE INTO zen_workspaces (
           uuid, name, icon, container_id, created_at, updated_at, "position",
-          theme_type, theme_colors, theme_opacity, theme_rotation, theme_texture
+          theme_type, theme_colors, theme_opacity, theme_rotation, theme_texture, icon_color
         ) VALUES (
           :uuid, :name, :icon, :container_id,
           COALESCE((SELECT created_at FROM zen_workspaces WHERE uuid = :uuid), :now),
           :now,
           :position,
-          :theme_type, :theme_colors, :theme_opacity, :theme_rotation, :theme_texture
+          :theme_type, :theme_colors, :theme_opacity, :theme_rotation, :theme_texture, :icon_color
         )
         `,
             {
@@ -161,6 +162,7 @@ window.ZenWorkspacesStorage = {
               theme_opacity: workspace.theme?.opacity || null,
               theme_rotation: workspace.theme?.rotation || null,
               theme_texture: workspace.theme?.texture || null,
+              icon_color: workspace.iconColor || null,
             }
           );
 
@@ -197,6 +199,7 @@ window.ZenWorkspacesStorage = {
       uuid: row.getResultByName('uuid'),
       name: row.getResultByName('name'),
       icon: row.getResultByName('icon'),
+      iconColor: row.getResultByName('icon_color'),
       containerTabId: row.getResultByName('container_id') ?? 0,
       position: row.getResultByName('position'),
       theme: row.getResultByName('theme_type')

--- a/src/zen/workspaces/create-workspace-form.css
+++ b/src/zen/workspaces/create-workspace-form.css
@@ -76,6 +76,10 @@ zen-workspace-creation {
             fill: currentColor;
           }
 
+          &[has-svg-icon='true'] image {
+            fill: var(--zen-workspace-icon-color, currentColor);
+          }
+
           &:not([has-svg-icon='true']) image {
             display: none;
           }

--- a/src/zen/workspaces/zen-workspaces.css
+++ b/src/zen/workspaces/zen-workspaces.css
@@ -48,8 +48,30 @@
 
       &:is(img) {
         width: 14px;
+
+        &[has-color='true'] {
+          filter: brightness(0) saturate(100%);
+          background-color: var(--zen-workspace-icon-color);
+          width: 14px;
+          height: 14px;
+        }
+
+        @supports ((-webkit-mask-image: url('')) or (mask-image: url(''))) {
+          &[has-color='true'] {
+            filter: none;
+            background-color: var(--zen-workspace-icon-color);
+            -webkit-mask-image: var(--zen-workspace-icon-src, url(''));
+            mask-image: var(--zen-workspace-icon-src, url(''));
+            -webkit-mask-size: contain;
+            mask-size: contain;
+            -webkit-mask-repeat: no-repeat;
+            mask-repeat: no-repeat;
+            -webkit-mask-position: center;
+            mask-position: center;
+          }
+        }
       }
-   
+
       &[no-icon='true'] {
         width: 6px;
         height: 6px;
@@ -210,6 +232,28 @@
       top: -4px;
       left: -4px;
       pointer-events: none;
+    }
+
+    & img[has-color='true'] {
+      filter: brightness(0) saturate(100%);
+      background-color: var(--zen-workspace-icon-color);
+      width: 16px;
+      height: 16px;
+    }
+
+    @supports ((-webkit-mask-image: url('')) or (mask-image: url(''))) {
+      & img[has-color='true'] {
+        filter: none;
+        background-color: var(--zen-workspace-icon-color);
+        -webkit-mask-image: var(--zen-workspace-icon-src, url(''));
+        mask-image: var(--zen-workspace-icon-src, url(''));
+        -webkit-mask-size: contain;
+        mask-size: contain;
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+        mask-position: center;
+      }
     }
 
     @media (-moz-platform: windows) {


### PR DESCRIPTION
Add the ability to customize the color of SVG icons in workspaces:
- Add icon_color column to workspace database schema
- Add color picker UI in emoji/icon picker panel with 12 preset colors
- Store and retrieve icon color alongside icon selection
- Apply icon color to workspace icons in sidebar and indicator
- Support color preview when selecting icons