### PR TITLE
gh-12730: conflict keybord shortcut name always shows "Escape"

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1067,7 +1067,7 @@ var gZenCKSSettings = {
             zenMissingKeyboardShortcutL10n[conflictShortcut.getID()] ??
             conflictShortcut.getL10NID();
 
-          const [group] = await document.l10n.formatValues([
+          const [group, conflictName] = await document.l10n.formatValues([
             { id: `${ZEN_CKS_GROUP_PREFIX}-${conflictShortcut.getGroup()}` },
             { id: shortcutL10nKey },
           ]);
@@ -1082,7 +1082,7 @@ var gZenCKSSettings = {
 
           document.l10n.setAttributes(input.nextElementSibling, "zen-key-conflict", {
             group: group ?? "",
-            shortcut: shortcut ?? "",
+            shortcut: conflictName ?? "",
           });
         }
       } else {

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1082,7 +1082,7 @@ var gZenCKSSettings = {
 
           document.l10n.setAttributes(input.nextElementSibling, "zen-key-conflict", {
             group: group ?? "",
-            shortcut: conflictName ?? "",
+            shortcut: conflictName ?? shortcut ?? "",
           });
         }
       } else {


### PR DESCRIPTION
Fix a bug in the keyboard shortcuts page where when a shortcut has a conflict it always shows "Conflict with <group> -> Escape" instead of the correct name.
Resolves #12730