### PR TITLE
fix: set zenDefaultUserContextId on live folder tabs, p=#12702

### DIFF
--- a/src/zen/live-folders/ZenLiveFoldersManager.sys.mjs
+++ b/src/zen/live-folders/ZenLiveFoldersManager.sys.mjs
@@ -407,6 +407,9 @@ class nsZenLiveFoldersManager {
         });
         // createLazyBrowser can't be pinned by default
         this.window.gBrowser.pinTab(tab);
+        if (userContextId) {
+          tab.setAttribute("zenDefaultUserContextId", "true");
+        }
         if (item.icon) {
           this.window.gBrowser.setIcon(tab, item.icon);
           if (tab.linkedBrowser) {


### PR DESCRIPTION
 ## Problem

Live folder tabs show the container indicator (colored stripe) inconsistently. Tabs created during an auto-refresh while a different workspace is active don't get `zenDefaultUserContextId`, because `getContextIdIfNeeded()` compares against the active workspace — not the workspace the live folder belongs to.

This means some tabs in the same folder show the stripe and others don't, depending on which workspace was active at the time of the refresh.

## Fix
Set `zenDefaultUserContextId` directly on live folder tabs after creation when the workspace has a container. The live folder manager already knows the container is the workspace default (it reads it from `space.containerTabId`), so it can make this decision without relying on `getContextIdIfNeeded()`.

  ---

This is my first contribution to Zen, happy to receive feedback! :)

