### PR TITLE
Fix video fullscreen rendering when split view is active

### DIFF
--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -81,7 +81,7 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
   dropZone;
   _edgeHoverSize;
   minResizeWidth;
-  _wasSplitBeforeFullscreen = false;
+
   _lastOpenedTab = null;
 
   MAX_TABS = 4;
@@ -115,43 +115,9 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
       "TabBrowserDiscarded",
       this.handleTabBrowserDiscarded.bind(this)
     );
-
     window.addEventListener("TabSelect", this.onTabSelect.bind(this));
     this.initializeContextMenu();
     this.insertIntoContextMenu();
-
-    window.addEventListener("fullscreenchange", () => {
-      const isFullscreen = !!document.fullscreenElement;
-      if (this.splitViewActive) {
-        document.documentElement.toggleAttribute(
-          "zen-split-fullscreen",
-          isFullscreen
-        );
-
-        const currentViewBrowsers = this.splitViewBrowsers;
-        const fullscreenBrowser = document.fullscreenElement;
-
-        for (const browser of currentViewBrowsers) {
-          const container = browser.closest(".browserSidebarContainer");
-          const isThisFullscreen =
-            isFullscreen &&
-            (browser === fullscreenBrowser ||
-              browser.contains(fullscreenBrowser));
-
-          if (container) {
-            if (isThisFullscreen) {
-              container.setAttribute("zen-fullscreen", "true");
-            } else {
-              container.removeAttribute("zen-fullscreen");
-            }
-          }
-
-          const isActive = !isFullscreen || isThisFullscreen;
-          browser.zenModeActive = isActive;
-          browser.docShellIsActive = isActive;
-        }
-      }
-    });
 
     window.addEventListener(
       "AfterWorkspacesSessionRestore",
@@ -1146,7 +1112,6 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     tab.linkedBrowser.zenModeActive = false;
     const container = tab.linkedBrowser.closest(".browserSidebarContainer");
     container.removeAttribute("is-zen-split");
-    container.removeAttribute("zen-fullscreen");
     container.style.inset = "";
     this._removeHeader(container);
     this.resetContainerStyle(container);
@@ -1515,7 +1480,6 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     if (this.currentView < 0) {
       return;
     }
-    document.documentElement.removeAttribute("zen-split-fullscreen");
     this.setTabsDocShellState(this._data[this.currentView].tabs, false);
     for (const tab of this._data[this.currentView].tabs) {
       const container = tab.linkedBrowser.closest(".browserSidebarContainer");

--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -81,7 +81,7 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
   dropZone;
   _edgeHoverSize;
   minResizeWidth;
-
+  _wasSplitBeforeFullscreen = false;
   _lastOpenedTab = null;
 
   MAX_TABS = 4;
@@ -115,9 +115,43 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
       "TabBrowserDiscarded",
       this.handleTabBrowserDiscarded.bind(this)
     );
+
     window.addEventListener("TabSelect", this.onTabSelect.bind(this));
     this.initializeContextMenu();
     this.insertIntoContextMenu();
+
+    window.addEventListener("fullscreenchange", () => {
+      const isFullscreen = !!document.fullscreenElement;
+      if (this.splitViewActive) {
+        document.documentElement.toggleAttribute(
+          "zen-split-fullscreen",
+          isFullscreen
+        );
+
+        const currentViewBrowsers = this.splitViewBrowsers;
+        const fullscreenBrowser = document.fullscreenElement;
+
+        for (const browser of currentViewBrowsers) {
+          const container = browser.closest(".browserSidebarContainer");
+          const isThisFullscreen =
+            isFullscreen &&
+            (browser === fullscreenBrowser ||
+              browser.contains(fullscreenBrowser));
+
+          if (container) {
+            if (isThisFullscreen) {
+              container.setAttribute("zen-fullscreen", "true");
+            } else {
+              container.removeAttribute("zen-fullscreen");
+            }
+          }
+
+          const isActive = !isFullscreen || isThisFullscreen;
+          browser.zenModeActive = isActive;
+          browser.docShellIsActive = isActive;
+        }
+      }
+    });
 
     window.addEventListener(
       "AfterWorkspacesSessionRestore",
@@ -1112,6 +1146,7 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     tab.linkedBrowser.zenModeActive = false;
     const container = tab.linkedBrowser.closest(".browserSidebarContainer");
     container.removeAttribute("is-zen-split");
+    container.removeAttribute("zen-fullscreen");
     container.style.inset = "";
     this._removeHeader(container);
     this.resetContainerStyle(container);
@@ -1480,6 +1515,7 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     if (this.currentView < 0) {
       return;
     }
+    document.documentElement.removeAttribute("zen-split-fullscreen");
     this.setTabsDocShellState(this._data[this.currentView].tabs, false);
     for (const tab of this._data[this.currentView].tabs) {
       const container = tab.linkedBrowser.closest(".browserSidebarContainer");

--- a/src/zen/split-view/zen-decks.css
+++ b/src/zen/split-view/zen-decks.css
@@ -7,6 +7,7 @@
 /** Zen Decks - ONLY USED FOR SPLIT VIEWS, DO NOT USE THIS CLASS FOR ANY OTHER PURPOSE **/
 
 %include zen-split-group.inc.css
+
 #tabbrowser-tabpanels[zen-split-view="true"] {
   display: flex;
   flex-direction: row;
@@ -264,6 +265,3 @@ zen-split-fake-tab {
   flex: 1;
 }
 
-:root[inDOMFullscreen="true"] #tabbrowser-tabpanels[zen-split-view="true"] {
-  display: block !important;
-}

--- a/src/zen/split-view/zen-decks.css
+++ b/src/zen/split-view/zen-decks.css
@@ -7,7 +7,6 @@
 /** Zen Decks - ONLY USED FOR SPLIT VIEWS, DO NOT USE THIS CLASS FOR ANY OTHER PURPOSE **/
 
 %include zen-split-group.inc.css
-
 #tabbrowser-tabpanels[zen-split-view="true"] {
   display: flex;
   flex-direction: row;
@@ -253,4 +252,20 @@ zen-split-fake-tab {
   background-color: color-mix(in srgb, var(--button-background-color-primary), transparent 40%);
   margin: var(--tab-block-margin);
   flex: 1;
+}
+
+:root[inDOMFullscreen="true"] #tabbrowser-tabpanels[zen-split-view="true"] {
+  display: block !important;
+}
+
+:root[zen-split-fullscreen] .browserSidebarContainer[is-zen-split="true"]:not([zen-fullscreen="true"]) {
+  display: none !important;
+}
+
+:root[zen-split-fullscreen] .browserSidebarContainer[is-zen-split="true"][zen-fullscreen="true"] {
+  inset: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+  margin: 0 !important;
+  z-index: 1000 !important;
 }

--- a/src/zen/split-view/zen-decks.css
+++ b/src/zen/split-view/zen-decks.css
@@ -37,6 +37,16 @@
     /* Fix for issue https://github.com/zen-browser/desktop/issues/7564 */
     position: absolute;
   }
