### PR TITLE
Folders for unpinned tabs feature

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -66,6 +66,8 @@ zen-tabs-cycle-by-attribute =
   .label = Ctrl+Tab cycles within Essential or Workspace tabs only
 zen-tabs-cycle-ignore-pending-tabs =
   .label = Ignore Pending tabs when cycling with Ctrl+Tab
+zen-tabs-folders-auto-pin =
+  .label = Automatically pin folders
 zen-tabs-cycle-by-attribute-warning = Ctrl+Tab will cycle by recently used order, as it is enabled
 
 zen-look-and-feel-compact-toolbar-themed =

--- a/locales/en-US/browser/browser/zen-folders.ftl
+++ b/locales/en-US/browser/browser/zen-folders.ftl
@@ -8,6 +8,12 @@ zen-folders-search-placeholder =
 zen-folders-panel-rename-folder =
     .label = Rename Folder
 
+zen-folders-panel-pin-folder =
+    .label = Pin Folder
+
+zen-folders-panel-unpin-folder =
+    .label = Unpin Folder
+
 zen-folders-panel-unpack-folder =
     .label = Unpack Folder
 

--- a/prefs/zen/folders.yaml
+++ b/prefs/zen/folders.yaml
@@ -11,5 +11,8 @@
 - name: zen.folders.max-subfolders
   value: 5
 
+- name: zen.folders.auto-pin
+  value: true
+
 - name: zen.folders.owned-tabs-in-folder
   value: false

--- a/src/browser/base/content/browser-js.patch
+++ b/src/browser/base/content/browser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/base/content/browser.js b/browser/base/content/browser.js
-index e2e0526a0ddd617291f1f6c17bcfb807954b481f..c3d2afff6eaa788309d1c1a7fa40f9b8b4f0fffe 100644
+index e2e0526a0ddd617291f1f6c17bcfb807954b481f..a7d8b2a08a27d9c445eb18facf65631ec7126ea1 100644
 --- a/browser/base/content/browser.js
 +++ b/browser/base/content/browser.js
 @@ -33,6 +33,7 @@ ChromeUtils.defineESModuleGetters(this, {
@@ -60,7 +60,15 @@ index e2e0526a0ddd617291f1f6c17bcfb807954b481f..c3d2afff6eaa788309d1c1a7fa40f9b8
        gBrowser.closingTabsEnum.ALL
      )
    );
