### PR TITLE
fix: Update notification popup icon styles to account for showing state

### DIFF
--- a/src/zen/common/styles/zen-omnibox.css
+++ b/src/zen/common/styles/zen-omnibox.css
@@ -309,7 +309,7 @@
     order: 2;
   }
 
-  #notification-popup-box:not([open]) {
+  #notification-popup-box:not([open]):not(:has(> [showing="true"])) {
     margin-inline-start: calc(-10px - 2 * var(--urlbar-icon-padding));
     opacity: 0;
     transition: all 0.2s;


### PR DESCRIPTION
Fixes #11870 

Icons in the omnibox indicate pending actions (e.g., password save modal) and should remain visible until the user completes or rejects the action.

When a modal is dismissed, JS keeps showing=true on the icon, but Zen wasn't accounting for this and hid the icon with opacity: 0 while keeping it clickable.
This also blocked clicks to icons positioned underneath.

https://github.com/user-attachments/assets/545fc42b-363f-4457-bcee-bec4957849a5
