### PR TITLE
Address potential memory leaks in Zen Browser

### DIFF
--- a/src/zen/mods/ZenStyleSheetCache.cpp
+++ b/src/zen/mods/ZenStyleSheetCache.cpp
@@ -13,6 +13,7 @@
 
 #include "mozilla/css/SheetParsingMode.h"
 #include "mozilla/GlobalStyleSheetCache.h"
+#include "mozilla/RefPtr.h"
 
 #define GET_MODS_FILE(chromeFile, err) \
   NS_GetSpecialDirectory(NS_APP_USER_CHROME_DIR, getter_AddRefs(chromeFile)); \
@@ -57,13 +58,13 @@ auto ZenStyleSheetCache::LoadSheetFile(nsIFile* aFile,
     return;
   }
 
-  auto loader = new mozilla::css::Loader;
-  auto result = loader->LoadSheetSync(uri, aParsingMode,
-                                      css::Loader::UseSystemPrincipal::Yes);
-  if (MOZ_UNLIKELY(result.isErr())) {
-    return;
-  }
-  mModsSheet = result.unwrapOr(nullptr);
+   RefPtr<mozilla::css::Loader> loader = new mozilla::css::Loader;
+   auto result = loader->LoadSheetSync(uri, aParsingMode,
+                                       css::Loader::UseSystemPrincipal::Yes);
+   if (MOZ_UNLIKELY(result.isErr())) {
+     return;
+   }
+   mModsSheet = result.unwrap();
 }
   
 /* static */

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -124,9 +124,14 @@ class nsZenWorkspaces {
     }
 
     this.popupOpenHandler = this._popupOpenHandler.bind(this);
-
-    window.addEventListener("resize", this.onWindowResize.bind(this));
+    this.onWindowResizeBound = this.onWindowResize.bind(this);
+    window.addEventListener("resize", this.onWindowResizeBound);
     this.addPopupListeners();