-@@ -4809,6 +4817,9 @@ var ConfirmationHint = {
+@@ -4107,6 +4115,7 @@ function duplicateTabIn(aTab, where, delta) {
+     case "tab":
+       SessionStore.duplicateTab(window, aTab, delta, true, {
+         inBackground: false,
++        tabIndex: aTab._tPos + 1,
+       });
+       break;
+   }
+@@ -4809,6 +4818,9 @@ var ConfirmationHint = {
      MozXULElement.insertFTLIfNeeded("toolkit/branding/brandings.ftl");
      MozXULElement.insertFTLIfNeeded("browser/confirmationHints.ftl");
      document.l10n.setAttributes(this._message, messageId, options.l10nArgs);

--- a/src/browser/base/content/zen-panels/popups.inc
+++ b/src/browser/base/content/zen-panels/popups.inc
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 <menupopup id="zenCreateNewPopup">
-  <menu data-l10n-id="zen-panel-ui-live-folder-create" id="zen-panel-ui-live-folder-create">
+<menu data-l10n-id="zen-panel-ui-live-folder-create" id="zen-panel-ui-live-folder-create">
     <menupopup>
       <menuitem
         data-l10n-id="zen-live-folder-github-pull-requests"
@@ -52,7 +52,7 @@
 </menupopup>
 
 <menupopup id="zenFolderActions">
-  <menu id="context_zenLiveFolderOptions"
+<menu id="context_zenLiveFolderOptions"
     data-l10n-id="zen-live-folder-options"
     hidden="true">
     <menupopup />
@@ -60,6 +60,9 @@
   <menuseparator id="live-folder-separator" hidden="true"/>
   <menuitem id="context_zenFolderRename" data-l10n-id="zen-folders-panel-rename-folder"/>
   <menuitem id="context_zenFolderChangeIcon" data-l10n-id="tab-context-zen-edit-icon"/>
+  <menuseparator />
+  <menuitem id="context_zenFolderPin" data-l10n-id="zen-folders-panel-pin-folder"/>
+  <menuitem id="context_zenFolderUnpin" data-l10n-id="zen-folders-panel-unpin-folder"/>
   <menuseparator />
   <menuitem id="context_zenFolderUnloadAll" data-l10n-id="zen-folders-unload-folder"/>
   <menuitem id="context_zenFolderNewSubfolder" data-l10n-id="zen-folders-new-subfolder"/>

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1215,6 +1215,11 @@ Preferences.addAll([
     default: true,
   },
   {
+    id: "zen.folders.auto-pin",
+    type: "bool",
+    default: true,
+  },
+  {
     id: "zen.window-sync.sync-only-pinned-tabs",
     type: "bool",
     default: false,

--- a/src/browser/components/preferences/zenTabsManagement.inc.xhtml
+++ b/src/browser/components/preferences/zenTabsManagement.inc.xhtml
@@ -3,80 +3,78 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 <html:template id="template-paneZenTabManagement">
-<hbox id="ZenWorkspacesCategory"
-      class="subcategory"
-      hidden="true"
-      data-category="paneZenTabManagement">
-</hbox>
-
-<hbox id="zenTabManagementCategory"
-      class="subcategory"
-      hidden="true"
-      data-category="paneZenTabManagement">
-<html:h1 data-l10n-id="pane-settings-workspaces-title"/>
-</hbox>
-
-<groupbox id="zenWorkspacesGroup" data-category="paneZenTabManagement" hidden="true" class="highlighting-group">
-      <label><html:h2 data-l10n-id="zen-settings-workspaces-header"/></label>
-      <description class="description-deemphasized" data-l10n-id="zen-settings-workspaces-description" />
-
-      <checkbox id="zenWorkspacesSyncUnpinnedTabs"
-            data-l10n-id="zen-settings-workspaces-sync-unpinned-tabs"
-            preference="zen.window-sync.sync-only-pinned-tabs"/>
-      <checkbox id="zenWorkspacesHideDefaultContainer"
-            data-l10n-id="zen-settings-workspaces-hide-default-container-indicator"
-            preference="zen.workspaces.hide-default-container-indicator"/>
-      <checkbox id="zenWorkspacesForceContainerTabsToWorkspace"
-            data-l10n-id="zen-settings-workspaces-force-container-tabs-to-workspace"
-            preference="zen.workspaces.force-container-workspace"/>
-      <checkbox id="zenTabsCloseOnBackWithNoHistory"
-            data-l10n-id="zen-tabs-close-on-back-with-no-history"
-            preference="zen.tabs.close-on-back-with-no-history"/>
-      <checkbox data-l10n-id="zen-tabs-cycle-ignore-pending-tabs"
-            preference="zen.tabs.ctrl-tab.ignore-pending-tabs"/>
-      <checkbox data-l10n-id="zen-tabs-cycle-by-attribute"
-            preference="zen.tabs.ctrl-tab.ignore-essential-tabs"/>
-      <description id="zenTabsCycleByAttributeWarning"
-            class="description-deemphasized"
-            data-l10n-id="zen-tabs-cycle-by-attribute-warning"
-            hidden="true"/>
-      <checkbox data-l10n-id="zen-tabs-select-recently-used-on-close"
-            preference="zen.tabs.select-recently-used-on-close"/>
-</groupbox>
-
-<hbox id="zenPinnedTabsManagerCategory"
-      class="subcategory"
-      hidden="true"
-      data-category="paneZenTabManagement">
-      <html:h1 data-l10n-id="pane-zen-pinned-tab-manager-title"/>
-</hbox>
-
-<groupbox id="zenPinnedTabsManagerGroup" data-category="paneZenTabManagement" hidden="true" class="highlighting-group">
-      <label><html:h2 data-l10n-id="zen-pinned-tab-manager-header"/></label>
-      <description class="description-deemphasized" data-l10n-id="zen-pinned-tab-manager-description" />
-
-      <checkbox id="zenPinnedTabRestorePinnedTabsToPinnedUrl"
-                data-l10n-id="zen-pinned-tab-manager-restore-pinned-tabs-to-pinned-url"
-                preference="zen.pinned-tab-manager.restore-pinned-tabs-to-pinned-url"/>
-      <checkbox id="zenPinnedTabContainerSpecificEssentials"
-                data-l10n-id="zen-pinned-tab-manager-container-specific-essentials-enabled"
-                preference="zen.workspaces.separate-essentials"/>
-
-      <hbox align="center">
-            <label id="zenPinnedTabCloseShortcutBehaviorLabel" data-l10n-id="zen-pinned-tab-manager-close-shortcut-behavior-label"/>
-            <menulist id="zenPinnedTabCloseShortcutBehavior" preference="zen.pinned-tab-manager.close-shortcut-behavior">
-                  <menupopup>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-reset-unload-switch-close-shortcut-option" value="reset-unload-switch"/>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-unload-switch-close-shortcut-option" value="unload-switch"/>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-reset-switch-close-shortcut-option" value="reset-switch"/>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-switch-close-shortcut-option" value="switch"/>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-reset-close-shortcut-option" value="reset"/>
-                        <menuitem data-l10n-id="zen-pinned-tab-manager-close-close-shortcut-option" value="close"/>
-                  </menupopup>
-            </menulist>
+      <hbox id="ZenWorkspacesCategory" class="subcategory" hidden="true" data-category="paneZenTabManagement">
       </hbox>
-</groupbox>
+
+      <hbox id="zenTabManagementCategory" class="subcategory" hidden="true" data-category="paneZenTabManagement">
+            <html:h1 data-l10n-id="pane-settings-workspaces-title" />
+      </hbox>
+
+      <groupbox id="zenWorkspacesGroup" data-category="paneZenTabManagement" hidden="true" class="highlighting-group">
+            <label>
+                  <html:h2 data-l10n-id="zen-settings-workspaces-header" />
+            </label>
+            <description class="description-deemphasized" data-l10n-id="zen-settings-workspaces-description" />
+
+            <checkbox id="zenWorkspacesSyncUnpinnedTabs" data-l10n-id="zen-settings-workspaces-sync-unpinned-tabs"
+                  preference="zen.window-sync.sync-only-pinned-tabs" />
+            <checkbox id="zenWorkspacesHideDefaultContainer"
+                  data-l10n-id="zen-settings-workspaces-hide-default-container-indicator"
+                  preference="zen.workspaces.hide-default-container-indicator" />
+            <checkbox id="zenWorkspacesForceContainerTabsToWorkspace"
+                  data-l10n-id="zen-settings-workspaces-force-container-tabs-to-workspace"
+                  preference="zen.workspaces.force-container-workspace" />
+            <checkbox id="zenTabsCloseOnBackWithNoHistory" data-l10n-id="zen-tabs-close-on-back-with-no-history"
+                  preference="zen.tabs.close-on-back-with-no-history" />
+            <checkbox data-l10n-id="zen-tabs-cycle-ignore-pending-tabs"
+                  preference="zen.tabs.ctrl-tab.ignore-pending-tabs" />
+            <checkbox data-l10n-id="zen-tabs-cycle-by-attribute" preference="zen.tabs.ctrl-tab.ignore-essential-tabs" />
+            <description id="zenTabsCycleByAttributeWarning" class="description-deemphasized"
+                  data-l10n-id="zen-tabs-cycle-by-attribute-warning" hidden="true" />
+            <checkbox data-l10n-id="zen-tabs-select-recently-used-on-close"
+                  preference="zen.tabs.select-recently-used-on-close" />
+            <checkbox data-l10n-id="zen-tabs-folders-auto-pin" preference="zen.folders.auto-pin" />
+      </groupbox>
+
+      <hbox id="zenPinnedTabsManagerCategory" class="subcategory" hidden="true" data-category="paneZenTabManagement">
+            <html:h1 data-l10n-id="pane-zen-pinned-tab-manager-title" />
+      </hbox>
+
+      <groupbox id="zenPinnedTabsManagerGroup" data-category="paneZenTabManagement" hidden="true"
+            class="highlighting-group">
+            <label>
+                  <html:h2 data-l10n-id="zen-pinned-tab-manager-header" />
+            </label>
+            <description class="description-deemphasized" data-l10n-id="zen-pinned-tab-manager-description" />
+
+            <checkbox id="zenPinnedTabRestorePinnedTabsToPinnedUrl"
+                  data-l10n-id="zen-pinned-tab-manager-restore-pinned-tabs-to-pinned-url"
+                  preference="zen.pinned-tab-manager.restore-pinned-tabs-to-pinned-url" />
+            <checkbox id="zenPinnedTabContainerSpecificEssentials"
+                  data-l10n-id="zen-pinned-tab-manager-container-specific-essentials-enabled"
+                  preference="zen.workspaces.separate-essentials" />
+
+            <hbox align="center">
+                  <label id="zenPinnedTabCloseShortcutBehaviorLabel"
+                        data-l10n-id="zen-pinned-tab-manager-close-shortcut-behavior-label" />
+                  <menulist id="zenPinnedTabCloseShortcutBehavior"
+                        preference="zen.pinned-tab-manager.close-shortcut-behavior">
+                        <menupopup>
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-reset-unload-switch-close-shortcut-option"
+                                    value="reset-unload-switch" />
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-unload-switch-close-shortcut-option"
+                                    value="unload-switch" />
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-reset-switch-close-shortcut-option"
+                                    value="reset-switch" />
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-switch-close-shortcut-option"
+                                    value="switch" />
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-reset-close-shortcut-option"
+                                    value="reset" />
+                              <menuitem data-l10n-id="zen-pinned-tab-manager-close-close-shortcut-option"
+                                    value="close" />
+                        </menupopup>
+                  </menulist>
+            </hbox>
+      </groupbox>
 
 </html:template>
-
-

--- a/src/browser/components/sessionstore/SessionStore-sys-mjs.patch
+++ b/src/browser/components/sessionstore/SessionStore-sys-mjs.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/sessionstore/SessionStore.sys.mjs b/browser/components/sessionstore/SessionStore.sys.mjs
-index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf06644d92 100644
+index f066bc7a9cca1788080d088141030c225a733931..346504793c545344caaead7cd3ee3201c61e759a 100644
 --- a/browser/components/sessionstore/SessionStore.sys.mjs
 +++ b/browser/components/sessionstore/SessionStore.sys.mjs
 @@ -127,6 +127,9 @@ const TAB_EVENTS = [
@@ -179,10 +179,12 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
        return;
      }
  
-@@ -4150,6 +4171,12 @@ var SessionStoreInternal = {
+@@ -4149,7 +4170,13 @@ var SessionStoreInternal = {
+         1,
          Math.min(tabState.index, tabState.entries.length)
        );
-       tabState.pinned = false;
+-      tabState.pinned = false;
++      tabState.pinned = !!(aTab.group?.isZenFolder && aTab.group?.pinned);
 +      tabState.zenEssential = false;
 +      tabState.zenSyncId = null;
 +      tabState.zenIsGlance = false;

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabbrowser.js b/browser/components/tabbrowser/content/tabbrowser.js
-index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498dd65b1fba 100644
+index d7765e0adb37216d35f2125abf96025cbb150bab..ac3238fdeda7154ca7f37e15a12617c04b415ea6 100644
 --- a/browser/components/tabbrowser/content/tabbrowser.js
 +++ b/browser/components/tabbrowser/content/tabbrowser.js
 @@ -405,6 +405,7 @@
@@ -247,15 +247,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        } else {
          aTab.linkedBrowser.browsingContext.hasSiblings = this.tabs.length > 1;
        }
-@@ -2858,7 +2943,6 @@
-             this.selectedTab = this.addTrustedTab(BROWSER_NEW_TAB_URL, {
-               tabIndex: tab._tPos + 1,
-               userContextId: tab.userContextId,
--              tabGroup: tab.group,
-               focusUrlBar: true,
-             });
-             resolve(this.selectedBrowser);
-@@ -2968,6 +3052,9 @@
+@@ -2968,6 +3053,9 @@
          schemelessInput,
          hasValidUserGestureActivation = false,
          textDirectiveUserActivation = false,
@@ -265,7 +257,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        } = {}
      ) {
        // all callers of addTab that pass a params object need to pass
-@@ -2978,10 +3065,17 @@
+@@ -2978,10 +3066,17 @@
          );
        }
  
@@ -283,7 +275,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        // If we're opening a foreground tab, set the owner by default.
        ownerTab ??= inBackground ? null : this.selectedTab;
  
-@@ -2989,6 +3083,7 @@
+@@ -2989,6 +3084,7 @@
        if (this.selectedTab.owner) {
          this.selectedTab.owner = null;
        }
@@ -291,7 +283,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
  
        // Find the tab that opened this one, if any. This is used for
        // determining positioning, and inherited attributes such as the
-@@ -3041,6 +3136,22 @@
+@@ -3041,6 +3137,22 @@
            noInitialLabel,
            skipBackgroundNotify,
          });
