### PR TITLE
fix(media): force metadata update on playback start and poll for changes

### DIFF
--- a/src/zen/media/ZenMediaController.mjs
+++ b/src/zen/media/ZenMediaController.mjs
@@ -350,7 +350,16 @@ class nsZenMediaController {
     this.updateMuteState();
     this.switchController();
 
-    if (!mediaController.isActive || this._currentBrowser?.browserId === browser.browserId) {
+    if (!mediaController.isActive) {
+      return;
+    }
+
+    if (this._currentBrowser?.browserId === browser.browserId) {
+      const metadata = mediaController.getMetadata();
+      if (metadata.title !== this.mediaTitle.textContent || metadata.artist !== this.mediaArtist.textContent) {
+        this.mediaTitle.textContent = metadata.title || "";
+        this.mediaArtist.textContent = metadata.artist || "";
+      }
       return;
     }
 
@@ -555,6 +564,15 @@ class nsZenMediaController {
     this.mediaProgressBar.value = (this._currentPosition / this._currentDuration) * 100;
 
     this._mediaUpdateInterval = setInterval(() => {
+      const metadata = this._currentMediaController?.getMetadata();
+      if (
+        metadata &&
+        (metadata.title !== this.mediaTitle.textContent ||
+          metadata.artist !== this.mediaArtist.textContent)
+      ) {
+        this._onMetadataChange({ target: this._currentMediaController });
+      }
+
       if (this._currentMediaController?.isPlaying) {
         this._currentPosition += 1 * this._currentPlaybackRate;
         if (this._currentPosition > this._currentDuration) {


### PR DESCRIPTION
## What this fixes

Closes #11948 - Media session metadata (title, artist, cover art) wasn't updating on single-page apps like VK.com without a page refresh.

## The Problem

When playing music on sites like VK.com, switching tracks would leave the old song info displayed in the media controls. The metadata from the page's Media Session API was updating, but the UI wasn't picking it up.

## The Fix

Two-part approach:

1. **Immediate update**: Force a metadata UI refresh in ctivateMediaControls even when the browser tab hasn't changed - this catches the initial track change event
2. **Polling fallback**: Added a metadata consistency check to the existing 1-second progress bar update interval to catch any delayed or missed updates

## Testing

1. Open VK.com (or any single-page music app)
2. Play a song - metadata should show in the toolbar
3. Switch to another song without refreshing
4. Metadata should update to show the new song