### PR TITLE
fix: Keyboard shortcut assignment issue caused by modifier, b=closes https://github.com/zen-browser/desktop/issues/10686, p=#12776

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1022,8 +1022,8 @@ var gZenCKSSettings = {
       shortcut = event.code.slice(3);
     } else if (event.code && event.code.startsWith("Digit")) {
       shortcut = event.code.slice(5);
-    } else if (AppConstants.platform === "macosx") {
-      // On macOS, we want to use the physical key for symbols to avoid alt-codes.
+    } else {
+      // Use physical key mapping for common symbols
       const CODE_TO_KEY_MAP = {
         Comma: ",",
         Period: ".",
@@ -1038,8 +1038,6 @@ var gZenCKSSettings = {
         Equal: "=",
       };
       shortcut = CODE_TO_KEY_MAP[event.code] || event.key;
-    } else {
-      shortcut = event.key;
     }
 
     shortcut = shortcut.replace(/Ctrl|Control|Shift|Alt|Option|Cmd|Meta/, ""); // Remove all modifiers

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1020,6 +1020,24 @@ var gZenCKSSettings = {
     let shortcut;
     if (event.code && event.code.startsWith("Key")) {
       shortcut = event.code.slice(3);
+    } else if (event.code && event.code.startsWith("Digit")) {
+      shortcut = event.code.slice(5);
+    } else if (AppConstants.platform === "macosx") {
+      // On macOS, we want to use the physical key for symbols to avoid alt-codes.
+      const CODE_TO_KEY_MAP = {
+        Comma: ",",
+        Period: ".",
+        Slash: "/",
+        Semicolon: ";",
+        Quote: "'",
+        BracketLeft: "[",
+        BracketRight: "]",
+        Backslash: "\\",
+        Backquote: "`",
+        Minus: "-",
+        Equal: "=",
+      };
+      shortcut = CODE_TO_KEY_MAP[event.code] || event.key;
     } else {
       shortcut = event.key;
     }


### PR DESCRIPTION
As described in #10686, when option/shift is included in the shortcut, Zen's `event.key` will return the result of the alt-code (such as `™`) instead of the physical key (such as `2`). This can break the shortkey listener.

Switching to `event.code` for digits and adding a mapping for symbol keys (such as comma) help translate the alt-code back to physical key. Since Windows does not have such issue, the fix is only applied to macOS.