### PR TITLE
feat: close new tab popup on Cmd/Ctrl + T, p=#12734

### DIFF
--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -438,6 +438,12 @@ window.gZenUIManager = {
       return false;
     }
 
+    // Close the new tab popup on cmd/ctrl + t
+    if (gURLBar.hasAttribute("zen-newtab")) {
+      this.handleUrlbarClose(false, false);
+      return true;
+    }
+
     // Clear any existing timeout
     if (this._clearTimeout) {
       clearTimeout(this._clearTimeout);

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -440,7 +440,7 @@ window.gZenUIManager = {
 
     // Close the new tab popup on cmd/ctrl + t
     if (gURLBar.hasAttribute("zen-newtab")) {
-      this.handleUrlbarClose(false, false);
+      this.handleUrlbarClose();
       return true;
     }
 

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -439,7 +439,7 @@ window.gZenUIManager = {
     }
 
     // Close the new tab popup on cmd/ctrl + t
-    if (gURLBar.hasAttribute("zen-newtab")) {
+    if (!overridePreferance && gURLBar.hasAttribute("zen-newtab")) {
       this.handleUrlbarClose();
       return true;
     }


### PR DESCRIPTION
Add functionality to close the new tab popup by pressing the same shortcut to open the popup (cmd/ctrl + t)