### PR TITLE
fix: resolve copy URL delay during pending navigations

### DIFF
--- a/src/zen/common/modules/ZenCommonUtils.mjs
+++ b/src/zen/common/modules/ZenCommonUtils.mjs
@@ -85,7 +85,29 @@ export class nsZenPreloadedFeature {
 window.gZenCommonActions = {
   copyCurrentURLToClipboard() {
     const [currentUrl, ClipboardHelper] = gURLBar.zenStrippedURI;
-    const displaySpec = currentUrl.displaySpec;
+
+    let clickedUrl = "";
+    if (window._zenPendingClick && Date.now() - window._zenPendingClick.time < 4000) {
+      clickedUrl = window._zenPendingClick.url;
+      window._zenPendingClick = null;
+    }
+
+    const activeBrowser = gBrowser.selectedBrowser;
+    const engineUrl = activeBrowser.currentURI ? activeBrowser.currentURI.displaySpec : "";
+
+    let visibleUrl = gURLBar.value;
+    if (
+      visibleUrl &&
+      !visibleUrl.startsWith("http") &&
+      !visibleUrl.startsWith("about:") &&
+      !visibleUrl.startsWith("file:") &&
+      !visibleUrl.startsWith("zen:")
+    ) {
+      visibleUrl = "https://" + visibleUrl;
+    }
+
+    const displaySpec = clickedUrl || engineUrl || visibleUrl || currentUrl.displaySpec;
+
     ClipboardHelper.copyString(displaySpec);
     let button;
     /* eslint-disable mozilla/valid-services */
@@ -112,8 +134,29 @@ window.gZenCommonActions = {
 
   copyCurrentURLAsMarkdownToClipboard() {
     const [currentUrl, ClipboardHelper] = gURLBar.zenStrippedURI;
-    const tabTitle = gBrowser.selectedTab.label;
-    const markdownLink = `[${tabTitle}](${currentUrl.displaySpec})`;
+    let clickedUrl = "";
+    if (window._zenPendingClick && Date.now() - window._zenPendingClick.time < 4000) {
+      clickedUrl = window._zenPendingClick.url;
+      window._zenPendingClick = null;
+    }
+
+    const activeBrowser = gBrowser.selectedBrowser;
+    const engineUrl = activeBrowser.currentURI ? activeBrowser.currentURI.displaySpec : "";
+
+    let visibleUrl = gURLBar.value;
+    if (
+      visibleUrl &&
+      !visibleUrl.startsWith("http") &&
+      !visibleUrl.startsWith("about:") &&
+      !visibleUrl.startsWith("file:") &&
+      !visibleUrl.startsWith("zen:")
+    ) {
+      visibleUrl = "https://" + visibleUrl;
+    }
+
+    const displaySpec = clickedUrl || engineUrl || visibleUrl || currentUrl.displaySpec;
+    const tabTitle = gBrowser.selectedTab.label || displaySpec;
+    const markdownLink = `[${tabTitle}](${displaySpec})`;
     ClipboardHelper.copyString(markdownLink);
     gZenUIManager.showToast("zen-copy-current-url-confirmation", { timeout: 3000 });
   },
@@ -141,3 +184,21 @@ window.gZenCommonActions = {
     return Boolean(tab.owner && !tab.pinned && !tab.hasAttribute("zen-empty-tab"));
   },
 };
+
+document.addEventListener(
+  "DOMContentLoaded",
+  () => {
+    const tabPanels = document.getElementById("tabbrowser-tabpanels") || window;
+
+    tabPanels.addEventListener(
+      "mousedown",
+      () => {
+        if (typeof XULBrowserWindow !== "undefined" && XULBrowserWindow.overLink) {
+          window._zenPendingClick = { url: XULBrowserWindow.overLink, time: Date.now() };
+        }
+      },
+      { capture: true, passive: true }
+    );
+  },
+  { once: true }
+);


### PR DESCRIPTION
Closed #11835 

# Summary

Fixes an issue where the "Copy URL" (`Ctrl+Shift+C`) and "Copy URL as Markdown" shortcuts copy the outdated/previous URL if pressed while a new page is still loading.

# Problem

When a user clicks a link that takes a while to load, pressing the Copy URL shortcut historically grabbed the URL of the currently fully loaded website or redirect to about:blank rather than the pending navigation. As a result, users expecting to quickly copy the link they just clicked would end up with the wrong URL in their clipboard.

# Solution
Updated the logic in `ZenCommonUtils.mjs` to prioritize the user's immediate intent over the resolved document state.

The new logic determines the correct URL in the following order:

1. **SPA & Click Interception:** Added a `passive: true` capture listener on `tabbrowser-tabpanels` that briefly caches `XULBrowserWindow.overLink` upon a mouse click. If the user copies within 4 seconds of clicking, it instantly grabs this link (perfectly bypassing SPA background-loading delays).
2. **Pending Engine State:** Checks `gBrowser.selectedBrowser.currentURI` to capture active browser navigations that haven't fully resolved into a loaded document yet. 
3. **Address Bar UI State:** Checks `gURLBar.value` (and automatically re-appends `https://` if visually trimmed) to guarantee the copied URL matches exactly what the user currently sees in their address bar. 
4. **Original Fallback:** If all the above are empty, it gracefully falls back to the original `currentUrl.displaySpec`.

Both `copyCurrentURLToClipboard` and `copyCurrentURLAsMarkdownToClipboard` have been updated to use this new logic.