### PR TITLE
fix external app links not working on linux

### DIFF
--- a/src/zen/common/modules/ZenStartup.mjs
+++ b/src/zen/common/modules/ZenStartup.mjs
@@ -59,6 +59,7 @@ class ZenStartup {
       setTimeout(() => {
         gZenUIManager.init();
         this.#checkForWelcomePage();
+        this.#editZenDesktopLinux();
       }, 0);
     } catch (e) {
       console.error("ZenThemeModifier: Error initializing browser layout", e);
@@ -77,6 +78,39 @@ class ZenStartup {
       Services.obs.removeObserver(this, "browser-delayed-startup-finished");
       this.delayedStartupFinished();
     }
+  }
+
+  async #editZenDesktopLinux() {
+    if (AppConstants.platform !== "linux") {
+      return;
+    }
+
+    if (Services.prefs.getBoolPref("zen-desktop-linux-external-app-links", false)) {
+      return;
+    }
+
+    let dataHome = Services.env.get("XDG_DATA_HOME");
+    if (!dataHome || !PathUtils.isAbsolute(dataHome)) {
+      dataHome = PathUtils.join(
+        Services.dirsvc.get("Home", Ci.nsIFile).path,
+        ".local",
+        "share"
+      );
+    }
+
+    const desktopFilePath = PathUtils.join(dataHome, "applications", "zen.desktop");
+    if (!(await IOUtils.exists(desktopFilePath))) {
+      return;
+    }
+
+    try {
+      let content = await IOUtils.readUTF8(desktopFilePath);
+      if (!/^Exec=.*%[uU]/m.test(content)) {
+        content = content.replace(/^(Exec=.+)$/m, "$1 %u");
+        await IOUtils.writeUTF8(desktopFilePath, content);
+      }
+      Services.prefs.setBoolPref("zen-desktop-linux-external-app-links", true);
+    } catch (ex) {}
   }
 
   delayedStartupFinished() {


### PR DESCRIPTION
Related to #9292

This PR adds %u to the Exec line in zen.desktop file if missing, according to [#10409 (comment)](https://github.com/zen-browser/desktop/issues/10409#issuecomment-3592503811)

I faced with this problem and adding %u fixed it. So I wanted to contribute with a code block that checks zen.desktop file once on startup and sets a pref to avoid rewriting the file on every launch. Changes are tested on Fedora 43 KDE.

Additionally: Tested also the Flatpak version and didn't face with the same issue, so the issue is related to tarball version I think. I don't know how to fix for Windows and MacOS, so this PR for Linux only.

Thank you for this great project.