### PR TITLE
Folders for unpinned tabs

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -66,6 +66,8 @@ zen-tabs-cycle-by-attribute =
   .label = Ctrl+Tab cycles within Essential or Workspace tabs only
 zen-tabs-cycle-ignore-pending-tabs =
   .label = Ignore Pending tabs when cycling with Ctrl+Tab
+zen-tabs-folders-auto-pin =
+  .label = Automatically pin folders
 zen-tabs-cycle-by-attribute-warning = Ctrl+Tab will cycle by recently used order, as it is enabled
 
 zen-look-and-feel-compact-toolbar-themed =

--- a/locales/en-US/browser/browser/zen-folders.ftl
+++ b/locales/en-US/browser/browser/zen-folders.ftl
@@ -8,6 +8,12 @@ zen-folders-search-placeholder =
 zen-folders-panel-rename-folder =
     .label = Rename Folder
 
+zen-folders-panel-pin-folder =
+    .label = Pin Folder
+
+zen-folders-panel-unpin-folder =
+    .label = Unpin Folder
+
 zen-folders-panel-unpack-folder =
     .label = Unpack Folder
 

--- a/prefs/zen/folders.yaml
+++ b/prefs/zen/folders.yaml
@@ -11,5 +11,8 @@
 - name: zen.folders.max-subfolders
   value: 5
 
+- name: zen.folders.auto-pin
+  value: true
+
 - name: zen.folders.owned-tabs-in-folder
   value: false

--- a/prefs/zen/gtk.yaml
+++ b/prefs/zen/gtk.yaml
@@ -4,7 +4,9 @@
 
 # GTK-specific preferences
 - name: widget.gtk.rounded-bottom-corners.enabled
-  value: true
+  # Disabled for https://github.com/zen-browser/desktop/issues/6302,
+  # also see https://bugzilla.mozilla.org/show_bug.cgi?id=1979083
+  value: false
   condition: "defined(MOZ_WIDGET_GTK)"
 
 - name: zen.widget.linux.transparency

--- a/src/browser/base/content/zen-panels/popups.inc
+++ b/src/browser/base/content/zen-panels/popups.inc
@@ -38,6 +38,9 @@
   <menuitem id="context_zenFolderRename" data-l10n-id="zen-folders-panel-rename-folder"/>
   <menuitem id="context_zenFolderChangeIcon" data-l10n-id="tab-context-zen-edit-icon"/>
   <menuseparator />
