### PR TITLE
feat: Add "Separate from pinned tab" when resetting pinned tab with CMD

### DIFF
--- a/locales/en-US/browser/browser/zen-vertical-tabs.ftl
+++ b/locales/en-US/browser/browser/zen-vertical-tabs.ftl
@@ -46,5 +46,6 @@ tabbrowser-reset-pin-button =
 zen-tab-sublabel =
     { $tabSubtitle ->
         [zen-default-pinned] Back to pinned url
+        [zen-default-pinned-cmd] Separate from pinned tab
         *[other] { $tabSubtitle }
     }

--- a/src/browser/base/content/browser-js.patch
+++ b/src/browser/base/content/browser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/base/content/browser.js b/browser/base/content/browser.js
-index e2e0526a0ddd617291f1f6c17bcfb807954b481f..c3d2afff6eaa788309d1c1a7fa40f9b8b4f0fffe 100644
+index e2e0526a0ddd617291f1f6c17bcfb807954b481f..7a4c3f95e9590d1f83f470f59052174d5f43f805 100644
 --- a/browser/base/content/browser.js
 +++ b/browser/base/content/browser.js
 @@ -33,6 +33,7 @@ ChromeUtils.defineESModuleGetters(this, {
@@ -60,7 +60,44 @@ index e2e0526a0ddd617291f1f6c17bcfb807954b481f..c3d2afff6eaa788309d1c1a7fa40f9b8
        gBrowser.closingTabsEnum.ALL
      )
    );
