### PR TITLE
fix: Hide folder icon remove action when no icon is set, b=closes #12401, c=folders, common

### DIFF
--- a/src/zen/common/emojis/ZenEmojiPicker.mjs
+++ b/src/zen/common/emojis/ZenEmojiPicker.mjs
@@ -35,6 +35,10 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
 
   #anchor;
   #emojiAsSVG = false;
+  #closeOnSelect = true;
+  #onSelect = null;
+  #hasSelection = false;
+  #lastSelectedEmoji = null;
 
   #currentPromise = null;
   #currentPromiseResolve = null;
@@ -120,6 +124,14 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     delete this._emojis;
   }
 
+  #setAllowNone(allowNone) {
+    if (allowNone) {
+      this.#panel.removeAttribute("hide-none-option");
+      return;
+    }
+    this.#panel.setAttribute("hide-none-option", "true");
+  }
+
   #onSearchInput(event) {
     const input = event.target;
     const value = input.value.trim().toLowerCase();
@@ -192,13 +204,19 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
 
     this.svgList.innerHTML = "";
 
-    if (this.#currentPromiseReject) {
-      this.#currentPromiseReject(new Error("Emoji picker closed without selection"));
+    if (!this.#hasSelection) {
+      this.#currentPromiseReject?.(new Error("Emoji picker closed without selection"));
+    } else if (!this.#closeOnSelect) {
+      this.#currentPromiseResolve?.(this.#lastSelectedEmoji);
     }
 
     this.#currentPromise = null;
     this.#currentPromiseResolve = null;
     this.#currentPromiseReject = null;
+    this.#onSelect = null;
+    this.#closeOnSelect = true;
+    this.#hasSelection = false;
+    this.#lastSelectedEmoji = null;
 
     this.#anchor.removeAttribute("zen-emoji-open");
     this.#anchor.parentElement.removeAttribute("zen-emoji-open");
@@ -213,15 +231,29 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
         )}</text></svg>`
       )}`;
     }
+    this.#setAllowNone(Boolean(emoji));
+    this.#hasSelection = true;
+    this.#lastSelectedEmoji = emoji;
+    this.#onSelect?.(emoji);
+    if (!this.#closeOnSelect) {
+      return;
+    }
     this.#currentPromiseResolve?.(emoji);
     this.#panel.hidePopup();
   }
 
-  open(anchor, { onlySvgIcons = false, emojiAsSVG = false, allowNone = true } = {}) {
+  open(
+    anchor,
+    { onlySvgIcons = false, emojiAsSVG = false, allowNone = true, closeOnSelect = true, onSelect = null } = {}
+  ) {
     if (this.#currentPromise) {
       return null;
     }
     this.#emojiAsSVG = emojiAsSVG;
+    this.#closeOnSelect = closeOnSelect;
+    this.#onSelect = onSelect;
+    this.#hasSelection = false;
+    this.#lastSelectedEmoji = null;
     this.#currentPromise = new Promise((resolve, reject) => {
       this.#currentPromiseResolve = resolve;
       this.#currentPromiseReject = reject;
@@ -234,11 +266,7 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     } else {
       this.#panel.removeAttribute("only-svg-icons");
     }
-    if (allowNone) {
-      this.#panel.removeAttribute("hide-none-option");
-    } else {
-      this.#panel.setAttribute("hide-none-option", "true");
-    }
+    this.#setAllowNone(allowNone);
     this.#panel.openPopup(anchor, "after_start", 0, 0, false, false);
     return this.#currentPromise;
   }

