### PR TITLE
chore: add ignored files in recalculate-patches

### DIFF
--- a/scripts/recalculate-patches.sh
+++ b/scripts/recalculate-patches.sh
@@ -12,6 +12,9 @@ IGNORE_FILES=(
   "shared.nsh"
   "ignorePrefs.json"
   "moz.configure"
+  "AsyncShutdown.sys.mjs"
+  "Info.plist.in"
+  "firefox.js"
 )
 
 # Recursively find all .patch files in the current directory and its subdirectories


### PR DESCRIPTION
## Motivation
Adds certain files to the ignore list of the `recalculate-patches.sh` scripts so certain patches won't be applied twice. See https://github.com/zen-browser/desktop/pull/12640#issuecomment-4004751060.

## Changes
- Ignore files that are already handled and would cause duplicate patches.
  - AsyncShutdown.sys.mjs -> `src/external-patches/firefox/no_liquid_glass_icon.patch`
  - Info.plist.in -> `src/external-patches/firefox/add_urlbar_closeonwindowblur_preference.patch`
  - firefox.js -> `src/external-patches/firefox/fix_macos_crash_on_shutdown_firefox_149.patch`
