### PR TITLE
feat: Smart tab hibernation for inactive background tabs

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -56,6 +56,20 @@ pane-settings-workspaces-title = Workspaces
 zen-tabs-select-recently-used-on-close =
     .label = When closing a tab, switch to the most recently used tab instead of the next tab
 
+zen-tabs-smart-hibernate-enabled =
+    .label = Automatically hibernate inactive background tabs
+zen-tabs-smart-hibernate-timeout-label = Hibernate tab after inactivity
+zen-tabs-smart-hibernate-timeout-5-minutes =
+    .label = 5 minutes
+zen-tabs-smart-hibernate-timeout-10-minutes =
+    .label = 10 minutes
+zen-tabs-smart-hibernate-timeout-15-minutes =
+    .label = 15 minutes
+zen-tabs-smart-hibernate-timeout-30-minutes =
+    .label = 30 minutes
+zen-tabs-smart-hibernate-timeout-60-minutes =
+    .label = 60 minutes
+
 zen-tabs-close-on-back-with-no-history =
     .label = Close tab and switch to its owner tab (or most recently used tab) when going back with no history
 

--- a/prefs/zen/zen.yaml
+++ b/prefs/zen/zen.yaml
@@ -26,6 +26,12 @@
 - name: zen.tabs.use-legacy-drag-and-drop
   value: false
 
+- name: zen.tabs.smart_hibernate.enabled
+  value: false
+
+- name: zen.tabs.smart_hibernate.timeout_minutes
+  value: 15
+
 - name: zen.tabs.folder-dragover-threshold-percent
   value: 20 # Percentage of folder height to trigger dragover
 

--- a/prefs/zen/zen.yaml
+++ b/prefs/zen/zen.yaml
@@ -26,10 +26,10 @@
 - name: zen.tabs.use-legacy-drag-and-drop
   value: false
 
-- name: zen.tabs.smart_hibernate.enabled
+- name: zen.tabs.smart-hibernate.enabled
   value: false
 
-- name: zen.tabs.smart_hibernate.timeout_minutes
+- name: zen.tabs.smart-hibernate.timeout-minutes
   value: 15
 
 - name: zen.tabs.folder-dragover-threshold-percent

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -736,7 +736,7 @@ var gZenWorkspacesSettings = {
         if (!timeout) {
           return;
         }
-        timeout.disabled = !Services.prefs.getBoolPref("zen.tabs.smart_hibernate.enabled", false);
+        timeout.disabled = !Services.prefs.getBoolPref("zen.tabs.smart-hibernate.enabled", false);
       },
     };
 
@@ -752,7 +752,7 @@ var gZenWorkspacesSettings = {
       toggleZenCycleByAttrWarning
     );
     Services.prefs.addObserver("browser.ctrlTab.sortByRecentlyUsed", toggleZenCycleByAttrWarning);
-    Services.prefs.addObserver("zen.tabs.smart_hibernate.enabled", toggleSmartHibernateTimeout);
+    Services.prefs.addObserver("zen.tabs.smart-hibernate.enabled", toggleSmartHibernateTimeout);
     window.addEventListener("unload", () => {
       Services.prefs.removeObserver("zen.glance.enabled", tabsUnloaderPrefListener);
       Services.prefs.removeObserver("zen.glance.activation-method", tabsUnloaderPrefListener);
@@ -770,7 +770,7 @@ var gZenWorkspacesSettings = {
         toggleZenCycleByAttrWarning
       );
       Services.prefs.removeObserver(
-        "zen.tabs.smart_hibernate.enabled",
+        "zen.tabs.smart-hibernate.enabled",
         toggleSmartHibernateTimeout
       );
     });
@@ -1230,12 +1230,12 @@ Preferences.addAll([
     default: true,
   },
   {
-    id: "zen.tabs.smart_hibernate.enabled",
+    id: "zen.tabs.smart-hibernate.enabled",
     type: "bool",
     default: false,
   },
   {
-    id: "zen.tabs.smart_hibernate.timeout_minutes",
+    id: "zen.tabs.smart-hibernate.timeout-minutes",
     type: "int",
     default: 15,
   },

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -730,8 +730,18 @@ var gZenWorkspacesSettings = {
         );
       },
     };
+    let toggleSmartHibernateTimeout = {
+      observe() {
+        const timeout = document.getElementById("zenTabsSmartHibernateTimeout");
+        if (!timeout) {
+          return;
+        }
+        timeout.disabled = !Services.prefs.getBoolPref("zen.tabs.smart_hibernate.enabled", false);
+      },
+    };
 
     toggleZenCycleByAttrWarning.observe(); // call it once on initial load
