### PR TITLE
feat(ui): Add pref to force native xdg popups instead of subsurfaces

### DIFF
--- a/prefs/zen/gtk.yaml
+++ b/prefs/zen/gtk.yaml
@@ -10,3 +10,7 @@
 - name: zen.widget.linux.transparency
   value: false
   condition: "defined(MOZ_WIDGET_GTK)"
+
+- name: zen.widget.wayland.force_native_menus
+  value: false
+  condition: "defined(MOZ_WIDGET_GTK)"

--- a/src/widget/gtk/nsWindow-cpp.patch
+++ b/src/widget/gtk/nsWindow-cpp.patch
@@ -1,0 +1,88 @@
+diff --git a/widget/gtk/nsWindow.cpp b/widget/gtk/nsWindow.cpp
+index e8cef42106..1eff90f9ee 100644
+--- a/widget/gtk/nsWindow.cpp
++++ b/widget/gtk/nsWindow.cpp
+@@ -794,2 +794,11 @@ bool nsWindow::WidgetTypeSupportsNativeCompositing() {
+ 
++// Small wrapper for hints that changes them to xdg_popups based on pref
++static GdkWindowTypeHint GetGdkTypeHint(GdkWindowTypeHint aOriginalHint) {
++  if (Preferences::GetBool("zen.widget.wayland.force_native_menus", false)) {
++    return GDK_WINDOW_TYPE_HINT_POPUP_MENU;
++  }
++
++  return aOriginalHint;
++}
++
+ static bool IsPenEvent(GdkEvent* aEvent, bool* isEraser) {
+@@ -1793,3 +1802,3 @@ bool nsWindow::WaylandPopupConfigure() {
+     case PopupType::Tooltip:
+-      gtkTypeHint = GDK_WINDOW_TYPE_HINT_TOOLTIP;
++      gtkTypeHint = GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_TOOLTIP);
+       LOG("  popup type Tooltip");
+@@ -1797,3 +1806,3 @@ bool nsWindow::WaylandPopupConfigure() {
+     default:
+-      gtkTypeHint = GDK_WINDOW_TYPE_HINT_UTILITY;
++      gtkTypeHint = GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_UTILITY);
+       LOG("  popup type Utility");
+@@ -1806,3 +1815,3 @@ bool nsWindow::WaylandPopupConfigure() {
+     LOG("  not tracked in popup hierarchy, switch to Utility");
+-    gtkTypeHint = GDK_WINDOW_TYPE_HINT_UTILITY;
++    gtkTypeHint = GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_UTILITY);
+   }
+@@ -2692,3 +2701,3 @@ void nsWindow::WaylandPopupPrepareForMove() {
+                                              ? GDK_WINDOW_TYPE_HINT_POPUP_MENU
+-                                             : GDK_WINDOW_TYPE_HINT_UTILITY;
++                                             : GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_UTILITY);
+ 
+@@ -2719,5 +2728,5 @@ void nsWindow::WaylandPopupMovePlain(int aX, int aY) {
+   MOZ_DIAGNOSTIC_ASSERT(gtk_window_get_type_hint(GTK_WINDOW(mShell)) ==
+-                            GDK_WINDOW_TYPE_HINT_UTILITY ||
++                            GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_UTILITY) ||
+                         gtk_window_get_type_hint(GTK_WINDOW(mShell)) ==
+-                            GDK_WINDOW_TYPE_HINT_TOOLTIP);
++                            GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_TOOLTIP));
+ 
+@@ -6232,3 +6241,3 @@ nsresult nsWindow::Create(nsIWidget* aParent, const LayoutDeviceIntRect& aRect,
+     LOG("  Is Media PiP window\n");
+-    gtk_window_set_type_hint(GTK_WINDOW(mShell), GDK_WINDOW_TYPE_HINT_UTILITY);
++    gtk_window_set_type_hint(GTK_WINDOW(mShell), GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_UTILITY));
+   } else if (mIsAlert) {
+@@ -6236,3 +6245,3 @@ nsresult nsWindow::Create(nsIWidget* aParent, const LayoutDeviceIntRect& aRect,
+     gtk_window_set_type_hint(GTK_WINDOW(mShell),
+-                             GDK_WINDOW_TYPE_HINT_NOTIFICATION);
++                             GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_NOTIFICATION));
+     gtk_window_set_skip_taskbar_hint(GTK_WINDOW(mShell), TRUE);
+@@ -6242,3 +6251,3 @@ nsresult nsWindow::Create(nsIWidget* aParent, const LayoutDeviceIntRect& aRect,
+     SetDefaultIcon();
+-    gtk_window_set_type_hint(GTK_WINDOW(mShell), GDK_WINDOW_TYPE_HINT_DIALOG);
++    gtk_window_set_type_hint(GTK_WINDOW(mShell), GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_DIALOG));
+     LOG("  nsWindow::Create(): dialog");
+@@ -6255,3 +6264,3 @@ nsresult nsWindow::Create(nsIWidget* aParent, const LayoutDeviceIntRect& aRect,
+     if (mIsDragPopup) {
+-      gtk_window_set_type_hint(GTK_WINDOW(mShell), GDK_WINDOW_TYPE_HINT_DND);
++      gtk_window_set_type_hint(GTK_WINDOW(mShell), GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_DND));
+       LOG("  nsWindow::Create() Drag popup\n");
+@@ -6266,6 +6275,6 @@ nsresult nsWindow::Create(nsIWidget* aParent, const LayoutDeviceIntRect& aRect,
+         case PopupType::Tooltip:
+-          gtkTypeHint = GDK_WINDOW_TYPE_HINT_TOOLTIP;
++          gtkTypeHint = GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_TOOLTIP);
+           break;
+         default:
+-          gtkTypeHint = GDK_WINDOW_TYPE_HINT_UTILITY;
++          gtkTypeHint = GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_UTILITY);
+           break;
+@@ -7210,3 +7219,3 @@ FullscreenTransitionWindow::FullscreenTransitionWindow(GtkWidget* aWidget) {
+ 
+-  gtk_window_set_type_hint(gtkWin, GDK_WINDOW_TYPE_HINT_SPLASHSCREEN);
++  gtk_window_set_type_hint(gtkWin, GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_SPLASHSCREEN));
+   GtkWindowSetTransientFor(gtkWin, GTK_WINDOW(aWidget));
+@@ -9897,3 +9906,3 @@ bool nsWindow::ApplyEnterLeaveMutterWorkaround() {
+       gtk_window_get_type_hint(GTK_WINDOW(mWaylandPopupNext->GetGtkWidget())) ==
+-          GDK_WINDOW_TYPE_HINT_UTILITY) {
++          GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_UTILITY)) {
+     LOG("nsWindow::ApplyEnterLeaveMutterWorkaround(): leave toplevel");
+@@ -9904,3 +9913,3 @@ bool nsWindow::ApplyEnterLeaveMutterWorkaround() {
+       gtk_window_get_type_hint(GTK_WINDOW(mShell)) ==
+-          GDK_WINDOW_TYPE_HINT_UTILITY) {
++          GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_UTILITY)) {
+     LOG("nsWindow::ApplyEnterLeaveMutterWorkaround(): leave popup");

--- a/src/widget/gtk/nsWindow-cpp.patch
+++ b/src/widget/gtk/nsWindow-cpp.patch
@@ -3,7 +3,7 @@ index e8cef42106..1eff90f9ee 100644
 --- a/widget/gtk/nsWindow.cpp
 +++ b/widget/gtk/nsWindow.cpp
 @@ -794,2 +794,11 @@ bool nsWindow::WidgetTypeSupportsNativeCompositing() {
- 
+
 +// Small wrapper for hints that changes them to xdg_popups based on pref
 +static GdkWindowTypeHint GetGdkTypeHint(GdkWindowTypeHint aOriginalHint) {
 +  if (Preferences::GetBool("zen.widget.wayland.force_native_menus", false)) {
@@ -33,7 +33,7 @@ index e8cef42106..1eff90f9ee 100644
                                               ? GDK_WINDOW_TYPE_HINT_POPUP_MENU
 -                                             : GDK_WINDOW_TYPE_HINT_UTILITY;
 +                                             : GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_UTILITY);
- 
+
 @@ -2719,5 +2728,5 @@ void nsWindow::WaylandPopupMovePlain(int aX, int aY) {
    MOZ_DIAGNOSTIC_ASSERT(gtk_window_get_type_hint(GTK_WINDOW(mShell)) ==
 -                            GDK_WINDOW_TYPE_HINT_UTILITY ||
@@ -41,9 +41,8 @@ index e8cef42106..1eff90f9ee 100644
                          gtk_window_get_type_hint(GTK_WINDOW(mShell)) ==
 -                            GDK_WINDOW_TYPE_HINT_TOOLTIP);
 +                            GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_TOOLTIP));
- 
-@@ -6232,3 +6241,3 @@ nsresult nsWindow::Create(nsIWidget* aParent, const LayoutDeviceIntRect& aRect,
-     LOG("  Is Media PiP window\n");
+
+@@ -6232,2 +6241,2 @@ nsresult nsWindow::Create(nsIWidget* aParent, const LayoutDeviceIntRect& aRect,
 -    gtk_window_set_type_hint(GTK_WINDOW(mShell), GDK_WINDOW_TYPE_HINT_UTILITY);
 +    gtk_window_set_type_hint(GTK_WINDOW(mShell), GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_UTILITY));
    } else if (mIsAlert) {
@@ -72,7 +71,7 @@ index e8cef42106..1eff90f9ee 100644
 +          gtkTypeHint = GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_UTILITY);
            break;
 @@ -7210,3 +7219,3 @@ FullscreenTransitionWindow::FullscreenTransitionWindow(GtkWidget* aWidget) {
- 
+
 -  gtk_window_set_type_hint(gtkWin, GDK_WINDOW_TYPE_HINT_SPLASHSCREEN);
 +  gtk_window_set_type_hint(gtkWin, GetGdkTypeHint(GDK_WINDOW_TYPE_HINT_SPLASHSCREEN));
    GtkWindowSetTransientFor(gtkWin, GTK_WINDOW(aWidget));


### PR DESCRIPTION
Just a small patch that changes all type hints related to some kind of popups to POPUP_MENU, so that they would use xdg_popup instead of subsurfaces, this allows compositors to apply some effects to them like blur.
Also kept under a pref to keep it opt-in, to not cause any sudden problems to every user.