### PR TITLE
refactor: Simplify new tab handling in collapsed live folders

### DIFF
--- a/src/zen/folders/ZenFolder.mjs
+++ b/src/zen/folders/ZenFolder.mjs
@@ -281,18 +281,10 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
   addTabs(tabs) {
     super.addTabs(tabs);
     if (this.collapsed && !gZenFolders._sessionRestoring && this.isLiveFolder && tabs.length) {
-      let activeTabs = this.activeTabs;
-      activeTabs.push(...tabs);
-      gZenFolders._dontAnimateFolder = true;
-      gZenFolders.on_TabGroupExpand({ target: this }).then(() => {
-        for (let tab of activeTabs) {
-          tab.setAttribute("folder-active", "true");
-        }
-        gZenFolders.on_TabGroupCollapse({ target: this }).then(() => {
-          delete gZenFolders._dontAnimateFolder;
-          gBrowser.tabContainer._invalidateCachedVisibleTabs();
-        });
+      tabs.forEach((tab) => {
+        tab.setAttribute("folder-active", "true");
       });
+      gZenFolders.animateCollapse(this);
     }
   }
 


### PR DESCRIPTION
We need the first set the `folder-active` attribute on the added tabs so that they are `visible` and `#collectGroupItems` can collect them, and then just call `animateCollapse` it will add `activeTabs` by itself and set the indentation for the tabs (line `ZenFolders.mjs:1332` and `ZenFolders.mjs:1335`). Since the folder is already collapsed we don't need any flags to cancel the animation. The folder with the `has-active` attribute has `margin-top: 0px` so there will be no visual shifts.