### PR TITLE
Fix: Show container indicator for non-default containers in workspace

### DIFF
--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -2801,7 +2801,7 @@ class nsZenWorkspaces {
       if (matchingWorkspaces.length === 1) {
         const workspace = matchingWorkspaces[0];
         if (workspace.uuid !== this.getActiveWorkspaceFromCache().uuid) {
-          return [userContextId, true, workspace.uuid];
+          return [userContextId, false, workspace.uuid];
         }
       }
     }


### PR DESCRIPTION
Hey there! 👋

This fixes #11951 where the container indicator wasn't showing up when opening tabs in a different container than the workspace's default.

## The Problem

When you have a workspace with a default container set (say, "Personal") and the "Hide the default container indicator" setting enabled, opening a tab in a *different* container (like "Work") would still hide the indicator. This makes it hard to tell which container a tab belongs to without clicking into it.

## The Fix

One-line change in `ZenWorkspaces.mjs` - when the code detects a tab should go to a different workspace based on its container, it was incorrectly marking the tab as having the 'default' container context. Changed that from `true` to `false` so the indicator shows correctly.

## Testing

- Have workspace A with container X as default
- Have workspace B with container Y as default
- Enable "Hide the default container indicator in the tab bar"
- Open a tab in container Y while in workspace A
- The container indicator should now show (before this fix, it was hidden)
