### PR TITLE
Fix other popover layou issues

### DIFF
--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -338,7 +338,8 @@ window.gZenUIManager = {
   // handle the constraint, enabling proper overflow scrolling.
   // See gh-12782
   _constrainNativePopoverHeight(panel) {
-    if (panel.id !== "appMenu-popup") {
+    const panelIds = ["appMenu-popup", "customizationui-widget-panel", "widget-overflow"];
+    if (!panelIds.includes(panel.id)) {
       return;
     }
     // NSPopover adds 13px of chrome on all sides (26px vertical total),

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -347,7 +347,14 @@ window.gZenUIManager = {
     // Previous macOS versions have similar or smaller values, so this is a
     // conservative upper bound.
     const popoverChrome = 26;
-    panel.style.maxHeight = `${window.screen.availHeight - popoverChrome}px`;
+    const anchorHeight = panel.anchorNode?.getBoundingClientRect().height ?? 30;
+    const maxHeight = window.screen.availHeight - popoverChrome;
+    panel.style.maxHeight = `${maxHeight}px`;
+    // Maxed-out panels with arrows look ugly on smaller/normal screens,
+    // and we don't want to patch panelUI.inc.xhtml for now, so we hide them here.
+    if (panel.id === "widget-overflow" || panel.getBoundingClientRect().height >= maxHeight - anchorHeight) {
+      panel.setAttribute("hidepopovertail", "true");
+    }
   },
 
   onPopupShowing(showEvent) {

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -338,7 +338,11 @@ window.gZenUIManager = {
   // handle the constraint, enabling proper overflow scrolling.
   // See gh-12782
   _constrainNativePopoverHeight(panel) {
-    const panelIds = ["appMenu-popup", "customizationui-widget-panel", "widget-overflow"];
+    const panelIds = [
+      "appMenu-popup",
+      "customizationui-widget-panel",
+      "widget-overflow",
+    ];
     if (!panelIds.includes(panel.id)) {
       return;
     }
@@ -347,14 +351,8 @@ window.gZenUIManager = {
     // Previous macOS versions have similar or smaller values, so this is a
     // conservative upper bound.
     const popoverChrome = 26;
-    const anchorHeight = panel.anchorNode?.getBoundingClientRect().height ?? 30;
     const maxHeight = window.screen.availHeight - popoverChrome;
     panel.style.maxHeight = `${maxHeight}px`;
-    // Maxed-out panels with arrows look ugly on smaller/normal screens,
-    // and we don't want to patch panelUI.inc.xhtml for now, so we hide them here.
-    if (panel.id === "widget-overflow" || panel.getBoundingClientRect().height >= maxHeight - anchorHeight) {
-      panel.setAttribute("hidepopovertail", "true");
-    }
   },
 
   onPopupShowing(showEvent) {

--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -596,7 +596,9 @@
 
 /* Overflow panel */
 #widget-overflow-mainView {
-  --menu-panel-width-wide: 200px;
+  /* Overflow popover can contain any panel depending on user settings,
+   * so match appMenu-popup width to ensure most titles are visible. */
+  --menu-panel-width-wide: calc(var(--menu-panel-width) + 32px);
 
   & toolbarbutton {
     scale: 1 !important;

--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -596,9 +596,7 @@
 
 /* Overflow panel */
 #widget-overflow-mainView {
-  /* Overflow popover can contain any panel depending on user settings,
-   * so match appMenu-popup width to ensure most titles are visible. */
-  --menu-panel-width-wide: calc(var(--menu-panel-width) + 32px);
+  --menu-panel-width-wide: 200px;
 
   & toolbarbutton {
     scale: 1 !important;


### PR DESCRIPTION
For popovers triggered by **History, List All Tabs, Library** and **Overflow** menu, there is still a chance that the content is cut off. (See the attachments bellow)

This pr serves as a follow-up to #12782:
- Add height constraint to more popup windows
  - `customisationui-widget-panel`: Triggered by History/List All Tabs/Library/Account/Forget/Developer button in the toolbar
  - `widget-overflow`: Overflow button in the toolbar

Following two commits can be dropped out if you feel like they're not an issue

- Hide popover arrow when panel height is maxed out
  Co-Authored-By: Claude Opus 4.6
- Update `widget-overflow` panel width the same as `appMenu-popup`

### AI Disclosure

Used Claude to generate comments and small refactors

Some comparison between Twilight and local build

[History in Overflow](https://github.com/user-attachments/assets/8e417bec-8006-43c0-9b73-ad40b4141b8a)
[History](https://github.com/user-attachments/assets/3e94b00b-1308-44c9-999a-121430b5d4ab)
[Hiding arrow based on height](https://github.com/user-attachments/assets/b240626a-6de4-4e0c-8b55-0887dc4b2212)
