### PR TITLE
fix: add preference gate for macOS dock progress to preserve Tahoe icon style

### DIFF
--- a/src/browser/components/downloads/DownloadsTaskbar-sys-mjs.patch
+++ b/src/browser/components/downloads/DownloadsTaskbar-sys-mjs.patch
@@ -1,0 +1,20 @@
+diff --git a/browser/components/downloads/DownloadsTaskbar.sys.mjs b/browser/components/downloads/DownloadsTaskbar.sys.mjs
+--- a/browser/components/downloads/DownloadsTaskbar.sys.mjs
++++ b/browser/components/downloads/DownloadsTaskbar.sys.mjs
+@@ -140,6 +140,16 @@
+         (!aForcedBackend && gInterfaces.macTaskbarProgress)
+       ) {
+         // On Mac OS X, we have to register the global indicator only once.
++        // Skip if dock progress is disabled (workaround for macOS Tahoe
++        // Clear icon style reverting to coloured). See Bug 1997246.
++        if (
++          !Services.prefs.getBoolPref(
++            "browser.taskbar.dockProgress.enabled",
++            true
++          )
++        ) {
++          return;
++        }
+         this.#taskbarProgresses.add(gInterfaces.macTaskbarProgress);
+         // Free the XPCOM reference on shutdown, to prevent detecting a leak.
+         Services.obs.addObserver(() => {


### PR DESCRIPTION
## Summary

Adds a `browser.taskbar.dockProgress.enabled` preference (default: `true`) that gates the macOS dock download progress indicator in `DownloadsTaskbar.sys.mjs`. When set to `false`, the dock icon is not replaced with a custom `NSView` during downloads, preserving the macOS Tahoe Clear/Dark/Tinted icon styling.

**Root cause**: Firefox's `nsMacDockSupport` sets `NSDockTile.contentView` to a static bitmap + progress bar overlay, replacing the OS-managed icon that macOS applies icon styling to. After the download completes, macOS does not re-apply the styling. There is no existing preference to control this behaviour.

**Upstream**: [Firefox Bug 1997246](https://bugzilla.mozilla.org/show_bug.cgi?id=1997246)

Closes #12676

## Implementation

Single patch file: `src/browser/components/downloads/DownloadsTaskbar-sys-mjs.patch`

The patch inserts a `Services.prefs.getBoolPref()` check before the `this.#taskbarProgresses.add(gInterfaces.macTaskbarProgress)` call in the macOS branch of `registerIndicator()`. Default is `true` (no behaviour change). Users who want to preserve their Tahoe icon style set `browser.taskbar.dockProgress.enabled` to `false` in `about:config`.

## Testing

I have verified this fix works by binary-patching the equivalent code in `omni.ja` on Zen 1.19.3b / macOS Tahoe. With the preference disabled:
- Downloads complete normally
- Dock icon remains in Clear style throughout
- No dock progress bar is shown (the only visual trade-off)

I have not set up the full Zen build environment to run `surfer import`, so I'd appreciate a maintainer verifying the patch applies cleanly.

## Notes

- Default `true` means no behaviour change for existing users
- macOS-only - Windows and Linux/GTK code paths are not affected
- The preference name follows the existing `browser.taskbar.*` convention

(Re-submitted - previous PR #12875 was inadvertently closed during a commit rewrite.)