--- a/src/zen/common/emojis/ZenEmojiPicker.mjs
+++ b/src/zen/common/emojis/ZenEmojiPicker.mjs
@@ -244,7 +244,13 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
 
   open(
     anchor,
-    { onlySvgIcons = false, emojiAsSVG = false, allowNone = true, closeOnSelect = true, onSelect = null } = {}
+    {
+      onlySvgIcons = false,
+      emojiAsSVG = false,
+      allowNone = true,
+      closeOnSelect = true,
+      onSelect = null,
+    } = {}
   ) {
     if (this.#currentPromise) {
       return null;

--- a/src/zen/common/emojis/ZenEmojiPicker.mjs
+++ b/src/zen/common/emojis/ZenEmojiPicker.mjs
@@ -217,7 +217,7 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     this.#panel.hidePopup();
   }
 
-  open(anchor, { onlySvgIcons = false, emojiAsSVG = false } = {}) {
+  open(anchor, { onlySvgIcons = false, emojiAsSVG = false, allowNone = true } = {}) {
     if (this.#currentPromise) {
       return null;
     }
@@ -233,6 +233,11 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
       this.#panel.setAttribute("only-svg-icons", "true");
     } else {
       this.#panel.removeAttribute("only-svg-icons");
+    }
+    if (allowNone) {
+      this.#panel.removeAttribute("hide-none-option");
+    } else {
+      this.#panel.setAttribute("hide-none-option", "true");
     }
     this.#panel.openPopup(anchor, "after_start", 0, 0, false, false);
     return this.#currentPromise;

--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -89,7 +89,7 @@
 
   &[hide-none-option="true"] {
     & #PanelUI-zen-emojis-picker-none {
-      visibility: hidden;
+      opacity: 0;
       pointer-events: none;
     }
   }
@@ -171,6 +171,7 @@
     width: 22px;
     height: 22px;
     appearance: none;
+    transition: opacity 0.08s ease-in-out;
 
     &:hover {
       background-color: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));

--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -87,6 +87,13 @@
     }
   }
 
+  &[hide-none-option="true"] {
+    & #PanelUI-zen-emojis-picker-none {
+      visibility: hidden;
+      pointer-events: none;
+    }
+  }
+
   #PanelUI-zen-emojis-picker-none label {
     display: none;
   }

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -920,20 +920,22 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
       return;
     }
 
-    gZenEmojiPicker
-      .open(group.icon, {
-        onlySvgIcons: true,
-        allowNone: Boolean(
-          group.icon?.querySelector("svg .icon image")?.getAttribute("href")
-        ),
-      })
-      .then((icon) => {
+    const pickerPromise = gZenEmojiPicker.open(group.icon, {
+      onlySvgIcons: true,
+      allowNone: Boolean(group.icon?.querySelector("svg .icon image")?.getAttribute("href")),
+      closeOnSelect: false,
+      onSelect: (icon) => {
         this.setFolderUserIcon(group, icon);
         group.dispatchEvent(new CustomEvent("TabGroupUpdate", { bubbles: true }));
-      })
-      .catch((err) => {
-        console.error(err);
-      });
+      },
+    });
+
+    pickerPromise?.catch((err) => {
+      if (err?.message === "Emoji picker closed without selection") {
+        return;
+      }
+      console.error(err);
+    });
   }
 
   setFolderUserIcon(group, icon) {

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -903,21 +903,14 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
       return;
     }
 
-    const pickerPromise = gZenEmojiPicker.open(group.icon, {
+    gZenEmojiPicker.open(group.icon, {
       onlySvgIcons: true,
-      allowNone: Boolean(group.icon?.querySelector("svg .icon image")?.getAttribute("href")),
+      allowNone: Boolean(group.iconURL),
       closeOnSelect: false,
       onSelect: (icon) => {
         this.setFolderUserIcon(group, icon);
         group.dispatchEvent(new CustomEvent("TabGroupUpdate", { bubbles: true }));
       },
-    });
-
-    pickerPromise?.catch((err) => {
-      if (err?.message === "Emoji picker closed without selection") {
-        return;
-      }
-      console.error(err);
     });
   }
 

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -921,7 +921,7 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     }
 
     gZenEmojiPicker
