### PR TITLE
gh-12966: rename split view tab labels for clarity

### DIFF
--- a/locales/bg/browser/browser/zen-split-view.ftl
+++ b/locales/bg/browser/browser/zen-split-view.ftl
@@ -5,8 +5,8 @@
 tab-zen-split-tabs = 
     .label =
         { $tabCount ->
-            [1] Split Tab (multiple selected tabs needed)
-           *[other] Split { $tabCount } Tabs
+            [1] Join Tab (multiple selected tabs needed)
+           *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 zen-split-link = 

--- a/locales/bs/browser/browser/zen-split-view.ftl
+++ b/locales/bs/browser/browser/zen-split-view.ftl
@@ -5,8 +5,8 @@
 tab-zen-split-tabs = 
     .label =
         { $tabCount ->
-            [1] Split Tab (multiple selected tabs needed)
-           *[other] Split { $tabCount } Tabs
+            [1] Join Tab (multiple selected tabs needed)
+           *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 zen-split-link = 

--- a/locales/en-GB/browser/browser/zen-split-view.ftl
+++ b/locales/en-GB/browser/browser/zen-split-view.ftl
@@ -5,8 +5,8 @@
 tab-zen-split-tabs = 
     .label =
         { $tabCount ->
-            [1] Split Tab (multiple selected tabs needed)
-           *[other] Split { $tabCount } Tabs
+            [1] Join Tab (multiple selected tabs needed)
+           *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 zen-split-link = 

--- a/locales/en-US/browser/browser/zen-split-view.ftl
+++ b/locales/en-US/browser/browser/zen-split-view.ftl
@@ -5,9 +5,9 @@
 tab-zen-split-tabs =
     .label =
         { $tabCount ->
-            [-1] Unsplit Tabs
-            [1] Split Tab (multiple selected tabs needed)
-           *[other] Split { $tabCount } Tabs
+            [-1] Split out tab
+            [1] Join Tab (multiple selected tabs needed)
+           *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 

--- a/locales/eu/browser/browser/zen-split-view.ftl
+++ b/locales/eu/browser/browser/zen-split-view.ftl
@@ -5,9 +5,9 @@
 tab-zen-split-tabs = 
     .label =
         { $tabCount ->
-            [-1] Unsplit Tabs
-            [1] Split Tab (multiple selected tabs needed)
-           *[other] Split { $tabCount } Tabs
+            [-1] Split out tab
+            [1] Join Tab (multiple selected tabs needed)
+           *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 zen-split-link = 

--- a/locales/fa/browser/browser/zen-split-view.ftl
+++ b/locales/fa/browser/browser/zen-split-view.ftl
@@ -5,8 +5,8 @@
 tab-zen-split-tabs = 
     .label =
         { $tabCount ->
-            [1] Split Tab (multiple selected tabs needed)
-           *[other] Split { $tabCount } Tabs
+            [1] Join Tab (multiple selected tabs needed)
+           *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 zen-split-link = 

--- a/locales/it/browser/browser/zen-split-view.ftl
+++ b/locales/it/browser/browser/zen-split-view.ftl
@@ -6,7 +6,7 @@ tab-zen-split-tabs =
     .label =
         { $tabCount ->
             [1] Split Tab (sono necessarie più schede selezionate)
-           *[other] Split { $tabCount } Tabs
+           *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 zen-split-link = 

--- a/locales/nn-NO/browser/browser/zen-split-view.ftl
+++ b/locales/nn-NO/browser/browser/zen-split-view.ftl
@@ -5,8 +5,8 @@
 tab-zen-split-tabs = 
     .label =
         { $tabCount ->
-            [1] Split Tab (multiple selected tabs needed)
-           *[other] Split { $tabCount } Tabs
+            [1] Join Tab (multiple selected tabs needed)
+           *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 zen-split-link = 

--- a/locales/ro/browser/browser/zen-split-view.ftl
+++ b/locales/ro/browser/browser/zen-split-view.ftl
@@ -5,8 +5,8 @@
 tab-zen-split-tabs = 
     .label =
         { $tabCount ->
-            [1] Split Tab (multiple selected tabs needed)
-           *[other] Split { $tabCount } Tabs
+            [1] Join Tab (multiple selected tabs needed)
+           *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 zen-split-link = 

--- a/locales/sk/browser/browser/zen-split-view.ftl
+++ b/locales/sk/browser/browser/zen-split-view.ftl
@@ -5,8 +5,8 @@
 tab-zen-split-tabs = 
     .label =
         { $tabCount ->
-            [1] Split Tab (multiple selected tabs needed)
-           *[other] Split { $tabCount } Tabs
+            [1] Join Tab (multiple selected tabs needed)
+           *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 zen-split-link = 

--- a/locales/th/browser/browser/zen-split-view.ftl
+++ b/locales/th/browser/browser/zen-split-view.ftl
@@ -5,8 +5,8 @@
 tab-zen-split-tabs = 
     .label =
         { $tabCount ->
-            [1] Split Tab (multiple selected tabs needed)
-           *[other] Split { $tabCount } Tabs
+            [1] Join Tab (multiple selected tabs needed)
+           *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 zen-split-link = 


### PR DESCRIPTION
## Problem

The split view menu items use confusing terminology (#12966). When tabs are being combined into a split view, the action says "Split N Tabs" — but the tabs are actually being *joined* together. When removing a tab from the split view, it says "Unsplit Tabs" which is awkward.

As discussed in #12951: "Tabs are joined, screen is split."

## Solution

Renamed the menu labels:
- **"Split {N} Tabs"** → **"Join {N} Tabs"** (tabs are being joined into one split view)
- **"Unsplit Tabs"** → **"Split out tab"** (removing a tab from the joined view)

## Files Changed

- `locales/en-US/browser/browser/zen-split-view.ftl` — primary locale
- `locales/en-GB/browser/browser/zen-split-view.ftl` — en-GB locale
- 9 other locale files that had untranslated English strings (bg, bs, eu, fa, it, nn-NO, ro, sk, th)

Locales with proper translations in their native language were intentionally left unchanged for their respective translation teams to update.

Closes #12966