### PR TITLE
fix(ui): prevent closeTabByDblclick pref from blocking context menu r…

### DIFF
--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -1403,7 +1403,8 @@ window.gZenVerticalTabsManager = {
     if (
       this._tabEdited ||
       ((!Services.prefs.getBoolPref("zen.tabs.rename-tabs") ||
-        Services.prefs.getBoolPref("browser.tabs.closeTabByDblclick")) &&
+        (Services.prefs.getBoolPref("browser.tabs.closeTabByDblclick") &&
+          event.type === "dblclick")) &&
         isTab) ||
       !gZenVerticalTabsManager._prefsSidebarExpanded
     ) {


### PR DESCRIPTION
Refined the logic in `renameTabStart` to check `event.type`. The function now only aborts if the event is a double-click AND the close-on-double-click preference is enabled, restoring functionality to the context menu.

This also closes #12060