### PR TITLE
fix: properly collapse folder when unloading all tabs

### DIFF
--- a/src/zen/folders/ZenFolder.mjs
+++ b/src/zen/folders/ZenFolder.mjs
@@ -247,6 +247,7 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
 
   unloadAllTabs(event) {
     this.#unloadAllActiveTabs(event, /* noClose */ true);
+    this.collapsed = true;
   }
 
   async #unloadAllActiveTabs(event, noClose = false) {

--- a/src/zen/folders/ZenFolder.mjs
+++ b/src/zen/folders/ZenFolder.mjs
@@ -247,7 +247,6 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
 
   unloadAllTabs(event) {
     this.#unloadAllActiveTabs(event, /* noClose */ true);
-    this.collapsed = true;
   }
 
   async #unloadAllActiveTabs(event, noClose = false) {
@@ -257,6 +256,7 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
       folderToUnload: this,
     });
     this.activeTabs = [];
+    this.collapsed = true;
   }
 
   on_click(event) {


### PR DESCRIPTION
When doing right click > Unload all tabs. It only collapses the folder visually. The folders were not gaining the "collapsed" attribute. So upon browser restart, those folders were expanded.

I don't think there's is a need to also collapse all the subfolders. Only the one we clicked is enough, so the user can just expand it and get back the previous structure state of folders.