### PR TITLE
feat: add .deb and .rpm package builds for Linux releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,6 +360,15 @@ jobs:
       build-version: ${{ needs.build-data.outputs.version }}
       release-branch: ${{ inputs.update_branch }}
 
+  linux-packages:
+    name: Linux packages (.deb / .rpm)
+    uses: ./.github/workflows/linux-package-build.yml
+    needs: [linux, build-data]
+    secrets: inherit
+    with:
+      build-version: ${{ needs.build-data.outputs.version }}
+      release-branch: ${{ inputs.update_branch }}
+
   appimage:
     name: AppImage build - Linux ${{ matrix.arch }}
     permissions:
@@ -481,6 +490,7 @@ jobs:
         check-release,
         mac-uni,
         appimage,
+        linux-packages,
         source,
         lint,
         stop-self-hosted,
@@ -557,6 +567,10 @@ jobs:
             ./zen-x86_64.AppImage.zsync/*
             ./zen-aarch64.AppImage/*
             ./zen-aarch64.AppImage.zsync/*
+            ./zen-browser_*_amd64.deb/*
+            ./zen-browser_*_arm64.deb/*
+            ./zen-browser_*_x86_64.rpm/*
+            ./zen-browser_*_aarch64.rpm/*
             ./zen.win-x86_64.zip/*
             ./zen.win-arm64.zip/*
             ./linux.mar/*
@@ -596,6 +610,10 @@ jobs:
             ./zen-x86_64.AppImage.zsync/*
             ./zen-aarch64.AppImage/*
             ./zen-aarch64.AppImage.zsync/*
+            ./zen-browser_*_amd64.deb/*
+            ./zen-browser_*_arm64.deb/*
+            ./zen-browser_*_x86_64.rpm/*
+            ./zen-browser_*_aarch64.rpm/*
             ./.github/workflows/object/windows-x64-signed-x86_64/zen.win-x86_64.zip
             ./.github/workflows/object/windows-x64-signed-arm64/zen.win-arm64.zip
             ./linux.mar/*

--- a/.github/workflows/linux-package-build.yml
+++ b/.github/workflows/linux-package-build.yml
@@ -1,0 +1,94 @@
+name: Linux Package Build (.deb / .rpm)
+
+on:
+  workflow_call:
+    inputs:
+      build-version:
+        description: "Release version string"
+        required: true
+        type: string
+      release-branch:
+        description: "Release branch (release | twilight)"
+        required: true
+        type: string
+
+jobs:
+  deb:
+    name: Debian package — ${{ matrix.arch }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            artifact: zen.linux-x86_64.tar.xz
+          - arch: arm64
+            artifact: zen.linux-aarch64.tar.xz
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download Linux build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+
+      - name: Install dpkg tools
+        run: sudo apt-get install -y dpkg-dev
+
+      - name: Build .deb
+        run: |
+          chmod +x scripts/package-linux-deb.sh
+          bash scripts/package-linux-deb.sh \
+            "${{ inputs.build-version }}" \
+            "${{ matrix.arch }}" \
+            "${{ matrix.artifact }}"
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 5
+          name: zen-browser_${{ inputs.build-version }}_${{ matrix.arch }}.deb
+          path: dist/zen-browser_${{ inputs.build-version }}_${{ matrix.arch }}.deb
+
+  rpm:
+    name: RPM package — ${{ matrix.arch }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            artifact: zen.linux-x86_64.tar.xz
+          - arch: aarch64
+            artifact: zen.linux-aarch64.tar.xz
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download Linux build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+
+      - name: Install rpm tools
+        run: sudo apt-get install -y rpm
+
+      - name: Build .rpm
+        run: |
+          chmod +x scripts/package-linux-rpm.sh
+          bash scripts/package-linux-rpm.sh \
+            "${{ inputs.build-version }}" \
+            "${{ matrix.arch }}" \
+            "${{ matrix.artifact }}"
+
+      - name: Upload .rpm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 5
+          name: zen-browser_${{ inputs.build-version }}_${{ matrix.arch }}.rpm
+          path: dist/*.rpm

--- a/build/linux/deb/DEBIAN/control
+++ b/build/linux/deb/DEBIAN/control
@@ -1,0 +1,14 @@
+Package: zen-browser
+Version: VERSION
+Architecture: ARCH
+Maintainer: Zen Browser <team@zen-browser.app>
+Installed-Size: INSTALLED_SIZE
+Depends: libgtk-3-0, libdbus-glib-1-2, libx11-xcb1, libxtst6, libxrandr2, libxcomposite1, libxdamage1, libxfixes3, libxcursor1, libxi6, libasound2, libpulse0, libssl3, libglib2.0-0
+Recommends: fonts-liberation, xdg-utils
+Section: web
+Priority: optional
+Homepage: https://zen-browser.app
+Description: Zen Browser — experience tranquillity while browsing the web
+ Zen is a privacy-focused, beautifully designed web browser based on
+ Firefox. It offers a calm browsing experience without compromising on
+ speed, security, or compatibility with modern web standards.

--- a/build/linux/deb/DEBIAN/postinst
+++ b/build/linux/deb/DEBIAN/postinst
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+# Register zen as a browser alternative
+update-alternatives --install \
+  /usr/bin/x-www-browser x-www-browser /usr/lib/zen/zen 200 \
+  --slave /usr/share/man/man1/x-www-browser.1.gz x-www-browser.1.gz /dev/null 2>/dev/null || true
+
+# Register MIME handler
+update-alternatives --install \
+  /usr/bin/zen-browser zen-browser /usr/lib/zen/zen 200 2>/dev/null || true
+
+# Ensure native messaging hosts directory exists with correct permissions
+# This allows system-installed apps (1Password, Bitwarden, KeePassXC, etc.)
+# to place their manifests here and be discovered by Zen automatically.
+install -d -m 755 /usr/lib/zen/native-messaging-hosts
+
+# Refresh desktop database and icon cache
+if command -v update-desktop-database > /dev/null 2>&1; then
+  update-desktop-database -q /usr/share/applications || true
+fi
+
+if command -v gtk-update-icon-cache > /dev/null 2>&1; then
+  gtk-update-icon-cache -q -t /usr/share/icons/hicolor || true
+fi
+
+if command -v xdg-mime > /dev/null 2>&1; then
+  xdg-mime default zen-browser.desktop x-scheme-handler/http  || true
+  xdg-mime default zen-browser.desktop x-scheme-handler/https || true
+fi

--- a/build/linux/deb/DEBIAN/prerm
+++ b/build/linux/deb/DEBIAN/prerm
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+update-alternatives --remove x-www-browser /usr/lib/zen/zen 2>/dev/null || true
+update-alternatives --remove zen-browser    /usr/lib/zen/zen 2>/dev/null || true
+
+if command -v update-desktop-database > /dev/null 2>&1; then
+  update-desktop-database -q /usr/share/applications || true
+fi

--- a/build/linux/rpm/zen-browser.spec
+++ b/build/linux/rpm/zen-browser.spec
@@ -1,0 +1,63 @@
+%global         appname     zen-browser
+%global         instdir     /usr/lib/zen
+
+Name:           zen-browser
+Version:        %{_version}
+Release:        1%{?dist}
+Summary:        Zen Browser — experience tranquillity while browsing the web
+License:        MPL-2.0
+URL:            https://zen-browser.app
+ExclusiveArch:  x86_64 aarch64
+
+Requires:       gtk3
+Requires:       dbus-glib
+Requires:       libXt
+Requires:       libXcomposite
+Requires:       libXdamage
+Requires:       libXrandr
+Requires:       libXtst
+Requires:       alsa-lib
+Requires:       pulseaudio-libs
+Requires:       openssl
+Requires:       glib2
+
+%description
+Zen is a privacy-focused, beautifully designed web browser based on
+Firefox. It offers a calm browsing experience without compromising on
+speed, security, or compatibility with modern web standards.
+
+%install
+mkdir -p %{buildroot}%{instdir}
+mkdir -p %{buildroot}%{instdir}/native-messaging-hosts
+mkdir -p %{buildroot}/usr/bin
+mkdir -p %{buildroot}/usr/share/applications
+mkdir -p %{buildroot}/usr/share/icons/hicolor/128x128/apps
+
+cp -a %{_sourcedir}/zen/* %{buildroot}%{instdir}/
+ln -sf %{instdir}/zen %{buildroot}/usr/bin/zen
+
+install -m 644 %{_sourcedir}/zen-browser.desktop  %{buildroot}/usr/share/applications/zen-browser.desktop
+install -m 644 %{_sourcedir}/zen.png               %{buildroot}/usr/share/icons/hicolor/128x128/apps/zen.png
+
+%post
+update-alternatives --install /usr/bin/x-www-browser x-www-browser %{instdir}/zen 200 2>/dev/null || :
+# Ensure native messaging hosts directory exists so system-installed apps
+# (1Password, Bitwarden, KeePassXC, etc.) can place their manifests here.
+install -d -m 755 %{instdir}/native-messaging-hosts
+/usr/bin/update-desktop-database -q /usr/share/applications &>/dev/null || :
+/usr/bin/gtk-update-icon-cache -q -t /usr/share/icons/hicolor &>/dev/null || :
+
+%preun
+if [ $1 -eq 0 ]; then
+  update-alternatives --remove x-www-browser %{instdir}/zen 2>/dev/null || :
+fi
+
+%postun
+/usr/bin/update-desktop-database -q /usr/share/applications &>/dev/null || :
+/usr/bin/gtk-update-icon-cache -q -t /usr/share/icons/hicolor &>/dev/null || :
+
+%files
+%{instdir}/
+/usr/bin/zen
+/usr/share/applications/zen-browser.desktop
+/usr/share/icons/hicolor/128x128/apps/zen.png

--- a/scripts/package-linux-deb.sh
+++ b/scripts/package-linux-deb.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Build a .deb package from the pre-built Linux tar.xz artifact.
+# Usage: ./scripts/package-linux-deb.sh <version> <arch> <tarball>
+#   arch: amd64 | arm64
+
+set -euo pipefail
+
+VERSION="$1"
+ARCH="$2"      # amd64 | arm64
+TARBALL="$3"   # path to zen.linux-<arch>.tar.xz
+
+DEB_ARCH="$ARCH"
+PKGDIR="$(mktemp -d)/zen-browser_${VERSION}_${DEB_ARCH}"
+INSTDIR="${PKGDIR}/usr/lib/zen"
+
+echo ">>> Preparing package directory"
+cp -a build/linux/deb/. "$PKGDIR/"
+
+echo ">>> Extracting browser binaries"
+mkdir -p "$INSTDIR"
+tar -xf "$TARBALL" -C "$INSTDIR" --strip-components=1
+
+echo ">>> Installing desktop entry and icons"
+mkdir -p "${PKGDIR}/usr/share/applications"
+mkdir -p "${PKGDIR}/usr/share/icons/hicolor/128x128/apps"
+
+sed "s/\$VERSION/${VERSION}/g" build/AppDir/zen.desktop \
+  > "${PKGDIR}/usr/share/applications/zen-browser.desktop"
+
+# Icon: use the one bundled in the browser directory
+ICON_SRC=$(find "$INSTDIR" -name "*.png" -path "*/icons/*128*" | head -1)
+if [ -n "$ICON_SRC" ]; then
+  cp "$ICON_SRC" "${PKGDIR}/usr/share/icons/hicolor/128x128/apps/zen.png"
+fi
+
+echo ">>> Creating /usr/bin symlink"
+mkdir -p "${PKGDIR}/usr/bin"
+ln -sf /usr/lib/zen/zen "${PKGDIR}/usr/bin/zen"
+
+echo ">>> Creating native-messaging-hosts directory"
+mkdir -p "${PKGDIR}/usr/lib/zen/native-messaging-hosts"
+
+echo ">>> Filling in control file"
+INSTALLED_SIZE=$(du -sk "$INSTDIR" | cut -f1)
+sed -i \
+  -e "s/VERSION/${VERSION}/" \
+  -e "s/ARCH/${DEB_ARCH}/" \
+  -e "s/INSTALLED_SIZE/${INSTALLED_SIZE}/" \
+  "${PKGDIR}/DEBIAN/control"
+
+chmod 755 "${PKGDIR}/DEBIAN/postinst" "${PKGDIR}/DEBIAN/prerm"
+
+echo ">>> Building .deb"
+mkdir -p dist
+dpkg-deb --build --root-owner-group "$PKGDIR" \
+  "dist/zen-browser_${VERSION}_${DEB_ARCH}.deb"
+
+echo ">>> Done: dist/zen-browser_${VERSION}_${DEB_ARCH}.deb"

--- a/scripts/package-linux-rpm.sh
+++ b/scripts/package-linux-rpm.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Build an .rpm package from the pre-built Linux tar.xz artifact.
+# Usage: ./scripts/package-linux-rpm.sh <version> <arch> <tarball>
+#   arch: x86_64 | aarch64
+
+set -euo pipefail
+
+VERSION="$1"
+ARCH="$2"     # x86_64 | aarch64
+TARBALL="$3"  # path to zen.linux-<arch>.tar.xz
+
+RPMROOT="$(mktemp -d)/rpmbuild"
+mkdir -p "${RPMROOT}"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+echo ">>> Extracting browser binaries"
+mkdir -p "${RPMROOT}/SOURCES/zen"
+tar -xf "$TARBALL" -C "${RPMROOT}/SOURCES/zen" --strip-components=1
+
+echo ">>> Copying desktop entry and icon"
+sed "s/\$VERSION/${VERSION}/g" build/AppDir/zen.desktop \
+  > "${RPMROOT}/SOURCES/zen-browser.desktop"
+
+ICON_SRC=$(find "${RPMROOT}/SOURCES/zen" -name "*.png" -path "*/icons/*128*" | head -1)
+if [ -n "$ICON_SRC" ]; then
+  cp "$ICON_SRC" "${RPMROOT}/SOURCES/zen.png"
+fi
+
+echo ">>> Building .rpm"
+mkdir -p dist
+rpmbuild -bb build/linux/rpm/zen-browser.spec \
+  --define "_topdir ${RPMROOT}" \
+  --define "_version ${VERSION}" \
+  --define "_target_cpu ${ARCH}"
+
+find "${RPMROOT}/RPMS" -name "*.rpm" -exec cp {} dist/ \;
+
+echo ">>> Done: $(ls dist/*.rpm)"


### PR DESCRIPTION
Zen ships Linux builds as .tar.xz and AppImage but lacks native system packages. This creates friction for users expecting apt/dnf integration, breaks enterprise environments that block AppImage execution, and makes password manager native messaging harder to configure.

This PR adds:

build/linux/deb/         — Debian package structure
  DEBIAN/control         — package metadata (version, arch, deps)
  DEBIAN/postinst        — registers update-alternatives, MIME types,
                           and creates /usr/lib/zen/native-messaging-hosts/
                           so system-installed apps (1Password, Bitwarden,
                           KeePassXC) can place manifests there automatically
  DEBIAN/prerm           — clean removal of alternatives

build/linux/rpm/zen-browser.spec — RPM spec file with equivalent %post/%preun

scripts/package-linux-deb.sh  — repackages zen.linux-*.tar.xz into .deb scripts/package-linux-rpm.sh  — repackages zen.linux-*.tar.xz into .rpm
  (no source rebuild required — wraps existing Linux build artifacts)

.github/workflows/linux-package-build.yml
  — workflow_call job that runs after the Linux build, produces
    zen-browser_VERSION_amd64.deb, arm64.deb, x86_64.rpm, aarch64.rpm

.github/workflows/build.yml
  — wires linux-packages into the release pipeline and adds .deb/.rpm
    to release artifact upload for both twilight and stable releases

The native-messaging-hosts directory created in postinst/%post directly complements the NativeManifests path fix in the sibling PR, making the full integration seamless for end users on system-packaged Zen installs.

