### PR TITLE
gh-12892 Fix a split-vew tab shrinks when pressing on close button

### DIFF
--- a/src/zen/split-view/zen-split-group.inc.css
+++ b/src/zen/split-view/zen-split-group.inc.css
@@ -120,7 +120,7 @@ tab-group[split-view-group] {
       }
     }
 
-    &:active {
+    &:active:not(:has(.tab-content > image:active)) {
       scale: var(--zen-active-tab-scale);
     }
 


### PR DESCRIPTION
This shoud fix #12892

Implementing a condition in CSS rule to prevent split-view tab scaling down when close button is pressed.
