### PR TITLE
Fix: Settings panel positioning on Wayland/Linux

### DIFF
--- a/src/browser/base/content/zen-panels/site-data.inc
+++ b/src/browser/base/content/zen-panels/site-data.inc
@@ -5,7 +5,8 @@
 <panel id="zen-unified-site-data-panel"
         role="group"
         type="arrow"
-        noautofocus="true">
+        noautofocus="true"
+        position="bottomright topright">
   <panelmultiview mainViewId="unified-extensions-view">
 # We'll keep the view with this name/id in order to prevent
 # any sort of future issues we may have if firefox decides


### PR DESCRIPTION
This PR fixes the issue where the settings menu appears outside the browser window on Linux (Wayland) systems, as reported in #11873.

### What happened?
On Linux/Wayland, clicking the 3-dots menu → Settings would cause the settings dropdown to appear **outside and to the right** of the main browser window, floating in desktop space instead of being anchored to the browser interface.

### Root cause
The `zen-unified-site-data-panel` element was missing a `position` attribute that controls how Firefox places the popup relative to its anchor. Without this attribute:
- Firefox uses default positioning behavior
- On Wayland, the positioning system has known issues (Firefox bugs 1764319, 1771104, 1765714)
- Panels can be placed incorrectly relative to the anchor or extend outside browser window bounds

Firefox's own `unified-extensions-panel` includes `position="bottomright topright"` for this exact reason.

### What this PR changes
- Adds `position="bottomright topright"` attribute to the `<panel>` element in `src/browser/base/content/zen-panels/site-data.inc`
- This aligns Zen's panel behavior with Firefox's unified extensions panel
- The position attribute tells Firefox to anchor the panel's bottom-right corner to the anchor's top-right corner

### Testing
- This fix should be tested on Linux/Wayland (Omarchy OS specifically mentioned in the original report)
- No changes needed for Windows/macOS (position attribute is cross-platform)

### Related issues
- Fixes #11873
- Related to upstream Firefox fixes: Bug 1764319, Bug 1771104, Bug 1765714