+    toggleSmartHibernateTimeout.observe();
 
     Services.prefs.addObserver("zen.glance.enabled", tabsUnloaderPrefListener); // We can use the same listener for both prefs
     Services.prefs.addObserver("zen.workspaces.separate-essentials", tabsUnloaderPrefListener);
@@ -742,6 +752,7 @@ var gZenWorkspacesSettings = {
       toggleZenCycleByAttrWarning
     );
     Services.prefs.addObserver("browser.ctrlTab.sortByRecentlyUsed", toggleZenCycleByAttrWarning);
+    Services.prefs.addObserver("zen.tabs.smart_hibernate.enabled", toggleSmartHibernateTimeout);
     window.addEventListener("unload", () => {
       Services.prefs.removeObserver("zen.glance.enabled", tabsUnloaderPrefListener);
       Services.prefs.removeObserver("zen.glance.activation-method", tabsUnloaderPrefListener);
@@ -757,6 +768,10 @@ var gZenWorkspacesSettings = {
       Services.prefs.removeObserver(
         "browser.ctrlTab.sortByRecentlyUsed",
         toggleZenCycleByAttrWarning
+      );
+      Services.prefs.removeObserver(
+        "zen.tabs.smart_hibernate.enabled",
+        toggleSmartHibernateTimeout
       );
     });
   },
@@ -1213,6 +1228,16 @@ Preferences.addAll([
     id: "zen.tabs.select-recently-used-on-close",
     type: "bool",
     default: true,
+  },
+  {
+    id: "zen.tabs.smart_hibernate.enabled",
+    type: "bool",
+    default: false,
+  },
+  {
+    id: "zen.tabs.smart_hibernate.timeout_minutes",
+    type: "int",
+    default: 15,
   },
   {
     id: "zen.window-sync.sync-only-pinned-tabs",

--- a/src/browser/components/preferences/zenTabsManagement.inc.xhtml
+++ b/src/browser/components/preferences/zenTabsManagement.inc.xhtml
@@ -42,6 +42,23 @@
             hidden="true"/>
       <checkbox data-l10n-id="zen-tabs-select-recently-used-on-close"
             preference="zen.tabs.select-recently-used-on-close"/>
+      <checkbox id="zenTabsSmartHibernateEnabled"
+            data-l10n-id="zen-tabs-smart-hibernate-enabled"
+            preference="zen.tabs.smart_hibernate.enabled"/>
+      <hbox align="center">
+            <label id="zenTabsSmartHibernateTimeoutLabel"
+                  data-l10n-id="zen-tabs-smart-hibernate-timeout-label"/>
+            <menulist id="zenTabsSmartHibernateTimeout"
+                  preference="zen.tabs.smart_hibernate.timeout_minutes">
+                  <menupopup>
+                        <menuitem data-l10n-id="zen-tabs-smart-hibernate-timeout-5-minutes" value="5"/>
+                        <menuitem data-l10n-id="zen-tabs-smart-hibernate-timeout-10-minutes" value="10"/>
+                        <menuitem data-l10n-id="zen-tabs-smart-hibernate-timeout-15-minutes" value="15"/>
+                        <menuitem data-l10n-id="zen-tabs-smart-hibernate-timeout-30-minutes" value="30"/>
+                        <menuitem data-l10n-id="zen-tabs-smart-hibernate-timeout-60-minutes" value="60"/>
+                  </menupopup>
+            </menulist>
+      </hbox>
 </groupbox>
 
 <hbox id="zenPinnedTabsManagerCategory"
@@ -78,5 +95,4 @@
 </groupbox>
 
 </html:template>
-
 

--- a/src/browser/components/preferences/zenTabsManagement.inc.xhtml
+++ b/src/browser/components/preferences/zenTabsManagement.inc.xhtml
@@ -44,12 +44,12 @@
             preference="zen.tabs.select-recently-used-on-close"/>
       <checkbox id="zenTabsSmartHibernateEnabled"
             data-l10n-id="zen-tabs-smart-hibernate-enabled"
-            preference="zen.tabs.smart_hibernate.enabled"/>
+            preference="zen.tabs.smart-hibernate.enabled"/>
       <hbox align="center">
             <label id="zenTabsSmartHibernateTimeoutLabel"
                   data-l10n-id="zen-tabs-smart-hibernate-timeout-label"/>
             <menulist id="zenTabsSmartHibernateTimeout"
-                  preference="zen.tabs.smart_hibernate.timeout_minutes">
+                  preference="zen.tabs.smart-hibernate.timeout-minutes">
                   <menupopup>
                         <menuitem data-l10n-id="zen-tabs-smart-hibernate-timeout-5-minutes" value="5"/>
                         <menuitem data-l10n-id="zen-tabs-smart-hibernate-timeout-10-minutes" value="10"/>

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -277,7 +277,9 @@ class nsZenWorkspaces {
     }
 
     this.#smartHibernationTimer = window.setInterval(() => {
-      this.#runSmartHibernationTick();
+      this.#runSmartHibernationTick().catch((error) => {
+        console.error("Unhandled error in smart hibernation tick:", error);
+      });
     }, SMART_HIBERNATION_SCAN_INTERVAL_MS);
   }
 

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -12,9 +12,9 @@ ChromeUtils.defineESModuleGetters(lazy, {
   ZenSessionStore: "resource:///modules/zen/ZenSessionManager.sys.mjs",
 });
 