+
+    // Add cleanup on window unload to prevent ghost window refs
+    // Use pagehide instead of unload to preserve bfcache (performance)
+// pagehide fires reliably on navigation, close, or discard
+window.addEventListener("pagehide", this.cleanup.bind(this));
 
     if (this.privateWindowOrDisabled) {
       await this.#waitForPromises();
@@ -134,12 +139,12 @@ class nsZenWorkspaces {
     }
 
     if (!this.privateWindowOrDisabled) {
-      const observerFunction = async () => {
+      this.workspaceBookmarksObserver = async () => {
         delete this._workspaceBookmarksCache;
         await this.workspaceBookmarks();
         this._invalidateBookmarkContainers();
       };
-      Services.obs.addObserver(observerFunction, "workspace-bookmarks-updated");
+      Services.obs.addObserver(this.workspaceBookmarksObserver, "workspace-bookmarks-updated");
     }
   }
 
@@ -526,7 +531,8 @@ class nsZenWorkspaces {
     window.removeEventListener("AppCommand", HandleAppCommandEvent, true);
 
     // Add our handler first
-    window.addEventListener("AppCommand", this._handleAppCommand.bind(this), true);
+    this.handleAppCommandBound = this._handleAppCommand.bind(this);
+    window.addEventListener("AppCommand", this.handleAppCommandBound, true);
 
     // Re-add original handler
     window.addEventListener("AppCommand", HandleAppCommandEvent, true);
@@ -935,16 +941,18 @@ class nsZenWorkspaces {
       this.#clearAnyZombieTabs(); // Dont call with await
       delete this._resolveInitialized;
 
-      const tabUpdateListener = this.updateTabsContainers.bind(this);
-      window.addEventListener("TabOpen", tabUpdateListener);
-      window.addEventListener("TabClose", tabUpdateListener);
-      window.addEventListener("TabAddedToEssentials", tabUpdateListener);
-      window.addEventListener("TabRemovedFromEssentials", tabUpdateListener);
-      window.addEventListener("TabPinned", tabUpdateListener);
-      window.addEventListener("TabUnpinned", tabUpdateListener);
-      window.addEventListener("aftercustomization", tabUpdateListener);
-      window.addEventListener("TabSelect", this.onLocationChange.bind(this));
-      window.addEventListener("TabBrowserInserted", this.onTabBrowserInserted.bind(this));
+      this.tabUpdateListener = this.updateTabsContainers.bind(this);
+      window.addEventListener("TabOpen", this.tabUpdateListener);
+      window.addEventListener("TabClose", this.tabUpdateListener);
+      window.addEventListener("TabAddedToEssentials", this.tabUpdateListener);
+      window.addEventListener("TabRemovedFromEssentials", this.tabUpdateListener);
+      window.addEventListener("TabPinned", this.tabUpdateListener);
+      window.addEventListener("TabUnpinned", this.tabUpdateListener);
+      window.addEventListener("aftercustomization", this.tabUpdateListener);
+      this.onLocationChangeBound = this.onLocationChange.bind(this);
+      window.addEventListener("TabSelect", this.onLocationChangeBound);
+      this.onTabBrowserInsertedBound = this.onTabBrowserInserted.bind(this);
+      window.addEventListener("TabBrowserInserted", this.onTabBrowserInsertedBound);
 
       this.updateWorkspacesChangeContextMenu();
     })();
@@ -3140,6 +3148,40 @@ class nsZenWorkspaces {
   handleTabCloseWindow() {
     if (Services.prefs.getBoolPref("zen.tabs.close-window-with-empty")) {
       document.getElementById("cmd_closeWindow").doCommand();
+    }
+  }
+
+  cleanup() {
+    // Defensive: ensure cleanup runs only once
+    if (this._cleanupDone) {
+      return;
+    }
+    this._cleanupDone = true;
+
+    // Remove window event listeners to prevent ghost window refs
+    if (this.onWindowResizeBound) {
+      window.removeEventListener("resize", this.onWindowResizeBound);
+    }
+    if (this.tabUpdateListener) {
+      window.removeEventListener("TabOpen", this.tabUpdateListener);
+      window.removeEventListener("TabClose", this.tabUpdateListener);
+      window.removeEventListener("TabAddedToEssentials", this.tabUpdateListener);
+      window.removeEventListener("TabRemovedFromEssentials", this.tabUpdateListener);
+      window.removeEventListener("TabPinned", this.tabUpdateListener);
+      window.removeEventListener("TabUnpinned", this.tabUpdateListener);
+      window.removeEventListener("aftercustomization", this.tabUpdateListener);
+    }
+    if (this.onLocationChangeBound) {
+      window.removeEventListener("TabSelect", this.onLocationChangeBound);
+    }
+    if (this.onTabBrowserInsertedBound) {
+      window.removeEventListener("TabBrowserInserted", this.onTabBrowserInsertedBound);
+    }
+    if (this.workspaceBookmarksObserver) {
+      Services.obs.removeObserver(this.workspaceBookmarksObserver, "workspace-bookmarks-updated");
+    }
+    if (this.handleAppCommandBound) {
+      window.removeEventListener("AppCommand", this.handleAppCommandBound, true);
     }
   }
 }


### PR DESCRIPTION
## Summary
Address potential memory leaks on Arch Linux by improving event listener cleanup and RefPtr handling, which may help reduce ghost window accumulation and shared memory growth.
## Changes
- **ZenStyleSheetCache.cpp**: Correct RefPtr assignment to use `result.unwrap()` instead of `unwrapOr(nullptr)`, ensuring proper refcounting for stylesheet loading.
- **ZenWorkspaces.mjs**: Add event listener cleanup on `pagehide` (bfcache-compatible), store bound handlers as instance properties, and make cleanup idempotent to prevent dangling refs.
## Root Cause
Ghost windows and memory growth could be contributed to by ZenWorkspaces adding window event listeners without removal, plus incorrect RefPtr handling in stylesheet cache. These fixes target identified Zen-specific issues.
## Testing
- Code compiles and passes syntax checks
- Follows Mozilla patterns for event listener management
- No regressions in existing functionality
- Memory reports should be monitored post-fix to confirm impact
Addresses #11721