-@@ -4809,6 +4817,9 @@ var ConfirmationHint = {
+@@ -4074,8 +4082,10 @@ function safeModeRestart() {
+  *  "window"      new window
+  *
+  * delta is the offset to the history entry that you want to load.
++ * 
++ * onRestore is called after the new tab is restored properly.
+  */
+-function duplicateTabIn(aTab, where, delta) {
++function duplicateTabIn(aTab, where, delta, onRestore = () => {}) {
+   switch (where) {
+     case "window": {
+       let otherWin = OpenBrowserWindow({
+@@ -4089,7 +4099,7 @@ function duplicateTabIn(aTab, where, delta) {
+           Services.obs.removeObserver(delayedStartupFinished, topic);
+           let otherGBrowser = otherWin.gBrowser;
+           let otherTab = otherGBrowser.selectedTab;
+-          SessionStore.duplicateTab(otherWin, aTab, delta);
++          SessionStore.duplicateTab(otherWin, aTab, delta, true, {}, onRestore);
+           otherGBrowser.removeTab(otherTab, { animate: false });
+         }
+       };
+@@ -4101,13 +4111,13 @@ function duplicateTabIn(aTab, where, delta) {
+       break;
+     }
+     case "tabshifted":
+-      SessionStore.duplicateTab(window, aTab, delta);
++      SessionStore.duplicateTab(window, aTab, delta, true, {}, onRestore);
+       // A background tab has been opened, nothing else to do here.
+       break;
+     case "tab":
+       SessionStore.duplicateTab(window, aTab, delta, true, {
+         inBackground: false,
+-      });
++      }, onRestore);
+       break;
+   }
+   if (aTab.group) {
+@@ -4809,6 +4819,9 @@ var ConfirmationHint = {
      MozXULElement.insertFTLIfNeeded("toolkit/branding/brandings.ftl");
      MozXULElement.insertFTLIfNeeded("browser/confirmationHints.ftl");
      document.l10n.setAttributes(this._message, messageId, options.l10nArgs);

--- a/src/browser/components/sessionstore/SessionStore-sys-mjs.patch
+++ b/src/browser/components/sessionstore/SessionStore-sys-mjs.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/sessionstore/SessionStore.sys.mjs b/browser/components/sessionstore/SessionStore.sys.mjs
-index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf06644d92 100644
+index f066bc7a9cca1788080d088141030c225a733931..ad639a56798ba125b689429ab62fb83ee2e3cc59 100644
 --- a/browser/components/sessionstore/SessionStore.sys.mjs
 +++ b/browser/components/sessionstore/SessionStore.sys.mjs
 @@ -127,6 +127,9 @@ const TAB_EVENTS = [
@@ -21,7 +21,26 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
  });
  
  ChromeUtils.defineLazyGetter(lazy, "blankURI", () => {
-@@ -1263,10 +1268,7 @@ var SessionStoreInternal = {
+@@ -332,14 +337,16 @@ export var SessionStore = {
+     aTab,
+     aDelta = 0,
+     aRestoreImmediately = true,
+-    aOptions = {}
++    aOptions = {},
++    onRestore = () => {}
+   ) {
+     return SessionStoreInternal.duplicateTab(
+       aWindow,
+       aTab,
+       aDelta,
+       aRestoreImmediately,
+-      aOptions
++      aOptions,
++      onRestore
+     );
+   },
+ 
+@@ -1263,10 +1270,7 @@ var SessionStoreInternal = {
     */
    get willAutoRestore() {
      return (
@@ -33,7 +52,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
      );
    },
  
-@@ -1940,6 +1942,9 @@ var SessionStoreInternal = {
+@@ -1940,6 +1944,9 @@ var SessionStoreInternal = {
        case "TabPinned":
        case "TabUnpinned":
        case "SwapDocShells":
@@ -43,7 +62,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
          this.saveStateDelayed(win);
          break;
        case "TabGroupCreate":
-@@ -2050,6 +2055,10 @@ var SessionStoreInternal = {
+@@ -2050,6 +2057,10 @@ var SessionStoreInternal = {
        this._windows[aWindow.__SSi].isTaskbarTab = true;
      }
  
@@ -54,7 +73,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
      if (lazy.AIWindow.isAIWindowActiveAndEnabled(aWindow)) {
        this._windows[aWindow.__SSi].isAIWindow = true;
      }
-@@ -2086,7 +2095,7 @@ var SessionStoreInternal = {
+@@ -2086,7 +2097,7 @@ var SessionStoreInternal = {
      let isTaskbarTab = this._windows[aWindow.__SSi].isTaskbarTab;
      // A regular window is not a private window, taskbar tab window, or popup window
      let isRegularWindow =
@@ -63,7 +82,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
  
      // perform additional initialization when the first window is loading
      if (lazy.RunState.isStopped) {
-@@ -2098,7 +2107,7 @@ var SessionStoreInternal = {
+@@ -2098,7 +2109,7 @@ var SessionStoreInternal = {
          // to disk to NOW() to enforce a full interval before the next write.
          lazy.SessionSaver.updateLastSaveTime();
  
@@ -72,7 +91,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
            this._log.debug(
              "initializeWindow, the window is private or a web app. Saving SessionStartup.state for possibly restoring later"
            );
-@@ -2141,6 +2150,7 @@ var SessionStoreInternal = {
+@@ -2141,6 +2152,7 @@ var SessionStoreInternal = {
            null,
            "sessionstore-one-or-no-tab-restored"
          );
@@ -80,7 +99,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
          this._deferredAllWindowsRestored.resolve();
        }
        // this window was opened by _openWindowWithState
-@@ -2190,7 +2200,6 @@ var SessionStoreInternal = {
+@@ -2190,7 +2202,6 @@ var SessionStoreInternal = {
        if (closedWindowState) {
          let newWindowState;
          if (
@@ -88,7 +107,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
            !lazy.SessionStartup.willRestore()
          ) {
            // We want to split the window up into pinned tabs and unpinned tabs.
-@@ -2226,6 +2235,7 @@ var SessionStoreInternal = {
+@@ -2226,6 +2237,7 @@ var SessionStoreInternal = {
          }
  
          if (newWindowState) {
@@ -96,7 +115,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
            // Ensure that the window state isn't hidden
            this._restoreCount = 1;
            let state = { windows: [newWindowState] };
-@@ -2254,6 +2264,15 @@ var SessionStoreInternal = {
+@@ -2254,6 +2266,15 @@ var SessionStoreInternal = {
        });
        this._shouldRestoreLastSession = false;
      }
@@ -112,7 +131,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
  
      if (this._restoreLastWindow && aWindow.toolbar.visible) {
        // always reset (if not a popup window)
-@@ -2404,7 +2423,7 @@ var SessionStoreInternal = {
+@@ -2404,7 +2425,7 @@ var SessionStoreInternal = {
  
      var tabbrowser = aWindow.gBrowser;
  
@@ -121,7 +140,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
  
      TAB_EVENTS.forEach(function (aEvent) {
        tabbrowser.tabContainer.removeEventListener(aEvent, this, true);
-@@ -2455,7 +2474,7 @@ var SessionStoreInternal = {
+@@ -2455,7 +2476,7 @@ var SessionStoreInternal = {
  
        let isLastRegularWindow =
          Object.values(this._windows).filter(
@@ -130,7 +149,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
          ).length == 1;
        this._log.debug(
          `onClose, closing window isLastRegularWindow? ${isLastRegularWindow}`
-@@ -2512,8 +2531,8 @@ var SessionStoreInternal = {
+@@ -2512,8 +2533,8 @@ var SessionStoreInternal = {
        // 2) Flush the window.
        // 3) When the flush is complete, revisit our decision to store the window
        //    in _closedWindows, and add/remove as necessary.
@@ -141,7 +160,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
        }
  
        completionPromise = lazy.TabStateFlusher.flushWindow(aWindow).then(() => {
-@@ -2533,8 +2552,9 @@ var SessionStoreInternal = {
+@@ -2533,8 +2554,9 @@ var SessionStoreInternal = {
  
          // Save non-private windows if they have at
          // least one saveable tab or are the last window.
@@ -153,7 +172,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
  
            if (!isLastWindow && winData.closedId > -1) {
              this._addClosedAction(
-@@ -2610,7 +2630,7 @@ var SessionStoreInternal = {
+@@ -2610,7 +2632,7 @@ var SessionStoreInternal = {
     *        to call this method again asynchronously (for example, after
     *        a window flush).
     */
@@ -162,7 +181,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
      // Make sure SessionStore is still running, and make sure that we
      // haven't chosen to forget this window.
      if (
-@@ -2627,6 +2647,7 @@ var SessionStoreInternal = {
+@@ -2627,6 +2649,7 @@ var SessionStoreInternal = {
        // _closedWindows from a previous call to this function.
        let winIndex = this._closedWindows.indexOf(winData);
        let alreadyStored = winIndex != -1;
@@ -170,7 +189,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
        // If sidebar command is truthy, i.e. sidebar is open, store sidebar settings
        let shouldStore = hasSaveableTabs || isLastWindow;
  
-@@ -3429,7 +3450,7 @@ var SessionStoreInternal = {
+@@ -3429,7 +3452,7 @@ var SessionStoreInternal = {
      if (!isPrivateWindow && tabState.isPrivate) {
        return;
      }
@@ -179,7 +198,17 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
        return;
      }
  
-@@ -4150,6 +4171,12 @@ var SessionStoreInternal = {
+@@ -4074,7 +4097,8 @@ var SessionStoreInternal = {
+     aTab,
+     aDelta = 0,
+     aRestoreImmediately = true,
+-    { inBackground, tabIndex } = {}
++    { inBackground, tabIndex } = {},
++    onRestore = () => {}
+   ) {
+     if (!aTab || !aTab.ownerGlobal) {
+       throw Components.Exception("Need a valid tab", Cr.NS_ERROR_INVALID_ARG);
+@@ -4150,6 +4174,12 @@ var SessionStoreInternal = {
          Math.min(tabState.index, tabState.entries.length)
        );
        tabState.pinned = false;
@@ -192,7 +221,15 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
  
        if (inBackground === false) {
          aWindow.gBrowser.selectedTab = newTab;
-@@ -4586,6 +4613,8 @@ var SessionStoreInternal = {
+@@ -4159,6 +4189,7 @@ var SessionStoreInternal = {
+       this.restoreTab(newTab, tabState, {
+         restoreImmediately: aRestoreImmediately,
+       });
++      onRestore();
+     });
+ 
+     return newTab;
+@@ -4586,6 +4617,8 @@ var SessionStoreInternal = {
        // Append the tab if we're opening into a different window,
        tabIndex: aSource == aTargetWindow ? pos : Infinity,
        pinned: state.pinned,
@@ -201,7 +238,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
        userContextId: state.userContextId,
        skipLoad: true,
        preferredRemoteType,
-@@ -5087,9 +5116,10 @@ var SessionStoreInternal = {
+@@ -5087,9 +5120,10 @@ var SessionStoreInternal = {
        if (activePageData.title && activePageData.title != activePageData.url) {
          win.gBrowser.setInitialTabTitle(tab, activePageData.title, {
            isContentTitle: true,
@@ -213,7 +250,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
        }
      }
  
-@@ -5446,7 +5476,7 @@ var SessionStoreInternal = {
+@@ -5446,7 +5480,7 @@ var SessionStoreInternal = {
  
      for (let i = tabbrowser.pinnedTabCount; i < tabbrowser.tabs.length; i++) {
        let tab = tabbrowser.tabs[i];
@@ -222,7 +259,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
          removableTabs.push(tab);
        }
      }
-@@ -5559,7 +5589,7 @@ var SessionStoreInternal = {
+@@ -5559,7 +5593,7 @@ var SessionStoreInternal = {
  
      // collect the data for all windows
      for (ix in this._windows) {
@@ -231,7 +268,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
          // window data is still in _statesToRestore
          continue;
        }
-@@ -5702,11 +5732,12 @@ var SessionStoreInternal = {
+@@ -5702,11 +5736,12 @@ var SessionStoreInternal = {
      }
  
      let tabbrowser = aWindow.gBrowser;
@@ -245,7 +282,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
      // update the internal state data for this window
      for (let tab of tabs) {
        if (tab == aWindow.FirefoxViewHandler.tab) {
-@@ -5717,6 +5748,9 @@ var SessionStoreInternal = {
+@@ -5717,6 +5752,9 @@ var SessionStoreInternal = {
        tabsData.push(tabData);
      }
  
@@ -255,7 +292,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
      // update tab group state for this window
      winData.groups = [];
      for (let tabGroup of aWindow.gBrowser.tabGroups) {
-@@ -5729,7 +5763,7 @@ var SessionStoreInternal = {
+@@ -5729,7 +5767,7 @@ var SessionStoreInternal = {
      // a window is closed, point to the first item in the tab strip instead (it will never be the Firefox View tab,
      // since it's only inserted into the tab strip after it's selected).
      if (aWindow.FirefoxViewHandler.tab?.selected) {
@@ -264,7 +301,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
        winData.title = tabbrowser.tabs[0].label;
      }
      winData.selected = selectedIndex;
-@@ -5844,8 +5878,8 @@ var SessionStoreInternal = {
+@@ -5844,8 +5882,8 @@ var SessionStoreInternal = {
      // selectTab represents.
      let selectTab = 0;
      if (overwriteTabs) {
@@ -275,7 +312,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
        selectTab = Math.min(selectTab, winData.tabs.length);
      }
  
-@@ -5867,6 +5901,7 @@ var SessionStoreInternal = {
+@@ -5867,6 +5905,7 @@ var SessionStoreInternal = {
      if (overwriteTabs) {
        for (let i = tabbrowser.browsers.length - 1; i >= 0; i--) {
          if (!tabbrowser.tabs[i].selected) {
@@ -283,7 +320,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
            tabbrowser.removeTab(tabbrowser.tabs[i]);
          }
        }
-@@ -5900,6 +5935,12 @@ var SessionStoreInternal = {
+@@ -5900,6 +5939,12 @@ var SessionStoreInternal = {
          savedTabGroup => !openTabGroupIdsInWindow.has(savedTabGroup.id)
        );
      }
@@ -296,7 +333,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
  
      // Move the originally open tabs to the end.
      if (initialTabs) {
-@@ -6453,6 +6494,25 @@ var SessionStoreInternal = {
+@@ -6453,6 +6498,25 @@ var SessionStoreInternal = {
  
      // Most of tabData has been restored, now continue with restoring
      // attributes that may trigger external events.
@@ -322,7 +359,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
  
      if (tabData.pinned) {
        tabbrowser.pinTab(tab);
-@@ -6601,6 +6661,9 @@ var SessionStoreInternal = {
+@@ -6601,6 +6665,9 @@ var SessionStoreInternal = {
          aWindow.gURLBar.readOnly = false;
        }
      }
@@ -332,7 +369,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
  
      let promiseParts = Promise.withResolvers();
      aWindow.setTimeout(() => {
-@@ -7389,7 +7452,7 @@ var SessionStoreInternal = {
+@@ -7389,7 +7456,7 @@ var SessionStoreInternal = {
  
        let groupsToSave = new Map();
        for (let tIndex = 0; tIndex < window.tabs.length; ) {
@@ -341,7 +378,7 @@ index f066bc7a9cca1788080d088141030c225a733931..accb078ebbc23f9a823ae6c277f1e1bf
            // Adjust window.selected
            if (tIndex + 1 < window.selected) {
              window.selected -= 1;
-@@ -7404,7 +7467,7 @@ var SessionStoreInternal = {
+@@ -7404,7 +7471,7 @@ var SessionStoreInternal = {
            );
            // We don't want to increment tIndex here.
            continue;

--- a/src/browser/components/tabbrowser/content/tab-js.patch
+++ b/src/browser/components/tabbrowser/content/tab-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tab.js b/browser/components/tabbrowser/content/tab.js
-index 836bee14d2b63604688ebe477a5d915a5e99b305..7e105a1ae07657b0a0e664a8e3d9d2eb894fa1d4 100644
+index 836bee14d2b63604688ebe477a5d915a5e99b305..922c1233fadab5bc0c0ea41ae86be63d8b4565ad 100644
 --- a/browser/components/tabbrowser/content/tab.js
 +++ b/browser/components/tabbrowser/content/tab.js
 @@ -21,6 +21,7 @@
@@ -110,7 +110,28 @@ index 836bee14d2b63604688ebe477a5d915a5e99b305..7e105a1ae07657b0a0e664a8e3d9d2eb
      }
  
      get splitview() {
-@@ -489,6 +515,8 @@
+@@ -444,6 +470,12 @@
+         : this;
+       gBrowser.warmupTab(tabToWarm);
+ 
++      if (event.target.classList.contains("tab-reset-pin-button")) {
++        gZenPinnedTabManager.updateTabWithResetPinButtonHovered(event.target.closest("tab"), event);
++      } else {
++        gZenPinnedTabManager.updateTabWithResetPinButtonHovered(null, event);
++      }
++      
+       // If the previous target wasn't part of this tab then this is a mouseenter event.
+       if (!this.contains(event.relatedTarget)) {
+         this._mouseenter();
+@@ -455,6 +487,7 @@
+       if (!this.contains(event.relatedTarget)) {
+         this._mouseleave();
+       }
++      gZenPinnedTabManager.updateTabWithResetPinButtonHovered(null, event);
+     }
+ 
+     on_dragstart(event) {
+@@ -489,6 +522,8 @@
          this.style.MozUserFocus = "ignore";
        } else if (
          event.target.classList.contains("tab-close-button") ||
@@ -119,7 +140,7 @@ index 836bee14d2b63604688ebe477a5d915a5e99b305..7e105a1ae07657b0a0e664a8e3d9d2eb
          event.target.classList.contains("tab-icon-overlay") ||
          event.target.classList.contains("tab-audio-button")
        ) {
-@@ -543,6 +571,10 @@
+@@ -543,16 +578,17 @@
        this.style.MozUserFocus = "";
      }
  
@@ -130,22 +151,63 @@ index 836bee14d2b63604688ebe477a5d915a5e99b305..7e105a1ae07657b0a0e664a8e3d9d2eb
      on_click(event) {
        if (event.button != 0) {
          return;
-@@ -603,6 +635,14 @@
+       }
+ 
+-      if (event.getModifierState("Accel") || event.shiftKey) {
+-        return;
+-      }
+-
+       if (
++        !((event.getModifierState("Accel") || event.shiftKey)) &&
+         gBrowser.multiSelectedTabsCount > 0 &&
+         !event.target.classList.contains("tab-close-button") &&
+         !event.target.classList.contains("tab-icon-overlay") &&
+@@ -564,8 +600,9 @@
+       }
+ 
+       if (
+-        event.target.classList.contains("tab-icon-overlay") ||
+-        event.target.classList.contains("tab-audio-button")
++        !((event.getModifierState("Accel") || event.shiftKey)) &&
++        (event.target.classList.contains("tab-icon-overlay") ||
++        event.target.classList.contains("tab-audio-button"))
+       ) {
+         if (this.activeMediaBlocked) {
+           if (this.multiselected) {
+@@ -583,7 +620,10 @@
+         return;
+       }
+ 
+-      if (event.target.classList.contains("tab-close-button")) {
++      if (
++        !((event.getModifierState("Accel") || event.shiftKey)) &&
++        event.target.classList.contains("tab-close-button")
++      ) {
+         if (this.multiselected) {
+           gBrowser.removeMultiSelectedTabs(
+             lazy.TabMetrics.userTriggeredContext(
+@@ -603,6 +643,20 @@
          // (see tabbrowser-tabs 'click' handler).
          gBrowser.tabContainer._blockDblClick = true;
        }
 +
-+      if (event.target.classList.contains("tab-reset-pin-button")) {
++      if (
++        !event.shiftKey && 
++        event.target.classList.contains("tab-reset-pin-button")
++      ) {
 +        gZenPinnedTabManager._onTabResetPinButton(event, this, 'reset');
 +        gBrowser.tabContainer._blockDblClick = true;
-+      } else if (event.target.classList.contains("tab-reset-button")) {
++      } else if (
++        !((event.getModifierState("Accel") || event.shiftKey)) &&
++        event.target.classList.contains("tab-reset-button")
++      ) {
 +        gZenPinnedTabManager.onCloseTabShortcut(event, this);
 +        gBrowser.tabContainer._blockDblClick = true;
 +      }
      }
  
      on_dblclick(event) {
-@@ -626,6 +666,8 @@
+@@ -626,6 +680,8 @@
            animate: true,
            triggeringEvent: event,
          });

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -74,6 +74,9 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     this.observer.addPinnedTabListener(this._onPinnedTabEvent.bind(this));
 
     this._zenClickEventListener = this._onTabClick.bind(this);
+    this._zenKeyDownEventListener = this._onKeyDown.bind(this);
+    this._zenKeyUpEventListener = this._onKeyUp.bind(this);
+    this._tabWithResetPinButtonHovered = null;
 
     gZenWorkspaces._resolvePinnedInitialized();
     if (lazy.zenPinnedTabRestorePinnedTabsToPinnedUrl) {
@@ -110,8 +113,15 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
 
   _onTabResetPinButton(event, tab) {
     event.stopPropagation();
-    this._resetTabToStoredState(tab);
-    gBrowser.selectedTab = tab;
+    if (event.getModifierState("Accel")) {
+      window.duplicateTabIn(tab, "tabshifted", 0, () => {
+        this._resetTabToStoredState(tab);
+        gBrowser.selectedTab = tab;
+      });
+    } else {
+      this._resetTabToStoredState(tab);
+      gBrowser.selectedTab = tab;
+    }
   }
 
   get enabled() {
@@ -134,13 +144,25 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     switch (action) {
       case "TabPinned":
         tab._zenClickEventListener = this._zenClickEventListener;
+        tab._zenKeyDownEventListener = this._zenKeyDownEventListener;
+        tab._zenKeyUpEventListener = this._zenKeyUpEventListener;
         tab.addEventListener("click", tab._zenClickEventListener);
+        window.addEventListener("keydown", tab._zenKeyDownEventListener);
+        window.addEventListener("keyup", tab._zenKeyUpEventListener);
         break;
       // [Fall through]
       case "TabUnpinned":
         if (tab._zenClickEventListener) {
           tab.removeEventListener("click", tab._zenClickEventListener);
           delete tab._zenClickEventListener;
+        }
+        if (tab._zenKeyDownEventListener) {
+          window.removeEventListener("keydown", tab._zenKeyDownEventListener);
+          delete tab._zenKeyDownEventListener;
+        }
+        if (tab._zenKeyUpEventListener) {
+          window.removeEventListener("keyup", tab._zenKeyUpEventListener);
+          delete tab._zenKeyUpEventListener;
         }
         this.resetPinChangedUrl(tab);
         break;
@@ -160,6 +182,39 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
       await this.onCloseTabShortcut(e, tab, {
         closeIfPending: Services.prefs.getBoolPref("zen.pinned-tab-manager.wheel-close-if-pending"),
       });
+    }
+  }
+
+  async _onKeyDown(e) {
+    this._updateZenTabSublabel(e);
+  }
+
+  async _onKeyUp(e) {
+    this._updateZenTabSublabel(e);
+  }
+
+  _updateZenTabSublabel(e) {
+    let label = this._tabWithResetPinButtonHovered?.querySelector(".zen-tab-sublabel")
+    if (label, e.getModifierState("Accel") || (e.metaKey && e.type == "keydown")) {
+      window.document.l10n.setArgs(label, {
+        tabSubtitle: "zen-default-pinned-cmd",
+      });
+    } else if (label) {
+      window.document.l10n.setArgs(label, {
+        tabSubtitle: "zen-default-pinned",
+      });
+    }
+  }
+
+  updateTabWithResetPinButtonHovered(tab, event) {
+    if (!tab) {
+      // reset subtitle first
+      this._updateZenTabSublabel(event);
+    }
+    this._tabWithResetPinButtonHovered = tab
+    if (tab) {
+      // now update subtitle
+      this._updateZenTabSublabel(event);
     }
   }
 


### PR DESCRIPTION
Pretty new to Firefox's code base, `duplicateTabIn` is the proper one, I think, I could find to duplicate a tab.

1. The first commit added a `onRestore` completion block parameter `duplicateTabIn` function, because we're resetting tab state when resetting a pinned tab, which would cause a duplicated tab to end up in the wrong index.

2. The second commit added event handlers for `keydown` and `keyup` to change the tab subtitle based on the combination. I didn't find a proper way to update the tool tip, but since Arc doesn't show a theme at all and I guess the current tool tip won't cause any confusion since the subtitle shows the action.

   This commit also added a new subtitle text, which I'm not sure whether it's the right way or not, please let me know if it's not.


https://github.com/user-attachments/assets/dba4d57b-c448-4d03-a099-76d34beae95e

