### PR TITLE
gh-12897: prevent live folder dismissed tabs from reappearing

### DIFF
--- a/src/zen/live-folders/ZenLiveFoldersManager.sys.mjs
+++ b/src/zen/live-folders/ZenLiveFoldersManager.sys.mjs
@@ -384,13 +384,18 @@ class nsZenLiveFoldersManager {
       animate: !folder.collapsed,
     });
 
-    // Remove the dismissed items that are no longer in the given list
-    for (const dismissedItemId of this.dismissedItems) {
-      if (
-        dismissedItemId.startsWith(`${liveFolder.id}:`) &&
-        !itemIds.has(dismissedItemId)
-      ) {
-        this.dismissedItems.delete(dismissedItemId);
+    // Remove the dismissed items that are no longer in the given list.
+    // Only do this when the fetch returned results — an empty list may
+    // indicate a transient failure (e.g. auth expired, HTML changed)
+    // and we must not wipe all dismissals in that case.
+    if (itemIds.size > 0) {
+      for (const dismissedItemId of this.dismissedItems) {
+        if (
+          dismissedItemId.startsWith(`${liveFolder.id}:`) &&
+          !itemIds.has(dismissedItemId)
+        ) {
+          this.dismissedItems.delete(dismissedItemId);
+        }
       }
     }
 


### PR DESCRIPTION
Dismissed live folder tabs (e.g. GitHub PRs) would reappear on startup. Two issues caused this:

1. **Empty fetch wipes dismissals**: `onLiveFolderFetch` cleaned up dismissed items by removing any not in the current fetch results. If a fetch returned an empty list (auth expired, HTML structure changed), all dismissals were cleared — causing every PR to reappear on the next successful fetch.

2. **`saveState` early return**: If any single folder's DOM element wasn't found, the entire `saveState` method returned early, preventing dismissed items for all folders from being persisted.

Fix: guard the dismissed-items cleanup with `itemIds.size > 0`, and change `return` to `continue` in `saveState`.