### PR TITLE
fix: keep bookmarks bar in fullscreen, b=closes #8163, p=#12763

### DIFF
--- a/src/browser/base/content/navigator-toolbox-inc-xhtml.patch
+++ b/src/browser/base/content/navigator-toolbox-inc-xhtml.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/base/content/navigator-toolbox.inc.xhtml b/browser/base/content/navigator-toolbox.inc.xhtml
-index 4d4223c508560136aba220adb18528aac913a188..c29194057efe15e6144f5114d7977a0e11619092 100644
+index 4d4223c508560136aba220adb18528aac913a188..10d4d9cecbb0e7cec9191d78fb81a57376b37ff1 100644
 --- a/browser/base/content/navigator-toolbox.inc.xhtml
 +++ b/browser/base/content/navigator-toolbox.inc.xhtml
 @@ -2,7 +2,7 @@
@@ -55,13 +55,3 @@ index 4d4223c508560136aba220adb18528aac913a188..c29194057efe15e6144f5114d7977a0e
  
    <toolbar id="nav-bar"
             class="browser-toolbar chromeclass-location"
-@@ -510,7 +518,8 @@
-            context="toolbar-context-menu"
-            data-l10n-id="bookmarks-toolbar"
-            data-l10n-attrs="toolbarname"
--           customizable="true">
-+           customizable="true"
-+           fullscreentoolbar="true">
-     <toolbartabstop skipintoolbarset="true"/>
- 
-     <hbox id="personal-toolbar-empty" skipintoolbarset="true" removable="false" hidden="true" role="alert">

--- a/src/browser/base/content/navigator-toolbox-inc-xhtml.patch
+++ b/src/browser/base/content/navigator-toolbox-inc-xhtml.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/base/content/navigator-toolbox.inc.xhtml b/browser/base/content/navigator-toolbox.inc.xhtml
-index 4d4223c508560136aba220adb18528aac913a188..10d4d9cecbb0e7cec9191d78fb81a57376b37ff1 100644
+index 4d4223c508560136aba220adb18528aac913a188..c29194057efe15e6144f5114d7977a0e11619092 100644
 --- a/browser/base/content/navigator-toolbox.inc.xhtml
 +++ b/browser/base/content/navigator-toolbox.inc.xhtml
 @@ -2,7 +2,7 @@
@@ -55,3 +55,13 @@ index 4d4223c508560136aba220adb18528aac913a188..10d4d9cecbb0e7cec9191d78fb81a573
  
    <toolbar id="nav-bar"
             class="browser-toolbar chromeclass-location"
+@@ -510,7 +518,8 @@
+            context="toolbar-context-menu"
+            data-l10n-id="bookmarks-toolbar"
+            data-l10n-attrs="toolbarname"
+-           customizable="true">
++           customizable="true"
++           fullscreentoolbar="true">
+     <toolbartabstop skipintoolbarset="true"/>
+ 
+     <hbox id="personal-toolbar-empty" skipintoolbarset="true" removable="false" hidden="true" role="alert">

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -76,8 +76,10 @@ window.gZenUIManager = {
     this._initBookmarkCollapseListener();
 
     gURLBar._setPlaceholder(null);
-    
-    document.getElementById("PersonalToolbar").setAttribute("fullscreentoolbar", "true");
+
+    document
+      .getElementById("PersonalToolbar")
+      .setAttribute("fullscreentoolbar", "true");
   },
 
   /**

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -76,6 +76,8 @@ window.gZenUIManager = {
     this._initBookmarkCollapseListener();
 
     gURLBar._setPlaceholder(null);
+    
+    document.getElementById("PersonalToolbar").setAttribute("fullscreentoolbar", "true");
   },
 
   /**


### PR DESCRIPTION
Issue: [When in fullscreen(F11) bookmarks bar disappear](https://github.com/zen-browser/desktop/issues/8163)

Hi, I saw this issue and thought it could be a good first issue for me to start contributing to an open source project that I'm a fan of using. 

I found that just setting `fullscreentoolbar="true"` for the PersonalToolbar resolved this issue and made sure that the bookmark bar stays with all bookmarks shown in fullscreen mode. Can easily test by:
- Have top toolbar shown
- Have bookmark toolbar shown
- Enter fullscreen mode (F11)