### PR TITLE
fix(split-view): correct backwards navigation in grid layout

### DIFF
--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -1386,10 +1386,10 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
           new nsSplitLeafNode(tabs[i], 50),
           new nsSplitLeafNode(tabs[i + 1], 50),
         ];
-        rootNode.addChild(columnNode);
+        rootNode.addChild(columnNode, false);
       }
       if (tabs.length % 2 !== 0) {
-        rootNode.addChild(new nsSplitLeafNode(tabs[tabs.length - 1], rowWidth));
+        rootNode.addChild(new nsSplitLeafNode(tabs[tabs.length - 1], rowWidth), false);
       }
     }
 


### PR DESCRIPTION
The grid layout was being constructed using `addChild`'s default behavior, which prepends nodes. This caused columns to be added in reverse order (Right-to-Left). This change explicitly sets `prepend` to `false` to ensure columns are appended Left-to-Right, matching the logical tab order.

Closes #12070