-const SMART_HIBERNATION_ENABLED_PREF = "zen.tabs.smart_hibernate.enabled";
-const SMART_HIBERNATION_TIMEOUT_PREF = "zen.tabs.smart_hibernate.timeout_minutes";
-const SMART_HIBERNATION_DEFAULT_TIMEOUT_MINUTES = 15;
+const SMART_HIBERNATION_ENABLED_PREF = "zen.tabs.smart-hibernate.enabled";
+const SMART_HIBERNATION_TIMEOUT_PREF = "zen.tabs.smart-hibernate.timeout-minutes";
+const SMART_HIBERNATION_DEFAULT_TIMEOUT_MIN = 15;
 const SMART_HIBERNATION_SCAN_INTERVAL_MS = 60_000;
 
 /**
@@ -231,11 +231,23 @@ class nsZenWorkspaces {
   }
 
   #handleSmartHibernationTabSelect(event) {
-    this.#recordTabActivity(event.target);
+    const tab =
+      typeof gZenGlanceManager !== "undefined" &&
+      gZenGlanceManager &&
+      typeof gZenGlanceManager.getTabOrGlanceParent === "function"
+        ? gZenGlanceManager.getTabOrGlanceParent(event.target)
+        : event.target;
+    this.#recordTabActivity(tab);
   }
 
   #handleSmartHibernationTabOpen(event) {
-    this.#recordTabActivity(event.target);
+    const tab =
+      typeof gZenGlanceManager !== "undefined" &&
+      gZenGlanceManager &&
+      typeof gZenGlanceManager.getTabOrGlanceParent === "function"
+        ? gZenGlanceManager.getTabOrGlanceParent(event.target)
+        : event.target;
+    this.#recordTabActivity(tab);
   }
 
   #seedTabActivityTimestamps() {
@@ -319,7 +331,7 @@ class nsZenWorkspaces {
   #pickTabForSmartHibernation() {
     const timeoutMinutes = Services.prefs.getIntPref(
       SMART_HIBERNATION_TIMEOUT_PREF,
-      SMART_HIBERNATION_DEFAULT_TIMEOUT_MINUTES
+      SMART_HIBERNATION_DEFAULT_TIMEOUT_MIN
     );
     if (timeoutMinutes <= 0) {
       return null;

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -41,6 +41,10 @@ class nsZenWorkspaces {
   _workspaceCache = [];
 
   #lastScrollTime = 0;
+  #tabLastActiveAt = new WeakMap();
+  #tabActivityListenersReady = false;
+  #onTabSelectedForHibernation = null;
+  #onTabOpenedForHibernation = null;
 
   bookmarkMenus = [
     "PlacesToolbar",
@@ -157,6 +161,75 @@ class nsZenWorkspaces {
       /* eslint-disable no-console */
       console.debug(`[gZenWorkspaces]:`, ...args);
     }