+  <menuitem id="context_zenFolderPin" data-l10n-id="zen-folders-panel-pin-folder"/>
+  <menuitem id="context_zenFolderUnpin" data-l10n-id="zen-folders-panel-unpin-folder"/>
+  <menuseparator />
   <menuitem id="context_zenFolderUnloadAll" data-l10n-id="zen-folders-unload-folder"/>
   <menuitem id="context_zenFolderNewSubfolder" data-l10n-id="zen-folders-new-subfolder"/>
   <menuseparator />

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1215,6 +1215,11 @@ Preferences.addAll([
     default: true,
   },
   {
+    id: "zen.folders.auto-pin",
+    type: "bool",
+    default: true,
+  },
+  {
     id: "zen.window-sync.sync-only-pinned-tabs",
     type: "bool",
     default: false,

--- a/src/browser/components/preferences/zenTabsManagement.inc.xhtml
+++ b/src/browser/components/preferences/zenTabsManagement.inc.xhtml
@@ -3,80 +3,78 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 <html:template id="template-paneZenTabManagement">
-<hbox id="ZenWorkspacesCategory"
-      class="subcategory"
-      hidden="true"
-      data-category="paneZenTabManagement">
-</hbox>
-
-<hbox id="zenTabManagementCategory"
-      class="subcategory"
-      hidden="true"
-      data-category="paneZenTabManagement">
-<html:h1 data-l10n-id="pane-settings-workspaces-title"/>
-</hbox>
-
-<groupbox id="zenWorkspacesGroup" data-category="paneZenTabManagement" hidden="true" class="highlighting-group">
-      <label><html:h2 data-l10n-id="zen-settings-workspaces-header"/></label>
-      <description class="description-deemphasized" data-l10n-id="zen-settings-workspaces-description" />
-
-      <checkbox id="zenWorkspacesSyncUnpinnedTabs"
-            data-l10n-id="zen-settings-workspaces-sync-unpinned-tabs"
-            preference="zen.window-sync.sync-only-pinned-tabs"/>
-      <checkbox id="zenWorkspacesHideDefaultContainer"
-            data-l10n-id="zen-settings-workspaces-hide-default-container-indicator"
-            preference="zen.workspaces.hide-default-container-indicator"/>
-      <checkbox id="zenWorkspacesForceContainerTabsToWorkspace"
-            data-l10n-id="zen-settings-workspaces-force-container-tabs-to-workspace"
-            preference="zen.workspaces.force-container-workspace"/>
-      <checkbox id="zenTabsCloseOnBackWithNoHistory"
-            data-l10n-id="zen-tabs-close-on-back-with-no-history"
-            preference="zen.tabs.close-on-back-with-no-history"/>
-      <checkbox data-l10n-id="zen-tabs-cycle-ignore-pending-tabs"
-            preference="zen.tabs.ctrl-tab.ignore-pending-tabs"/>
-      <checkbox data-l10n-id="zen-tabs-cycle-by-attribute"
-            preference="zen.tabs.ctrl-tab.ignore-essential-tabs"/>
-      <description id="zenTabsCycleByAttributeWarning"
-            class="description-deemphasized"
-            data-l10n-id="zen-tabs-cycle-by-attribute-warning"
-            hidden="true"/>
-      <checkbox data-l10n-id="zen-tabs-select-recently-used-on-close"
-            preference="zen.tabs.select-recently-used-on-close"/>
-</groupbox>
-
-<hbox id="zenPinnedTabsManagerCategory"
-      class="subcategory"
-      hidden="true"
-      data-category="paneZenTabManagement">
-      <html:h1 data-l10n-id="pane-zen-pinned-tab-manager-title"/>
-</hbox>
-
-<groupbox id="zenPinnedTabsManagerGroup" data-category="paneZenTabManagement" hidden="true" class="highlighting-group">
-      <label><html:h2 data-l10n-id="zen-pinned-tab-manager-header"/></label>
-      <description class="description-deemphasized" data-l10n-id="zen-pinned-tab-manager-description" />
-
-      <checkbox id="zenPinnedTabRestorePinnedTabsToPinnedUrl"
-                data-l10n-id="zen-pinned-tab-manager-restore-pinned-tabs-to-pinned-url"
-                preference="zen.pinned-tab-manager.restore-pinned-tabs-to-pinned-url"/>
-      <checkbox id="zenPinnedTabContainerSpecificEssentials"
-                data-l10n-id="zen-pinned-tab-manager-container-specific-essentials-enabled"
-                preference="zen.workspaces.separate-essentials"/>
-
-      <hbox align="center">
-            <label id="zenPinnedTabCloseShortcutBehaviorLabel" data-l10n-id="zen-pinned-tab-manager-close-shortcut-behavior-label"/>
-            <menulist id="zenPinnedTabCloseShortcutBehavior" preference="zen.pinned-tab-manager.close-shortcut-behavior">
-                  <menupopup>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-reset-unload-switch-close-shortcut-option" value="reset-unload-switch"/>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-unload-switch-close-shortcut-option" value="unload-switch"/>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-reset-switch-close-shortcut-option" value="reset-switch"/>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-switch-close-shortcut-option" value="switch"/>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-reset-close-shortcut-option" value="reset"/>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-close-close-shortcut-option" value="close"/>
-                  </menupopup>
-            </menulist>
+      <hbox id="ZenWorkspacesCategory" class="subcategory" hidden="true" data-category="paneZenTabManagement">
       </hbox>
-</groupbox>
+
+      <hbox id="zenTabManagementCategory" class="subcategory" hidden="true" data-category="paneZenTabManagement">
+            <html:h1 data-l10n-id="pane-settings-workspaces-title" />
+      </hbox>
+
+      <groupbox id="zenWorkspacesGroup" data-category="paneZenTabManagement" hidden="true" class="highlighting-group">
+            <label>
+                  <html:h2 data-l10n-id="zen-settings-workspaces-header" />
+            </label>
+            <description class="description-deemphasized" data-l10n-id="zen-settings-workspaces-description" />
+
+            <checkbox id="zenWorkspacesSyncUnpinnedTabs" data-l10n-id="zen-settings-workspaces-sync-unpinned-tabs"
+                  preference="zen.window-sync.sync-only-pinned-tabs" />
+            <checkbox id="zenWorkspacesHideDefaultContainer"
+                  data-l10n-id="zen-settings-workspaces-hide-default-container-indicator"
+                  preference="zen.workspaces.hide-default-container-indicator" />
+            <checkbox id="zenWorkspacesForceContainerTabsToWorkspace"
+                  data-l10n-id="zen-settings-workspaces-force-container-tabs-to-workspace"
+                  preference="zen.workspaces.force-container-workspace" />
+            <checkbox id="zenTabsCloseOnBackWithNoHistory" data-l10n-id="zen-tabs-close-on-back-with-no-history"
+                  preference="zen.tabs.close-on-back-with-no-history" />
+            <checkbox data-l10n-id="zen-tabs-cycle-ignore-pending-tabs"
+                  preference="zen.tabs.ctrl-tab.ignore-pending-tabs" />
+            <checkbox data-l10n-id="zen-tabs-cycle-by-attribute" preference="zen.tabs.ctrl-tab.ignore-essential-tabs" />
+            <description id="zenTabsCycleByAttributeWarning" class="description-deemphasized"
+                  data-l10n-id="zen-tabs-cycle-by-attribute-warning" hidden="true" />
+            <checkbox data-l10n-id="zen-tabs-select-recently-used-on-close"
+                  preference="zen.tabs.select-recently-used-on-close" />
+            <checkbox data-l10n-id="zen-tabs-folders-auto-pin" preference="zen.folders.auto-pin" />
+      </groupbox>
+
+      <hbox id="zenPinnedTabsManagerCategory" class="subcategory" hidden="true" data-category="paneZenTabManagement">
+            <html:h1 data-l10n-id="pane-zen-pinned-tab-manager-title" />
+      </hbox>
+
+      <groupbox id="zenPinnedTabsManagerGroup" data-category="paneZenTabManagement" hidden="true"
+            class="highlighting-group">
+            <label>
+                  <html:h2 data-l10n-id="zen-pinned-tab-manager-header" />
+            </label>
+            <description class="description-deemphasized" data-l10n-id="zen-pinned-tab-manager-description" />
+
+            <checkbox id="zenPinnedTabRestorePinnedTabsToPinnedUrl"
+                  data-l10n-id="zen-pinned-tab-manager-restore-pinned-tabs-to-pinned-url"
+                  preference="zen.pinned-tab-manager.restore-pinned-tabs-to-pinned-url" />
+            <checkbox id="zenPinnedTabContainerSpecificEssentials"
+                  data-l10n-id="zen-pinned-tab-manager-container-specific-essentials-enabled"
+                  preference="zen.workspaces.separate-essentials" />
+
+            <hbox align="center">
+                  <label id="zenPinnedTabCloseShortcutBehaviorLabel"
+                        data-l10n-id="zen-pinned-tab-manager-close-shortcut-behavior-label" />
+                  <menulist id="zenPinnedTabCloseShortcutBehavior"
+                        preference="zen.pinned-tab-manager.close-shortcut-behavior">
+                        <menupopup>
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-reset-unload-switch-close-shortcut-option"
+                                    value="reset-unload-switch" />
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-unload-switch-close-shortcut-option"
+                                    value="unload-switch" />
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-reset-switch-close-shortcut-option"
+                                    value="reset-switch" />
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-switch-close-shortcut-option"
+                                    value="switch" />
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-reset-close-shortcut-option"
+                                    value="reset" />
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-close-close-shortcut-option"
+                                    value="close" />
+                        </menupopup>
+                  </menulist>
+            </hbox>
+      </groupbox>
 
 </html:template>
-
-

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -482,7 +482,7 @@ index 0eaca7a58e0026237b71b2ad515efe84d9e8c779..41cbe295b29abd014cc0425972be45b5
        if (ownerTab) {
          tab.owner = ownerTab;
        }
-+      if ((!tab.pinned && tabGroup?.isZenFolder && !Services.prefs.getBoolPref('zen.folders.owned-tabs-in-folder')) || (tabGroup && tabGroup.hasAttribute("split-view-group"))) {
++      if ((tab.pinned != !!tabGroup?.pinned && tabGroup?.isZenFolder && !Services.prefs.getBoolPref('zen.folders.owned-tabs-in-folder')) || (tabGroup && tabGroup.hasAttribute("split-view-group"))) {
 +        tabGroup = null;
 +      }
  

--- a/src/browser/components/urlbar/content/UrlbarInput-mjs.patch
+++ b/src/browser/components/urlbar/content/UrlbarInput-mjs.patch
@@ -128,7 +128,7 @@ index edb0482f0bfb22c70a585b0770e5b0437983779e..109e9eb18b90c650caff1287caef04dc
  
 +    if (this._zenHandleUrlbarClose) {
 +      this._zenHandleUrlbarClose();
-+    } else if (!this._untrimmedValue) {
++    } else if (!this._untrimmedValue || this.searchMode) {
 +      // Restore the current page URL when the urlbar is empty on blur
 +      this.handleRevert();
 +    }

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -164,11 +164,6 @@ window.gZenUIManager = {
       return;
     }
     const contextMenusToClean = [
-      // Remove the 'new tab below' context menu.
-      // reason: It doesn't properly work with zen and it's philosophy of not having
-      //   new tabs. It's also semi-not working as it doesn't create a new tab below
-      //   the current one.
-      "context_openANewTab",
     ];
     for (const id of contextMenusToClean) {
       const menu = document.getElementById(id);

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -1002,7 +1002,7 @@
         isTabGroupLabel(draggedTab) &&
         draggedTab.group?.isZenFolder &&
         (((isTab(dropElement) || dropElement.hasAttribute("split-view-group")) &&
-          (!dropElement.pinned || dropElement.hasAttribute("zen-essential"))) ||
+          dropElement.hasAttribute("zen-essential")) ||
           showIndicatorUnderNewTabButton)
       ) {
         dropElement = null;

--- a/src/zen/folders/ZenFolder.mjs
+++ b/src/zen/folders/ZenFolder.mjs
@@ -62,7 +62,6 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
 
   connectedCallback() {
     super.connectedCallback();
-    this.labelElement.pinned = true;
     if (this.#initialized) {
       return;
     }
@@ -196,18 +195,21 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
     );
   }
 
-  get pinned() {
-    return this.isZenFolder;
+  get emptyTab() {
+    return this.tabs.find((tab) => tab.hasAttribute("zen-empty-tab"));
   }
 
-  /**
-   * Intentionally ignore attempts to change the pinned state.
-   * ZenFolder instances determine their "pinned" status based on their type (isZenFolder)
-   * and do not support being pinned or unpinned via this setter.
-   * This no-op setter ensures compatibility with interfaces expecting a pinned property,
-   * while preserving the invariant that ZenFolders cannot have their pinned state changed externally.
-   */
-  set pinned(value) {}
+  get pinned() {
+    return this.hasAttribute("pinned");
+  }
+
+  set pinned(value) {
+    if (value) {
+      this.setAttribute("pinned", "true");
+    } else {
+      this.removeAttribute("pinned");
+    }
+  }
 
   get iconURL() {
     return this.icon.querySelector("image")?.getAttribute("href") || "";

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -98,6 +98,16 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
         folder.level >= this.#ZEN_MAX_SUBFOLDERS - 1 ? "true" : "false"
       );
 
+      const pinItem = document.getElementById("context_zenFolderPin");
+      const unpinItem = document.getElementById("context_zenFolderUnpin");
+      if (folder.pinned) {
+        pinItem.hidden = true;
+        unpinItem.hidden = false;
+      } else {
+        pinItem.hidden = false;
+        unpinItem.hidden = true;
+      }
+
       const changeFolderSpace = document
         .getElementById("context_zenChangeFolderSpace")
         .querySelector("menupopup");
@@ -134,6 +144,16 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
       switch (event.target.id) {
         case "context_zenFolderRename":
           this.#lastFolderContextMenu.rename();
+          break;
+        case "context_zenFolderPin":
+          if (this.#lastFolderContextMenu.emptyTab) {
+            gBrowser.pinTab(this.#lastFolderContextMenu.emptyTab);
+          }
+          break;
+        case "context_zenFolderUnpin":
+          if (this.#lastFolderContextMenu.emptyTab) {
+            gBrowser.unpinTab(this.#lastFolderContextMenu.emptyTab);
+          }
           break;
         case "context_zenFolderUnpack":
           this.#lastFolderContextMenu.unpackTabs();
@@ -298,15 +318,20 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
   on_TabOpen(event) {
     const tab = event.target;
     const group = tab.group;
-    if (!group?.isZenFolder || tab.pinned) {
+    if (!group?.isZenFolder) {
       return;
     }
     // Edge case: In occations where we add a tab with an ownerTab
     // inside a folder, the tab gets added into the folder in an
-    // unpinned state. We need to pin it and re-add it into the folder.
+    // incorrect pinned state. We need to fix it and re-add it into the folder.
     if (Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder")) {
-      gBrowser.pinTab(tab);
-      group.addTabs([tab]);
+      if (group.pinned && !tab.pinned) {
+        gBrowser.pinTab(tab);
+        group.addTabs([tab]);
+      } else if (!group.pinned && tab.pinned) {
+        gBrowser.unpinTab(tab);
+        group.addTabs([tab]);
+      }
     }
   }
 
@@ -426,11 +451,10 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
         beforeChangeCallback: async (newWorkspace) => {
           await new Promise((resolve) => {
             requestAnimationFrame(async () => {
-              const workspacePinnedContainer = gZenWorkspaces.workspaceElement(
-                newWorkspace.uuid
-              ).pinnedTabsContainer;
+              const workspaceElement = gZenWorkspaces.workspaceElement(newWorkspace.uuid);
+              const targetContainer = folder.pinned ? workspaceElement.pinnedTabsContainer : workspaceElement.tabsContainer;
               const tabs = folder.allItems.filter((tab) => !tab.hasAttribute("zen-empty-tab"));
-              workspacePinnedContainer.append(...tabs);
+              targetContainer.append(...tabs);
               await folder.delete();
               gBrowser.tabContainer._invalidateCachedTabs();
               if (selectedTab) {
@@ -468,8 +492,13 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     const workspaceElement = gZenWorkspaces.workspaceElement(workspaceId);
 
     if (!hasDndSwitch) {
-      const pinnedTabsContainer = workspaceElement.pinnedTabsContainer;
-      pinnedTabsContainer.insertBefore(folder, pinnedTabsContainer.lastChild);
+      if (folder.pinned) {
+        const pinnedTabsContainer = workspaceElement.pinnedTabsContainer;
+        pinnedTabsContainer.insertBefore(folder, pinnedTabsContainer.lastChild);
+      } else {
+        const tabsContainer = workspaceElement.tabsContainer;
+        tabsContainer.appendChild(folder);
+      }
     }
 
     const { lastSelectedWorkspaceTabs } = gZenWorkspaces;
@@ -503,40 +532,67 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
   }
 
   createFolder(tabs = [], options = {}) {
+    let isPinned = options.pinned;
+    if (isPinned === undefined) {
+      if (Services.prefs.getBoolPref("zen.folders.auto-pin", true)) {
+        isPinned = true;
+      } else if (options.insertBefore) {
+        isPinned = options.insertBefore.pinned;
+      } else if (options.insertAfter) {
+        isPinned = options.insertAfter.pinned;
+      } else if (tabs.length > 0) {
+        isPinned = tabs[0].pinned;
+      } else {
+        isPinned = false;
+      }
+    }
+
     const filteredTabs = tabs
       .filter((tab) => !tab.hasAttribute("zen-essential"))
       .map((tab) => {
-        gBrowser.pinTab(tab);
+        if (isPinned) {
+          gBrowser.pinTab(tab);
+        } else {
+          gBrowser.unpinTab(tab);
+        }
         if (tab?.group?.hasAttribute("split-view-group")) {
           tab = tab.group;
         }
         return tab;
       });
 
-    const workspacePinned = gZenWorkspaces.workspaceElement(
-      options.workspaceId
-    )?.pinnedTabsContainer;
-    const pinnedContainer =
-      options.workspaceId && workspacePinned ? workspacePinned : gZenWorkspaces.pinnedTabsContainer;
-    const insertBefore =
-      options.insertBefore || pinnedContainer.querySelector(".pinned-tabs-container-separator");
+    const workspaceElement = gZenWorkspaces.workspaceElement(options.workspaceId) || gZenWorkspaces.activeWorkspaceElement;
+    const pinnedContainer = workspaceElement?.pinnedTabsContainer || gZenWorkspaces.pinnedTabsContainer;
+    const tabsContainer = workspaceElement?.tabsContainer || gZenWorkspaces.tabsContainer;
+
     const emptyTab = gBrowser.addTab("about:blank", {
       skipAnimation: true,
-      pinned: true,
+      pinned: isPinned,
       triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
       _forZenEmptyTab: true,
       createLazyBrowser: true,
     });
 
-    gBrowser.pinTab(emptyTab);
+    if (isPinned) {
+      gBrowser.pinTab(emptyTab);
+    }
+
     tabs = [emptyTab, ...filteredTabs];
 
     const folder = this._createFolderNode(options);
+    folder.pinned = isPinned;
 
     if (options.insertAfter) {
       options.insertAfter.after(folder);
+    } else if (options.insertBefore) {
+      options.insertBefore.before(folder);
     } else {
-      insertBefore.before(folder);
+      if (isPinned) {
+        const insertBefore = pinnedContainer.querySelector(".pinned-tabs-container-separator");
+        insertBefore.before(folder);
+      } else {
+        tabsContainer.appendChild(folder);
+      }
     }
     gZenVerticalTabsManager.animateItemOpen(folder);
 
@@ -598,8 +654,14 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     if (!group) {
       return false;
     }
-    if (group.hasAttribute("split-view-group") && !this._piningFolder) {
+    if ((group.hasAttribute("split-view-group") || (group.isZenFolder && (tab === group.emptyTab || Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder")))) && !this._piningFolder) {
       this._piningFolder = true;
+      if (group.isZenFolder) {
+        group.pinned = true;
+        if (group.emptyTab) {
+          gBrowser.pinTab(group.emptyTab);
+        }
+      }
       for (const otherTab of group.tabs) {
         gZenPinnedTabManager.resetPinChangedUrl(otherTab);
         if (tab === otherTab) {
@@ -621,8 +683,14 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     if (!group) {
       return false;
     }
-    if (group.hasAttribute("split-view-group") && !this._piningFolder) {
+    if ((group.hasAttribute("split-view-group") || (group.isZenFolder && (tab === group.emptyTab || Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder")))) && !this._piningFolder) {
       this._piningFolder = true;
+      if (group.isZenFolder) {
+        group.pinned = false;
+        if (group.emptyTab) {
+          gBrowser.unpinTab(group.emptyTab);
+        }
+      }
       for (const otherTab of group.tabs) {
         if (tab === otherTab) {
           continue;

--- a/src/zen/sessionstore/ZenSessionManager.sys.mjs
+++ b/src/zen/sessionstore/ZenSessionManager.sys.mjs
@@ -194,7 +194,7 @@ export class nsZenSessionManager {
       } catch {
         /* ignore errors reading recovery data */
       }
-      if (!data.recoverYData) {
+      if (!data.recoveryData) {
         try {
           data.recoveryData = await IOUtils.readJSON(
             PathUtils.join(

--- a/src/zen/sessionstore/ZenSessionManager.sys.mjs
+++ b/src/zen/sessionstore/ZenSessionManager.sys.mjs
@@ -110,6 +110,23 @@ export class nsZenSessionManager {
     return PathUtils.join(PathUtils.profileDir, "zen-sessions-backup");
   }
 
+  async #getBackupRecoveryOrder() {
+    // Also add the most recent backup file to the recovery order
+    let backupFiles = [PathUtils.join(this.#backupFolderPath, "clean.jsonlz4")];
+    let prefix = PathUtils.join(this.#backupFolderPath, "zen-sessions-");
+    try {
+      let files = await IOUtils.getChildren(this.#backupFolderPath);
+      files = files
+        .filter((file) => file.startsWith(prefix))
+        .sort()
+        .reverse();
+      backupFiles.push(files[0]);
+    } catch {
+      /* ignore errors reading backup folder */
+    }
+    return backupFiles;
+  }
+
   /**
    * Gets the spaces data from the Places database for migration.
    * This is only called once during the first run after updating
@@ -199,6 +216,31 @@ export class nsZenSessionManager {
     }
   }
 
+  async #readDataFromFile() {
+    try {
+      await this.#file.load();
+      this._dataFromFile = this.#file.data;
+      if (!this._dataFromFile?.spaces) {
+        // Go to the catch block to try to recover from backup files
+        // if the file is empty or has invalid data, as it can happen if the app
+        // crashes while writing the session file.
+        throw new Error("No data in session file");
+      }
+    } catch {
+      for (const backupFile of await this.#getBackupRecoveryOrder()) {
+        try {
+          let data = await IOUtils.readJSON(backupFile, { decompress: true });
+          this.log(`Recovered data from backup file ${backupFile}`);
+          this._dataFromFile = data;
+          break;
+        } catch (e) {
+          /* ignore errors reading backup files */
+          console.error(`Failed to read backup file ${backupFile}`, e);
+        }
+      }
+    }
+  }
+
   /**
    * Reads the session file and populates the sidebar object.
    * This should be only called once at startup.
@@ -206,24 +248,14 @@ export class nsZenSessionManager {
    * @see SessionFileInternal.read
    */
   async readFile() {
-    let fileExists = await IOUtils.exists(this.#storeFilePath);
-    if (!fileExists) {
-      this.log("Session file does not exist, running migration", this.#storeFilePath);
-      this._shouldRunMigration = true;
-    }
     this.init();
     try {
       this.log("Reading Zen session file from disk");
-      let promises = [];
-      promises.push(this.#file.load());
-      if (this._shouldRunMigration) {
-        promises.push(this.#getDataFromDBForMigration());
-      }
-      await Promise.all(promises);
+      await this.#readDataFromFile();
     } catch (e) {
       console.error("ZenSessionManager: Failed to read session file", e);
     }
-    this.#sidebar = this.#file.data || {};
+    this.#sidebar = this._dataFromFile || {};
     if (!this.#sidebar.spaces?.length && !this._shouldRunMigration) {
       this.log("No spaces data found in session file, running migration", this.#sidebar);
       // If we have no spaces data, we should run migration
@@ -237,6 +269,7 @@ export class nsZenSessionManager {
         this.log("Tab entry in session file:", tab);
       }
     }
+    delete this._dataFromFile;
   }
 
   get #shouldRestoreOnlyPinned() {
@@ -413,7 +446,7 @@ export class nsZenSessionManager {
       ];
     }
     for (const winData of initialState?.windows || []) {
-      winData.spaces = this._migrationData?.spaces || [];
+      winData.spaces = winData.spaces || this._migrationData?.spaces || [];
       if (winData.tabs) {
         for (const tabData of winData.tabs) {
           let storeId = tabData.zenSyncId || tabData.zenPinnedId;
@@ -474,6 +507,11 @@ export class nsZenSessionManager {
       // browsing mode. We also don't want to save if there are no windows.
       return;
     }
+    const cleanPath = PathUtils.join(this.#backupFolderPath, "clean.jsonlz4");
+    IOUtils.copy(this.#storeFilePath, cleanPath, { recursive: true }).catch(() => {
+      /* ignore errors creating clean backup, as it is not critical and
+       * we want to save the session even if we fail to create it */
+    });
     this.#collectWindowData(windows);
     // This would save the data to disk asynchronously or when quitting the app.
     let sidebar = this.#sidebar;

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -620,15 +620,9 @@ class nsZenWindowSync {
       this.log(`Cannot swap browsers, other tab ${aOtherTab.id} is closing`);
       return;
     }
-    let promise = this.#maybeFlushTabState(aOtherTab);
-    await this.#styleSwapedBrowsers(
-      aOurTab,
-      aOtherTab,
-      () => {
-        this.#swapBrowserDocShellsInner(aOurTab, aOtherTab);
-      },
-      promise
-    );
+    await this.#styleSwapedBrowsers(aOurTab, aOtherTab, () => {
+      this.#swapBrowserDocShellsInner(aOurTab, aOtherTab);
+    });
   }
 
   /**
@@ -708,28 +702,23 @@ class nsZenWindowSync {
       );
       return null;
     }
-    // See https://github.com/zen-browser/desktop/issues/11851, swapping the browsers
-    // don't seem to update the state's cache properly, leading to issues when restoring
-    // the session later on.
-    let tabStateEntries = this.#getTabEntriesFromCache(aOtherTab);
-    const setStateToTab = () => {
-      if (!tabStateEntries?.entries.length) {
-        this.log(`Error: No tab state entries found for tab ${aOurTab.id} during swap`);
-        return;
-      }
-      lazy.TabStateCache.update(aOurTab.linkedBrowser.permanentKey, {
-        history: Cu.cloneInto(tabStateEntries, {}),
-      });
-    };
     // Running `swapBrowsersAndCloseOther` doesn't expect us to use the tab after
     // the operation, so it doesn't really care about cleaning up the other tab.
     // We need to make a new tab progress listener for the other tab after the swap.
     this.#withRestoreTabProgressListener(
       aOtherTab,
       () => {
-        setStateToTab();
         this.log(`Swapping docshells between windows for tab ${aOurTab.id}`);
         aOurTab.ownerGlobal.gBrowser.swapBrowsersAndCloseOther(aOurTab, aOtherTab, false);
+
+        // Swap permanent keys
+        const ourPermanentKey = aOurTab.linkedBrowser.permanentKey;
+        const otherPermanentKey = aOtherTab.linkedBrowser.permanentKey;
+        aOurTab.linkedBrowser.permanentKey = otherPermanentKey;
+        aOtherTab.linkedBrowser.permanentKey = ourPermanentKey;
+        aOurTab.permanentKey = otherPermanentKey;
+        aOtherTab.permanentKey = ourPermanentKey;
+
         // Since we are moving progress listeners around, there's a chance that we
         // trigger a load while making the switch, and since we remove the previous
         // tab's listeners, the other browser window will never get the 'finish load' event
@@ -772,14 +761,6 @@ class nsZenWindowSync {
       aOurTab.ownerGlobal.gBrowser._adjustFocusAfterTabSwitch(aOurTab);
       aOurTab.linkedBrowser.docShellIsActive = true;
     }
-    // Ensure the tab's state is flushed after the swap. By doing this,
-    // we can re-schedule another session store delayed process to fire.
-    // It's also important to note that if we don't flush the state here,
-    // we would start receiving invalid history changes from the the incorrect
-    // browser view that was just swapped out.
-    return this.#maybeFlushTabState(aOurTab).finally(() => {
-      setStateToTab();
-    });
   }
 
   /**
@@ -788,9 +769,8 @@ class nsZenWindowSync {
    * @param {object} aOurTab - The tab in the current window.
    * @param {object} aOtherTab - The tab in the other window.
    * @param {Function|undefined} callback - The callback function to execute after styling.
-   * @param {Promise|null} promiseToWait - A promise to wait for before executing the callback.
    */
-  #styleSwapedBrowsers(aOurTab, aOtherTab, callback = undefined, promiseToWait = null) {
+  #styleSwapedBrowsers(aOurTab, aOtherTab, callback = undefined) {
     const ourBrowser = aOurTab.linkedBrowser;
     const otherBrowser = aOtherTab.linkedBrowser;
     // eslint-disable-next-line no-async-promise-executor
@@ -817,8 +797,7 @@ class nsZenWindowSync {
           };
         });
 
-        let promise = this.#createPseudoImageForBrowser(otherBrowser, mySrc);
-        await Promise.all([promiseToWait, promise]);
+        await this.#createPseudoImageForBrowser(otherBrowser, mySrc);
         callback();
         lazy.setTimeout(() => {
           otherBrowser.setAttribute("zen-pseudo-hidden", "true");
@@ -1006,7 +985,7 @@ class nsZenWindowSync {
    * @returns {Promise} A promise that resolves when the operation is complete.
    */
   #maybeFlushTabState(aTab) {
-    if (!aTab.linkedBrowser) {
+    if (!aTab.linkedBrowser || aTab.hasAttribute("pending")) {
       return Promise.resolve();
     }
     return lazy.TabStateFlusher.flush(aTab.linkedBrowser);

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -216,7 +216,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
               }
               return tab;
             })
-            .filter((tab) => tab?.pinned)
+            .filter((tab) => tab?.pinned || folderToUnload)
         ),
       ];
 
@@ -625,7 +625,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
 
       movingTabs = movingTabs.filter((tab) =>
         gBrowser.isTabGroupLabel(tab) && tab.group?.isZenFolder
-          ? !tabsTarget && !essentialTabsTarget
+          ? (tab.group.pinned ? pinnedTabsTarget : !pinnedTabsTarget) && !essentialTabsTarget
           : true
       );
 

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -287,7 +287,7 @@ class nsZenWorkspaces {
   #initializeEmptyTab() {
     for (const tab of gBrowser.tabs) {
       // Check if session store has an empty tab
-      if (tab.hasAttribute("zen-empty-tab") && !tab.pinned) {
+      if (tab.hasAttribute("zen-empty-tab") && !tab.pinned && !tab.group) {
         this.log("Found existing empty tab from session store!");
         this._emptyTab = tab;
         return;
@@ -1123,7 +1123,7 @@ class nsZenWorkspaces {
           !workspaces.find((workspace) => workspace.uuid === workspaceID)) ||
         // Also remove empty tabs that are supposed to be from parent folders but
         // they dont exist anymore
-        (tab.pinned && tab.hasAttribute("zen-empty-tab") && !tab.group)
+        (tab.hasAttribute("zen-empty-tab") && !tab.group && tab !== this._emptyTab)
       ) {
         // Remove any tabs where their workspace doesn't exist anymore
         this.log("Removed zombie tab from non-existing workspace", tab);

--- a/surfer.json
+++ b/surfer.json
@@ -20,7 +20,7 @@
       "brandShortName": "Zen",
       "brandFullName": "Zen Browser",
       "release": {
-        "displayVersion": "1.18.9b",
+        "displayVersion": "1.18.10b",
         "github": {
           "repo": "zen-browser/desktop"
         },


### PR DESCRIPTION
Features added:
- New toggle in settings under tab management called "Automatically pin folders" so you can disable or enable having folders pinned by default when creating a new folder
- You can now create folders with unpinned tabs
- New option in the context menu of folders where you pin or unpin a folder