@@ -314,7 +306,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          if (insertTab) {
            // Insert the tab into the tab container in the correct position.
            this.#insertTabAtIndex(t, {
-@@ -3049,6 +3160,7 @@
+@@ -3049,6 +3161,7 @@
              ownerTab,
              openerTab,
              pinned,
@@ -322,7 +314,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
              bulkOrderedOpen,
              tabGroup: tabGroup ?? openerTab?.group,
            });
-@@ -3067,6 +3179,7 @@
+@@ -3067,6 +3180,7 @@
            openWindowInfo,
            skipLoad,
            triggeringRemoteType,
@@ -330,7 +322,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          }));
  
          if (focusUrlBar) {
-@@ -3191,6 +3304,12 @@
+@@ -3191,6 +3305,12 @@
          }
        }
  
@@ -343,7 +335,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        // Additionally send pinned tab events
        if (pinned) {
          this.#notifyPinnedStatus(t);
-@@ -3426,6 +3545,7 @@
+@@ -3426,6 +3546,7 @@
          isAdoptingGroup = false,
          isUserTriggered = false,
          telemetryUserCreateSource = "unknown",
@@ -351,7 +343,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        } = {}
      ) {
        if (
-@@ -3436,9 +3556,6 @@
+@@ -3436,9 +3557,6 @@
              !this.isSplitViewWrapper(tabOrSplitView)
          )
        ) {
@@ -361,7 +353,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        }
  
        if (!color) {
-@@ -3459,9 +3576,14 @@
+@@ -3459,9 +3577,14 @@
          label,
          isAdoptingGroup
        );
@@ -378,7 +370,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        );
        group.addTabs(tabsAndSplitViews);
  
-@@ -3582,7 +3704,7 @@
+@@ -3582,7 +3705,7 @@
        }
  
        this.#handleTabMove(tab, () =>
@@ -387,7 +379,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        );
      }
  
