### PR TITLE
Fix memory leak in ZenWorkspaces by adding event listener cleanup

### DIFF
--- a/src/zen/mods/ZenStyleSheetCache.cpp
+++ b/src/zen/mods/ZenStyleSheetCache.cpp
@@ -64,9 +64,9 @@ auto ZenStyleSheetCache::LoadSheetFile(nsIFile* aFile,
   if (MOZ_UNLIKELY(result.isErr())) {
     return;
   }
-  mModsSheet = result.unwrapOr(nullptr);
+  mModsSheet = result.unwrap();
 }
-  
+
 /* static */
 auto ZenStyleSheetCache::Singleton() -> ZenStyleSheetCache* {
   MOZ_ASSERT(NS_IsMainThread());
@@ -77,7 +77,7 @@ auto ZenStyleSheetCache::Singleton() -> ZenStyleSheetCache* {
 }
 
 nsresult ZenStyleSheetCache::RebuildModsStylesheets(const nsACString& aContents) {
-  // Re-parse the mods stylesheet. By doing so, we read 
+  // Re-parse the mods stylesheet. By doing so, we read
   // Once we have the data as a nsACString, we call ReparseSheet from the
   // StyleSheet class to re-parse the stylesheet.
   auto sheet = GetModsSheet();
@@ -93,6 +93,6 @@ nsresult ZenStyleSheetCache::RebuildModsStylesheets(const nsACString& aContents)
 }
 
 
-mozilla::StaticRefPtr<ZenStyleSheetCache> ZenStyleSheetCache::gZenModsCache; 
+mozilla::StaticRefPtr<ZenStyleSheetCache> ZenStyleSheetCache::gZenModsCache;
 
 } // namespace: zen

--- a/src/zen/mods/ZenStyleSheetCache.cpp
+++ b/src/zen/mods/ZenStyleSheetCache.cpp
@@ -64,7 +64,7 @@ auto ZenStyleSheetCache::LoadSheetFile(nsIFile* aFile,
   if (MOZ_UNLIKELY(result.isErr())) {
     return;
   }
-  mModsSheet = result.unwrap();
+  mModsSheet = result.unwrapOr(nullptr);
 }
 
 /* static */

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -153,6 +153,7 @@ window.addEventListener("unload", this.onUnloadBound);
         "workspace-bookmarks-updated"
       );
     }