+  }
+
+  #initSmartTabActivityTracking() {
+    if (this.#tabActivityListenersReady) {
+      return;
+    }
+
+    this.#tabActivityListenersReady = true;
+    this.#onTabSelectedForHibernation = this.#handleSmartHibernationTabSelect.bind(this);
+    this.#onTabOpenedForHibernation = this.#handleSmartHibernationTabOpen.bind(this);
+
+    window.addEventListener("TabSelect", this.#onTabSelectedForHibernation);
+    window.addEventListener("TabOpen", this.#onTabOpenedForHibernation);
+
+    this.#seedTabActivityTimestamps();
+
+    window.addEventListener(
+      "unload",
+      () => {
+        this.#shutdownSmartTabActivityTracking();
+      },
+      { once: true }
+    );
+  }
+
+  #shutdownSmartTabActivityTracking() {
+    if (!this.#tabActivityListenersReady) {
+      return;
+    }
+
+    this.#tabActivityListenersReady = false;
+
+    if (this.#onTabSelectedForHibernation) {
+      window.removeEventListener("TabSelect", this.#onTabSelectedForHibernation);
+      this.#onTabSelectedForHibernation = null;
+    }
+
+    if (this.#onTabOpenedForHibernation) {
+      window.removeEventListener("TabOpen", this.#onTabOpenedForHibernation);
+      this.#onTabOpenedForHibernation = null;
+    }
+  }
+
+  #handleSmartHibernationTabSelect(event) {
+    this.#recordTabActivity(event.target);
+  }
+
+  #handleSmartHibernationTabOpen(event) {
+    this.#recordTabActivity(event.target);
+  }
+
+  #seedTabActivityTimestamps() {
+    const now = Date.now();
+    for (const tab of this.#getCurrentTabsForSmartHibernation()) {
+      this.#tabLastActiveAt.set(tab, now);
+    }
+  }
+
+  #recordTabActivity(tab) {
+    if (!tab || !gBrowser.isTab(tab)) {
+      return;
+    }
+
+    this.#tabLastActiveAt.set(tab, Date.now());
+  }
+
+  #getCurrentTabsForSmartHibernation() {
+    delete this._allStoredTabs;
+    return this.allStoredTabs;
   }
 
   #afterLoadInit() {
@@ -938,6 +1011,7 @@ class nsZenWorkspaces {
       window.addEventListener("TabSelect", this.onLocationChange.bind(this));
       window.addEventListener("TabBrowserInserted", this.onTabBrowserInserted.bind(this));
 
+      this.#initSmartTabActivityTracking();
       this.updateWorkspacesChangeContextMenu();
     })();
   }

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -12,6 +12,11 @@ ChromeUtils.defineESModuleGetters(lazy, {
   ZenSessionStore: "resource:///modules/zen/ZenSessionManager.sys.mjs",
 });
 