-      .open(group.icon, { onlySvgIcons: true })
+      .open(group.icon, { onlySvgIcons: true, allowNone: Boolean(group.iconURL) })
       .then((icon) => {
         this.setFolderUserIcon(group, icon);
         group.dispatchEvent(new CustomEvent("TabGroupUpdate", { bubbles: true }));

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -921,7 +921,12 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     }
 
     gZenEmojiPicker
-      .open(group.icon, { onlySvgIcons: true, allowNone: Boolean(group.iconURL) })
+      .open(group.icon, {
+        onlySvgIcons: true,
+        allowNone: Boolean(
+          group.icon?.querySelector("svg .icon image")?.getAttribute("href")
+        ),
+      })
       .then((icon) => {
         this.setFolderUserIcon(group, icon);
         group.dispatchEvent(new CustomEvent("TabGroupUpdate", { bubbles: true }));

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -504,9 +504,11 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     });
     document.getElementById("context_zen-edit-tab-icon").addEventListener("command", () => {
       const tab = TabContextMenu.contextTab;
-      gZenEmojiPicker
-        .open(tab.iconImage, { emojiAsSVG: true })
-        .then((icon) => {
+      gZenEmojiPicker.open(tab.iconImage, {
+        emojiAsSVG: true,
+        closeOnSelect: false,
+        allowNone: Boolean(tab.zenStaticIcon),
+        onSelect: (icon) => {
           if (icon) {
             tab.zenStaticIcon = icon;
           } else {
@@ -516,10 +518,8 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
           lazy.TabStateCache.update(tab.permanentKey, {
             image: null,
           });
-        })
-        .catch((err) => {
-          console.error(err);
-        });
+        },
+      });
     });
   }
 

--- a/src/zen/workspaces/ZenWorkspaceCreation.mjs
+++ b/src/zen/workspaces/ZenWorkspaceCreation.mjs
@@ -218,23 +218,21 @@ class nsZenWorkspaceCreation extends MozXULElement {
   }
 
   onIconCommand(event) {
-    gZenEmojiPicker
-      .open(event.target)
-      .then(async (emoji) => {
-        const isSvg = emoji && emoji.endsWith(".svg");
+    gZenEmojiPicker.open(event.target, {
+      closeOnSelect: false,
+      onSelect: async (icon) => {
+        const isSvg = icon && icon.endsWith(".svg");
         if (isSvg) {
           this.inputIcon.label = "";
-          this.inputIcon.image = emoji;
+          this.inputIcon.image = icon;
           this.inputIcon.setAttribute("has-svg-icon", "true");
         } else {
           this.inputIcon.image = "";
-          this.inputIcon.label = emoji || "";
+          this.inputIcon.label = icon || "";
           this.inputIcon.removeAttribute("has-svg-icon");
         }
-      })
-      .catch((error) => {
-        console.warn("Error changing workspace icon:", error);
-      });
+      },
+    });
   }
 
   set currentProfile(profile) {

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -1085,23 +1085,19 @@ class nsZenWorkspaces {
     if (hasNoIcon) {
       anchor.textContent = "";
     }
-    gZenEmojiPicker
-      .open(anchor)
-      .then(async (emoji) => {
+    gZenEmojiPicker.open(anchor, {
+      closeOnSelect: false,
+      allowNone: hasNoIcon,
+      onSelect: async (icon) => {
         const workspace = this.getWorkspaceFromId(workspaceId);
         if (!workspace) {
           console.warn("No active workspace found to change icon");
           return;
         }
-        workspace.icon = emoji;
+        workspace.icon = icon;
         await this.saveWorkspace(workspace);
-      })
-      .catch((error) => {
-        console.warn("Error changing workspace icon:", error);
-        if (hasNoIcon) {
-          anchor.setAttribute("no-icon", "true");
-        }
-      });
+      },
+    });
   }
 
   shouldCloseWindow() {


### PR DESCRIPTION
## Summary
- hide the remove/trash action in the folder “Change Icon” picker when the folder has no custom icon
- keep the remove action available when a folder icon is already set
- add a picker option to control remove-action visibility without changing behavior for other picker call sites

## Fixed issue
- Closes #12401