### PR TITLE
chore: fix issue where transparent browsers have a forced-white sync …

### DIFF
--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -798,7 +798,7 @@ class nsZenWindowSync {
           {
             fullScale: true,
             fullViewport: true,
-            backgroundColor: "transparent"
+            backgroundColor: "transparent",
           }
         );
 

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -798,6 +798,7 @@ class nsZenWindowSync {
           {
             fullScale: true,
             fullViewport: true,
+            backgroundColor: "transparent"
           }
         );
 


### PR DESCRIPTION
This pull request introduces a minor enhancement to the window synchronization options by specifying a transparent background color. This change helps ensure that synchronized windows have a consistent and visually clear appearance.

* Added the `backgroundColor: "transparent"` option to the window synchronization settings in the `nsZenWindowSync` class.
This doesn't break non-transparent browsers.