### PR TITLE
Fix workspace bookmark cache lookup to prevent temporary bookmark disappearance

### DIFF
--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -153,7 +153,7 @@ class nsZenWorkspaces {
     if (!this.privateWindowOrDisabled) {
       const observerFunction = async () => {
         delete this._workspaceBookmarksCache;
-        await this.workspaceBookmarks();
+        await this.#ensureWorkspaceBookmarksCache();
         this._invalidateBookmarkContainers();
       };
       Services.obs.addObserver(observerFunction, "workspace-bookmarks-updated");
@@ -746,17 +746,17 @@ class nsZenWorkspaces {
     return spacesForSS;
   }
 
-  async workspaceBookmarks() {
+  async #ensureWorkspaceBookmarksCache() {
     if (this.privateWindowOrDisabled) {
       this._workspaceBookmarksCache = {
         bookmarks: [],
         lastChangeTimestamp: 0,
       };
-      return this._workspaceBookmarksCache;
+      return;
     }
 
     if (this._workspaceBookmarksCache) {
-      return this._workspaceBookmarksCache;
+      return;
     }
 
     const [bookmarks, lastChangeTimestamp] = await Promise.all([
@@ -765,8 +765,6 @@ class nsZenWorkspaces {
     ]);
 
     this._workspaceBookmarksCache = { bookmarks, lastChangeTimestamp };
-
-    return this._workspaceBookmarksCache;
   }
 
   restoreWorkspacesFromSessionStore(aWinData = {}) {
@@ -826,7 +824,7 @@ class nsZenWorkspaces {
     return (async () => {
       await this.#waitForPromises();
       this.#afterLoadInit();
-      await this.workspaceBookmarks();
+      await this.#ensureWorkspaceBookmarksCache();
       await this.changeWorkspace(activeWorkspace, { onInit: true });
       this.#fixTabPositions();
       this.onWindowResize();
@@ -3018,7 +3016,7 @@ class nsZenWorkspaces {
 
   isBookmarkInAnotherWorkspace(bookmark) {
     const workspaceBookmarks = this._workspaceBookmarksCache?.bookmarks;
-    if (!workspaceBookmarks || typeof workspaceBookmarks !== "object") {
+    if (typeof workspaceBookmarks !== "object") {
       return false;
     }
 

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -53,11 +53,11 @@ class nsZenWorkspaces {
     "BMB_mobileBookmarks",
   ];
 
-  promisePinnedInitialized = new Promise((resolve) => {
+  promisePinnedInitialized = new Promise(resolve => {
     this._resolvePinnedInitialized = resolve;
   });
 
-  promiseInitialized = new Promise((resolve) => {
+  promiseInitialized = new Promise(resolve => {
     this._resolveInitialized = resolve;
   });
 
@@ -85,7 +85,7 @@ class nsZenWorkspaces {
     if (!this.shouldHaveWorkspaces) {
       this._resolveInitialized();
       console.warn(
-        "gZenWorkspaces: !!! gZenWorkspaces is disabled in hidden windows !!!",
+        "gZenWorkspaces: !!! gZenWorkspaces is disabled in hidden windows !!!"
       );
       return; // We are in a hidden window, don't initialize gZenWorkspaces
     }
@@ -95,45 +95,45 @@ class nsZenWorkspaces {
       this,
       "activationMethod",
       "zen.workspaces.scroll-modifier-key",
-      "ctrl",
+      "ctrl"
     );
     XPCOMUtils.defineLazyPreferenceGetter(
       this,
       "naturalScroll",
       "zen.workspaces.natural-scroll",
-      true,
+      true
     );
     XPCOMUtils.defineLazyPreferenceGetter(
       this,
       "shouldWrapAroundNavigation",
       "zen.workspaces.wrap-around-navigation",
-      true,
+      true
     );
     XPCOMUtils.defineLazyPreferenceGetter(
       this,
       "shouldForceContainerTabsToWorkspace",
       "zen.workspaces.force-container-workspace",
-      true,
+      true
     );
     XPCOMUtils.defineLazyPreferenceGetter(
       this,
       "shouldOpenNewTabIfLastUnpinnedTabIsClosed",
       "zen.workspaces.open-new-tab-if-last-unpinned-tab-is-closed",
-      false,
+      false
     );
     this.containerSpecificEssentials = Services.prefs.getBoolPref(
       "zen.workspaces.separate-essentials",
-      false,
+      false
     );
     ChromeUtils.defineLazyGetter(this, "tabContainer", () =>
-      document.getElementById("tabbrowser-tabs"),
+      document.getElementById("tabbrowser-tabs")
     );
     ChromeUtils.defineLazyGetter(this, "workspaceIcons", () =>
-      document.getElementById("zen-workspaces-button"),
+      document.getElementById("zen-workspaces-button")
     );
     this.#activeWorkspace ||= Services.prefs.getStringPref(
       "zen.workspaces.active",
-      "",
+      ""
     );
 
     if (this.isPrivateWindow) {
@@ -160,7 +160,7 @@ class nsZenWorkspaces {
       window.addEventListener("unload", () => {
         Services.obs.removeObserver(
           observerFunction,
-          "workspace-bookmarks-updated",
+          "workspace-bookmarks-updated"
         );
       });
     }
@@ -226,11 +226,11 @@ class nsZenWorkspaces {
       now - this._tabSelectionState.lastSelectionTime;
 
     if (timeSinceLastSelection < this._tabSelectionState.debounceTime) {
-      await new Promise((resolve) =>
+      await new Promise(resolve =>
         setTimeout(
           resolve,
-          this._tabSelectionState.debounceTime - timeSinceLastSelection,
-        ),
+          this._tabSelectionState.debounceTime - timeSinceLastSelection
+        )
       );
     }
 
@@ -364,7 +364,7 @@ class nsZenWorkspaces {
 
   get tabboxChildrenWithoutEmpty() {
     return this.tabboxChildren.filter(
-      (child) => !child.hasAttribute("zen-empty-tab"),
+      child => !child.hasAttribute("zen-empty-tab")
     );
   }
 
@@ -388,7 +388,7 @@ class nsZenWorkspaces {
 
   #initializeTabsStripSections() {
     const perifery = document.getElementById(
-      "tabbrowser-arrowscrollbox-periphery",
+      "tabbrowser-arrowscrollbox-periphery"
     );
     perifery.setAttribute("hidden", "true");
     const tabs = gBrowser.tabContainer.allTabs;
@@ -398,10 +398,10 @@ class nsZenWorkspaces {
     }
     if (tabs.length) {
       const defaultSelectedContainer = this.workspaceElement(
-        this.activeWorkspace,
+        this.activeWorkspace
       )?.querySelector(".zen-workspace-normal-tabs-section");
       const pinnedContainer = this.workspaceElement(
-        this.activeWorkspace,
+        this.activeWorkspace
       )?.querySelector(".zen-workspace-pinned-tabs-section");
       // New profile with no workspaces does not have a default selected container
       if (defaultSelectedContainer) {
@@ -416,7 +416,7 @@ class nsZenWorkspaces {
           // before to the last child (perifery)
           defaultSelectedContainer.insertBefore(
             tab,
-            defaultSelectedContainer.lastChild,
+            defaultSelectedContainer.lastChild
           );
         }
       }
@@ -436,7 +436,7 @@ class nsZenWorkspaces {
       container = 0;
     }
     let essentialsContainer = document.querySelector(
-      `.zen-essentials-container[container="${container}"]:not([cloned])`,
+      `.zen-essentials-container[container="${container}"]:not([cloned])`
     );
     if (!essentialsContainer) {
       essentialsContainer = document.createXULElement("hbox");
@@ -491,12 +491,12 @@ class nsZenWorkspaces {
     let section = spaceElement.tabsContainer;
     let pinnedSection = spaceElement.pinnedTabsContainer;
     const workspaceTabs = Array.from(tabs).filter(
-      (tab) =>
+      tab =>
         tab.getAttribute("zen-workspace-id") === workspace.uuid &&
-        !tab.hasAttribute("zen-essential"),
+        !tab.hasAttribute("zen-essential")
     );
     let folders = new Set();
-    const getFolderRoot = (tab) => {
+    const getFolderRoot = tab => {
       let root = tab?.group;
       while (root?.group) {
         root = root?.group;
@@ -544,7 +544,7 @@ class nsZenWorkspaces {
     window.addEventListener(
       "AppCommand",
       this._handleAppCommand.bind(this),
-      true,
+      true
     );
 
     // Re-add original handler
@@ -590,7 +590,7 @@ class nsZenWorkspaces {
 
     toolbox.addEventListener(
       "wheel",
-      (event) => {
+      event => {
         if (this.privateWindowOrDisabled) {
           return;
         }
@@ -638,7 +638,7 @@ class nsZenWorkspaces {
 
         this.#lastScrollTime = currentTime;
       },
-      { passive: true },
+      { passive: true }
     );
   }
 
@@ -658,7 +658,7 @@ class nsZenWorkspaces {
 
   set activeWorkspace(value) {
     const spaces = this.getWorkspaces();
-    if (!spaces.some((ws) => ws.uuid === value)) {
+    if (!spaces.some(ws => ws.uuid === value)) {
       value = spaces[0]?.uuid || "";
     }
     if (value === this.#activeWorkspace) {
@@ -716,7 +716,7 @@ class nsZenWorkspaces {
 
   getWorkspaceFromId(id) {
     try {
-      return this.getWorkspaces().find((workspace) => workspace.uuid === id);
+      return this.getWorkspaces().find(workspace => workspace.uuid === id);
     } catch {
       return null;
     }
@@ -725,7 +725,7 @@ class nsZenWorkspaces {
   getWorkspaces(lieToMe = false) {
     if (lieToMe) {
       const { ZenSessionStore } = ChromeUtils.importESModule(
-        "resource:///modules/zen/ZenSessionManager.sys.mjs",
+        "resource:///modules/zen/ZenSessionManager.sys.mjs"
       );
       return ZenSessionStore.getClonedSpaces();
     }
@@ -845,7 +845,7 @@ class nsZenWorkspaces {
       window.addEventListener("TabSelect", this.onLocationChange.bind(this));
       window.addEventListener(
         "TabBrowserInserted",
-        this.onTabBrowserInserted.bind(this),
+        this.onTabBrowserInserted.bind(this)
       );
 
       this.updateWorkspacesChangeContextMenu();
@@ -859,7 +859,7 @@ class nsZenWorkspaces {
     await this.promiseInitialized;
     let showed = false;
     let resolveSelectPromise;
-    let selectPromise = new Promise((resolve) => {
+    let selectPromise = new Promise(resolve => {
       resolveSelectPromise = resolve;
     });
 
@@ -890,20 +890,20 @@ class nsZenWorkspaces {
       !removedEmptyTab &&
       !this._shouldOverrideTabs
     ) {
-      const tabs = gBrowser.tabs.filter((tab) => !tab.collapsed);
+      const tabs = gBrowser.tabs.filter(tab => !tab.collapsed);
       if (
         typeof this._tabToSelect === "number" &&
         this._tabToSelect >= 0 &&
         tabs[this._tabToSelect] &&
         (await this.#shouldShowTabInCurrentWorkspace(
-          tabs[this._tabToSelect],
+          tabs[this._tabToSelect]
         )) &&
         tabs[this._tabToSelect] !== this._tabToRemoveForEmpty
       ) {
         this.log(`Found tab to select: ${this._tabToSelect}, ${tabs.length}`);
         setTimeout(() => {
           let tabToUse = gZenGlanceManager.getTabOrGlanceParent(
-            tabs[this._tabToSelect + 1] || this._emptyTab,
+            tabs[this._tabToSelect + 1] || this._emptyTab
           );
           gBrowser.selectedTab = tabToUse;
           this._removedByStartupPage = true;
@@ -960,11 +960,11 @@ class nsZenWorkspaces {
       // Go through each tab and see if there's another tab with the same startup URL.
       // If we do find one, remove it.
       const newTabUrl = Services.prefs.getStringPref(
-        "browser.startup.homepage",
+        "browser.startup.homepage"
       );
       const tabs = gBrowser.tabs.filter(
-        (tab) =>
-          !tab.collapsed && !tab.hasAttribute("zen-empty-tab") && !tab.pinned,
+        tab =>
+          !tab.collapsed && !tab.hasAttribute("zen-empty-tab") && !tab.pinned
       );
       for (const tab of tabs) {
         if (tab._originalUrl === newTabUrl && tab !== gBrowser.selectedTab) {
@@ -976,7 +976,7 @@ class nsZenWorkspaces {
     }
 
     window.dispatchEvent(
-      new CustomEvent("AfterWorkspacesSessionRestore", { bubbles: true }),
+      new CustomEvent("AfterWorkspacesSessionRestore", { bubbles: true })
     );
   }
 
@@ -999,7 +999,7 @@ class nsZenWorkspaces {
 
   changeWorkspaceIcon() {
     let anchor = this.activeWorkspaceIndicator?.querySelector(
-      ".zen-current-workspace-indicator-icon",
+      ".zen-current-workspace-indicator-icon"
     );
     if (this.#contextMenuData?.workspaceId) {
       anchor = this.#contextMenuData.originalTarget;
@@ -1017,7 +1017,7 @@ class nsZenWorkspaces {
     gZenEmojiPicker.open(anchor, {
       closeOnSelect: false,
       allowNone: hasNoIcon,
-      onSelect: async (icon) => {
+      onSelect: async icon => {
         const workspace = this.getWorkspaceFromId(workspaceId);
         if (!workspace) {
           console.warn("No active workspace found to change icon");
@@ -1045,7 +1045,7 @@ class nsZenWorkspaces {
       if (
         (workspaceID &&
           !tab.hasAttribute("zen-essential") &&
-          !workspaces.find((workspace) => workspace.uuid === workspaceID)) ||
+          !workspaces.find(workspace => workspace.uuid === workspaceID)) ||
         // Also remove empty tabs that are supposed to be from parent folders but
         // they dont exist anymore
         (tab.pinned && tab.hasAttribute("zen-empty-tab") && !tab.group)
@@ -1077,7 +1077,7 @@ class nsZenWorkspaces {
 
     let tabs = gBrowser.visibleTabs;
     let tabsPinned = tabs.filter(
-      (t) => !this.shouldOpenNewTabIfLastUnpinnedTabIsClosed || !t.pinned,
+      t => !this.shouldOpenNewTabIfLastUnpinnedTabIsClosed || !t.pinned
     );
     const shouldCloseWindow =
       closeWindowWithLastTab != null
@@ -1114,7 +1114,7 @@ class nsZenWorkspaces {
     const workspaceActions = document.getElementById("zenWorkspaceMoreActions");
     workspaceActions.addEventListener(
       "popupshowing",
-      this.updateWorkspaceActionsMenu.bind(this),
+      this.updateWorkspaceActionsMenu.bind(this)
     );
     workspaceActions.addEventListener("popuphidden", () => {
       setTimeout(() => {
@@ -1125,15 +1125,15 @@ class nsZenWorkspaces {
     });
 
     const contextChangeContainerTabMenu = document.getElementById(
-      "context_zenWorkspacesOpenInContainerTab",
+      "context_zenWorkspacesOpenInContainerTab"
     );
     contextChangeContainerTabMenu.addEventListener(
       "popupshowing",
-      this.updateWorkspaceActionsMenuContainer.bind(this),
+      this.updateWorkspaceActionsMenuContainer.bind(this)
     );
     contextChangeContainerTabMenu.addEventListener(
       "command",
-      this.contextChangeContainerTab.bind(this),
+      this.contextChangeContainerTab.bind(this)
     );
   }
 
@@ -1166,7 +1166,7 @@ class nsZenWorkspaces {
       return;
     }
     const openInContainerMenuItem = document.getElementById(
-      "context_zenWorkspacesOpenInContainerTab",
+      "context_zenWorkspacesOpenInContainerTab"
     );
     if (this.shouldShowContainers) {
       openInContainerMenuItem.removeAttribute("hidden");
@@ -1186,12 +1186,12 @@ class nsZenWorkspaces {
     };
     const workspaceName = document.getElementById("context_zenEditWorkspace");
     const themePicker = document.getElementById(
-      "context_zenChangeWorkspaceTheme",
+      "context_zenChangeWorkspaceTheme"
     );
     /* We can't show the rename input properly in collapsed state,
     so hide the workspace edit input */
     const isCollapsed = !Services.prefs.getBoolPref(
-      "zen.view.sidebar-expanded",
+      "zen.view.sidebar-expanded"
     );
     workspaceName.hidden =
       isCollapsed ||
@@ -1202,7 +1202,7 @@ class nsZenWorkspaces {
       this.#contextMenuData.workspaceId !== this.activeWorkspace;
     const separator = document.getElementById("context_zenWorkspacesSeparator");
     for (const item of event.target.querySelectorAll(
-      ".zen-workspace-context-menu-item",
+      ".zen-workspace-context-menu-item"
     )) {
       item.remove();
     }
@@ -1210,9 +1210,9 @@ class nsZenWorkspaces {
       separator.hidden = false;
       for (const workspace of this.getWorkspaces().reverse()) {
         const item = this.generateMenuItemForWorkspace(workspace);
-        item.addEventListener("command", (e) => {
+        item.addEventListener("command", e => {
           this.changeWorkspaceWithID(
-            e.target.closest("menuitem").getAttribute("zen-workspace-id"),
+            e.target.closest("menuitem").getAttribute("zen-workspace-id")
           );
         });
         separator.after(item);
@@ -1225,7 +1225,7 @@ class nsZenWorkspaces {
       () => {
         this.#contextMenuData = null;
       },
-      { once: true },
+      { once: true }
     );
   }
 
@@ -1250,7 +1250,7 @@ class nsZenWorkspaces {
     }
     const workspacesData = this._workspaceCache;
     const index = workspacesData.findIndex(
-      (ws) => ws.uuid === workspaceData.uuid,
+      ws => ws.uuid === workspaceData.uuid
     );
     if (index !== -1) {
       workspacesData[index] = workspaceData;
@@ -1264,7 +1264,7 @@ class nsZenWorkspaces {
     let workspacesData = this.getWorkspaces();
     // Remove the workspace from the cache
     workspacesData = workspacesData.filter(
-      (workspace) => workspace.uuid !== windowID,
+      workspace => workspace.uuid !== windowID
     );
     this.#propagateWorkspaceData(workspacesData);
   }
@@ -1310,7 +1310,7 @@ class nsZenWorkspaces {
       bubbles: true,
     });
     window.gZenWindowSync.propagateWorkspacesToAllWindows(
-      aSpaceData ?? this._workspaceCache,
+      aSpaceData ?? this._workspaceCache
     );
   }
 
@@ -1322,13 +1322,13 @@ class nsZenWorkspaces {
     for (const previousWorkspace of previousWorkspaces) {
       if (
         this.workspaceElement(previousWorkspace.uuid) &&
-        !aWorkspaces.find((w) => w.uuid === previousWorkspace.uuid)
+        !aWorkspaces.find(w => w.uuid === previousWorkspace.uuid)
       ) {
         let promise = Promise.resolve();
         if (this.isWorkspaceActive(previousWorkspace)) {
           // If the removed workspace was active, switch to another one
           const newActiveWorkspace =
-            aWorkspaces.find((w) => w.uuid !== previousWorkspace.uuid) || null;
+            aWorkspaces.find(w => w.uuid !== previousWorkspace.uuid) || null;
           promise = this.changeWorkspace(newActiveWorkspace);
         }
         promise = promise.then(() => {
@@ -1355,13 +1355,13 @@ class nsZenWorkspaces {
         if (previousElement === null) {
           arrowScrollbox.moveBefore(
             workspaceElement,
-            arrowScrollbox.firstChild,
+            arrowScrollbox.firstChild
           );
           hasChanged = true;
         } else if (previousElement.nextSibling !== workspaceElement) {
           arrowScrollbox.moveBefore(
             workspaceElement,
-            previousElement.nextSibling,
+            previousElement.nextSibling
           );
           hasChanged = true;
         }
@@ -1384,7 +1384,7 @@ class nsZenWorkspaces {
       return;
     }
     const workspaces = this._workspaceCache;
-    const workspace = workspaces.find((w) => w.uuid === id);
+    const workspace = workspaces.find(w => w.uuid === id);
     if (!workspace) {
       console.warn(`Workspace with ID ${id} not found for reordering.`);
       return;
@@ -1399,7 +1399,7 @@ class nsZenWorkspaces {
     // Insert the workspace at the new position
     if (newPosition < 0 || newPosition > workspaces.length) {
       console.warn(
-        `Invalid position ${newPosition} for reordering workspace with ID ${id}.`,
+        `Invalid position ${newPosition} for reordering workspace with ID ${id}.`
       );
       return;
     }
@@ -1415,12 +1415,12 @@ class nsZenWorkspaces {
     const previousWorkspace = this.getActiveWorkspace();
     document.documentElement.setAttribute("zen-creating-workspace", "true");
     await this.createAndSaveWorkspace("Space", undefined, false, 0, {
-      beforeChangeCallback: async (workspace) => {
+      beforeChangeCallback: async workspace => {
         createForm = document.createXULElement("zen-workspace-creation");
         createForm.setAttribute("workspace-id", workspace.uuid);
         createForm.setAttribute(
           "previous-workspace-id",
-          previousWorkspace?.uuid || "",
+          previousWorkspace?.uuid || ""
         );
         gBrowser.tabContainer.after(createForm);
         await createForm.promiseInitialized;
@@ -1431,15 +1431,15 @@ class nsZenWorkspaces {
 
   #unpinnedTabsInWorkspace(workspaceID) {
     return Array.from(this.allStoredTabs).filter(
-      (tab) =>
+      tab =>
         tab.getAttribute("zen-workspace-id") === workspaceID &&
         tab.visible &&
-        !tab.pinned,
+        !tab.pinned
     );
   }
 
   #getClosableTabs(tabs) {
-    const remainingTabs = tabs.filter((tab) => {
+    const remainingTabs = tabs.filter(tab => {
       const attributes = [
         "selected",
         "multiselected",
@@ -1477,11 +1477,11 @@ class nsZenWorkspaces {
       this.#contextMenuData?.workspaceId || this.activeWorkspace;
 
     const tabsToUnload = this.allStoredTabs.filter(
-      (tab) =>
+      tab =>
         tab.getAttribute("zen-workspace-id") === workspaceId &&
         !tab.hasAttribute("zen-empty-tab") &&
         !tab.hasAttribute("zen-essential") &&
-        !tab.hasAttribute("pending"),
+        !tab.hasAttribute("pending")
     );
 
     if (tabsToUnload.length === 0) {
@@ -1498,11 +1498,11 @@ class nsZenWorkspaces {
       this.#contextMenuData?.workspaceId || this.activeWorkspace;
 
     const tabsToUnload = this.allStoredTabs.filter(
-      (tab) =>
+      tab =>
         tab.getAttribute("zen-workspace-id") !== workspaceId &&
         !tab.hasAttribute("zen-empty-tab") &&
         !tab.hasAttribute("zen-essential") &&
-        !tab.hasAttribute("pending"),
+        !tab.hasAttribute("pending")
     );
 
     await gBrowser.explicitUnloadTabs(tabsToUnload); // TODO: unit test this
@@ -1575,7 +1575,7 @@ class nsZenWorkspaces {
     func,
     opts = {
       once: false,
-    },
+    }
   ) {
     if (!this._changeListeners) {
       this._changeListeners = [];
@@ -1588,7 +1588,7 @@ class nsZenWorkspaces {
       return;
     }
     this._changeListeners = this._changeListeners.filter(
-      (listener) => listener.func !== func,
+      listener => listener.func !== func
     );
   }
 
@@ -1617,7 +1617,7 @@ class nsZenWorkspaces {
 
   async #performWorkspaceChange(
     workspace,
-    { onInit = false, alwaysChange = false, whileScrolling = false } = {},
+    { onInit = false, alwaysChange = false, whileScrolling = false } = {}
   ) {
     const previousWorkspace = this.getActiveWorkspace();
     alwaysChange = alwaysChange || onInit;
@@ -1657,7 +1657,7 @@ class nsZenWorkspaces {
     const tabToSelect = await this._handleTabSelection(
       workspace,
       onInit,
-      previousWorkspace.uuid,
+      previousWorkspace.uuid
     );
     if (tabToSelect.linkedBrowser) {
       gBrowser.warmupTab(tabToSelect);
@@ -1665,7 +1665,7 @@ class nsZenWorkspaces {
 
     // Update UI and state
     const previousWorkspaceIndex = workspaces.findIndex(
-      (w) => w.uuid === previousWorkspace.uuid,
+      w => w.uuid === previousWorkspace.uuid
     );
     await this.#updateWorkspaceState(workspace, onInit, tabToSelect, {
       previousWorkspaceIndex,
@@ -1698,7 +1698,7 @@ class nsZenWorkspaces {
     const usedGroups = new Set();
     let tPos = 0; // _tPos is used for the session store, not needed for folders
     let pPos = 0; // _pPos is used for the pinned tabs manager
-    const recurseFolder = (tab) => {
+    const recurseFolder = tab => {
       if (tab.group) {
         recurseFolder(tab.group);
         if (!usedGroups.has(tab.group.id)) {
@@ -1719,7 +1719,7 @@ class nsZenWorkspaces {
   #updatePaddingTopOnTabs(
     workspaceElement,
     essentialContainer,
-    forAnimation = false,
+    forAnimation = false
   ) {
     if (
       workspaceElement &&
@@ -1741,7 +1741,7 @@ class nsZenWorkspaces {
   _organizeWorkspaceStripLocations(
     workspace,
     justMove = false,
-    offsetPixels = 0,
+    offsetPixels = 0
   ) {
     if (document.documentElement.hasAttribute("zen-creating-workspace")) {
       // If we are creating a workspace, we don't want to animate the strip
@@ -1749,12 +1749,12 @@ class nsZenWorkspaces {
     }
     this._organizingWorkspaceStrip = true;
     const workspaces = this.getWorkspaces();
-    let workspaceIndex = workspaces.findIndex((w) => w.uuid === workspace.uuid);
+    let workspaceIndex = workspaces.findIndex(w => w.uuid === workspace.uuid);
     if (!justMove) {
       this._fixIndicatorsNames(workspaces);
     }
     const otherContainersEssentials = document.querySelectorAll(
-      `#zen-essentials .zen-workspace-tabs-section`,
+      `#zen-essentials .zen-workspace-tabs-section`
     );
     const workspaceContextId = workspace.containerTabId;
     const nextWorkspaceContextId =
@@ -1808,22 +1808,22 @@ class nsZenWorkspaces {
           gZenThemePicker.getGradientForWorkspace(workspace).grain;
         const percentage = Math.abs(offsetPixels) / 200;
         [lazy.browserBackgroundElement, lazy.toolbarBackgroundElement].forEach(
-          (element) => {
+          element => {
             element.style.setProperty(
               "--zen-background-opacity",
-              1 - percentage,
+              1 - percentage
             );
-          },
+          }
         );
         if (!this._hasAnimatedBackgrounds) {
           this._hasAnimatedBackgrounds = true;
           lazy.browserBackgroundElement.style.setProperty(
             "--zen-main-browser-background-old",
-            nextGradient,
+            nextGradient
           );
           lazy.toolbarBackgroundElement.style.setProperty(
             "--zen-main-browser-background-toolbar-old",
-            nextToolbarGradient,
+            nextToolbarGradient
           );
           document.documentElement.setAttribute("animating-background", "true");
         }
@@ -1852,13 +1852,13 @@ class nsZenWorkspaces {
       return;
     }
     const indicatorName = workspaceIndicator.querySelector(
-      ".zen-current-workspace-indicator-name",
+      ".zen-current-workspace-indicator-name"
     );
     const indicatorIcon = workspaceIndicator.querySelector(
-      ".zen-current-workspace-indicator-icon",
+      ".zen-current-workspace-indicator-icon"
     );
     const iconStack = workspaceIndicator.querySelector(
-      ".zen-current-workspace-indicator-stack",
+      ".zen-current-workspace-indicator-stack"
     );
 
     if (this.workspaceHasIcon(currentWorkspace)) {
@@ -1883,7 +1883,7 @@ class nsZenWorkspaces {
   _fixIndicatorsNames(workspaces) {
     for (const workspace of workspaces) {
       const workspaceIndicator = this.workspaceElement(
-        workspace.uuid,
+        workspace.uuid
       )?.indicator;
       this.updateWorkspaceIndicator(workspace, workspaceIndicator);
     }
@@ -1898,7 +1898,7 @@ class nsZenWorkspaces {
       previousWorkspaceIndex = null,
       previousWorkspace = null,
       onInit = false,
-    } = {},
+    } = {}
   ) {
     gZenUIManager.tabsWrapper.style.scrollbarWidth = "none";
     const kGlobalAnimationDuration = 0.2;
@@ -1906,14 +1906,14 @@ class nsZenWorkspaces {
     const animations = [];
     const workspaces = this.getWorkspaces();
     const newWorkspaceIndex = workspaces.findIndex(
-      (w) => w.uuid === newWorkspace.uuid,
+      w => w.uuid === newWorkspace.uuid
     );
     const isGoingLeft = newWorkspaceIndex <= previousWorkspaceIndex;
     const clonedEssentials = [];
     if (shouldAnimate && this.shouldAnimateEssentials && previousWorkspace) {
       for (const workspace of workspaces) {
         const essentialsContainer = this.getEssentialsSection(
-          workspace.containerTabId,
+          workspace.containerTabId
         );
         let lastCloned = clonedEssentials[clonedEssentials.length - 1];
         if (lastCloned && lastCloned.contextId == workspace.containerTabId) {
@@ -1938,7 +1938,7 @@ class nsZenWorkspaces {
     if (shouldAnimate && previousWorkspace) {
       let previousBackgroundOpacity =
         lazy.browserBackgroundElement.style.getPropertyValue(
-          "--zen-background-opacity",
+          "--zen-background-opacity"
         );
       try {
         // Prevent NaN from being set
@@ -1958,10 +1958,10 @@ class nsZenWorkspaces {
         lazy.browserBackgroundElement,
         lazy.toolbarBackgroundElement,
       ];
-      elements.forEach((element) => {
+      elements.forEach(element => {
         element.style.setProperty(
           "--zen-background-opacity",
-          previousBackgroundOpacity,
+          previousBackgroundOpacity
         );
       });
       animations.push(
@@ -1974,8 +1974,8 @@ class nsZenWorkspaces {
             type: "spring",
             bounce: 0,
             duration: kGlobalAnimationDuration,
-          },
-        ),
+          }
+        )
       );
     }
     for (const element of document.querySelectorAll("zen-workspace")) {
@@ -1985,7 +1985,7 @@ class nsZenWorkspaces {
       const existingTransform = element.style.transform;
       const elementWorkspaceId = element.id;
       const elementWorkspaceIndex = workspaces.findIndex(
-        (w) => w.uuid === elementWorkspaceId,
+        w => w.uuid === elementWorkspaceId
       );
       const offset = -(newWorkspaceIndex - elementWorkspaceIndex) * 100;
       const newTransform = `translateX(${offset}%)`;
@@ -2006,8 +2006,8 @@ class nsZenWorkspaces {
               type: "spring",
               bounce: 0,
               duration: kGlobalAnimationDuration,
-            },
-          ),
+            }
+          )
         );
       }
       element.active = offset === 0;
@@ -2019,31 +2019,29 @@ class nsZenWorkspaces {
     }
     if (this.shouldAnimateEssentials && previousWorkspace) {
       // Animate essentials
-      const newWorkspaceEssentialsContainer = clonedEssentials.find((cloned) =>
-        cloned.workspaces.some((w) => w.uuid === newWorkspace.uuid),
+      const newWorkspaceEssentialsContainer = clonedEssentials.find(cloned =>
+        cloned.workspaces.some(w => w.uuid === newWorkspace.uuid)
       );
       // Get a list of essentials containers that are in between the first and last workspace
-      const essentialsContainersInBetween = clonedEssentials.filter(
-        (cloned) => {
-          const essentialsWorkspaces = cloned.workspaces;
-          const firstIndex = workspaces.findIndex(
-            (w) => w.uuid === essentialsWorkspaces[0].uuid,
-          );
-          const lastIndex = workspaces.findIndex(
-            (w) =>
-              w.uuid ===
-              essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid,
-          );
+      const essentialsContainersInBetween = clonedEssentials.filter(cloned => {
+        const essentialsWorkspaces = cloned.workspaces;
+        const firstIndex = workspaces.findIndex(
+          w => w.uuid === essentialsWorkspaces[0].uuid
+        );
+        const lastIndex = workspaces.findIndex(
+          w =>
+            w.uuid ===
+            essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid
+        );
 
-          const [start, end] = [
-            Math.min(previousWorkspaceIndex, newWorkspaceIndex),
-            Math.max(previousWorkspaceIndex, newWorkspaceIndex),
-          ];
+        const [start, end] = [
+          Math.min(previousWorkspaceIndex, newWorkspaceIndex),
+          Math.max(previousWorkspaceIndex, newWorkspaceIndex),
+        ];
 
-          // Check if any part of the container overlaps with the movement range
-          return firstIndex <= end && lastIndex >= start;
-        },
-      );
+        // Check if any part of the container overlaps with the movement range
+        return firstIndex <= end && lastIndex >= start;
+      });
       for (const cloned of clonedEssentials) {
         const container = cloned.container;
         const essentialsWorkspaces = cloned.workspaces;
@@ -2062,12 +2060,12 @@ class nsZenWorkspaces {
 
         // Get the index from first and last workspace
         const firstWorkspaceIndex = workspaces.findIndex(
-          (w) => w.uuid === essentialsWorkspaces[0].uuid,
+          w => w.uuid === essentialsWorkspaces[0].uuid
         );
         const lastWorkspaceIndex = workspaces.findIndex(
-          (w) =>
+          w =>
             w.uuid ===
-            essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid,
+            essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid
         );
         cloned.originalContainer.style.removeProperty("transform");
         // Check if the container is even going to appear on the screen, to save on animation
@@ -2078,15 +2076,15 @@ class nsZenWorkspaces {
           // so we need to check if any of the workspaces in the container are between the
           // first and last workspace.
           !essentialsContainersInBetween.find(
-            (ce) =>
+            ce =>
               ce.workspaces.some(
-                (w) => w.uuid === essentialsWorkspaces[0].uuid,
+                w => w.uuid === essentialsWorkspaces[0].uuid
               ) &&
               ce.workspaces.some(
-                (w) =>
+                w =>
                   w.uuid ===
-                  essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid,
-              ),
+                  essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid
+              )
           )
         ) {
           continue;
@@ -2095,14 +2093,14 @@ class nsZenWorkspaces {
         let stepsInBetween =
           Math.abs(
             newWorkspaceIndex -
-              (isGoingLeft ? firstWorkspaceIndex : lastWorkspaceIndex),
+              (isGoingLeft ? firstWorkspaceIndex : lastWorkspaceIndex)
           ) + 1;
         const usingSameContainer =
           newWorkspaceEssentialsContainer?.workspaces.some(
-            (w) => w.uuid === newWorkspace.uuid,
+            w => w.uuid === newWorkspace.uuid
           ) &&
           newWorkspaceEssentialsContainer?.workspaces.some(
-            (w) => w.uuid === previousWorkspace.uuid,
+            w => w.uuid === previousWorkspace.uuid
           );
         let newOffset =
           -(
@@ -2122,8 +2120,8 @@ class nsZenWorkspaces {
         // we can simply not animate the essentials
         if (
           usingSameContainer &&
-          essentialsWorkspaces.some((w) => w.uuid === newWorkspace.uuid) &&
-          essentialsWorkspaces.some((w) => w.uuid === previousWorkspace.uuid)
+          essentialsWorkspaces.some(w => w.uuid === newWorkspace.uuid) &&
+          essentialsWorkspaces.some(w => w.uuid === previousWorkspace.uuid)
         ) {
           newOffset = 0;
           existingOffset = 0;
@@ -2209,8 +2207,8 @@ class nsZenWorkspaces {
                 type: "spring",
                 bounce: 0,
                 duration: kGlobalAnimationDuration,
-              },
-            ),
+              }
+            )
           );
         }
       }
@@ -2219,14 +2217,14 @@ class nsZenWorkspaces {
       gZenUIManager._preventToolbarRebuild = true;
       gZenUIManager.updateTabsToolbar();
     }
-    let promiseTimeout = new Promise((resolve) =>
-      setTimeout(resolve, kGlobalAnimationDuration * 1000 + 50),
+    let promiseTimeout = new Promise(resolve =>
+      setTimeout(resolve, kGlobalAnimationDuration * 1000 + 50)
     );
     // See issue https://github.com/zen-browser/desktop/issues/9334, we need to add
     // some sort of timeout to the animation promise, just in case it gets stuck.
     // We are doing a race between the timeout and the animations finishing.
     await Promise.race([Promise.all(animations), promiseTimeout]).catch(
-      console.error,
+      console.error
     );
     document.documentElement.removeAttribute("animating-background");
     if (shouldAnimate) {
@@ -2237,7 +2235,7 @@ class nsZenWorkspaces {
       this.updateTabsContainers();
     }
     const essentialsContainer = this.getEssentialsSection(
-      newWorkspace.containerTabId,
+      newWorkspace.containerTabId
     );
     essentialsContainer.removeAttribute("hidden");
     essentialsContainer.style.transform = "none";
@@ -2256,7 +2254,7 @@ class nsZenWorkspaces {
       tab,
       currentWorkspace.uuid,
       currentWorkspace.containerTabId,
-      this.getWorkspaces(),
+      this.getWorkspaces()
     );
   }
 
@@ -2292,8 +2290,7 @@ class nsZenWorkspaces {
         !tabContextId ||
         tabContextId === "0" ||
         !workspaces.some(
-          (workspace) =>
-            workspace.containerTabId === parseInt(tabContextId, 10),
+          workspace => workspace.containerTabId === parseInt(tabContextId, 10)
         )
       );
     }
@@ -2331,14 +2328,14 @@ class nsZenWorkspaces {
         lastSelectedTab,
         workspace.uuid,
         containerId,
-        workspaces,
+        workspaces
       )
     ) {
       tabToSelect = lastSelectedTab;
     }
     // Find first suitable tab
     else {
-      tabToSelect = gBrowser.visibleTabs.find((tab) => !tab.pinned);
+      tabToSelect = gBrowser.visibleTabs.find(tab => !tab.pinned);
       if (!tabToSelect && gBrowser.visibleTabs.length) {
         tabToSelect = gBrowser.visibleTabs[gBrowser.visibleTabs.length - 1];
       }
@@ -2369,7 +2366,7 @@ class nsZenWorkspaces {
     workspace,
     onInit,
     tabToSelect,
-    { previousWorkspaceIndex, previousWorkspace } = {},
+    { previousWorkspaceIndex, previousWorkspace } = {}
   ) {
     // Update document state
     document.documentElement.setAttribute("zen-workspace-id", workspace.uuid);
@@ -2378,7 +2375,7 @@ class nsZenWorkspaces {
     gBrowser.tabContainer.observe(
       null,
       "nsPref:changed",
-      "privacy.userContext.enabled",
+      "privacy.userContext.enabled"
     );
 
     gBrowser.tabContainer.arrowScrollbox = this.activeScrollbox;
@@ -2398,7 +2395,7 @@ class nsZenWorkspaces {
         previousWorkspaceIndex,
         previousWorkspace,
         onInit,
-      },
+      }
     );
     this._organizeWorkspaceStripLocations(workspace, true);
     gZenUIManager.tabsWrapper.style.scrollbarWidth = "";
@@ -2447,7 +2444,7 @@ class nsZenWorkspaces {
       new CustomEvent("ZenWorkspacesUIUpdate", {
         bubbles: true,
         detail: { activeIndex: this.activeWorkspace },
-      }),
+      })
     );
   }
 
@@ -2489,7 +2486,7 @@ class nsZenWorkspaces {
     for (const popup of itemsToFill) {
       let isMoveTabPopup = popup.id === menuPopupID;
       for (const item of popup.querySelectorAll(
-        ".zen-workspace-context-menu-item",
+        ".zen-workspace-context-menu-item"
       )) {
         item.remove();
       }
@@ -2506,7 +2503,7 @@ class nsZenWorkspaces {
         : workspaces) {
         const menuItem = this.generateMenuItemForWorkspace(
           workspace,
-          /* disableCurrent = */ isMoveTabPopup,
+          /* disableCurrent = */ isMoveTabPopup
         );
         if (isMoveTabPopup) {
           popup.prepend(menuItem);
@@ -2552,20 +2549,20 @@ class nsZenWorkspaces {
     icon = undefined,
     dontChange = false,
     containerTabId = 0,
-    { beforeChangeCallback } = { beforeChangeCallback: null }, // Callback to run before changing workspace
+    { beforeChangeCallback } = { beforeChangeCallback: null } // Callback to run before changing workspace
   ) {
     if (!this.workspaceEnabled) {
       return null;
     }
     // get extra tabs remaning (e.g. on new profiles) and just move them to the new workspace
     const extraTabs = Array.from(
-      gBrowser.tabContainer.arrowScrollbox.children,
+      gBrowser.tabContainer.arrowScrollbox.children
     ).filter(
-      (child) =>
+      child =>
         gBrowser.isTab(child) &&
         !child.hasAttribute("zen-workspace-id") &&
         !child.hasAttribute("zen-empty-tab") &&
-        !child.hasAttribute("zen-essential"),
+        !child.hasAttribute("zen-essential")
     );
     let workspaceData = this.#createWorkspaceData(name, icon, containerTabId);
     if (!dontChange) {
@@ -2612,14 +2609,14 @@ class nsZenWorkspaces {
             this.pinnedTabsContainer,
         },
       ],
-      forAnimation,
+      forAnimation
     );
   }
 
   updateShouldHideSeparator(
     arrowScrollbox,
     pinnedContainer,
-    fromTabSelection = false,
+    fromTabSelection = false
   ) {
     const visibleTabsFound = () => {
       let count = 0;
@@ -2650,7 +2647,7 @@ class nsZenWorkspaces {
       const tabs = this.#unpinnedTabsInWorkspace(workspaceID);
       const closableTabs = this.#getClosableTabs(tabs);
       const button = pinnedContainer.querySelector(
-        ".zen-workspace-close-unpinned-tabs-button",
+        ".zen-workspace-close-unpinned-tabs-button"
       );
       if (tabs.length === closableTabs.length) {
         button.setAttribute("can-close", "true");
@@ -2685,12 +2682,12 @@ class nsZenWorkspaces {
       if (entry.target.closest("#zen-essentials")) {
         // Get all workspaces that have the same userContextId
         const userContextId = parseInt(
-          entry.target.getAttribute("container") || "0",
+          entry.target.getAttribute("container") || "0"
         );
         const workspaces = this.getWorkspaces().filter(
-          (w) => w.containerTabId === userContextId,
+          w => w.containerTabId === userContextId
         );
-        workspacesIds.push(...workspaces.map((w) => w.uuid));
+        workspacesIds.push(...workspaces.map(w => w.uuid));
       } else {
         workspacesIds.push(originalWorkspaceId);
       }
@@ -2700,14 +2697,14 @@ class nsZenWorkspaces {
         if (!workspaceElement || !workspaceObject) {
           console.warn(
             "Workspace element or object not found for id",
-            workspaceId,
+            workspaceId
           );
           continue;
         }
         const arrowScrollbox = workspaceElement.tabsContainer;
         const pinnedContainer = workspaceElement.pinnedTabsContainer;
         const essentialContainer = this.getEssentialsSection(
-          workspaceObject.containerTabId,
+          workspaceObject.containerTabId
         );
         const essentialNumChildren = essentialContainer.children.length;
         let essentialHackType = 0;
@@ -2726,7 +2723,7 @@ class nsZenWorkspaces {
         this.#updatePaddingTopOnTabs(
           workspaceElement,
           essentialContainer,
-          forAnimation,
+          forAnimation
         );
         this.updateShouldHideSeparator(arrowScrollbox, pinnedContainer);
       }
@@ -2775,7 +2772,7 @@ class nsZenWorkspaces {
     const isEmpty = gBrowser.selectedTab.hasAttribute("zen-empty-tab");
     gZenCompactModeManager.sidebar.toggleAttribute(
       "zen-has-empty-tab",
-      isEmpty,
+      isEmpty
     );
     document.documentElement.setAttribute("zen-has-empty-tab", isEmpty);
   }
@@ -2834,11 +2831,11 @@ class nsZenWorkspaces {
     this._organizingWorkspaceStrip = true;
     let workspaces = this.getWorkspaces();
     let workspace = workspaces.find(
-      (w) =>
-        w.uuid === (this.#contextMenuData?.workspaceId || this.activeWorkspace),
+      w =>
+        w.uuid === (this.#contextMenuData?.workspaceId || this.activeWorkspace)
     );
     let userContextId = parseInt(
-      event.target.getAttribute("data-usercontextid"),
+      event.target.getAttribute("data-usercontextid")
     );
     workspace.containerTabId = userContextId + 0; // +0 to convert to number
     this.saveWorkspace(workspace);
@@ -2857,7 +2854,7 @@ class nsZenWorkspaces {
 
     const restoreClosedTabsShortcut =
       gZenKeyboardShortcutsManager.getShortcutDisplayFromCommand(
-        "History:RestoreLastClosedTabOrWindowOrSession",
+        "History:RestoreLastClosedTabOrWindowOrSession"
       );
 
     gZenUIManager.showToast("zen-workspaces-close-all-unpinned-tabs-toast", {
@@ -2892,7 +2889,7 @@ class nsZenWorkspaces {
   async changeWorkspaceShortcut(
     offset = 1,
     whileScrolling = false,
-    disableWrap = false,
+    disableWrap = false
   ) {
     // Cycle through workspaces
     let workspaces = this.getWorkspaces();
@@ -2921,7 +2918,7 @@ class nsZenWorkspaces {
         "cmd_zenOpenWorkspaceCreation",
         "zen-context-menu-new-folder-toolbar",
       ];
-      commandsToDisable.forEach((cmd) => {
+      commandsToDisable.forEach(cmd => {
         const element = document.getElementById(cmd);
         if (element) {
           element.setAttribute("disabled", true);
@@ -2950,7 +2947,7 @@ class nsZenWorkspaces {
       gZenGlanceManager.getTabOrGlanceParent(tabs[tabs.length - 1]);
     const workspaces = this.getWorkspaces();
     await this.changeWorkspace(
-      workspaces.find((workspace) => workspace.uuid === workspaceID),
+      workspaces.find(workspace => workspace.uuid === workspaceID)
     );
   }
 
@@ -2969,7 +2966,7 @@ class nsZenWorkspaces {
     ) {
       // Find all workspaces that match the given userContextId
       const matchingWorkspaces = this._workspaceCache.filter(
-        (workspace) => workspace.containerTabId === userContextId,
+        workspace => workspace.containerTabId === userContextId
       );
 
       // Check if exactly one workspace matches
@@ -2999,13 +2996,13 @@ class nsZenWorkspaces {
     const containerId = aTab.getAttribute("usercontextid") ?? "0";
     // Return all tabs that are not on the same workspace
     return gBrowser.tabs.filter(
-      (tab) =>
+      tab =>
         !this._shouldShowTab(
           tab,
           tabWorkspaceId,
           containerId,
-          this._workspaceCache,
-        ) && !tab.hasAttribute("zen-empty-tab"),
+          this._workspaceCache
+        ) && !tab.hasAttribute("zen-empty-tab")
     );
   }
 
@@ -3036,14 +3033,14 @@ class nsZenWorkspaces {
     }
 
     const validWorkspaceIds = new Set(
-      this.getWorkspaces().map((workspace) => workspace.uuid),
+      this._workspaceCache.map(workspace => workspace.uuid)
     );
 
     let isInActiveWorkspace = false;
     let isInOtherWorkspace = false;
 
     for (const [workspaceUuid, bookmarkGuids] of Object.entries(
-      workspaceBookmarks,
+      workspaceBookmarks
     )) {
       if (
         !validWorkspaceIds.has(workspaceUuid) ||
@@ -3073,7 +3070,7 @@ class nsZenWorkspaces {
     const tabs = [];
     // we need to go through each tab in each container
     const essentialsContainer = document.querySelectorAll(
-      "#zen-essentials .zen-workspace-tabs-section",
+      "#zen-essentials .zen-workspace-tabs-section"
     );
     let pinnedContainers = [];
     let normalContainers = [];
@@ -3089,7 +3086,7 @@ class nsZenWorkspaces {
           ? -1
           : b.uuid === this.activeWorkspace
             ? 1
-            : 0,
+            : 0
       );
       for (const workspace of workspaces) {
         const container = this.workspaceElement(workspace.uuid);
@@ -3132,7 +3129,7 @@ class nsZenWorkspaces {
   get allTabGroups() {
     if (!this._hasInitializedTabsStrip) {
       let children = this.tabboxChildren;
-      return children.filter((node) => gBrowser.isTabGroup(node));
+      return children.filter(node => gBrowser.isTabGroup(node));
     }
     const pinnedContainers = [];
     const normalContainers = [];
@@ -3176,8 +3173,8 @@ class nsZenWorkspaces {
 
   reorganizeTabsAfterWelcome() {
     const children = gBrowser.tabContainer.arrowScrollbox.children;
-    const remainingTabs = Array.from(children).filter((child) =>
-      gBrowser.isTab(child),
+    const remainingTabs = Array.from(children).filter(child =>
+      gBrowser.isTab(child)
     );
     for (const tab of remainingTabs) {
       this.moveTabToWorkspace(tab, this.activeWorkspace);
@@ -3225,7 +3222,7 @@ class nsZenWorkspaces {
         // Use a mutex-like approach to prevent concurrent workspace changes
         if (this._workspaceChangeInProgress) {
           console.warn(
-            "Workspace change already in progress, deferring tab switch",
+            "Workspace change already in progress, deferring tab switch"
           );
           return;
         }
@@ -3234,15 +3231,15 @@ class nsZenWorkspaces {
         if (tab.hasAttribute("zen-essential")) {
           // Find first workspace with the same container
           const containerTabId = parseInt(
-            tab.parentNode.getAttribute("container"),
+            tab.parentNode.getAttribute("container")
           );
           // +0 to convert to number
           workspaceToSwitch = this._workspaceCache.find(
-            (workspace) => workspace.containerTabId + 0 === containerTabId,
+            workspace => workspace.containerTabId + 0 === containerTabId
           );
         } else {
           workspaceToSwitch = this.getWorkspaceFromId(
-            tab.getAttribute("zen-workspace-id"),
+            tab.getAttribute("zen-workspace-id")
           );
         }
         if (!workspaceToSwitch) {
@@ -3277,7 +3274,7 @@ class nsZenWorkspaces {
       return 0;
     }
     const activeWorkspace = this.activeWorkspace;
-    const workspace = workspaces.find((w) => w.uuid === activeWorkspace);
+    const workspace = workspaces.find(w => w.uuid === activeWorkspace);
     return workspace.containerTabId;
   }
 
@@ -3323,7 +3320,7 @@ class nsZenWorkspaces {
     const widthPerButton = Math.max(
       (parent.clientWidth - separation * (parent.children.length - 1)) /
         parent.children.length,
-      minButtonSize,
+      minButtonSize
     );
     for (const icon of parent.children) {
       if (icon.tagName === "toolbarbutton") {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -53,11 +53,11 @@ class nsZenWorkspaces {
     "BMB_mobileBookmarks",
   ];
 
-  promisePinnedInitialized = new Promise(resolve => {
+  promisePinnedInitialized = new Promise((resolve) => {
     this._resolvePinnedInitialized = resolve;
   });
 
-  promiseInitialized = new Promise(resolve => {
+  promiseInitialized = new Promise((resolve) => {
     this._resolveInitialized = resolve;
   });
 
@@ -85,7 +85,7 @@ class nsZenWorkspaces {
     if (!this.shouldHaveWorkspaces) {
       this._resolveInitialized();
       console.warn(
-        "gZenWorkspaces: !!! gZenWorkspaces is disabled in hidden windows !!!"
+        "gZenWorkspaces: !!! gZenWorkspaces is disabled in hidden windows !!!",
       );
       return; // We are in a hidden window, don't initialize gZenWorkspaces
     }
@@ -95,45 +95,45 @@ class nsZenWorkspaces {
       this,
       "activationMethod",
       "zen.workspaces.scroll-modifier-key",
-      "ctrl"
+      "ctrl",
     );
     XPCOMUtils.defineLazyPreferenceGetter(
       this,
       "naturalScroll",
       "zen.workspaces.natural-scroll",
-      true
+      true,
     );
     XPCOMUtils.defineLazyPreferenceGetter(
       this,
       "shouldWrapAroundNavigation",
       "zen.workspaces.wrap-around-navigation",
-      true
+      true,
     );
     XPCOMUtils.defineLazyPreferenceGetter(
       this,
       "shouldForceContainerTabsToWorkspace",
       "zen.workspaces.force-container-workspace",
-      true
+      true,
     );
     XPCOMUtils.defineLazyPreferenceGetter(
       this,
       "shouldOpenNewTabIfLastUnpinnedTabIsClosed",
       "zen.workspaces.open-new-tab-if-last-unpinned-tab-is-closed",
-      false
+      false,
     );
     this.containerSpecificEssentials = Services.prefs.getBoolPref(
       "zen.workspaces.separate-essentials",
-      false
+      false,
     );
     ChromeUtils.defineLazyGetter(this, "tabContainer", () =>
-      document.getElementById("tabbrowser-tabs")
+      document.getElementById("tabbrowser-tabs"),
     );
     ChromeUtils.defineLazyGetter(this, "workspaceIcons", () =>
-      document.getElementById("zen-workspaces-button")
+      document.getElementById("zen-workspaces-button"),
     );
     this.#activeWorkspace ||= Services.prefs.getStringPref(
       "zen.workspaces.active",
-      ""
+      "",
     );
 
     if (this.isPrivateWindow) {
@@ -160,7 +160,7 @@ class nsZenWorkspaces {
       window.addEventListener("unload", () => {
         Services.obs.removeObserver(
           observerFunction,
-          "workspace-bookmarks-updated"
+          "workspace-bookmarks-updated",
         );
       });
     }
@@ -226,11 +226,11 @@ class nsZenWorkspaces {
       now - this._tabSelectionState.lastSelectionTime;
 
     if (timeSinceLastSelection < this._tabSelectionState.debounceTime) {
-      await new Promise(resolve =>
+      await new Promise((resolve) =>
         setTimeout(
           resolve,
-          this._tabSelectionState.debounceTime - timeSinceLastSelection
-        )
+          this._tabSelectionState.debounceTime - timeSinceLastSelection,
+        ),
       );
     }
 
@@ -364,7 +364,7 @@ class nsZenWorkspaces {
 
   get tabboxChildrenWithoutEmpty() {
     return this.tabboxChildren.filter(
-      child => !child.hasAttribute("zen-empty-tab")
+      (child) => !child.hasAttribute("zen-empty-tab"),
     );
   }
 
@@ -388,7 +388,7 @@ class nsZenWorkspaces {
 
   #initializeTabsStripSections() {
     const perifery = document.getElementById(
-      "tabbrowser-arrowscrollbox-periphery"
+      "tabbrowser-arrowscrollbox-periphery",
     );
     perifery.setAttribute("hidden", "true");
     const tabs = gBrowser.tabContainer.allTabs;
@@ -398,10 +398,10 @@ class nsZenWorkspaces {
     }
     if (tabs.length) {
       const defaultSelectedContainer = this.workspaceElement(
-        this.activeWorkspace
+        this.activeWorkspace,
       )?.querySelector(".zen-workspace-normal-tabs-section");
       const pinnedContainer = this.workspaceElement(
-        this.activeWorkspace
+        this.activeWorkspace,
       )?.querySelector(".zen-workspace-pinned-tabs-section");
       // New profile with no workspaces does not have a default selected container
       if (defaultSelectedContainer) {
@@ -416,7 +416,7 @@ class nsZenWorkspaces {
           // before to the last child (perifery)
           defaultSelectedContainer.insertBefore(
             tab,
-            defaultSelectedContainer.lastChild
+            defaultSelectedContainer.lastChild,
           );
         }
       }
@@ -436,7 +436,7 @@ class nsZenWorkspaces {
       container = 0;
     }
     let essentialsContainer = document.querySelector(
-      `.zen-essentials-container[container="${container}"]:not([cloned])`
+      `.zen-essentials-container[container="${container}"]:not([cloned])`,
     );
     if (!essentialsContainer) {
       essentialsContainer = document.createXULElement("hbox");
@@ -491,12 +491,12 @@ class nsZenWorkspaces {
     let section = spaceElement.tabsContainer;
     let pinnedSection = spaceElement.pinnedTabsContainer;
     const workspaceTabs = Array.from(tabs).filter(
-      tab =>
+      (tab) =>
         tab.getAttribute("zen-workspace-id") === workspace.uuid &&
-        !tab.hasAttribute("zen-essential")
+        !tab.hasAttribute("zen-essential"),
     );
     let folders = new Set();
-    const getFolderRoot = tab => {
+    const getFolderRoot = (tab) => {
       let root = tab?.group;
       while (root?.group) {
         root = root?.group;
@@ -544,7 +544,7 @@ class nsZenWorkspaces {
     window.addEventListener(
       "AppCommand",
       this._handleAppCommand.bind(this),
-      true
+      true,
     );
 
     // Re-add original handler
@@ -590,7 +590,7 @@ class nsZenWorkspaces {
 
     toolbox.addEventListener(
       "wheel",
-      event => {
+      (event) => {
         if (this.privateWindowOrDisabled) {
           return;
         }
@@ -638,7 +638,7 @@ class nsZenWorkspaces {
 
         this.#lastScrollTime = currentTime;
       },
-      { passive: true }
+      { passive: true },
     );
   }
 
@@ -658,7 +658,7 @@ class nsZenWorkspaces {
 
   set activeWorkspace(value) {
     const spaces = this.getWorkspaces();
-    if (!spaces.some(ws => ws.uuid === value)) {
+    if (!spaces.some((ws) => ws.uuid === value)) {
       value = spaces[0]?.uuid || "";
     }
     if (value === this.#activeWorkspace) {
@@ -716,7 +716,7 @@ class nsZenWorkspaces {
 
   getWorkspaceFromId(id) {
     try {
-      return this.getWorkspaces().find(workspace => workspace.uuid === id);
+      return this.getWorkspaces().find((workspace) => workspace.uuid === id);
     } catch {
       return null;
     }
@@ -725,7 +725,7 @@ class nsZenWorkspaces {
   getWorkspaces(lieToMe = false) {
     if (lieToMe) {
       const { ZenSessionStore } = ChromeUtils.importESModule(
-        "resource:///modules/zen/ZenSessionManager.sys.mjs"
+        "resource:///modules/zen/ZenSessionManager.sys.mjs",
       );
       return ZenSessionStore.getClonedSpaces();
     }
@@ -766,7 +766,7 @@ class nsZenWorkspaces {
 
     this._workspaceBookmarksCache = { bookmarks, lastChangeTimestamp };
 
-    return this._workspaceCache;
+    return this._workspaceBookmarksCache;
   }
 
   restoreWorkspacesFromSessionStore(aWinData = {}) {
@@ -845,7 +845,7 @@ class nsZenWorkspaces {
       window.addEventListener("TabSelect", this.onLocationChange.bind(this));
       window.addEventListener(
         "TabBrowserInserted",
-        this.onTabBrowserInserted.bind(this)
+        this.onTabBrowserInserted.bind(this),
       );
 
       this.updateWorkspacesChangeContextMenu();
@@ -859,7 +859,7 @@ class nsZenWorkspaces {
     await this.promiseInitialized;
     let showed = false;
     let resolveSelectPromise;
-    let selectPromise = new Promise(resolve => {
+    let selectPromise = new Promise((resolve) => {
       resolveSelectPromise = resolve;
     });
 
@@ -890,20 +890,20 @@ class nsZenWorkspaces {
       !removedEmptyTab &&
       !this._shouldOverrideTabs
     ) {
-      const tabs = gBrowser.tabs.filter(tab => !tab.collapsed);
+      const tabs = gBrowser.tabs.filter((tab) => !tab.collapsed);
       if (
         typeof this._tabToSelect === "number" &&
         this._tabToSelect >= 0 &&
         tabs[this._tabToSelect] &&
         (await this.#shouldShowTabInCurrentWorkspace(
-          tabs[this._tabToSelect]
+          tabs[this._tabToSelect],
         )) &&
         tabs[this._tabToSelect] !== this._tabToRemoveForEmpty
       ) {
         this.log(`Found tab to select: ${this._tabToSelect}, ${tabs.length}`);
         setTimeout(() => {
           let tabToUse = gZenGlanceManager.getTabOrGlanceParent(
-            tabs[this._tabToSelect + 1] || this._emptyTab
+            tabs[this._tabToSelect + 1] || this._emptyTab,
           );
           gBrowser.selectedTab = tabToUse;
           this._removedByStartupPage = true;
@@ -960,11 +960,11 @@ class nsZenWorkspaces {
       // Go through each tab and see if there's another tab with the same startup URL.
       // If we do find one, remove it.
       const newTabUrl = Services.prefs.getStringPref(
-        "browser.startup.homepage"
+        "browser.startup.homepage",
       );
       const tabs = gBrowser.tabs.filter(
-        tab =>
-          !tab.collapsed && !tab.hasAttribute("zen-empty-tab") && !tab.pinned
+        (tab) =>
+          !tab.collapsed && !tab.hasAttribute("zen-empty-tab") && !tab.pinned,
       );
       for (const tab of tabs) {
         if (tab._originalUrl === newTabUrl && tab !== gBrowser.selectedTab) {
@@ -976,7 +976,7 @@ class nsZenWorkspaces {
     }
 
     window.dispatchEvent(
-      new CustomEvent("AfterWorkspacesSessionRestore", { bubbles: true })
+      new CustomEvent("AfterWorkspacesSessionRestore", { bubbles: true }),
     );
   }
 
@@ -999,7 +999,7 @@ class nsZenWorkspaces {
 
   changeWorkspaceIcon() {
     let anchor = this.activeWorkspaceIndicator?.querySelector(
-      ".zen-current-workspace-indicator-icon"
+      ".zen-current-workspace-indicator-icon",
     );
     if (this.#contextMenuData?.workspaceId) {
       anchor = this.#contextMenuData.originalTarget;
@@ -1017,7 +1017,7 @@ class nsZenWorkspaces {
     gZenEmojiPicker.open(anchor, {
       closeOnSelect: false,
       allowNone: hasNoIcon,
-      onSelect: async icon => {
+      onSelect: async (icon) => {
         const workspace = this.getWorkspaceFromId(workspaceId);
         if (!workspace) {
           console.warn("No active workspace found to change icon");
@@ -1045,7 +1045,7 @@ class nsZenWorkspaces {
       if (
         (workspaceID &&
           !tab.hasAttribute("zen-essential") &&
-          !workspaces.find(workspace => workspace.uuid === workspaceID)) ||
+          !workspaces.find((workspace) => workspace.uuid === workspaceID)) ||
         // Also remove empty tabs that are supposed to be from parent folders but
         // they dont exist anymore
         (tab.pinned && tab.hasAttribute("zen-empty-tab") && !tab.group)
@@ -1077,7 +1077,7 @@ class nsZenWorkspaces {
 
     let tabs = gBrowser.visibleTabs;
     let tabsPinned = tabs.filter(
-      t => !this.shouldOpenNewTabIfLastUnpinnedTabIsClosed || !t.pinned
+      (t) => !this.shouldOpenNewTabIfLastUnpinnedTabIsClosed || !t.pinned,
     );
     const shouldCloseWindow =
       closeWindowWithLastTab != null
@@ -1114,7 +1114,7 @@ class nsZenWorkspaces {
     const workspaceActions = document.getElementById("zenWorkspaceMoreActions");
     workspaceActions.addEventListener(
       "popupshowing",
-      this.updateWorkspaceActionsMenu.bind(this)
+      this.updateWorkspaceActionsMenu.bind(this),
     );
     workspaceActions.addEventListener("popuphidden", () => {
       setTimeout(() => {
@@ -1125,15 +1125,15 @@ class nsZenWorkspaces {
     });
 
     const contextChangeContainerTabMenu = document.getElementById(
-      "context_zenWorkspacesOpenInContainerTab"
+      "context_zenWorkspacesOpenInContainerTab",
     );
     contextChangeContainerTabMenu.addEventListener(
       "popupshowing",
-      this.updateWorkspaceActionsMenuContainer.bind(this)
+      this.updateWorkspaceActionsMenuContainer.bind(this),
     );
     contextChangeContainerTabMenu.addEventListener(
       "command",
-      this.contextChangeContainerTab.bind(this)
+      this.contextChangeContainerTab.bind(this),
     );
   }
 
@@ -1166,7 +1166,7 @@ class nsZenWorkspaces {
       return;
     }
     const openInContainerMenuItem = document.getElementById(
-      "context_zenWorkspacesOpenInContainerTab"
+      "context_zenWorkspacesOpenInContainerTab",
     );
     if (this.shouldShowContainers) {
       openInContainerMenuItem.removeAttribute("hidden");
@@ -1186,12 +1186,12 @@ class nsZenWorkspaces {
     };
     const workspaceName = document.getElementById("context_zenEditWorkspace");
     const themePicker = document.getElementById(
-      "context_zenChangeWorkspaceTheme"
+      "context_zenChangeWorkspaceTheme",
     );
     /* We can't show the rename input properly in collapsed state,
     so hide the workspace edit input */
     const isCollapsed = !Services.prefs.getBoolPref(
-      "zen.view.sidebar-expanded"
+      "zen.view.sidebar-expanded",
     );
     workspaceName.hidden =
       isCollapsed ||
@@ -1202,7 +1202,7 @@ class nsZenWorkspaces {
       this.#contextMenuData.workspaceId !== this.activeWorkspace;
     const separator = document.getElementById("context_zenWorkspacesSeparator");
     for (const item of event.target.querySelectorAll(
-      ".zen-workspace-context-menu-item"
+      ".zen-workspace-context-menu-item",
     )) {
       item.remove();
     }
@@ -1210,9 +1210,9 @@ class nsZenWorkspaces {
       separator.hidden = false;
       for (const workspace of this.getWorkspaces().reverse()) {
         const item = this.generateMenuItemForWorkspace(workspace);
-        item.addEventListener("command", e => {
+        item.addEventListener("command", (e) => {
           this.changeWorkspaceWithID(
-            e.target.closest("menuitem").getAttribute("zen-workspace-id")
+            e.target.closest("menuitem").getAttribute("zen-workspace-id"),
           );
         });
         separator.after(item);
@@ -1225,7 +1225,7 @@ class nsZenWorkspaces {
       () => {
         this.#contextMenuData = null;
       },
-      { once: true }
+      { once: true },
     );
   }
 
@@ -1250,7 +1250,7 @@ class nsZenWorkspaces {
     }
     const workspacesData = this._workspaceCache;
     const index = workspacesData.findIndex(
-      ws => ws.uuid === workspaceData.uuid
+      (ws) => ws.uuid === workspaceData.uuid,
     );
     if (index !== -1) {
       workspacesData[index] = workspaceData;
@@ -1264,7 +1264,7 @@ class nsZenWorkspaces {
     let workspacesData = this.getWorkspaces();
     // Remove the workspace from the cache
     workspacesData = workspacesData.filter(
-      workspace => workspace.uuid !== windowID
+      (workspace) => workspace.uuid !== windowID,
     );
     this.#propagateWorkspaceData(workspacesData);
   }
@@ -1310,7 +1310,7 @@ class nsZenWorkspaces {
       bubbles: true,
     });
     window.gZenWindowSync.propagateWorkspacesToAllWindows(
-      aSpaceData ?? this._workspaceCache
+      aSpaceData ?? this._workspaceCache,
     );
   }
 
@@ -1322,13 +1322,13 @@ class nsZenWorkspaces {
     for (const previousWorkspace of previousWorkspaces) {
       if (
         this.workspaceElement(previousWorkspace.uuid) &&
-        !aWorkspaces.find(w => w.uuid === previousWorkspace.uuid)
+        !aWorkspaces.find((w) => w.uuid === previousWorkspace.uuid)
       ) {
         let promise = Promise.resolve();
         if (this.isWorkspaceActive(previousWorkspace)) {
           // If the removed workspace was active, switch to another one
           const newActiveWorkspace =
-            aWorkspaces.find(w => w.uuid !== previousWorkspace.uuid) || null;
+            aWorkspaces.find((w) => w.uuid !== previousWorkspace.uuid) || null;
           promise = this.changeWorkspace(newActiveWorkspace);
         }
         promise = promise.then(() => {
@@ -1355,13 +1355,13 @@ class nsZenWorkspaces {
         if (previousElement === null) {
           arrowScrollbox.moveBefore(
             workspaceElement,
-            arrowScrollbox.firstChild
+            arrowScrollbox.firstChild,
           );
           hasChanged = true;
         } else if (previousElement.nextSibling !== workspaceElement) {
           arrowScrollbox.moveBefore(
             workspaceElement,
-            previousElement.nextSibling
+            previousElement.nextSibling,
           );
           hasChanged = true;
         }
@@ -1384,7 +1384,7 @@ class nsZenWorkspaces {
       return;
     }
     const workspaces = this._workspaceCache;
-    const workspace = workspaces.find(w => w.uuid === id);
+    const workspace = workspaces.find((w) => w.uuid === id);
     if (!workspace) {
       console.warn(`Workspace with ID ${id} not found for reordering.`);
       return;
@@ -1399,7 +1399,7 @@ class nsZenWorkspaces {
     // Insert the workspace at the new position
     if (newPosition < 0 || newPosition > workspaces.length) {
       console.warn(
-        `Invalid position ${newPosition} for reordering workspace with ID ${id}.`
+        `Invalid position ${newPosition} for reordering workspace with ID ${id}.`,
       );
       return;
     }
@@ -1415,12 +1415,12 @@ class nsZenWorkspaces {
     const previousWorkspace = this.getActiveWorkspace();
     document.documentElement.setAttribute("zen-creating-workspace", "true");
     await this.createAndSaveWorkspace("Space", undefined, false, 0, {
-      beforeChangeCallback: async workspace => {
+      beforeChangeCallback: async (workspace) => {
         createForm = document.createXULElement("zen-workspace-creation");
         createForm.setAttribute("workspace-id", workspace.uuid);
         createForm.setAttribute(
           "previous-workspace-id",
-          previousWorkspace?.uuid || ""
+          previousWorkspace?.uuid || "",
         );
         gBrowser.tabContainer.after(createForm);
         await createForm.promiseInitialized;
@@ -1431,15 +1431,15 @@ class nsZenWorkspaces {
 
   #unpinnedTabsInWorkspace(workspaceID) {
     return Array.from(this.allStoredTabs).filter(
-      tab =>
+      (tab) =>
         tab.getAttribute("zen-workspace-id") === workspaceID &&
         tab.visible &&
-        !tab.pinned
+        !tab.pinned,
     );
   }
 
   #getClosableTabs(tabs) {
-    const remainingTabs = tabs.filter(tab => {
+    const remainingTabs = tabs.filter((tab) => {
       const attributes = [
         "selected",
         "multiselected",
@@ -1477,11 +1477,11 @@ class nsZenWorkspaces {
       this.#contextMenuData?.workspaceId || this.activeWorkspace;
 
     const tabsToUnload = this.allStoredTabs.filter(
-      tab =>
+      (tab) =>
         tab.getAttribute("zen-workspace-id") === workspaceId &&
         !tab.hasAttribute("zen-empty-tab") &&
         !tab.hasAttribute("zen-essential") &&
-        !tab.hasAttribute("pending")
+        !tab.hasAttribute("pending"),
     );
 
     if (tabsToUnload.length === 0) {
@@ -1498,11 +1498,11 @@ class nsZenWorkspaces {
       this.#contextMenuData?.workspaceId || this.activeWorkspace;
 
     const tabsToUnload = this.allStoredTabs.filter(
-      tab =>
+      (tab) =>
         tab.getAttribute("zen-workspace-id") !== workspaceId &&
         !tab.hasAttribute("zen-empty-tab") &&
         !tab.hasAttribute("zen-essential") &&
-        !tab.hasAttribute("pending")
+        !tab.hasAttribute("pending"),
     );
 
     await gBrowser.explicitUnloadTabs(tabsToUnload); // TODO: unit test this
@@ -1575,7 +1575,7 @@ class nsZenWorkspaces {
     func,
     opts = {
       once: false,
-    }
+    },
   ) {
     if (!this._changeListeners) {
       this._changeListeners = [];
@@ -1588,7 +1588,7 @@ class nsZenWorkspaces {
       return;
     }
     this._changeListeners = this._changeListeners.filter(
-      listener => listener.func !== func
+      (listener) => listener.func !== func,
     );
   }
 
@@ -1617,7 +1617,7 @@ class nsZenWorkspaces {
 
   async #performWorkspaceChange(
     workspace,
-    { onInit = false, alwaysChange = false, whileScrolling = false } = {}
+    { onInit = false, alwaysChange = false, whileScrolling = false } = {},
   ) {
     const previousWorkspace = this.getActiveWorkspace();
     alwaysChange = alwaysChange || onInit;
@@ -1657,7 +1657,7 @@ class nsZenWorkspaces {
     const tabToSelect = await this._handleTabSelection(
       workspace,
       onInit,
-      previousWorkspace.uuid
+      previousWorkspace.uuid,
     );
     if (tabToSelect.linkedBrowser) {
       gBrowser.warmupTab(tabToSelect);
@@ -1665,7 +1665,7 @@ class nsZenWorkspaces {
 
     // Update UI and state
     const previousWorkspaceIndex = workspaces.findIndex(
-      w => w.uuid === previousWorkspace.uuid
+      (w) => w.uuid === previousWorkspace.uuid,
     );
     await this.#updateWorkspaceState(workspace, onInit, tabToSelect, {
       previousWorkspaceIndex,
@@ -1698,7 +1698,7 @@ class nsZenWorkspaces {
     const usedGroups = new Set();
     let tPos = 0; // _tPos is used for the session store, not needed for folders
     let pPos = 0; // _pPos is used for the pinned tabs manager
-    const recurseFolder = tab => {
+    const recurseFolder = (tab) => {
       if (tab.group) {
         recurseFolder(tab.group);
         if (!usedGroups.has(tab.group.id)) {
@@ -1719,7 +1719,7 @@ class nsZenWorkspaces {
   #updatePaddingTopOnTabs(
     workspaceElement,
     essentialContainer,
-    forAnimation = false
+    forAnimation = false,
   ) {
     if (
       workspaceElement &&
@@ -1741,7 +1741,7 @@ class nsZenWorkspaces {
   _organizeWorkspaceStripLocations(
     workspace,
     justMove = false,
-    offsetPixels = 0
+    offsetPixels = 0,
   ) {
     if (document.documentElement.hasAttribute("zen-creating-workspace")) {
       // If we are creating a workspace, we don't want to animate the strip
@@ -1749,12 +1749,12 @@ class nsZenWorkspaces {
     }
     this._organizingWorkspaceStrip = true;
     const workspaces = this.getWorkspaces();
-    let workspaceIndex = workspaces.findIndex(w => w.uuid === workspace.uuid);
+    let workspaceIndex = workspaces.findIndex((w) => w.uuid === workspace.uuid);
     if (!justMove) {
       this._fixIndicatorsNames(workspaces);
     }
     const otherContainersEssentials = document.querySelectorAll(
-      `#zen-essentials .zen-workspace-tabs-section`
+      `#zen-essentials .zen-workspace-tabs-section`,
     );
     const workspaceContextId = workspace.containerTabId;
     const nextWorkspaceContextId =
@@ -1808,22 +1808,22 @@ class nsZenWorkspaces {
           gZenThemePicker.getGradientForWorkspace(workspace).grain;
         const percentage = Math.abs(offsetPixels) / 200;
         [lazy.browserBackgroundElement, lazy.toolbarBackgroundElement].forEach(
-          element => {
+          (element) => {
             element.style.setProperty(
               "--zen-background-opacity",
-              1 - percentage
+              1 - percentage,
             );
-          }
+          },
         );
         if (!this._hasAnimatedBackgrounds) {
           this._hasAnimatedBackgrounds = true;
           lazy.browserBackgroundElement.style.setProperty(
             "--zen-main-browser-background-old",
-            nextGradient
+            nextGradient,
           );
           lazy.toolbarBackgroundElement.style.setProperty(
             "--zen-main-browser-background-toolbar-old",
-            nextToolbarGradient
+            nextToolbarGradient,
           );
           document.documentElement.setAttribute("animating-background", "true");
         }
@@ -1852,13 +1852,13 @@ class nsZenWorkspaces {
       return;
     }
     const indicatorName = workspaceIndicator.querySelector(
-      ".zen-current-workspace-indicator-name"
+      ".zen-current-workspace-indicator-name",
     );
     const indicatorIcon = workspaceIndicator.querySelector(
-      ".zen-current-workspace-indicator-icon"
+      ".zen-current-workspace-indicator-icon",
     );
     const iconStack = workspaceIndicator.querySelector(
-      ".zen-current-workspace-indicator-stack"
+      ".zen-current-workspace-indicator-stack",
     );
 
     if (this.workspaceHasIcon(currentWorkspace)) {
@@ -1883,7 +1883,7 @@ class nsZenWorkspaces {
   _fixIndicatorsNames(workspaces) {
     for (const workspace of workspaces) {
       const workspaceIndicator = this.workspaceElement(
-        workspace.uuid
+        workspace.uuid,
       )?.indicator;
       this.updateWorkspaceIndicator(workspace, workspaceIndicator);
     }
@@ -1898,7 +1898,7 @@ class nsZenWorkspaces {
       previousWorkspaceIndex = null,
       previousWorkspace = null,
       onInit = false,
-    } = {}
+    } = {},
   ) {
     gZenUIManager.tabsWrapper.style.scrollbarWidth = "none";
     const kGlobalAnimationDuration = 0.2;
@@ -1906,14 +1906,14 @@ class nsZenWorkspaces {
     const animations = [];
     const workspaces = this.getWorkspaces();
     const newWorkspaceIndex = workspaces.findIndex(
-      w => w.uuid === newWorkspace.uuid
+      (w) => w.uuid === newWorkspace.uuid,
     );
     const isGoingLeft = newWorkspaceIndex <= previousWorkspaceIndex;
     const clonedEssentials = [];
     if (shouldAnimate && this.shouldAnimateEssentials && previousWorkspace) {
       for (const workspace of workspaces) {
         const essentialsContainer = this.getEssentialsSection(
-          workspace.containerTabId
+          workspace.containerTabId,
         );
         let lastCloned = clonedEssentials[clonedEssentials.length - 1];
         if (lastCloned && lastCloned.contextId == workspace.containerTabId) {
@@ -1938,7 +1938,7 @@ class nsZenWorkspaces {
     if (shouldAnimate && previousWorkspace) {
       let previousBackgroundOpacity =
         lazy.browserBackgroundElement.style.getPropertyValue(
-          "--zen-background-opacity"
+          "--zen-background-opacity",
         );
       try {
         // Prevent NaN from being set
@@ -1958,10 +1958,10 @@ class nsZenWorkspaces {
         lazy.browserBackgroundElement,
         lazy.toolbarBackgroundElement,
       ];
-      elements.forEach(element => {
+      elements.forEach((element) => {
         element.style.setProperty(
           "--zen-background-opacity",
-          previousBackgroundOpacity
+          previousBackgroundOpacity,
         );
       });
       animations.push(
@@ -1974,8 +1974,8 @@ class nsZenWorkspaces {
             type: "spring",
             bounce: 0,
             duration: kGlobalAnimationDuration,
-          }
-        )
+          },
+        ),
       );
     }
     for (const element of document.querySelectorAll("zen-workspace")) {
@@ -1985,7 +1985,7 @@ class nsZenWorkspaces {
       const existingTransform = element.style.transform;
       const elementWorkspaceId = element.id;
       const elementWorkspaceIndex = workspaces.findIndex(
-        w => w.uuid === elementWorkspaceId
+        (w) => w.uuid === elementWorkspaceId,
       );
       const offset = -(newWorkspaceIndex - elementWorkspaceIndex) * 100;
       const newTransform = `translateX(${offset}%)`;
@@ -2006,8 +2006,8 @@ class nsZenWorkspaces {
               type: "spring",
               bounce: 0,
               duration: kGlobalAnimationDuration,
-            }
-          )
+            },
+          ),
         );
       }
       element.active = offset === 0;
@@ -2019,29 +2019,31 @@ class nsZenWorkspaces {
     }
     if (this.shouldAnimateEssentials && previousWorkspace) {
       // Animate essentials
-      const newWorkspaceEssentialsContainer = clonedEssentials.find(cloned =>
-        cloned.workspaces.some(w => w.uuid === newWorkspace.uuid)
+      const newWorkspaceEssentialsContainer = clonedEssentials.find((cloned) =>
+        cloned.workspaces.some((w) => w.uuid === newWorkspace.uuid),
       );
       // Get a list of essentials containers that are in between the first and last workspace
-      const essentialsContainersInBetween = clonedEssentials.filter(cloned => {
-        const essentialsWorkspaces = cloned.workspaces;
-        const firstIndex = workspaces.findIndex(
-          w => w.uuid === essentialsWorkspaces[0].uuid
-        );
-        const lastIndex = workspaces.findIndex(
-          w =>
-            w.uuid ===
-            essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid
-        );
+      const essentialsContainersInBetween = clonedEssentials.filter(
+        (cloned) => {
+          const essentialsWorkspaces = cloned.workspaces;
+          const firstIndex = workspaces.findIndex(
+            (w) => w.uuid === essentialsWorkspaces[0].uuid,
+          );
+          const lastIndex = workspaces.findIndex(
+            (w) =>
+              w.uuid ===
+              essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid,
+          );
 
-        const [start, end] = [
-          Math.min(previousWorkspaceIndex, newWorkspaceIndex),
-          Math.max(previousWorkspaceIndex, newWorkspaceIndex),
-        ];
+          const [start, end] = [
+            Math.min(previousWorkspaceIndex, newWorkspaceIndex),
+            Math.max(previousWorkspaceIndex, newWorkspaceIndex),
+          ];
 
-        // Check if any part of the container overlaps with the movement range
-        return firstIndex <= end && lastIndex >= start;
-      });
+          // Check if any part of the container overlaps with the movement range
+          return firstIndex <= end && lastIndex >= start;
+        },
+      );
       for (const cloned of clonedEssentials) {
         const container = cloned.container;
         const essentialsWorkspaces = cloned.workspaces;
@@ -2060,12 +2062,12 @@ class nsZenWorkspaces {
 
         // Get the index from first and last workspace
         const firstWorkspaceIndex = workspaces.findIndex(
-          w => w.uuid === essentialsWorkspaces[0].uuid
+          (w) => w.uuid === essentialsWorkspaces[0].uuid,
         );
         const lastWorkspaceIndex = workspaces.findIndex(
-          w =>
+          (w) =>
             w.uuid ===
-            essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid
+            essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid,
         );
         cloned.originalContainer.style.removeProperty("transform");
         // Check if the container is even going to appear on the screen, to save on animation
@@ -2076,15 +2078,15 @@ class nsZenWorkspaces {
           // so we need to check if any of the workspaces in the container are between the
           // first and last workspace.
           !essentialsContainersInBetween.find(
-            ce =>
+            (ce) =>
               ce.workspaces.some(
-                w => w.uuid === essentialsWorkspaces[0].uuid
+                (w) => w.uuid === essentialsWorkspaces[0].uuid,
               ) &&
               ce.workspaces.some(
-                w =>
+                (w) =>
                   w.uuid ===
-                  essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid
-              )
+                  essentialsWorkspaces[essentialsWorkspaces.length - 1].uuid,
+              ),
           )
         ) {
           continue;
@@ -2093,14 +2095,14 @@ class nsZenWorkspaces {
         let stepsInBetween =
           Math.abs(
             newWorkspaceIndex -
-              (isGoingLeft ? firstWorkspaceIndex : lastWorkspaceIndex)
+              (isGoingLeft ? firstWorkspaceIndex : lastWorkspaceIndex),
           ) + 1;
         const usingSameContainer =
           newWorkspaceEssentialsContainer?.workspaces.some(
-            w => w.uuid === newWorkspace.uuid
+            (w) => w.uuid === newWorkspace.uuid,
           ) &&
           newWorkspaceEssentialsContainer?.workspaces.some(
-            w => w.uuid === previousWorkspace.uuid
+            (w) => w.uuid === previousWorkspace.uuid,
           );
         let newOffset =
           -(
@@ -2120,8 +2122,8 @@ class nsZenWorkspaces {
         // we can simply not animate the essentials
         if (
           usingSameContainer &&
-          essentialsWorkspaces.some(w => w.uuid === newWorkspace.uuid) &&
-          essentialsWorkspaces.some(w => w.uuid === previousWorkspace.uuid)
+          essentialsWorkspaces.some((w) => w.uuid === newWorkspace.uuid) &&
+          essentialsWorkspaces.some((w) => w.uuid === previousWorkspace.uuid)
         ) {
           newOffset = 0;
           existingOffset = 0;
@@ -2207,8 +2209,8 @@ class nsZenWorkspaces {
                 type: "spring",
                 bounce: 0,
                 duration: kGlobalAnimationDuration,
-              }
-            )
+              },
+            ),
           );
         }
       }
@@ -2217,14 +2219,14 @@ class nsZenWorkspaces {
       gZenUIManager._preventToolbarRebuild = true;
       gZenUIManager.updateTabsToolbar();
     }
-    let promiseTimeout = new Promise(resolve =>
-      setTimeout(resolve, kGlobalAnimationDuration * 1000 + 50)
+    let promiseTimeout = new Promise((resolve) =>
+      setTimeout(resolve, kGlobalAnimationDuration * 1000 + 50),
     );
     // See issue https://github.com/zen-browser/desktop/issues/9334, we need to add
     // some sort of timeout to the animation promise, just in case it gets stuck.
     // We are doing a race between the timeout and the animations finishing.
     await Promise.race([Promise.all(animations), promiseTimeout]).catch(
-      console.error
+      console.error,
     );
     document.documentElement.removeAttribute("animating-background");
     if (shouldAnimate) {
@@ -2235,7 +2237,7 @@ class nsZenWorkspaces {
       this.updateTabsContainers();
     }
     const essentialsContainer = this.getEssentialsSection(
-      newWorkspace.containerTabId
+      newWorkspace.containerTabId,
     );
     essentialsContainer.removeAttribute("hidden");
     essentialsContainer.style.transform = "none";
@@ -2254,7 +2256,7 @@ class nsZenWorkspaces {
       tab,
       currentWorkspace.uuid,
       currentWorkspace.containerTabId,
-      this.getWorkspaces()
+      this.getWorkspaces(),
     );
   }
 
@@ -2290,7 +2292,8 @@ class nsZenWorkspaces {
         !tabContextId ||
         tabContextId === "0" ||
         !workspaces.some(
-          workspace => workspace.containerTabId === parseInt(tabContextId, 10)
+          (workspace) =>
+            workspace.containerTabId === parseInt(tabContextId, 10),
         )
       );
     }
@@ -2328,14 +2331,14 @@ class nsZenWorkspaces {
         lastSelectedTab,
         workspace.uuid,
         containerId,
-        workspaces
+        workspaces,
       )
     ) {
       tabToSelect = lastSelectedTab;
     }
     // Find first suitable tab
     else {
-      tabToSelect = gBrowser.visibleTabs.find(tab => !tab.pinned);
+      tabToSelect = gBrowser.visibleTabs.find((tab) => !tab.pinned);
       if (!tabToSelect && gBrowser.visibleTabs.length) {
         tabToSelect = gBrowser.visibleTabs[gBrowser.visibleTabs.length - 1];
       }
@@ -2366,7 +2369,7 @@ class nsZenWorkspaces {
     workspace,
     onInit,
     tabToSelect,
-    { previousWorkspaceIndex, previousWorkspace } = {}
+    { previousWorkspaceIndex, previousWorkspace } = {},
   ) {
     // Update document state
     document.documentElement.setAttribute("zen-workspace-id", workspace.uuid);
@@ -2375,7 +2378,7 @@ class nsZenWorkspaces {
     gBrowser.tabContainer.observe(
       null,
       "nsPref:changed",
-      "privacy.userContext.enabled"
+      "privacy.userContext.enabled",
     );
 
     gBrowser.tabContainer.arrowScrollbox = this.activeScrollbox;
@@ -2395,7 +2398,7 @@ class nsZenWorkspaces {
         previousWorkspaceIndex,
         previousWorkspace,
         onInit,
-      }
+      },
     );
     this._organizeWorkspaceStripLocations(workspace, true);
     gZenUIManager.tabsWrapper.style.scrollbarWidth = "";
@@ -2444,7 +2447,7 @@ class nsZenWorkspaces {
       new CustomEvent("ZenWorkspacesUIUpdate", {
         bubbles: true,
         detail: { activeIndex: this.activeWorkspace },
-      })
+      }),
     );
   }
 
@@ -2486,7 +2489,7 @@ class nsZenWorkspaces {
     for (const popup of itemsToFill) {
       let isMoveTabPopup = popup.id === menuPopupID;
       for (const item of popup.querySelectorAll(
-        ".zen-workspace-context-menu-item"
+        ".zen-workspace-context-menu-item",
       )) {
         item.remove();
       }
@@ -2503,7 +2506,7 @@ class nsZenWorkspaces {
         : workspaces) {
         const menuItem = this.generateMenuItemForWorkspace(
           workspace,
-          /* disableCurrent = */ isMoveTabPopup
+          /* disableCurrent = */ isMoveTabPopup,
         );
         if (isMoveTabPopup) {
           popup.prepend(menuItem);
@@ -2549,20 +2552,20 @@ class nsZenWorkspaces {
     icon = undefined,
     dontChange = false,
     containerTabId = 0,
-    { beforeChangeCallback } = { beforeChangeCallback: null } // Callback to run before changing workspace
+    { beforeChangeCallback } = { beforeChangeCallback: null }, // Callback to run before changing workspace
   ) {
     if (!this.workspaceEnabled) {
       return null;
     }
     // get extra tabs remaning (e.g. on new profiles) and just move them to the new workspace
     const extraTabs = Array.from(
-      gBrowser.tabContainer.arrowScrollbox.children
+      gBrowser.tabContainer.arrowScrollbox.children,
     ).filter(
-      child =>
+      (child) =>
         gBrowser.isTab(child) &&
         !child.hasAttribute("zen-workspace-id") &&
         !child.hasAttribute("zen-empty-tab") &&
-        !child.hasAttribute("zen-essential")
+        !child.hasAttribute("zen-essential"),
     );
     let workspaceData = this.#createWorkspaceData(name, icon, containerTabId);
     if (!dontChange) {
@@ -2609,14 +2612,14 @@ class nsZenWorkspaces {
             this.pinnedTabsContainer,
         },
       ],
-      forAnimation
+      forAnimation,
     );
   }
 
   updateShouldHideSeparator(
     arrowScrollbox,
     pinnedContainer,
-    fromTabSelection = false
+    fromTabSelection = false,
   ) {
     const visibleTabsFound = () => {
       let count = 0;
@@ -2647,7 +2650,7 @@ class nsZenWorkspaces {
       const tabs = this.#unpinnedTabsInWorkspace(workspaceID);
       const closableTabs = this.#getClosableTabs(tabs);
       const button = pinnedContainer.querySelector(
-        ".zen-workspace-close-unpinned-tabs-button"
+        ".zen-workspace-close-unpinned-tabs-button",
       );
       if (tabs.length === closableTabs.length) {
         button.setAttribute("can-close", "true");
@@ -2682,12 +2685,12 @@ class nsZenWorkspaces {
       if (entry.target.closest("#zen-essentials")) {
         // Get all workspaces that have the same userContextId
         const userContextId = parseInt(
-          entry.target.getAttribute("container") || "0"
+          entry.target.getAttribute("container") || "0",
         );
         const workspaces = this.getWorkspaces().filter(
-          w => w.containerTabId === userContextId
+          (w) => w.containerTabId === userContextId,
         );
-        workspacesIds.push(...workspaces.map(w => w.uuid));
+        workspacesIds.push(...workspaces.map((w) => w.uuid));
       } else {
         workspacesIds.push(originalWorkspaceId);
       }
@@ -2697,14 +2700,14 @@ class nsZenWorkspaces {
         if (!workspaceElement || !workspaceObject) {
           console.warn(
             "Workspace element or object not found for id",
-            workspaceId
+            workspaceId,
           );
           continue;
         }
         const arrowScrollbox = workspaceElement.tabsContainer;
         const pinnedContainer = workspaceElement.pinnedTabsContainer;
         const essentialContainer = this.getEssentialsSection(
-          workspaceObject.containerTabId
+          workspaceObject.containerTabId,
         );
         const essentialNumChildren = essentialContainer.children.length;
         let essentialHackType = 0;
@@ -2723,7 +2726,7 @@ class nsZenWorkspaces {
         this.#updatePaddingTopOnTabs(
           workspaceElement,
           essentialContainer,
-          forAnimation
+          forAnimation,
         );
         this.updateShouldHideSeparator(arrowScrollbox, pinnedContainer);
       }
@@ -2772,7 +2775,7 @@ class nsZenWorkspaces {
     const isEmpty = gBrowser.selectedTab.hasAttribute("zen-empty-tab");
     gZenCompactModeManager.sidebar.toggleAttribute(
       "zen-has-empty-tab",
-      isEmpty
+      isEmpty,
     );
     document.documentElement.setAttribute("zen-has-empty-tab", isEmpty);
   }
@@ -2831,11 +2834,11 @@ class nsZenWorkspaces {
     this._organizingWorkspaceStrip = true;
     let workspaces = this.getWorkspaces();
     let workspace = workspaces.find(
-      w =>
-        w.uuid === (this.#contextMenuData?.workspaceId || this.activeWorkspace)
+      (w) =>
+        w.uuid === (this.#contextMenuData?.workspaceId || this.activeWorkspace),
     );
     let userContextId = parseInt(
-      event.target.getAttribute("data-usercontextid")
+      event.target.getAttribute("data-usercontextid"),
     );
     workspace.containerTabId = userContextId + 0; // +0 to convert to number
     this.saveWorkspace(workspace);
@@ -2854,7 +2857,7 @@ class nsZenWorkspaces {
 
     const restoreClosedTabsShortcut =
       gZenKeyboardShortcutsManager.getShortcutDisplayFromCommand(
-        "History:RestoreLastClosedTabOrWindowOrSession"
+        "History:RestoreLastClosedTabOrWindowOrSession",
       );
 
     gZenUIManager.showToast("zen-workspaces-close-all-unpinned-tabs-toast", {
@@ -2889,7 +2892,7 @@ class nsZenWorkspaces {
   async changeWorkspaceShortcut(
     offset = 1,
     whileScrolling = false,
-    disableWrap = false
+    disableWrap = false,
   ) {
     // Cycle through workspaces
     let workspaces = this.getWorkspaces();
@@ -2918,7 +2921,7 @@ class nsZenWorkspaces {
         "cmd_zenOpenWorkspaceCreation",
         "zen-context-menu-new-folder-toolbar",
       ];
-      commandsToDisable.forEach(cmd => {
+      commandsToDisable.forEach((cmd) => {
         const element = document.getElementById(cmd);
         if (element) {
           element.setAttribute("disabled", true);
@@ -2947,7 +2950,7 @@ class nsZenWorkspaces {
       gZenGlanceManager.getTabOrGlanceParent(tabs[tabs.length - 1]);
     const workspaces = this.getWorkspaces();
     await this.changeWorkspace(
-      workspaces.find(workspace => workspace.uuid === workspaceID)
+      workspaces.find((workspace) => workspace.uuid === workspaceID),
     );
   }
 
@@ -2966,7 +2969,7 @@ class nsZenWorkspaces {
     ) {
       // Find all workspaces that match the given userContextId
       const matchingWorkspaces = this._workspaceCache.filter(
-        workspace => workspace.containerTabId === userContextId
+        (workspace) => workspace.containerTabId === userContextId,
       );
 
       // Check if exactly one workspace matches
@@ -2996,13 +2999,13 @@ class nsZenWorkspaces {
     const containerId = aTab.getAttribute("usercontextid") ?? "0";
     // Return all tabs that are not on the same workspace
     return gBrowser.tabs.filter(
-      tab =>
+      (tab) =>
         !this._shouldShowTab(
           tab,
           tabWorkspaceId,
           containerId,
-          this._workspaceCache
-        ) && !tab.hasAttribute("zen-empty-tab")
+          this._workspaceCache,
+        ) && !tab.hasAttribute("zen-empty-tab"),
     );
   }
 
@@ -3017,23 +3020,43 @@ class nsZenWorkspaces {
   }
 
   isBookmarkInAnotherWorkspace(bookmark) {
-    if (!this._workspaceBookmarksCache?.bookmarks) {
+    const workspaceBookmarks = this._workspaceBookmarksCache?.bookmarks;
+    if (!workspaceBookmarks || typeof workspaceBookmarks !== "object") {
       return false;
     }
+
     const bookmarkGuid = bookmark.bookmarkGuid;
-    const activeWorkspaceUuid = this.activeWorkspace;
+    if (!bookmarkGuid) {
+      return false;
+    }
+
+    const activeWorkspaceUuid = this.getActiveWorkspaceFromCache()?.uuid;
+    if (!activeWorkspaceUuid) {
+      return false;
+    }
+
+    const validWorkspaceIds = new Set(
+      this.getWorkspaces().map((workspace) => workspace.uuid),
+    );
+
     let isInActiveWorkspace = false;
     let isInOtherWorkspace = false;
 
     for (const [workspaceUuid, bookmarkGuids] of Object.entries(
-      this._workspaceBookmarksCache.bookmarks
+      workspaceBookmarks,
     )) {
-      if (bookmarkGuids.includes(bookmarkGuid)) {
-        if (workspaceUuid === activeWorkspaceUuid) {
-          isInActiveWorkspace = true;
-        } else {
-          isInOtherWorkspace = true;
-        }
+      if (
+        !validWorkspaceIds.has(workspaceUuid) ||
+        !Array.isArray(bookmarkGuids) ||
+        !bookmarkGuids.includes(bookmarkGuid)
+      ) {
+        continue;
+      }
+
+      if (workspaceUuid === activeWorkspaceUuid) {
+        isInActiveWorkspace = true;
+      } else {
+        isInOtherWorkspace = true;
       }
     }
 
@@ -3050,7 +3073,7 @@ class nsZenWorkspaces {
     const tabs = [];
     // we need to go through each tab in each container
     const essentialsContainer = document.querySelectorAll(
-      "#zen-essentials .zen-workspace-tabs-section"
+      "#zen-essentials .zen-workspace-tabs-section",
     );
     let pinnedContainers = [];
     let normalContainers = [];
@@ -3066,7 +3089,7 @@ class nsZenWorkspaces {
           ? -1
           : b.uuid === this.activeWorkspace
             ? 1
-            : 0
+            : 0,
       );
       for (const workspace of workspaces) {
         const container = this.workspaceElement(workspace.uuid);
@@ -3109,7 +3132,7 @@ class nsZenWorkspaces {
   get allTabGroups() {
     if (!this._hasInitializedTabsStrip) {
       let children = this.tabboxChildren;
-      return children.filter(node => gBrowser.isTabGroup(node));
+      return children.filter((node) => gBrowser.isTabGroup(node));
     }
     const pinnedContainers = [];
     const normalContainers = [];
@@ -3153,8 +3176,8 @@ class nsZenWorkspaces {
 
   reorganizeTabsAfterWelcome() {
     const children = gBrowser.tabContainer.arrowScrollbox.children;
-    const remainingTabs = Array.from(children).filter(child =>
-      gBrowser.isTab(child)
+    const remainingTabs = Array.from(children).filter((child) =>
+      gBrowser.isTab(child),
     );
     for (const tab of remainingTabs) {
       this.moveTabToWorkspace(tab, this.activeWorkspace);
@@ -3202,7 +3225,7 @@ class nsZenWorkspaces {
         // Use a mutex-like approach to prevent concurrent workspace changes
         if (this._workspaceChangeInProgress) {
           console.warn(
-            "Workspace change already in progress, deferring tab switch"
+            "Workspace change already in progress, deferring tab switch",
           );
           return;
         }
@@ -3211,15 +3234,15 @@ class nsZenWorkspaces {
         if (tab.hasAttribute("zen-essential")) {
           // Find first workspace with the same container
           const containerTabId = parseInt(
-            tab.parentNode.getAttribute("container")
+            tab.parentNode.getAttribute("container"),
           );
           // +0 to convert to number
           workspaceToSwitch = this._workspaceCache.find(
-            workspace => workspace.containerTabId + 0 === containerTabId
+            (workspace) => workspace.containerTabId + 0 === containerTabId,
           );
         } else {
           workspaceToSwitch = this.getWorkspaceFromId(
-            tab.getAttribute("zen-workspace-id")
+            tab.getAttribute("zen-workspace-id"),
           );
         }
         if (!workspaceToSwitch) {
@@ -3254,7 +3277,7 @@ class nsZenWorkspaces {
       return 0;
     }
     const activeWorkspace = this.activeWorkspace;
-    const workspace = workspaces.find(w => w.uuid === activeWorkspace);
+    const workspace = workspaces.find((w) => w.uuid === activeWorkspace);
     return workspace.containerTabId;
   }
 
@@ -3300,7 +3323,7 @@ class nsZenWorkspaces {
     const widthPerButton = Math.max(
       (parent.clientWidth - separation * (parent.children.length - 1)) /
         parent.children.length,
-      minButtonSize
+      minButtonSize,
     );
     for (const icon of parent.children) {
       if (icon.tagName === "toolbarbutton") {


### PR DESCRIPTION
# Issue: https://github.com/zen-browser/desktop/issues/12241
## What this fixes
This change resolves a workspace bookmark edge case where bookmarks could be treated as missing temporarily (notably when the homepage bookmark is involved across multiple windows/workspaces).

## Changes made
- Fixed `workspaceBookmarks()` to return the bookmark cache object (`_workspaceBookmarksCache`) instead of the workspace cache.
- Hardened `isBookmarkInAnotherWorkspace(...)` by:
  - validating bookmark/cache state before processing,
  - resolving the active workspace safely from cache,
  - ignoring stale/invalid workspace entries,
  - requiring valid bookmark-guid arrays before membership checks.

## Why
The previous cache return path and loose validation could lead to inconsistent workspace-bookmark detection, which caused UI state to incorrectly hide/show bookmarks in some multi-window scenarios.

## Scope
Only `src/zen/spaces/ZenSpaceManager.mjs` was changed.