### PR TITLE
Add print to command palette

### DIFF
--- a/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
+++ b/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
@@ -187,6 +187,9 @@ const globalActionsTemplate = [
     label: 'Print',
     command: 'cmd_print',
     icon: 'chrome://browser/skin/zen-icons/print.svg',
+    isAvailable: (window) => {
+      return isNotEmptyTab(window);
+    },
   },
 ];
 

--- a/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
+++ b/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
@@ -183,6 +183,11 @@ const globalActionsTemplate = [
       return lazy.currentTheme !== 0;
     },
   },
+  {
+    label: 'Print',
+    command: 'cmd_print',
+    icon: 'chrome://browser/skin/zen-icons/print.svg',
+  },
 ];
 
 export const globalActions = globalActionsTemplate.map((action) => ({


### PR DESCRIPTION
Hey,

I'd love to add the print command to the command palette.

~~The command and SVG seems to exist. Unfortunately, I didn't manage to build Zen on macOS even after multiple tries, so I couldn't verify whether this works.~~

Managed to build the app locally and it's working 🎉