### PR TITLE
fix: use workspace-aware essentials count for slot limit check

### DIFF
--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -631,7 +631,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     zenAddEssential.hidden = isEssential || !!contextTab.group;
     document.l10n
       .formatValue("tab-context-zen-add-essential-badge", {
-        num: gBrowser._numZenEssentials,
+        num: this._numEssentialsForCurrentWorkspace(),
         max: this.maxEssentialTabs,
       })
       .then(badgeText => {
@@ -911,13 +911,31 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     );
   }
 
+  _numEssentialsForCurrentWorkspace() {
+    if (!gZenWorkspaces.containerSpecificEssentials) {
+      return gBrowser._numZenEssentials;
+    }
+    const activeContainerId =
+      gZenWorkspaces.getActiveWorkspaceFromCache().containerTabId;
+    let count = 0;
+    for (let tab of gBrowser.tabs) {
+      if (
+        tab.hasAttribute("zen-essential") &&
+        (tab.getAttribute("usercontextid") || 0) == activeContainerId
+      ) {
+        count++;
+      }
+    }
+    return count;
+  }
+
   canEssentialBeAdded(tab) {
     return (
       !(
         (tab.getAttribute("usercontextid") || 0) !=
           gZenWorkspaces.getActiveWorkspaceFromCache().containerTabId &&
         gZenWorkspaces.containerSpecificEssentials
-      ) && gBrowser._numZenEssentials < this.maxEssentialTabs
+      ) && this._numEssentialsForCurrentWorkspace() < this.maxEssentialTabs
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #12852

When `zen.workspaces.separate-essentials` is enabled, the "Add to Essentials" context menu uses the **global** essentials count (`gBrowser._numZenEssentials`) for the slot limit check and badge text. This incorrectly disables adding essentials when the total across all workspaces reaches the max (12), even though the current workspace has available slots.

### Changes

- Added `_numEssentialsForCurrentWorkspace()` to `ZenPinnedTabManager` — returns the global count when `separate-essentials` is off (no behavior change), or filters by the active workspace's `containerTabId` when it's on
- Updated `canEssentialBeAdded()` to use the workspace-aware count
- Updated the badge text in `updatePinnedTabContextMenu()` to show per-workspace count

### Notes

- `gBrowser._numZenEssentials` is intentionally left unchanged — it's used elsewhere for DOM tab indexing where the global count is correct
- When `separate-essentials` is disabled, behavior is identical to before (falls through to `gBrowser._numZenEssentials`)

## Test plan

- [ ] Enable `zen.workspaces.separate-essentials` in `about:config`
- [ ] Create 2+ workspaces, add essentials to each so global total >= 12
- [ ] Verify "Add to Essentials" is still available per-workspace when that workspace has < 12
- [ ] Verify badge shows correct per-workspace count (e.g. "5 / 12" not "12 / 12")
- [ ] Disable `separate-essentials`, verify behavior unchanged (global count used)