### PR TITLE
Fix screenshot actions hidden behind Glance

### DIFF
--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -9,6 +9,7 @@
   position: absolute !important;
   top: 3%;
   right: 1.5%;
+  z-index: 2;
 }
 
 #zen-workspaces-button .zen-workspace-sidebar-name {


### PR DESCRIPTION
The screenshot actions panel (`#screenshotsPagePanel`) could render behind the Glance overlay.
This patch sets `z-index: 2` for `#screenshotsPagePanel`, which keeps “Save visible” and “Save full page” above Glance (`z-index: 1`) and clickable.
Closes zen-browser/desktop#12196