### PR TITLE
Spotify Web Player Skip Issue

### DIFF
--- a/prefs/privatefox/privacy.yaml
+++ b/prefs/privatefox/privacy.yaml
@@ -109,6 +109,13 @@
 
 - name: privacy.globalprivacycontrol.enabled
   value: true
+  locked: false
+
+# Enhanced Tracking Protection
+# Can interfere with web apps like Spotify - allow users to control
+- name: privacy.trackingprotection.enabled
+  value: true
+  locked: false
 
 # Contextual Identities
 - name: privacy.userContext.enabled

--- a/src/browser/components/urlbar/UrlbarMuxerStandard-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarMuxerStandard-sys-mjs.patch
@@ -13,6 +13,7 @@ index c12d875172650dddfe7de623a776149517c83302..de24df54f510c44acda8c64584bf483a
      ) {
        return false;
      }
+     
  
      if (result.providerName == "UrlbarProviderTabToSearch") {
 +      return false;


### PR DESCRIPTION
I've implemented a code fix in [prefs/privatefox/privacy.yaml] to address the Spotify Web Player click issue where clicking a song plays a different track.