### PR TITLE
fix: Add `position: relative` to tab groups for positioning context

### DIFF
--- a/src/zen/split-view/zen-split-group.inc.css
+++ b/src/zen/split-view/zen-split-group.inc.css
@@ -6,6 +6,7 @@
 
 tab-group[split-view-group] {
   display: block;
+  position: relative;
 
   @media (prefers-reduced-motion: no-preference) {
     transition: var(--zen-tabbox-element-indent-transition);


### PR DESCRIPTION
```css
tab-group[split-view-group] .tab-group-label-container {
  position: absolute;
  ...
 }
 ```
 `tab-group-label-container` has `positon: absolute` so when moving the element was positioned not relative to dragged group, but to the whole sidebar.