+
+  :root[inDOMFullscreen="true"] & {
+    &:not(.deck-selected) {
+      -moz-subtree-hidden-only-visually: 1 !important;
+    }
+
+    &.deck-selected {
+      inset: 0 !important;
+    }
+  }
 }
 
 .browserSidebarContainer[is-zen-split="true"],
@@ -66,7 +76,7 @@
   }
 }
 
-#tabbrowser-tabpanels[zen-split-view="true"] .browserSidebarContainer.deck-selected {
+:root:not([inDOMFullscreen="true"]) #tabbrowser-tabpanels[zen-split-view="true"] .browserSidebarContainer.deck-selected {
   &:not(.zen-glance-overlay) {
     outline: 2px solid var(--zen-active-split-outline-color) !important;
   }
@@ -256,16 +266,4 @@ zen-split-fake-tab {
 
 :root[inDOMFullscreen="true"] #tabbrowser-tabpanels[zen-split-view="true"] {
   display: block !important;
-}
-
-:root[zen-split-fullscreen] .browserSidebarContainer[is-zen-split="true"]:not([zen-fullscreen="true"]) {
-  display: none !important;
-}
-
-:root[zen-split-fullscreen] .browserSidebarContainer[is-zen-split="true"][zen-fullscreen="true"] {
-  inset: 0 !important;
-  width: 100% !important;
-  height: 100% !important;
-  margin: 0 !important;
-  z-index: 1000 !important;
 }

--- a/src/zen/split-view/zen-decks.css
+++ b/src/zen/split-view/zen-decks.css
@@ -264,4 +264,3 @@ zen-split-fake-tab {
   margin: var(--tab-block-margin);
   flex: 1;
 }
-


### PR DESCRIPTION
Fixes #11559

## Problem
Fullscreen videos do not work correctly when split view is active.
Firefox expects only one active browser docshell for fullscreen,
but Zen split view keeps multiple browsers active, preventing the
fullscreen browser from being promoted correctly.

## Solution
When entering fullscreen:
- Only the fullscreen browser remains active
- Other split browsers are deactivated
- Non-fullscreen split containers are hidden
- The fullscreen container expands to fill the window

Split layout is restored automatically when exiting fullscreen.

## Changes
- Added fullscreenchange handler in ZenViewSplitter
- Toggle zen-split-fullscreen and zen-fullscreen attributes
- Deactivate other split browsers using docShellIsActive
- CSS override to hide non-fullscreen split containers

## Testing
Tested with:
- 2–4 split tabs
- YouTube fullscreen
- Fullscreen exit restoring split layout