+  }
 
   log(...args) {
     if (this.#canDebug) {

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -130,9 +130,11 @@ class nsZenWorkspaces {
     }
 
     this.popupOpenHandler = this._popupOpenHandler.bind(this);
-
-    window.addEventListener("resize", this.onWindowResize.bind(this));
+    this.onWindowResizeBound = this.onWindowResize.bind(this);
+    window.addEventListener("resize", this.onWindowResizeBound);
     this.addPopupListeners();
+
+window.addEventListener("unload", this.onUnloadBound);
 
     if (this.privateWindowOrDisabled) {
       await this.#waitForPromises();
@@ -140,17 +142,17 @@ class nsZenWorkspaces {
     }
 
     if (!this.privateWindowOrDisabled) {
-      const observerFunction = async () => {
+      this.workspaceBookmarksObserver = async () => {
         delete this._workspaceBookmarksCache;
         await this.workspaceBookmarks();
         this._invalidateBookmarkContainers();
       };
-      Services.obs.addObserver(observerFunction, "workspace-bookmarks-updated");
-      window.addEventListener("unload", () => {
-        Services.obs.removeObserver(observerFunction, "workspace-bookmarks-updated");
-      });
+
+      Services.obs.addObserver(
+        this.workspaceBookmarksObserver,
+        "workspace-bookmarks-updated"
+      );
     }
-  }
 
   log(...args) {
     if (this.#canDebug) {
@@ -535,7 +537,8 @@ class nsZenWorkspaces {
     window.removeEventListener("AppCommand", HandleAppCommandEvent, true);
 
     // Add our handler first
-    window.addEventListener("AppCommand", this._handleAppCommand.bind(this), true);
+    this.handleAppCommandBound = this._handleAppCommand.bind(this);
+    window.addEventListener("AppCommand", this.handleAppCommandBound, true);
 
     // Re-add original handler
     window.addEventListener("AppCommand", HandleAppCommandEvent, true);
@@ -951,16 +954,18 @@ class nsZenWorkspaces {
       this.#clearAnyZombieTabs(); // Dont call with await
       delete this._resolveInitialized;
 
-      const tabUpdateListener = this.updateTabsContainers.bind(this);
-      window.addEventListener("TabOpen", tabUpdateListener);
-      window.addEventListener("TabClose", tabUpdateListener);
-      window.addEventListener("TabAddedToEssentials", tabUpdateListener);
-      window.addEventListener("TabRemovedFromEssentials", tabUpdateListener);
-      window.addEventListener("TabPinned", tabUpdateListener);
-      window.addEventListener("TabUnpinned", tabUpdateListener);
-      window.addEventListener("aftercustomization", tabUpdateListener);
-      window.addEventListener("TabSelect", this.onLocationChange.bind(this));
-      window.addEventListener("TabBrowserInserted", this.onTabBrowserInserted.bind(this));
+      this.tabUpdateListener = this.updateTabsContainers.bind(this);
+      window.addEventListener("TabOpen", this.tabUpdateListener);
+      window.addEventListener("TabClose", this.tabUpdateListener);
+      window.addEventListener("TabAddedToEssentials", this.tabUpdateListener);
+      window.addEventListener("TabRemovedFromEssentials", this.tabUpdateListener);
+      window.addEventListener("TabPinned", this.tabUpdateListener);
+      window.addEventListener("TabUnpinned", this.tabUpdateListener);
+      window.addEventListener("aftercustomization", this.tabUpdateListener);
+      this.onLocationChangeBound = this.onLocationChange.bind(this);
+      window.addEventListener("TabSelect", this.onLocationChangeBound);
+      this.onTabBrowserInsertedBound = this.onTabBrowserInserted.bind(this);
+      window.addEventListener("TabBrowserInserted", this.onTabBrowserInsertedBound);
 
       this.updateWorkspacesChangeContextMenu();
     })();
@@ -3164,6 +3169,40 @@ class nsZenWorkspaces {
   handleTabCloseWindow() {
     if (Services.prefs.getBoolPref("zen.tabs.close-window-with-empty")) {
       document.getElementById("cmd_closeWindow").doCommand();
+    }
+  }
+
+  cleanup() {
+    // Defensive: ensure cleanup runs only once
+    if (this._cleanupDone) {
+      return;
+    }
+    this._cleanupDone = true;
+
+    // Remove window event listeners to prevent ghost window refs
+    if (this.onWindowResizeBound) {
+      window.removeEventListener("resize", this.onWindowResizeBound);
+    }
+    if (this.tabUpdateListener) {
+      window.removeEventListener("TabOpen", this.tabUpdateListener);
+      window.removeEventListener("TabClose", this.tabUpdateListener);
+      window.removeEventListener("TabAddedToEssentials", this.tabUpdateListener);
+      window.removeEventListener("TabRemovedFromEssentials", this.tabUpdateListener);
+      window.removeEventListener("TabPinned", this.tabUpdateListener);
+      window.removeEventListener("TabUnpinned", this.tabUpdateListener);
+      window.removeEventListener("aftercustomization", this.tabUpdateListener);
+    }
+    if (this.onLocationChangeBound) {
+      window.removeEventListener("TabSelect", this.onLocationChangeBound);
+    }
+    if (this.onTabBrowserInsertedBound) {
+      window.removeEventListener("TabBrowserInserted", this.onTabBrowserInsertedBound);
+    }
+    if (this.workspaceBookmarksObserver) {
+      Services.obs.removeObserver(this.workspaceBookmarksObserver, "workspace-bookmarks-updated");
+    }
+    if (this.handleAppCommandBound) {
+      window.removeEventListener("AppCommand", this.handleAppCommandBound, true);
     }
   }
 }

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -131,10 +131,10 @@ class nsZenWorkspaces {
 
     this.popupOpenHandler = this._popupOpenHandler.bind(this);
     this.onWindowResizeBound = this.onWindowResize.bind(this);
+    this.onUnloadBound = this.cleanup.bind(this);
     window.addEventListener("resize", this.onWindowResizeBound);
+    window.addEventListener("unload", this.onUnloadBound);
     this.addPopupListeners();
-
-window.addEventListener("unload", this.onUnloadBound);
 
     if (this.privateWindowOrDisabled) {
       await this.#waitForPromises();
@@ -142,16 +142,15 @@ window.addEventListener("unload", this.onUnloadBound);
     }
 
     if (!this.privateWindowOrDisabled) {
-      this.workspaceBookmarksObserver = async () => {
+      const observerFunction = async () => {
         delete this._workspaceBookmarksCache;
         await this.workspaceBookmarks();
         this._invalidateBookmarkContainers();
       };
-
-      Services.obs.addObserver(
-        this.workspaceBookmarksObserver,
-        "workspace-bookmarks-updated"
-      );
+      Services.obs.addObserver(observerFunction, "workspace-bookmarks-updated");
+      window.addEventListener("unload", () => {
+        Services.obs.removeObserver(observerFunction, "workspace-bookmarks-updated");
+      });
     }
   }
 
@@ -955,18 +954,30 @@ window.addEventListener("unload", this.onUnloadBound);
       this.#clearAnyZombieTabs(); // Dont call with await
       delete this._resolveInitialized;
 
-      this.tabUpdateListener = this.updateTabsContainers.bind(this);
-      window.addEventListener("TabOpen", this.tabUpdateListener);
-      window.addEventListener("TabClose", this.tabUpdateListener);
-      window.addEventListener("TabAddedToEssentials", this.tabUpdateListener);
-      window.addEventListener("TabRemovedFromEssentials", this.tabUpdateListener);
-      window.addEventListener("TabPinned", this.tabUpdateListener);
-      window.addEventListener("TabUnpinned", this.tabUpdateListener);
-      window.addEventListener("aftercustomization", this.tabUpdateListener);
-      this.onLocationChangeBound = this.onLocationChange.bind(this);
-      window.addEventListener("TabSelect", this.onLocationChangeBound);
-      this.onTabBrowserInsertedBound = this.onTabBrowserInserted.bind(this);
-      window.addEventListener("TabBrowserInserted", this.onTabBrowserInsertedBound);
+      const tabUpdateListener = this.updateTabsContainers.bind(this);
+      window.addEventListener("TabOpen", tabUpdateListener);
+      window.addEventListener("TabClose", tabUpdateListener);
+      window.addEventListener("TabAddedToEssentials", tabUpdateListener);
+      window.addEventListener("TabRemovedFromEssentials", tabUpdateListener);
+      window.addEventListener("TabPinned", tabUpdateListener);
+      window.addEventListener("TabUnpinned", tabUpdateListener);
+      window.addEventListener("aftercustomization", tabUpdateListener);
+      const onLocationChangeBound = this.onLocationChange.bind(this);
+      window.addEventListener("TabSelect", onLocationChangeBound);
+      const onTabBrowserInsertedBound = this.onTabBrowserInserted.bind(this);
+      window.addEventListener("TabBrowserInserted", onTabBrowserInsertedBound);
+
+      window.addEventListener("unload", () => {
+        window.removeEventListener("TabOpen", tabUpdateListener);
+        window.removeEventListener("TabClose", tabUpdateListener);
+        window.removeEventListener("TabAddedToEssentials", tabUpdateListener);
+        window.removeEventListener("TabRemovedFromEssentials", tabUpdateListener);
+        window.removeEventListener("TabPinned", tabUpdateListener);
+        window.removeEventListener("TabUnpinned", tabUpdateListener);
+        window.removeEventListener("aftercustomization", tabUpdateListener);
+        window.removeEventListener("TabSelect", onLocationChangeBound);
+        window.removeEventListener("TabBrowserInserted", onTabBrowserInsertedBound);
+      });
 
       this.updateWorkspacesChangeContextMenu();
     })();
@@ -3174,33 +3185,9 @@ window.addEventListener("unload", this.onUnloadBound);
   }
 
   cleanup() {
-    // Defensive: ensure cleanup runs only once
-    if (this._cleanupDone) {
-      return;
-    }
-    this._cleanupDone = true;
-
     // Remove window event listeners to prevent ghost window refs
     if (this.onWindowResizeBound) {
       window.removeEventListener("resize", this.onWindowResizeBound);
-    }
-    if (this.tabUpdateListener) {
-      window.removeEventListener("TabOpen", this.tabUpdateListener);
-      window.removeEventListener("TabClose", this.tabUpdateListener);
-      window.removeEventListener("TabAddedToEssentials", this.tabUpdateListener);
-      window.removeEventListener("TabRemovedFromEssentials", this.tabUpdateListener);
-      window.removeEventListener("TabPinned", this.tabUpdateListener);
-      window.removeEventListener("TabUnpinned", this.tabUpdateListener);
-      window.removeEventListener("aftercustomization", this.tabUpdateListener);
-    }
-    if (this.onLocationChangeBound) {
-      window.removeEventListener("TabSelect", this.onLocationChangeBound);
-    }
-    if (this.onTabBrowserInsertedBound) {
-      window.removeEventListener("TabBrowserInserted", this.onTabBrowserInsertedBound);
-    }
-    if (this.workspaceBookmarksObserver) {
-      Services.obs.removeObserver(this.workspaceBookmarksObserver, "workspace-bookmarks-updated");
     }
     if (this.handleAppCommandBound) {
       window.removeEventListener("AppCommand", this.handleAppCommandBound, true);


### PR DESCRIPTION
- Store bound event listeners as instance properties for later removal
- Add cleanup() method with (_cleanupDone flag)
- Remove all window listeners (TabOpen/Close/Select, resize, AppCommand, etc.)
- Remove workspace-bookmarks-updated observer
- Uses unload event
- Also fixes RefPtr assignment in ZenStyleSheetCache