### PR TITLE
feat: use `sidebar-keep-hover` delay while hiding sidebar

### DIFF
--- a/prefs/zen/compact-mode.yaml
+++ b/prefs/zen/compact-mode.yaml
@@ -17,6 +17,9 @@
 - name: zen.view.compact.toolbar-hide-after-hover.duration
   value: 1000
 
+- name: zen.view.compact.sidebar-keep-hover.duration
+  value: 150
+
 - name: zen.view.compact.animate-sidebar
   value: true
 

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -589,7 +589,7 @@ window.gZenCompactModeManager = {
       {
         element: this.sidebar,
         screenEdge: this.sidebarIsOnRight ? "right" : "left",
-        keepHoverDuration: 100,
+        keepHoverDuration: Services.prefs.getIntPref("zen.view.compact.sidebar-keep-hover.duration"),
       },
       {
         element: document.getElementById("zen-appcontent-navbar-wrapper"),

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -589,7 +589,9 @@ window.gZenCompactModeManager = {
       {
         element: this.sidebar,
         screenEdge: this.sidebarIsOnRight ? "right" : "left",
-        keepHoverDuration: Services.prefs.getIntPref("zen.view.compact.sidebar-keep-hover.duration"),
+        keepHoverDuration: Services.prefs.getIntPref(
+          "zen.view.compact.sidebar-keep-hover.duration"
+        ),
       },
       {
         element: document.getElementById("zen-appcontent-navbar-wrapper"),


### PR DESCRIPTION
This patch introduces a new preference as `zen.view.compact.sidebar-keep-hover.duration`.

The pref is used as a timeout to decide when to hide the sidebar if hover is no longer active.