+const SMART_HIBERNATION_ENABLED_PREF = "zen.tabs.smart_hibernate.enabled";
+const SMART_HIBERNATION_TIMEOUT_PREF = "zen.tabs.smart_hibernate.timeout_minutes";
+const SMART_HIBERNATION_DEFAULT_TIMEOUT_MINUTES = 15;
+const SMART_HIBERNATION_SCAN_INTERVAL_MS = 60_000;
+
 /**
  * Zen Spaces manager. This class is mainly responsible for the UI
  * and user interactions but it also contains some logic to manage
@@ -45,6 +50,9 @@ class nsZenWorkspaces {
   #tabActivityListenersReady = false;
   #onTabSelectedForHibernation = null;
   #onTabOpenedForHibernation = null;
+  #smartHibernationTimer = null;
+  #smartHibernationPrefObserver = null;
+  #smartHibernationTickInProgress = false;
 
   bookmarkMenus = [
     "PlacesToolbar",
@@ -176,6 +184,10 @@ class nsZenWorkspaces {
     window.addEventListener("TabOpen", this.#onTabOpenedForHibernation);
 
     this.#seedTabActivityTimestamps();
+    this.#smartHibernationPrefObserver = this.#onSmartHibernationPrefChanged.bind(this);
+    Services.prefs.addObserver(SMART_HIBERNATION_ENABLED_PREF, this.#smartHibernationPrefObserver);
+    Services.prefs.addObserver(SMART_HIBERNATION_TIMEOUT_PREF, this.#smartHibernationPrefObserver);
+    this.#updateSmartHibernationTimer();
 
     window.addEventListener(
       "unload",
@@ -192,6 +204,20 @@ class nsZenWorkspaces {
     }
 
     this.#tabActivityListenersReady = false;
+
+    this.#stopSmartHibernationTimer();
+
+    if (this.#smartHibernationPrefObserver) {
+      Services.prefs.removeObserver(
+        SMART_HIBERNATION_ENABLED_PREF,
+        this.#smartHibernationPrefObserver
+      );
+      Services.prefs.removeObserver(
+        SMART_HIBERNATION_TIMEOUT_PREF,
+        this.#smartHibernationPrefObserver
+      );
+      this.#smartHibernationPrefObserver = null;
+    }
 
     if (this.#onTabSelectedForHibernation) {
       window.removeEventListener("TabSelect", this.#onTabSelectedForHibernation);
@@ -230,6 +256,139 @@ class nsZenWorkspaces {
   #getCurrentTabsForSmartHibernation() {
     delete this._allStoredTabs;
     return this.allStoredTabs;
+  }
+
+  #onSmartHibernationPrefChanged() {
+    this.#updateSmartHibernationTimer();
+  }
+
+  #updateSmartHibernationTimer() {
+    if (!Services.prefs.getBoolPref(SMART_HIBERNATION_ENABLED_PREF, false)) {
+      this.#stopSmartHibernationTimer();
+      return;
+    }
+
+    this.#startSmartHibernationTimer();
+  }
+
+  #startSmartHibernationTimer() {
+    if (this.#smartHibernationTimer) {
+      return;
+    }
+
+    this.#smartHibernationTimer = window.setInterval(() => {
+      this.#runSmartHibernationTick();
+    }, SMART_HIBERNATION_SCAN_INTERVAL_MS);
+  }
+
+  #stopSmartHibernationTimer() {
+    if (!this.#smartHibernationTimer) {
+      return;
+    }
+
+    window.clearInterval(this.#smartHibernationTimer);
+    this.#smartHibernationTimer = null;
+  }
+
+  async #runSmartHibernationTick() {
+    if (this.#smartHibernationTickInProgress || window.closed) {
+      return;
+    }
+
+    if (!Services.prefs.getBoolPref(SMART_HIBERNATION_ENABLED_PREF, false)) {
+      return;
+    }
+
+    const tabToUnload = this.#pickTabForSmartHibernation();
+    if (!tabToUnload) {
+      return;
+    }
+
+    this.#smartHibernationTickInProgress = true;
+    try {
+      await gBrowser.explicitUnloadTabs([tabToUnload]);
+    } catch (error) {
+      console.error("Error while unloading a smart hibernation tab:", error);
+    } finally {
+      this.#smartHibernationTickInProgress = false;
+    }
+  }
+
+  #pickTabForSmartHibernation() {
+    const timeoutMinutes = Services.prefs.getIntPref(
+      SMART_HIBERNATION_TIMEOUT_PREF,
+      SMART_HIBERNATION_DEFAULT_TIMEOUT_MINUTES
+    );
+    if (timeoutMinutes <= 0) {
+      return null;
+    }
+
+    const now = Date.now();
+    const inactiveBefore = now - timeoutMinutes * 60_000;
+    let oldestTab = null;
+    let oldestActiveTime = Infinity;
+
+    for (const tab of this.#getCurrentTabsForSmartHibernation()) {
+      if (!this.#canSmartHibernateTab(tab)) {
+        continue;
+      }
+
+      let lastActiveTime = this.#tabLastActiveAt.get(tab);
+      if (!lastActiveTime) {
+        lastActiveTime = now;
+        this.#tabLastActiveAt.set(tab, now);
+      }
+
+      if (lastActiveTime > inactiveBefore || lastActiveTime >= oldestActiveTime) {
+        continue;
+      }
+
+      oldestActiveTime = lastActiveTime;
+      oldestTab = tab;
+    }
+
+    return oldestTab;
+  }
+
+  #canSmartHibernateTab(tab) {
+    if (!tab || !gBrowser.isTab(tab)) {
+      return false;
+    }
+
+    if (tab.closing || tab.selected || tab.pinned) {
+      return false;
+    }
+
+    if (tab.undiscardable || tab.hasAttribute("zen-empty-tab")) {
+      return false;
+    }
+
+    if (tab.hasAttribute("pending") || tab.hasAttribute("discarded")) {
+      return false;
+    }
+
+    if (tab.hasAttribute("soundplaying") || tab.hasAttribute("pictureinpicture")) {
+      return false;
+    }
+
+    if (tab.hasAttribute("glance-id") || tab.hasAttribute("zen-glance-tab")) {
+      return false;
+    }
+
+    const browser = tab.linkedBrowser;
+    if (!browser) {
+      return false;
+    }
+
+    if (window.webrtcUI?.browserHasStreams(browser)) {
+      return false;
+    }
+
+    if (browser.browsingContext?.currentWindowGlobal?.hasActivePeerConnections()) {
+      return false;
+    }
+
+    return true;
   }
 
   #afterLoadInit() {


### PR DESCRIPTION
This adds an MVP smart tab hibernation feature that proactively unloads inactive background tabs using Zen’s existing unload path. Tabs are tracked for inactivity and the oldest eligible background tab is discarded on a periodic timer when the feature is enabled.

The implementation reuses gBrowser.explicitUnloadTabs to preserve Firefox session behavior and avoids introducing a new tab termination path. Eligibility checks exclude selected tabs, pinned tabs, audio-playing tabs, and PiP tabs. The feature is controlled via about:config using zen.tabs.smart_hibernate.enabled and zen.tabs.smart_hibernate.timeout_minutes.

Manual testing confirms that inactive background tabs unload after the configured timeout, excluded tabs remain active, and discarded tabs restore normally when selected.