### PR TITLE
fix(ui): prevent titlebar hover expansion when disabled in single-toolbar mode

### DIFF
--- a/src/zen/tabs/zen-tabs/vertical-tabs-topbar.inc.css
+++ b/src/zen/tabs/zen-tabs/vertical-tabs-topbar.inc.css
@@ -32,6 +32,19 @@ z-index: 1;
 %include ../../compact-mode/windows-captions-fix-default.inc.css
   }
 
+  /* Issue #11915: In single-toolbar mode without bookmarks, prevent hover from
+   * expanding the toolbar when it's disabled. This mirrors the behavior of
+   * zen.view.experimental-no-window-controls but for the normal disable setting. */
+  @media -moz-pref('zen.view.use-single-toolbar') {
+    :root:not([zen-has-bookmarks]) & {
+      max-height: 0 !important;
+      height: 0 !important;
+      opacity: 0 !important;
+      pointer-events: none !important;
+      overflow: hidden !important;
+    }
+  }
+
   @media -moz-pref('zen.view.experimental-no-window-controls') {
     :root:not([zen-has-bookmarks]) & {
       max-height: 0 !important;


### PR DESCRIPTION
## What this fixes

Closes #11915 - The titlebar was expanding on hover even when the titlebar setting was disabled via Customize Toolbar in Sidebar only mode.

## What was happening

When you go to Settings > Look and Feel > Only Sidebar, then disable the titlebar through Customize Toolbar, hovering over the top of the window would still cause the titlebar to expand. The workaround zen.view.experimental-no-window-controls worked correctly, but the normal disable setting didn't.

## The fix

The CSS that collapses the toolbar when disabled had a :not([zen-has-hover]) selector, which meant hovering bypassed the collapse. I added a new CSS rule inside the existing @media -moz-pref('zen.view.hide-window-controls') block that uses !important overrides for single-toolbar mode - the same approach that makes the experimental setting work.

## Testing

1. Set Look and Feel to Only Sidebar
2. Right-click toolbar > Customize Toolbar > Disable Titlebar
3. Hover over the top of the window
4. Titlebar should NOT expand

Regression check: with titlebar enabled, hover should still work normally.