### PR TITLE
fix: Merge duplicate fullscreen shortcuts into single toggle

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -818,6 +818,13 @@ const zenMissingKeyboardShortcutL10n = {
   key_accessibility: "zen-devtools-toggle-accessibility-shortcut",
 };
 
+var zenIgnoreKeyboardShortcutIDs = [
+  "key_enterFullScreen_old",
+  "key_enterFullScreen_compat",
+  "key_exitFullScreen_old",
+  "key_exitFullScreen_compat",
+];
+
 var zenIgnoreKeyboardShortcutL10n = [
   "zen-full-zoom-reduce-shortcut-alt-b",
   "zen-full-zoom-reduce-shortcut-alt-a",
@@ -888,7 +895,11 @@ var gZenCKSSettings = {
 
       const labelValue = zenMissingKeyboardShortcutL10n[keyID] ?? l10nID;
 
-      if (zenIgnoreKeyboardShortcutL10n.includes(labelValue) || shortcut.shouldBeEmpty) {
+      if (
+        zenIgnoreKeyboardShortcutIDs.includes(keyID) ||
+        zenIgnoreKeyboardShortcutL10n.includes(labelValue) ||
+        shortcut.shouldBeEmpty
+      ) {
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Removes the separate "Exit Full Screen" shortcut entry from keyboard settings, since `key_enterFullScreen` already toggles fullscreen (both enter and exit via `View:FullScreen` command)
- Renames "Enter Full Screen" label to "Toggle Full Screen" to accurately reflect its behavior
- Changes across 3 files:
  - `src/zen/kbs/ZenKeyboardShortcuts.mjs` — removed `zen-key-exit-full-screen` from `windowAndTabManagement` group
  - `src/browser/components/preferences/zen-settings.js` — removed `key_exitFullScreen` from l10n map
  - `locales/en-US/.../zen-preferences.ftl` — renamed label and removed exit string

Closes #12237

## Test plan
- [ ] Open Settings > Keyboard Shortcuts > Window & Tab Management
- [ ] Verify only one fullscreen shortcut appears ("Toggle Full Screen") instead of two
- [ ] Verify the shortcut correctly toggles fullscreen both in and out
- [ ] Verify editing the shortcut works as expected