### PR TITLE
Workspace search filter

### DIFF
--- a/src/browser/components/sessionstore/TabState-sys-mjs.patch
+++ b/src/browser/components/sessionstore/TabState-sys-mjs.patch
@@ -2,7 +2,7 @@ diff --git a/browser/components/sessionstore/TabState.sys.mjs b/browser/componen
 index eb24c3ffdd2cfb33379aca993af5171fdb91ac2c..15d3fbff397df23f112355e22ca5dba5bf29528f 100644
 --- a/browser/components/sessionstore/TabState.sys.mjs
 +++ b/browser/components/sessionstore/TabState.sys.mjs
-@@ -99,7 +99,25 @@ class _TabState {
+@@ -99,7 +99,26 @@ class _TabState {
        }
      }
  
@@ -22,7 +22,8 @@ index eb24c3ffdd2cfb33379aca993af5171fdb91ac2c..15d3fbff397df23f112355e22ca5dba5
 +    tabData.zenLiveFolderItemId = tab.getAttribute("zen-live-folder-item-id");
 +
      tabData.searchMode = tab.ownerGlobal.gURLBar.getSearchMode(browser, true);
-+    if (tabData.searchMode?.source === tab.ownerGlobal.UrlbarUtils.RESULT_SOURCE.ZEN_ACTIONS) {
++    if (tabData.searchMode?.source === tab.ownerGlobal.UrlbarUtils.RESULT_SOURCE.ZEN_ACTIONS ||
++      tabData.searchMode?.source === tab.ownerGlobal.UrlbarUtils.RESULT_SOURCE.ZEN_WORKSPACES) {
 +      delete tabData.searchMode;
 +    }
  

--- a/src/browser/components/urlbar/UrlbarMuxerStandard-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarMuxerStandard-sys-mjs.patch
@@ -19,11 +19,12 @@ index 136c66310f37bda3229b82eef32a4a22a716a0b0..4ca15850002cefda0484179839280e58
        // Discard the result if a tab-to-search result was added already.
        if (!state.canAddTabToSearch) {
          return false;
-@@ -1490,7 +1495,9 @@ class MuxerUnifiedComplete extends UrlbarMuxer {
+@@ -1490,7 +1495,10 @@ class MuxerUnifiedComplete extends UrlbarMuxer {
        usedLimits.maxResultCount++;
      }
  
-+    if (!(result.heuristic && result.source == UrlbarUtils.RESULT_SOURCE.ZEN_ACTIONS)) {
++    if (!(result.heuristic && (result.source == UrlbarUtils.RESULT_SOURCE.ZEN_ACTIONS ||
++        result.source == UrlbarUtils.RESULT_SOURCE.ZEN_WORKSPACES))) {
      state.usedResultSpan += span;
 +    }
      this._updateStatePostAdd(result, state);

--- a/src/browser/components/urlbar/UrlbarPrefs-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarPrefs-sys-mjs.patch
@@ -2,11 +2,12 @@ diff --git a/browser/components/urlbar/UrlbarPrefs.sys.mjs b/browser/components/
 index ec7b7eeee7999aba76286e84808ed09ffc6df463..12bfafdc7e34c5d6345579cd0aaf515a19d82b31 100644
 --- a/browser/components/urlbar/UrlbarPrefs.sys.mjs
 +++ b/browser/components/urlbar/UrlbarPrefs.sys.mjs
-@@ -760,6 +760,7 @@ function makeDefaultResultGroups({ showSearchSuggestionsFirst }) {
+@@ -760,6 +760,8 @@ function makeDefaultResultGroups({ showSearchSuggestionsFirst }) {
     */
    let rootGroup = {
      children: [
 +      { children: [{ group: lazy.UrlbarUtils.RESULT_GROUP.ZEN_ACTION }] },
++      { children: [{ group: lazy.UrlbarUtils.RESULT_GROUP.ZEN_WORKSPACE }] },
        // heuristic
        {
          maxResultCount: 1,

--- a/src/browser/components/urlbar/UrlbarProvidersManager-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarProvidersManager-sys-mjs.patch
@@ -2,11 +2,13 @@ diff --git a/browser/components/urlbar/UrlbarProvidersManager.sys.mjs b/browser/
 index d9a0566c5ad2a9ae375a23769f856aecc6efd86c..f6e5004806d24e009f96de9482e24c88590939b1 100644
 --- a/browser/components/urlbar/UrlbarProvidersManager.sys.mjs
 +++ b/browser/components/urlbar/UrlbarProvidersManager.sys.mjs
-@@ -912,6 +912,7 @@ export class Query {
+@@ -912,6 +912,9 @@ export class Query {
      if (
        result.heuristic &&
        this.context.searchMode &&
 +      !(this.context.searchMode.source === lazy.UrlbarUtils.RESULT_SOURCE.ZEN_ACTIONS && result.payload?.zenAction) &&
++      !(this.context.searchMode.source === lazy.UrlbarUtils.RESULT_SOURCE.ZEN_WORKSPACES &&
++        result.source === lazy.UrlbarUtils.RESULT_SOURCE.ZEN_WORKSPACES) &&
        (!this.context.trimmedSearchString ||
          (!this.context.searchMode.engineName && !result.autofill))
      ) {

--- a/src/browser/components/urlbar/UrlbarUtils-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarUtils-sys-mjs.patch
@@ -2,28 +2,32 @@ diff --git a/browser/components/urlbar/UrlbarUtils.sys.mjs b/browser/components/
 index 9e9f786b6fd3441000d9cdb0b582f817b73ad814..8f86652520a433c94e34fc0e35dc8aad4a86faa2 100644
 --- a/browser/components/urlbar/UrlbarUtils.sys.mjs
 +++ b/browser/components/urlbar/UrlbarUtils.sys.mjs
-@@ -84,6 +84,7 @@ export var UrlbarUtils = {
+@@ -84,6 +84,8 @@ export var UrlbarUtils = {
      RESTRICT_SEARCH_KEYWORD: "restrictSearchKeyword",
      SUGGESTED_INDEX: "suggestedIndex",
      TAIL_SUGGESTION: "tailSuggestion",
 +    ZEN_ACTION: "zenAction",
++    ZEN_WORKSPACE: "zenWorkspace",
    }),
  
    // Defines provider types.
-@@ -145,6 +146,7 @@ export var UrlbarUtils = {
+@@ -145,6 +147,8 @@ export var UrlbarUtils = {
      OTHER_NETWORK: 6,
      ADDON: 7,
      ACTIONS: 8,
 +    ZEN_ACTIONS: 9,
++    ZEN_WORKSPACES: 10,
    }),
  
    // Per-result exposure telemetry.
-@@ -585,6 +587,8 @@ export var UrlbarUtils = {
+@@ -585,6 +589,10 @@ export var UrlbarUtils = {
            return this.RESULT_GROUP.HEURISTIC_FALLBACK;
          case "UrlbarProviderHistoryUrlHeuristic":
            return this.RESULT_GROUP.HEURISTIC_HISTORY_URL;
 +        case "ZenUrlbarProviderGlobalActions":
 +          return this.RESULT_GROUP.ZEN_ACTION;
++        case "ZenUrlbarProviderWorkspaces":
++          return this.RESULT_GROUP.ZEN_WORKSPACE;
          case "UrlbarProviderOmnibox":
            return this.RESULT_GROUP.HEURISTIC_OMNIBOX;
          case "UrlbarProviderRestrictKeywordsAutofill":

--- a/src/browser/components/urlbar/content/UrlbarInput-mjs.patch
+++ b/src/browser/components/urlbar/content/UrlbarInput-mjs.patch
@@ -328,12 +328,13 @@ index 2e6e2be9d7e28c3f189131ec19a26d552d13af99..101b5a3a70c24f28a755f2ca6630a6bc
            break;
          }
  
-@@ -5235,7 +5354,7 @@ export class UrlbarInput extends HTMLElement {
+@@ -5235,7 +5354,8 @@ export class UrlbarInput extends HTMLElement {
      // When we are in actions search mode we can show more results so
      // increase the limit.
      let maxResults =
 -      this.searchMode?.source != lazy.UrlbarUtils.RESULT_SOURCE.ACTIONS
-+      this.searchMode?.source != lazy.UrlbarUtils.RESULT_SOURCE.ZEN_ACTIONS
++      this.searchMode?.source != lazy.UrlbarUtils.RESULT_SOURCE.ZEN_ACTIONS &&
++      this.searchMode?.source != lazy.UrlbarUtils.RESULT_SOURCE.ZEN_WORKSPACES
          ? lazy.UrlbarPrefs.get("maxRichResults")
          : UNLIMITED_MAX_RESULTS;
      let options = {

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -192,6 +192,20 @@ window.gZenUIManager = {
     registerZenUrlbarProviders();
     window.gZenSiteDataPanel = new ZenSiteDataPanel(window);
     gURLBar._zenTrimURL = this.urlbarTrim.bind(this);
+
+    // Listen for '!' as the workspace restriction character in the URL bar.
+    // When the user types '!' as the first character, we enter workspace search
+    // mode (similar to how Firefox uses '*' for bookmarks or '%' for open tabs).
+    gURLBar.inputField.addEventListener("input", () => {
+      const value = gURLBar.inputField.value;
+      if (
+        value.startsWith("!") &&
+        gURLBar.hasAttribute("breakout-extend") &&
+        !this._handlingWorkspaceMode
+      ) {
+        this.enableWorkspaceSearchMode();
+      }
+    });
   },
 
   _debloatContextMenus() {
@@ -446,6 +460,49 @@ window.gZenUIManager = {
       allowAutofill: false,
       event,
     });
+  },
+
+  /**
+   * Enter workspace search mode when the user types '!' in the URL bar.
+   * This is the workspace equivalent of Firefox's restriction characters
+   * (e.g. '*' for bookmarks, '%' for open tabs).
+   */
+  _handlingWorkspaceMode: false,
+  enableWorkspaceSearchMode() {
+    if (!gURLBar.hasAttribute("breakout-extend") || this._animatingSearchMode) {
+      return;
+    }
+    const currentSearchMode = gURLBar.getSearchMode(gBrowser.selectedBrowser);
+    if (currentSearchMode) {
+      // Already in a search mode (e.g. commands mode) — do not override.
+      return;
+    }
+
+    this._handlingWorkspaceMode = true;
+    try {
+      // Strip the leading '!' from the URL bar value so it becomes the
+      // workspace name filter (empty string = show all workspaces).
+      const rawValue = gURLBar.inputField.value;
+      const workspaceQuery = rawValue.startsWith("!")
+        ? rawValue.slice(1).trimStart()
+        : rawValue;
+
+      gURLBar.searchMode = {
+        source: UrlbarUtils.RESULT_SOURCE.ZEN_WORKSPACES,
+        isPreview: true,
+      };
+
+      // Update the URL bar value to the stripped query so the user sees the
+      // workspace filter text without the leading '!'.
+      gURLBar.value = workspaceQuery;
+
+      gURLBar.startQuery({
+        allowAutofill: false,
+        searchString: workspaceQuery,
+      });
+    } finally {
+      this._handlingWorkspaceMode = false;
+    }
   },
 
   get newtabButtons() {

--- a/src/zen/urlbar/ZenUBActionsProvider.sys.mjs
+++ b/src/zen/urlbar/ZenUBActionsProvider.sys.mjs
@@ -158,6 +158,8 @@ export class ZenUrlbarProviderGlobalActions extends UrlbarProvider {
       queryContext.searchMode?.source ==
         UrlbarUtils.RESULT_SOURCE.ZEN_ACTIONS ||
       (lazy.enabledPref &&
+        queryContext.searchMode?.source !==
+          UrlbarUtils.RESULT_SOURCE.ZEN_WORKSPACES &&
         queryContext.searchString &&
         queryContext.searchString.length < UrlbarUtils.MAX_TEXT_LENGTH &&
         queryContext.searchString.length > 2 &&

--- a/src/zen/urlbar/ZenUBProvider.sys.mjs
+++ b/src/zen/urlbar/ZenUBProvider.sys.mjs
@@ -9,6 +9,8 @@ ChromeUtils.defineESModuleGetters(lazy, {
   /* eslint-disable mozilla/valid-lazy */
   ZenUrlbarProviderGlobalActions:
     "resource:///modules/ZenUBActionsProvider.sys.mjs",
+  ZenUrlbarProviderWorkspaces:
+    "resource:///modules/ZenUrlbarProviderWorkspaces.sys.mjs",
 });
 
 export function registerZenUrlbarProviders() {

--- a/src/zen/urlbar/ZenUrlbarProviderWorkspaces.sys.mjs
+++ b/src/zen/urlbar/ZenUrlbarProviderWorkspaces.sys.mjs
@@ -1,0 +1,251 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  UrlbarProvider,
+  UrlbarUtils,
+} from "moz-src:///browser/components/urlbar/UrlbarUtils.sys.mjs";
+
+const lazy = {};
+
+const DYNAMIC_TYPE_NAME = "zen-workspace";
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  UrlbarResult: "moz-src:///browser/components/urlbar/UrlbarResult.sys.mjs",
+  BrowserWindowTracker: "resource:///modules/BrowserWindowTracker.sys.mjs",
+});
+
+/**
+ * A provider that shows workspace switching results when the user types '!'
+ * in the URL bar, or when in the ZEN_WORKSPACES search mode.
+ */
+export class ZenUrlbarProviderWorkspaces extends UrlbarProvider {
+  constructor() {
+    super();
+    lazy.UrlbarResult.addDynamicResultType(DYNAMIC_TYPE_NAME);
+  }
+
+  get name() {
+    return "ZenUrlbarProviderWorkspaces";
+  }
+
+  /**
+   * @returns {Values<typeof UrlbarUtils.PROVIDER_TYPE>}
+   */
+  get type() {
+    return UrlbarUtils.PROVIDER_TYPE.HEURISTIC;
+  }
+
+  /**
+   * Whether this provider should be invoked for the given context.
+   *
+   * @param {UrlbarQueryContext} queryContext The query context object
+   */
+  async isActive(queryContext) {
+    return (
+      queryContext.searchMode?.source ===
+      UrlbarUtils.RESULT_SOURCE.ZEN_WORKSPACES
+    );
+  }
+
+  /**
+   * Calculates a simple fuzzy score for matching a workspace name against a query.
+   *
+   * @param {string} target The workspace name to score.
+   * @param {string} query The user's search query.
+   * @returns {number} A score representing the match quality (higher is better).
+   */
+  #calculateScore(target, query) {
+    if (!query) {
+      return 1;
+    }
+    const targetLower = target.toLowerCase();
+    const queryLower = query.toLowerCase();
+    if (targetLower === queryLower) {
+      return 200;
+    }
+    if (targetLower.startsWith(queryLower)) {
+      return 100 + queryLower.length;
+    }
+    if (targetLower.includes(queryLower)) {
+      return 50;
+    }
+    // Fuzzy: check all query chars appear in order
+    let qi = 0;
+    for (let i = 0; i < targetLower.length && qi < queryLower.length; i++) {
+      if (targetLower[i] === queryLower[qi]) {
+        qi++;
+      }
+    }
+    return qi === queryLower.length ? 10 : 0;
+  }
+
+  /**
+   * Starts a search query for available workspaces.
+   *
+   * @param {UrlbarQueryContext} queryContext
+   * @param {Function} addCallback
+   */
+  async startQuery(queryContext, addCallback) {
+    const query = queryContext.trimmedLowerCaseSearchString;
+    const window = lazy.BrowserWindowTracker.getTopWindow();
+
+    if (window.gZenWorkspaces.privateWindowOrDisabled) {
+      return;
+    }
+
+    const workspaces = window.gZenWorkspaces.getWorkspaces();
+    if (!workspaces?.length) {
+      return;
+    }
+
+    const activeSpaceUUID = window.gZenWorkspaces.activeWorkspace;
+
+    // Score and filter workspaces (exclude the currently active workspace)
+    let scored = [];
+    for (const workspace of workspaces) {
+      if (workspace.uuid === activeSpaceUUID) {
+        continue;
+      }
+      const score = this.#calculateScore(workspace.name || "", query);
+      if (!query || score > 0) {
+        scored.push({ workspace, score });
+      }
+    }
+
+    // Sort by score descending
+    scored.sort((a, b) => b.score - a.score);
+
+    let isFirst = true;
+    for (const { workspace } of scored) {
+      const accentColor = window.gZenWorkspaces
+        .workspaceElement(workspace.uuid)
+        ?.style.getPropertyValue("--zen-primary-color");
+
+      const prettyIconIsSvgOrPng =
+        workspace.icon &&
+        (workspace.icon.endsWith(".svg") || workspace.icon.endsWith(".png"));
+
+      const result = new lazy.UrlbarResult({
+        type: UrlbarUtils.RESULT_TYPE.DYNAMIC,
+        source: UrlbarUtils.RESULT_SOURCE.ZEN_WORKSPACES,
+        payload: {
+          dynamicType: DYNAMIC_TYPE_NAME,
+          workspaceId: workspace.uuid,
+          workspaceName: workspace.name,
+          workspaceIcon: workspace.icon,
+          accentColor: accentColor || "",
+          prettyIconIsSvgOrPng,
+          icon: "chrome://browser/skin/zen-icons/forward.svg",
+        },
+        heuristic: isFirst,
+      });
+      addCallback(this, result);
+      isFirst = false;
+    }
+  }
+
+  /**
+   * Provides the view template for workspace results.
+   */
+  getViewTemplate() {
+    return {
+      attributes: {
+        selectable: true,
+      },
+      children: [
+        {
+          name: "icon",
+          tag: "img",
+          classList: ["urlbarView-favicon"],
+        },
+        {
+          name: "title",
+          tag: "span",
+          classList: ["urlbarView-title"],
+          children: [
+            {
+              name: "titleStrong",
+              tag: "strong",
+            },
+          ],
+        },
+        {
+          tag: "span",
+          classList: ["urlbarView-prettyName"],
+          hidden: true,
+          name: "prettyName",
+          children: [
+            {
+              tag: "img",
+              name: "prettyNameIcon",
+              attributes: { hidden: true },
+            },
+            {
+              name: "prettyNameTitle",
+              tag: "span",
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  /**
+   * Provides the view update for a workspace result.
+   *
+   * @param {UrlbarResult} result
+   */
+  getViewUpdate(result) {
+    const { workspaceName, workspaceIcon, accentColor, prettyIconIsSvgOrPng } =
+      result.payload;
+    return {
+      icon: {
+        attributes: {
+          src: result.payload.icon,
+        },
+      },
+      titleStrong: {
+        textContent: "Switch to",
+        attributes: { dir: "ltr" },
+      },
+      prettyName: {
+        attributes: {
+          hidden: !workspaceName,
+          style: `--zen-primary-color: ${accentColor || "currentColor"}`,
+        },
+      },
+      prettyNameTitle: {
+        /* eslint-disable-next-line no-nested-ternary */
+        textContent: workspaceName
+          ? prettyIconIsSvgOrPng || !workspaceIcon
+            ? workspaceName
+            : `${workspaceIcon}  ${workspaceName}`
+          : "",
+        attributes: { dir: "ltr" },
+      },
+      prettyNameIcon: {
+        attributes: {
+          src: workspaceIcon || "",
+          hidden: !prettyIconIsSvgOrPng || !workspaceIcon,
+        },
+      },
+    };
+  }
+
+  /**
+   * Handles user selection of a workspace result.
+   *
+   * @param {UrlbarQueryContext} queryContext
+   * @param {UrlbarController} controller
+   * @param {object} details
+   */
+  onEngagement(queryContext, controller, details) {
+    const result = details.result;
+    const { workspaceId } = result.payload;
+    const ownerGlobal = details.element.ownerGlobal;
+    ownerGlobal.gBrowser.selectedBrowser.focus();
+    ownerGlobal.gZenWorkspaces.changeWorkspaceWithID(workspaceId);
+  }
+}

--- a/src/zen/urlbar/moz.build
+++ b/src/zen/urlbar/moz.build
@@ -8,4 +8,5 @@ EXTRA_JS_MODULES += [
   "ZenUBGlobalActions.sys.mjs",
   "ZenUBProvider.sys.mjs",
   "ZenUBResultsLearner.sys.mjs",
+  "ZenUrlbarProviderWorkspaces.sys.mjs",
 ]


### PR DESCRIPTION
feat: Add '!' restriction character to filter URL bar results to workspaces

When the user types '!' as the first character in the URL bar, Zen now enters a dedicated workspace search mode (ZEN_WORKSPACES). This works similarly to Firefox's built-in restriction characters:
  * = bookmarks, % = open tabs, ^ = history, > = actions

Changes:
- Add ZenUrlbarProviderWorkspaces provider (zen-workspace dynamic type) that shows workspace-switching results, filtered by name when additional text is typed (e.g. '! work' shows workspaces matching 'work')
- Add '!' input detection in ZenUIManager that strips '!' from the URL bar and enters ZEN_WORKSPACES search mode via enableWorkspaceSearchMode()
- Add ZEN_WORKSPACES (10) to RESULT_SOURCE and ZEN_WORKSPACE to RESULT_GROUP in UrlbarUtils patch
- Add ZEN_WORKSPACE result group to UrlbarPrefs default groups
- Update UrlbarProvidersManager and UrlbarMuxerStandard patches to handle ZEN_WORKSPACES heuristic results correctly
- Prevent ZenUrlbarProviderGlobalActions from activating in ZEN_WORKSPACES mode (avoids duplicate workspace results)
- Do not persist ZEN_WORKSPACES search mode in session store

<img width="1233" height="367" alt="image" src="https://github.com/user-attachments/assets/eef55ca5-9db8-4ff7-a274-24af290509f9" />


Agent-Logs-Url: https://github.com/jababda/zen-desktop/sessions/be5d5852-707d-46d4-acd8-30af05a0b2be
