### PR TITLE
feat: Change selected tab when resetting pinned tab, p=#12696

### DIFF
--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -111,6 +111,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
   _onTabResetPinButton(event, tab) {
     event.stopPropagation();
     this._resetTabToStoredState(tab);
+    gBrowser.selectedTab = tab;
   }
 
   get enabled() {


### PR DESCRIPTION
Currently, if you reset a **non-selected pinned tab**, the reset happens, but the tab is not changing. Arc selects the tab for you, which makes sense to me almost all the time. 

Tested on macOS only, but this doesn't look harmful to me.

- Before

https://github.com/user-attachments/assets/3575da7e-1233-4809-a0ce-2172d0bb3be8

- After

https://github.com/user-attachments/assets/6a791dbb-0ede-4917-87f0-d0738e17b6c1



