### PR TITLE
fix: Correctly identify child active groups for `zen-workspace-collap…

### DIFF
--- a/src/zen/folders/ZenFolder.mjs
+++ b/src/zen/folders/ZenFolder.mjs
@@ -118,6 +118,9 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
   }
 
   get childActiveGroups() {
+    if (this.tagName === "zen-workspace-collapsible-pins" ) {
+      return Array.from(this.parentElement.querySelectorAll('zen-folder[has-active]'));
+    }
     return Array.from(this.querySelectorAll('zen-folder[has-active]'));
   }
 

--- a/src/zen/folders/ZenFolder.mjs
+++ b/src/zen/folders/ZenFolder.mjs
@@ -118,7 +118,7 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
   }
 
   get childActiveGroups() {
-    if (this.tagName === "zen-workspace-collapsible-pins" ) {
+    if (this.tagName === 'zen-workspace-collapsible-pins') {
       return Array.from(this.parentElement.querySelectorAll('zen-folder[has-active]'));
     }
     return Array.from(this.querySelectorAll('zen-folder[has-active]'));


### PR DESCRIPTION
…sible-pins` (#11799)