### PR TITLE
fix: Fixed Incorrect (Reset pinned tab/Replace pinned url) Text on Essential tab context menu.

### DIFF
--- a/locales/en-US/browser/browser/zen-general.ftl
+++ b/locales/en-US/browser/browser/zen-general.ftl
@@ -6,7 +6,11 @@ zen-panel-ui-current-profile-text = current profile
 
 unified-extensions-description = Extensions are used to bring more extra functionality into { -brand-short-name }.
 tab-context-zen-reset-pinned-tab =
-    .label = Reset Pinned Tab
+    .label =
+        { $isEssential ->
+            [true] Reset Essential Tab
+           *[false] Reset Pinned Tab
+        }
     .accesskey = R
 tab-context-zen-add-essential =
     .label = Add to Essentials
@@ -16,7 +20,11 @@ tab-context-zen-remove-essential =
     .label = Remove from Essentials
     .accesskey = R
 tab-context-zen-replace-pinned-url-with-current =
-    .label = Replace Pinned URL with Current
+    .label =
+        { $isEssential ->
+            [true] Replace Essential URL with Current
+           *[false] Replace Pinned URL with Current
+        }
     .accesskey = C
 tab-context-zen-edit-title =
     .label = Change Label...

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -531,8 +531,14 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     const isVisible = contextTab.pinned && !contextTab.multiselected;
     const isEssential = contextTab.getAttribute("zen-essential");
     const zenAddEssential = document.getElementById("context_zen-add-essential");
-    document.getElementById("context_zen-reset-pinned-tab").hidden = !isVisible;
-    document.getElementById("context_zen-replace-pinned-url-with-current").hidden = !isVisible;
+    const zenResetPinnedTab = document.getElementById("context_zen-reset-pinned-tab");
+    const zenReplacePinnedUrl = document.getElementById("context_zen-replace-pinned-url-with-current");
+    [zenResetPinnedTab, zenReplacePinnedUrl].forEach((element) => {
+      if (element) {
+        element.hidden = !isVisible;
+        document.l10n.setArgs(element, { isEssential });
+      }
+    });
     zenAddEssential.hidden = isEssential || !!contextTab.group;
     document.l10n
       .formatValue("tab-context-zen-add-essential-badge", {


### PR DESCRIPTION
Added conditional labels for reset pinned tabs and replace pinned url options based on whether they are in an `$isEssential` tab context menu or not.

I've Tested and confirmed that Essential tab context menu now correctly shows "Reset Essential tab" and "Replace Essential URL with current", while Pinned tabs context menu retains existing behaviour

Fixes #12177 