-@@ -3666,6 +3788,7 @@
+@@ -3666,6 +3789,7 @@
          color: group.color,
          insertBefore: newTabs[0],
          isAdoptingGroup: true,
@@ -395,7 +387,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        });
      }
  
-@@ -3856,6 +3979,7 @@
+@@ -3856,6 +3980,7 @@
          openWindowInfo,
          skipLoad,
          triggeringRemoteType,
@@ -403,7 +395,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        }
      ) {
        // If we don't have a preferred remote type (or it is `NOT_REMOTE`), and
-@@ -3925,6 +4049,7 @@
+@@ -3925,6 +4050,7 @@
            openWindowInfo,
            name,
            skipLoad,
@@ -411,7 +403,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          });
        }
  
-@@ -4120,9 +4245,9 @@
+@@ -4120,9 +4246,9 @@
          }
  
          // Add a new tab if needed.
@@ -423,7 +415,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
  
            let url = "about:blank";
            if (tabData.entries?.length) {
-@@ -4159,8 +4284,10 @@
+@@ -4159,8 +4285,10 @@
              insertTab: false,
              skipLoad: true,
              preferredRemoteType,
@@ -435,7 +427,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
            if (select) {
              tabToSelect = tab;
            }
-@@ -4172,7 +4299,8 @@
+@@ -4172,7 +4300,8 @@
            this.pinTab(tab);
            // Then ensure all the tab open/pinning information is sent.
            this._fireTabOpen(tab, {});
@@ -445,7 +437,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
            let { groupId } = tabData;
            const tabGroup = tabGroupWorkingData.get(groupId);
            // if a tab refers to a tab group we don't know, skip any group
-@@ -4186,7 +4314,10 @@
+@@ -4186,7 +4315,10 @@
                  tabGroup.stateData.id,
                  tabGroup.stateData.color,
                  tabGroup.stateData.collapsed,
@@ -457,7 +449,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
                );
                tabsFragment.appendChild(tabGroup.node);
              }
-@@ -4231,9 +4362,23 @@
+@@ -4231,9 +4363,23 @@
        // to remove the old selected tab.
        if (tabToSelect) {
          let leftoverTab = this.selectedTab;
@@ -473,20 +465,27 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
 +            gZenWorkspaces._initialTab._shouldRemove = true;
 +          }
 +        }
