### PR TITLE
fix: fallback to default position when panelUIPosition returns undefined

### DIFF
--- a/src/browser/modules/ExtensionsUI-sys-mjs.patch
+++ b/src/browser/modules/ExtensionsUI-sys-mjs.patch
@@ -6,8 +6,8 @@ index 31229b3bc1b93565a57c2c0b0307ceeb594c3936..30456ef5d3c58e96717cd292f861a04a
          eventCallback,
          removeOnDismissal: true,
          popupOptions: {
--          position: "bottomright topright",
-+          position: window.gZenUIManager.panelUIPosition(),
+-          position: window.gZenUIManager.panelUIPosition(),
++          position: window.gZenUIManager.panelUIPosition() || "bottomright topright",
          },
          // Pass additional options used internally by the
          // addon-webext-permissions-notification custom element


### PR DESCRIPTION
Fixes #12624

The extension install notification was appearing off-screen on Linux because `panelUIPosition()` was being called without arguments in the ExtensionsUI patch, causing it to return undefined. This made the notification appear at an incorrect position, preventing users from interacting with it.

Added a fallback to the default position "bottomright topright" when `panelUIPosition()` returns undefined.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*