### PR TITLE
gh-10189: folder name truncated in search popup (gh-12881)

### DIFF
--- a/src/zen/folders/zen-folders.css
+++ b/src/zen/folders/zen-folders.css
@@ -225,7 +225,9 @@ zen-folder[collapsed] > .tab-group-container {
 /* Tabs popup */
 #zen-folder-tabs-popup {
   --arrowpanel-padding: 0;
-  width: 250px;
+  min-width: 250px;
+  max-width: 400px;
+  width: max-content;
 
   & #zen-folder-tabs-search-no-results {
     height: 100%;
@@ -298,7 +300,6 @@ zen-folder[collapsed] > .tab-group-container {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  width: 250px;
   color: light-dark(black, white);
 }
 


### PR DESCRIPTION
Fixes #10189

The folder tabs popup had a hardcoded `width: 250px` causing folder names to truncate, especially in languages with longer labels (e.g. French "Rechercher dans" vs English "Search").

### Changes

- Popup uses `min-width: 250px` with `max-width: 400px` instead of fixed width, allowing it to grow for longer folder names
- Removed hardcoded `width: 250px` from label elements since they already use flex layout with `text-overflow: ellipsis`