-       }
++      }
 +      else {
 +        gZenWorkspaces._tabToRemoveForEmpty = this.selectedTab;
-+      }
+       }
 +      this._hasAlreadyInitializedZenSessionStore = true;
  
        if (tabs.length > 1 || !tabs[0].selected) {
          this._updateTabsAfterInsert();
-@@ -4424,11 +4569,14 @@
+@@ -4424,11 +4570,21 @@
        if (ownerTab) {
          tab.owner = ownerTab;
        }
-+      if ((!tab.pinned && tabGroup?.isZenFolder && !Services.prefs.getBoolPref('zen.folders.owned-tabs-in-folder')) || (tabGroup && tabGroup.hasAttribute("split-view-group"))) {
++      if (tabGroup && tabGroup.hasAttribute("split-view-group")) {
 +        tabGroup = null;
++      } else if (!tab.pinned && tabGroup?.isZenFolder && !Services.prefs.getBoolPref('zen.folders.owned-tabs-in-folder')) {
++        if (!openerTab && tabGroup.pinned) {
++          pinned = true;
++          tab.setAttribute("pinned", "true");
++        } else if (openerTab) {
++          tabGroup = null;
++        }
 +      }
  
        // Ensure we have an index if one was not provided.
@@ -497,7 +496,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          if (
            !bulkOrderedOpen &&
            ((openerTab &&
-@@ -4440,7 +4588,7 @@
+@@ -4440,7 +4596,7 @@
            let lastRelatedTab =
              openerTab && this._lastRelatedTabMap.get(openerTab);
            let previousTab = lastRelatedTab || openerTab || this.selectedTab;
@@ -506,7 +505,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
              tabGroup = previousTab.group;
            }
            if (
-@@ -4456,7 +4604,7 @@
+@@ -4456,7 +4612,7 @@
                  previousTab.splitview
                ) + 1;
            } else if (previousTab.visible) {
@@ -515,7 +514,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
            } else if (previousTab == FirefoxViewHandler.tab) {
              elementIndex = 0;
            }
-@@ -4484,14 +4632,14 @@
+@@ -4484,14 +4640,14 @@
        }
        // Ensure index is within bounds.
        if (tab.pinned) {
@@ -534,7 +533,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
  
        if (pinned && !itemAfter?.pinned) {
          itemAfter = null;
-@@ -4504,7 +4652,7 @@
+@@ -4504,7 +4660,7 @@
  
        this.tabContainer._invalidateCachedTabs();
  
@@ -543,7 +542,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          if (
            (this.isTab(itemAfter) && itemAfter.group == tabGroup) ||
            this.isSplitViewWrapper(itemAfter)
-@@ -4535,7 +4683,11 @@
+@@ -4535,7 +4691,11 @@
          const tabContainer = pinned
            ? this.tabContainer.pinnedTabsContainer
            : this.tabContainer;
@@ -555,7 +554,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        }
  
        if (tab.group?.collapsed) {
-@@ -4550,6 +4702,7 @@
+@@ -4550,6 +4710,7 @@
        if (pinned) {
          this._updateTabBarForPinnedTabs();
        }
@@ -563,7 +562,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
  
        TabBarVisibility.update();
      }
-@@ -5102,6 +5255,7 @@
+@@ -5102,6 +5263,7 @@
          telemetrySource,
        } = {}
      ) {
@@ -571,7 +570,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        // When 'closeWindowWithLastTab' pref is enabled, closing all tabs
        // can be considered equivalent to closing the window.
        if (
-@@ -5191,6 +5345,7 @@
+@@ -5191,6 +5353,7 @@
          if (lastToClose) {
            this.removeTab(lastToClose, aParams);
          }
@@ -579,7 +578,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        } catch (e) {
          console.error(e);
        }
-@@ -5229,6 +5384,12 @@
+@@ -5229,6 +5392,12 @@
          aTab._closeTimeNoAnimTimerId = Glean.browserTabclose.timeNoAnim.start();
        }
  
@@ -592,7 +591,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        // Handle requests for synchronously removing an already
        // asynchronously closing tab.
        if (!animate && aTab.closing) {
-@@ -5243,6 +5404,9 @@
+@@ -5243,6 +5412,9 @@
        // state).
        let tabWidth = window.windowUtils.getBoundsWithoutFlushing(aTab).width;
        let isLastTab = this.#isLastTabInWindow(aTab);
@@ -602,7 +601,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        if (
          !this._beginRemoveTab(aTab, {
            closeWindowFastpath: true,
-@@ -5291,7 +5455,13 @@
+@@ -5291,7 +5463,13 @@
          // We're not animating, so we can cancel the animation stopwatch.
          Glean.browserTabclose.timeAnim.cancel(aTab._closeTimeAnimTimerId);
          aTab._closeTimeAnimTimerId = null;
@@ -617,7 +616,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          return;
        }
  
-@@ -5425,7 +5595,7 @@
+@@ -5425,7 +5603,7 @@
            closeWindowWithLastTab != null
              ? closeWindowWithLastTab
              : !window.toolbar.visible ||
@@ -626,7 +625,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
  
          if (closeWindow) {
            // We've already called beforeunload on all the relevant tabs if we get here,
-@@ -5449,6 +5619,7 @@
+@@ -5449,6 +5627,7 @@
  
          newTab = true;
        }
@@ -634,7 +633,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        aTab._endRemoveArgs = [closeWindow, newTab];
  
        // swapBrowsersAndCloseOther will take care of closing the window without animation.
-@@ -5489,13 +5660,7 @@
+@@ -5489,13 +5668,7 @@
        aTab._mouseleave();
  
        if (newTab) {
@@ -649,7 +648,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        } else {
          TabBarVisibility.update();
        }
-@@ -5628,6 +5793,7 @@
+@@ -5628,6 +5801,7 @@
          this.tabs[i]._tPos = i;
        }
  
@@ -657,7 +656,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        if (!this._windowIsClosing) {
          // update tab close buttons state
          this.tabContainer._updateCloseButtons();
-@@ -5851,6 +6017,7 @@
+@@ -5851,6 +6025,7 @@
        }
  
        let excludeTabs = new Set(aExcludeTabs);
@@ -665,7 +664,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
  
        // If this tab has a successor, it should be selectable, since
        // hiding or closing a tab removes that tab as a successor.
-@@ -5863,15 +6030,22 @@
+@@ -5863,15 +6038,22 @@
          !excludeTabs.has(aTab.owner) &&
          Services.prefs.getBoolPref("browser.tabs.selectOwnerOnClose")
        ) {
@@ -690,7 +689,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        let tab = this.tabContainer.findNextTab(aTab, {
          direction: 1,
          filter: _tab => remainingTabs.includes(_tab),
-@@ -5885,7 +6059,7 @@
+@@ -5885,7 +6067,7 @@
        }
  
        if (tab) {
@@ -699,7 +698,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        }
  
        // If no qualifying visible tab was found, see if there is a tab in
-@@ -5906,7 +6080,7 @@
+@@ -5906,7 +6088,7 @@
          });
        }
  
@@ -708,7 +707,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
      }
  
      _blurTab(aTab) {
-@@ -5917,7 +6091,7 @@
+@@ -5917,7 +6099,7 @@
       * @returns {boolean}
       *   False if swapping isn't permitted, true otherwise.
       */
@@ -717,7 +716,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        // Do not allow transfering a private tab to a non-private window
        // and vice versa.
        if (
-@@ -5971,6 +6145,7 @@
+@@ -5971,6 +6153,7 @@
        // fire the beforeunload event in the process.  Close the other
        // window if this was its last tab.
        if (
@@ -725,7 +724,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          !remoteBrowser._beginRemoveTab(aOtherTab, {
            adoptedByTab: aOurTab,
            closeWindowWithLastTab: true,
-@@ -5982,7 +6157,7 @@
+@@ -5982,7 +6165,7 @@
        // If this is the last tab of the window, hide the window
        // immediately without animation before the docshell swap, to avoid
        // about:blank being painted.
@@ -734,7 +733,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        if (closeWindow) {
          let win = aOtherTab.ownerGlobal;
          win.windowUtils.suppressAnimation(true);
-@@ -6110,11 +6285,13 @@
+@@ -6110,11 +6293,13 @@
        }
  
        // Finish tearing down the tab that's going away.
@@ -748,7 +747,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
  
        this.setTabTitle(aOurTab);
  
-@@ -6316,10 +6493,10 @@
+@@ -6316,10 +6501,10 @@
        SessionStore.deleteCustomTabValue(aTab, "hiddenBy");
      }
  
@@ -761,7 +760,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          aTab.selected ||
          aTab.closing ||
          // Tabs that are sharing the screen, microphone or camera cannot be hidden.
-@@ -6377,7 +6554,8 @@
+@@ -6377,7 +6562,8 @@
       *
       * @param {MozTabbrowserTab|MozTabbrowserTabGroup|MozTabbrowserTabGroup.labelElement} aTab
       */
@@ -771,7 +770,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        if (this.tabs.length == 1) {
          return null;
        }
-@@ -6401,12 +6579,14 @@
+@@ -6401,12 +6587,14 @@
        }
  
        // tell a new window to take the "dropped" tab
@@ -787,7 +786,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
      }
  
      /**
-@@ -6511,7 +6691,7 @@
+@@ -6511,7 +6699,7 @@
       *   `true` if element is a `<tab-group>`
       */
      isTabGroup(element) {
@@ -796,7 +795,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
      }
  
      /**
-@@ -6596,8 +6776,8 @@
+@@ -6596,8 +6784,8 @@
        }
  
        // Don't allow mixing pinned and unpinned tabs.
@@ -807,7 +806,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        } else {
          tabIndex = Math.max(tabIndex, this.pinnedTabCount);
        }
-@@ -6623,10 +6803,16 @@
+@@ -6623,10 +6811,16 @@
        this.#handleTabMove(
          element,
          () => {
@@ -826,7 +825,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
            if (neighbor && this.isTab(element) && tabIndex > element._tPos) {
              neighbor.after(element);
            } else {
-@@ -6684,23 +6870,31 @@
+@@ -6684,23 +6878,31 @@
      #moveTabNextTo(element, targetElement, moveBefore = false, metricsContext) {
        if (this.isTabGroupLabel(targetElement)) {
          targetElement = targetElement.group;
@@ -864,7 +863,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        } else if (!element.pinned && targetElement && targetElement.pinned) {
          // If the caller asks to move an unpinned element next to a pinned
          // tab, move the unpinned element to be the first unpinned element
-@@ -6713,14 +6907,38 @@
+@@ -6713,14 +6915,38 @@
          //    move the tab group right before the first unpinned tab.
          // 4. Moving a tab group and the first unpinned tab is grouped:
          //    move the tab group right before the first unpinned tab's tab group.
@@ -904,7 +903,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          element.pinned
            ? this.tabContainer.pinnedTabsContainer
            : this.tabContainer;
-@@ -6729,11 +6947,15 @@
+@@ -6729,11 +6955,15 @@
          element,
          () => {
            if (moveBefore) {
@@ -921,7 +920,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
            }
          },
          metricsContext
-@@ -6799,10 +7021,10 @@
+@@ -6799,10 +7029,10 @@
       * @param {TabMetricsContext} [metricsContext]
       */
      moveTabToExistingGroup(aTab, aGroup, metricsContext) {
@@ -934,7 +933,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          return;
        }
        if (aTab.group && aTab.group.id === aGroup.id) {
-@@ -6874,6 +7096,7 @@
+@@ -6874,6 +7104,7 @@
  
        let state = {
          tabIndex: tab._tPos,
@@ -942,7 +941,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        };
        if (tab.visible) {
          state.elementIndex = tab.elementIndex;
-@@ -6903,7 +7126,7 @@
+@@ -6903,7 +7134,7 @@
        let changedTabGroup =
          previousTabState.tabGroupId != currentTabState.tabGroupId;
  
@@ -951,7 +950,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          tab.dispatchEvent(
            new CustomEvent("TabMove", {
              bubbles: true,
-@@ -6942,6 +7165,10 @@
+@@ -6942,6 +7173,10 @@
  
        moveActionCallback();
  
@@ -962,7 +961,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        // Clear tabs cache after moving nodes because the order of tabs may have
        // changed.
        this.tabContainer._invalidateCachedTabs();
-@@ -6992,7 +7219,22 @@
+@@ -6992,7 +7227,22 @@
       * @returns {object}
       *    The new tab in the current window, null if the tab couldn't be adopted.
       */
@@ -986,7 +985,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
        // Swap the dropped tab with a new one we create and then close
        // it in the other window (making it seem to have moved between
        // windows). We also ensure that the tab we create to swap into has
-@@ -7035,6 +7277,8 @@
+@@ -7035,6 +7285,8 @@
        }
        params.skipLoad = true;
        let newTab = this.addWebTab("about:blank", params);
@@ -995,7 +994,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
  
        aTab.container.tabDragAndDrop.finishAnimateTabMove();
  
-@@ -7837,7 +8081,7 @@
+@@ -7837,7 +8089,7 @@
              // preventDefault(). It will still raise the window if appropriate.
              break;
            }
@@ -1004,7 +1003,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
            window.focus();
            aEvent.preventDefault();
            break;
-@@ -7854,7 +8098,6 @@
+@@ -7854,7 +8106,6 @@
          }
          case "TabGroupCollapse":
            aEvent.target.tabs.forEach(tab => {
@@ -1012,7 +1011,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
            });
            break;
          case "TabGroupCreateByUser":
-@@ -8014,7 +8257,9 @@
+@@ -8014,7 +8265,9 @@
  
          let filter = this._tabFilters.get(tab);
          if (filter) {
@@ -1022,7 +1021,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
  
            let listener = this._tabListeners.get(tab);
            if (listener) {
-@@ -8817,6 +9062,7 @@
+@@ -8817,6 +9070,7 @@
              aWebProgress.isTopLevel
            ) {
              this.mTab.setAttribute("busy", "true");
@@ -1030,7 +1029,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
              gBrowser._tabAttrModified(this.mTab, ["busy"]);
              this.mTab._notselectedsinceload = !this.mTab.selected;
            }
-@@ -8897,6 +9143,7 @@
+@@ -8897,6 +9151,7 @@
          // known defaults. Note we use the original URL since about:newtab
          // redirects to a prerendered page.
          const shouldRemoveFavicon =
@@ -1038,7 +1037,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
            !this.mBrowser.mIconURL &&
            !ignoreBlank &&
            !(originalLocation.spec in FAVICON_DEFAULTS);
-@@ -9071,13 +9318,6 @@
+@@ -9071,13 +9326,6 @@
              this.mBrowser.originalURI = aRequest.originalURI;
            }
  
@@ -1052,7 +1051,7 @@ index d7765e0adb37216d35f2125abf96025cbb150bab..d787c39f68ea4507b2cb902df325498d
          }
  
          let userContextId = this.mBrowser.getAttribute("usercontextid") || 0;
-@@ -9941,7 +10181,7 @@ var TabContextMenu = {
+@@ -9941,7 +10189,7 @@ var TabContextMenu = {
      );
      contextUnpinSelectedTabs.hidden =
        !this.contextTab.pinned || !this.multiselected;

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -165,11 +165,6 @@ window.gZenUIManager = {
       return;
     }
     const contextMenusToClean = [
-      // Remove the 'new tab below' context menu.
-      // reason: It doesn't properly work with zen and it's philosophy of not having
-      //   new tabs. It's also semi-not working as it doesn't create a new tab below
-      //   the current one.
-      "context_openANewTab",
     ];
     for (const id of contextMenusToClean) {
       const menu = document.getElementById(id);

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -1212,7 +1212,7 @@
         isTabGroupLabel(draggedTab) &&
         draggedTab.group?.isZenFolder &&
         (((isTab(dropElement) || dropElement.hasAttribute("split-view-group")) &&
-          (!dropElement.pinned || dropElement.hasAttribute("zen-essential"))) ||
+          dropElement.hasAttribute("zen-essential")) ||
           showIndicatorUnderNewTabButton)
       ) {
         dropElement = null;

--- a/src/zen/folders/ZenFolder.mjs
+++ b/src/zen/folders/ZenFolder.mjs
@@ -67,7 +67,6 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
 
   connectedCallback() {
     super.connectedCallback();
-    this.labelElement.pinned = true;
     if (this.#initialized) {
       return;
     }
@@ -201,18 +200,21 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
     );
   }
 
-  get pinned() {
-    return this.isZenFolder;
+  get emptyTab() {
+    return this.tabs.find((tab) => tab.hasAttribute("zen-empty-tab"));
   }
 
-  /**
-   * Intentionally ignore attempts to change the pinned state.
-   * ZenFolder instances determine their "pinned" status based on their type (isZenFolder)
-   * and do not support being pinned or unpinned via this setter.
-   * This no-op setter ensures compatibility with interfaces expecting a pinned property,
-   * while preserving the invariant that ZenFolders cannot have their pinned state changed externally.
-   */
-  set pinned(value) {}
+  get pinned() {
+    return this.hasAttribute("pinned");
+  }
+
+  set pinned(value) {
+    if (value) {
+      this.setAttribute("pinned", "true");
+    } else {
+      this.removeAttribute("pinned");
+    }
+  }
 
   get iconURL() {
     return this.icon.querySelector("image")?.getAttribute("href") || "";
@@ -271,7 +273,7 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
       if (event.target.hasAttribute("live-folder-action")) {
         lazy.ZenLiveFoldersManager.handleEvent(event);
       } else {
-        this.unloadAllTabs(event);
+      this.unloadAllTabs(event);
       }
       return;
     }

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -99,6 +99,16 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
         folder.level >= this.#ZEN_MAX_SUBFOLDERS - 1 ? "true" : "false"
       );
 
+      const pinItem = document.getElementById("context_zenFolderPin");
+      const unpinItem = document.getElementById("context_zenFolderUnpin");
+      if (folder.pinned) {
+        pinItem.hidden = true;
+        unpinItem.hidden = false;
+      } else {
+        pinItem.hidden = false;
+        unpinItem.hidden = true;
+      }
+
       const changeFolderSpace = document
         .getElementById("context_zenChangeFolderSpace")
         .querySelector("menupopup");
@@ -135,6 +145,16 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
       switch (event.target.id) {
         case "context_zenFolderRename":
           this.#lastFolderContextMenu.rename();
+          break;
+        case "context_zenFolderPin":
+          if (this.#lastFolderContextMenu.emptyTab) {
+            gBrowser.pinTab(this.#lastFolderContextMenu.emptyTab);
+          }
+          break;
+        case "context_zenFolderUnpin":
+          if (this.#lastFolderContextMenu.emptyTab) {
+            gBrowser.unpinTab(this.#lastFolderContextMenu.emptyTab);
+          }
           break;
         case "context_zenFolderUnpack":
           this.#lastFolderContextMenu.unpackTabs();
@@ -299,15 +319,20 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
   on_TabOpen(event) {
     const tab = event.target;
     const group = tab.group;
-    if (!group?.isZenFolder || tab.pinned) {
+    if (!group?.isZenFolder) {
       return;
     }
     // Edge case: In occations where we add a tab with an ownerTab
     // inside a folder, the tab gets added into the folder in an
-    // unpinned state. We need to pin it and re-add it into the folder.
+    // incorrect pinned state. We need to fix it and re-add it into the folder.
     if (Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder")) {
-      gBrowser.pinTab(tab);
-      group.addTabs([tab]);
+      if (group.pinned && !tab.pinned) {
+        gBrowser.pinTab(tab);
+        group.addTabs([tab]);
+      } else if (!group.pinned && tab.pinned) {
+        gBrowser.unpinTab(tab);
+        group.addTabs([tab]);
+      }
     }
   }
 
@@ -435,11 +460,10 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
         beforeChangeCallback: async (newWorkspace) => {
           await new Promise((resolve) => {
             requestAnimationFrame(async () => {
-              const workspacePinnedContainer = gZenWorkspaces.workspaceElement(
-                newWorkspace.uuid
-              ).pinnedTabsContainer;
+              const workspaceElement = gZenWorkspaces.workspaceElement(newWorkspace.uuid);
+              const targetContainer = folder.pinned ? workspaceElement.pinnedTabsContainer : workspaceElement.tabsContainer;
               const tabs = folder.allItems.filter((tab) => !tab.hasAttribute("zen-empty-tab"));
-              workspacePinnedContainer.append(...tabs);
+              targetContainer.append(...tabs);
               await folder.delete();
               gBrowser.tabContainer._invalidateCachedTabs();
               if (selectedTab) {
@@ -477,8 +501,13 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     const workspaceElement = gZenWorkspaces.workspaceElement(workspaceId);
 
     if (!hasDndSwitch) {
-      const pinnedTabsContainer = workspaceElement.pinnedTabsContainer;
-      pinnedTabsContainer.insertBefore(folder, pinnedTabsContainer.lastChild);
+      if (folder.pinned) {
+        const pinnedTabsContainer = workspaceElement.pinnedTabsContainer;
+        pinnedTabsContainer.insertBefore(folder, pinnedTabsContainer.lastChild);
+      } else {
+        const tabsContainer = workspaceElement.tabsContainer;
+        tabsContainer.appendChild(folder);
+      }
     }
 
     const { lastSelectedWorkspaceTabs } = gZenWorkspaces;
@@ -512,40 +541,67 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
   }
 
   createFolder(tabs = [], options = {}) {
+    let isPinned = options.pinned;
+    if (isPinned === undefined) {
+      if (Services.prefs.getBoolPref("zen.folders.auto-pin", true)) {
+        isPinned = true;
+      } else if (options.insertBefore) {
+        isPinned = options.insertBefore.pinned;
+      } else if (options.insertAfter) {
+        isPinned = options.insertAfter.pinned;
+      } else if (tabs.length > 0) {
+        isPinned = tabs[0].pinned;
+      } else {
+        isPinned = false;
+      }
+    }
+
     const filteredTabs = tabs
       .filter((tab) => !tab.hasAttribute("zen-essential"))
       .map((tab) => {
-        gBrowser.pinTab(tab);
+        if (isPinned) {
+          gBrowser.pinTab(tab);
+        } else {
+          gBrowser.unpinTab(tab);
+        }
         if (tab?.group?.hasAttribute("split-view-group")) {
           tab = tab.group;
         }
         return tab;
       });
 
-    const workspacePinned = gZenWorkspaces.workspaceElement(
-      options.workspaceId
-    )?.pinnedTabsContainer;
-    const pinnedContainer =
-      options.workspaceId && workspacePinned ? workspacePinned : gZenWorkspaces.pinnedTabsContainer;
-    const insertBefore =
-      options.insertBefore || pinnedContainer.querySelector(".pinned-tabs-container-separator");
+    const workspaceElement = gZenWorkspaces.workspaceElement(options.workspaceId) || gZenWorkspaces.activeWorkspaceElement;
+    const pinnedContainer = workspaceElement?.pinnedTabsContainer || gZenWorkspaces.pinnedTabsContainer;
+    const tabsContainer = workspaceElement?.tabsContainer || gZenWorkspaces.tabsContainer;
+
     const emptyTab = gBrowser.addTab("about:blank", {
       skipAnimation: true,
-      pinned: true,
+      pinned: isPinned,
       triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
       _forZenEmptyTab: true,
       createLazyBrowser: true,
     });
 
-    gBrowser.pinTab(emptyTab);
+    if (isPinned) {
+      gBrowser.pinTab(emptyTab);
+    }
+
     tabs = [emptyTab, ...filteredTabs];
 
     const folder = this._createFolderNode(options);
+    folder.pinned = isPinned;
 
     if (options.insertAfter) {
       options.insertAfter.after(folder);
+    } else if (options.insertBefore) {
+      options.insertBefore.before(folder);
     } else {
-      insertBefore.before(folder);
+      if (isPinned) {
+        const insertBefore = pinnedContainer.querySelector(".pinned-tabs-container-separator");
+        insertBefore.before(folder);
+      } else {
+        tabsContainer.appendChild(folder);
+      }
     }
     gZenVerticalTabsManager.animateItemOpen(folder);
 
@@ -608,8 +664,14 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     if (!group) {
       return false;
     }
-    if (group.hasAttribute("split-view-group") && !this._piningFolder) {
+    if ((group.hasAttribute("split-view-group") || (group.isZenFolder && (tab === group.emptyTab || Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder")))) && !this._piningFolder) {
       this._piningFolder = true;
+      if (group.isZenFolder) {
+        group.pinned = true;
+        if (group.emptyTab) {
+          gBrowser.pinTab(group.emptyTab);
+        }
+      }
       for (const otherTab of group.tabs) {
         gZenPinnedTabManager.resetPinChangedUrl(otherTab);
         if (tab === otherTab) {
@@ -631,8 +693,14 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     if (!group) {
       return false;
     }
-    if (group.hasAttribute("split-view-group") && !this._piningFolder) {
+    if ((group.hasAttribute("split-view-group") || (group.isZenFolder && (tab === group.emptyTab || Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder")))) && !this._piningFolder) {
       this._piningFolder = true;
+      if (group.isZenFolder) {
+        group.pinned = false;
+        if (group.emptyTab) {
+          gBrowser.unpinTab(group.emptyTab);
+        }
+      }
       for (const otherTab of group.tabs) {
         if (tab === otherTab) {
           continue;
@@ -919,7 +987,7 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
         this.setFolderUserIcon(group, icon);
         group.dispatchEvent(new CustomEvent("TabGroupUpdate", { bubbles: true }));
       },
-    });
+      });
   }
 
   setFolderUserIcon(group, icon) {

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -216,7 +216,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
               }
               return tab;
             })
-            .filter((tab) => tab?.pinned)
+            .filter((tab) => tab?.pinned || folderToUnload)
         ),
       ];
 
@@ -519,7 +519,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
             image: null,
           });
         },
-      });
+        });
     });
   }
 
@@ -625,7 +625,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
 
       movingTabs = movingTabs.filter((tab) =>
         gBrowser.isTabGroupLabel(tab) && tab.group?.isZenFolder
-          ? !tabsTarget && !essentialTabsTarget
+          ? (tab.group.pinned ? pinnedTabsTarget : !pinnedTabsTarget) && !essentialTabsTarget
           : true
       );
 

--- a/src/zen/workspaces/ZenWorkspaces.mjs
+++ b/src/zen/workspaces/ZenWorkspaces.mjs
@@ -287,7 +287,7 @@ class nsZenWorkspaces {
   #initializeEmptyTab() {
     for (const tab of gBrowser.tabs) {
       // Check if session store has an empty tab
-      if (tab.hasAttribute("zen-empty-tab") && !tab.pinned) {
+      if (tab.hasAttribute("zen-empty-tab") && !tab.pinned && !tab.group) {
         this.log("Found existing empty tab from session store!");
         this._emptyTab = tab;
         return;
@@ -1095,7 +1095,7 @@ class nsZenWorkspaces {
         workspace.icon = icon;
         await this.saveWorkspace(workspace);
       },
-    });
+      });
   }
 
   shouldCloseWindow() {
@@ -1117,7 +1117,7 @@ class nsZenWorkspaces {
           !workspaces.find((workspace) => workspace.uuid === workspaceID)) ||
         // Also remove empty tabs that are supposed to be from parent folders but
         // they dont exist anymore
-        (tab.pinned && tab.hasAttribute("zen-empty-tab") && !tab.group)
+        (tab.hasAttribute("zen-empty-tab") && !tab.group && tab !== this._emptyTab)
       ) {
         // Remove any tabs where their workspace doesn't exist anymore
         this.log("Removed zombie tab from non-existing workspace", tab);
@@ -3106,6 +3106,9 @@ class nsZenWorkspaces {
   }
 
   fixTabInsertLocation(tab) {
+    if (tab.group) {
+      return;
+    }
     if (tab.hasAttribute("zen-essential")) {
       // Essential tabs should always be inserted at the end of the essentials section
       const essentialsSection = this.getEssentialsSection(tab);


### PR DESCRIPTION
Features added:
- New toggle in settings under tab management called "Automatically pin folders" so you can disable or enable having folders pinned by default when creating a new folder
- You can now create folders with unpinned tabs
- New option in the context menu of folders where you pin or unpin a folder

Features to be added: 
- "move tab/tabs to folder" context menu option

Bugs:

- Unpinned folders:
-- When the last tab of a folder is focused, and the user wants to duplicate the tab, the duplicated tab is created outside the folder
-- When selecting a tab inside a folder and positioned just before a subfolder (focused), when you use "new tab below" it creates the new tab at the end of the folder and not below the original tab
-- When selecting a tab inside a folder and positioned just before a subfolder (unfocused), both "new tab below" and "duplicate tab" create the tab at the end of the folder

- Pinned folders:
-- Using duplicate tab on a focused tab creates the new duplicated tab outside the folder and not below the original tab
-- When selecting a tab inside a folder and positioned just before a subfolder (unfocused or focused), "new tab below" will create a tab at the end of the folder and "duplicate tab" will create a tab outside the folder (exception: when the tab is unfocused, the duplicated tab is created at the end of the folder)

- Pinned tabs:
-- "new tab below" and "duplicate tab" on pinned tabs (outside folders) (focused or unfocused) create the new tab in the unpinned tabs section
-- Opening links inside pinned tabs (outside or inside a folder) opens the tab in the unpinned section (same thing for opening glanced links)

Some bugs might not be considered bugs (behaviour that some users expect) so let's have a discussion about that.