### PR TITLE
gh-12112: auto-focus URL bar when `zen.urlbar.replace-newtab` is disabled

### DIFF
--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -191,7 +191,7 @@ index d88bc0e5570c8fd428a84fdf5af0f6bab1e2a636..be4bedce98f404325e547dd8a4e73e89
        // In full screen mode, only bother making the location bar visible
        // if the tab is a blank one.
 -      if (gURLBar.getBrowserState(newBrowser).urlbarFocused) {
-+      if (gURLBar.getBrowserState(newBrowser).urlbarFocused && (!gZenVerticalTabsManager._hasSetSingleToolbar || isBlankPageURL(newBrowser.currentURI?.spec))) {
++      if (gURLBar.getBrowserState(newBrowser).urlbarFocused && !gZenVerticalTabsManager._hasSetSingleToolbar) {
          let selectURL = () => {
            if (this._asyncTabSwitching) {
              // Set _awaitingSetURI flag to suppress popup notification

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -191,7 +191,7 @@ index d88bc0e5570c8fd428a84fdf5af0f6bab1e2a636..be4bedce98f404325e547dd8a4e73e89
        // In full screen mode, only bother making the location bar visible
        // if the tab is a blank one.
 -      if (gURLBar.getBrowserState(newBrowser).urlbarFocused) {
-+      if (gURLBar.getBrowserState(newBrowser).urlbarFocused && !gZenVerticalTabsManager._hasSetSingleToolbar) {
++      if (gURLBar.getBrowserState(newBrowser).urlbarFocused && (!gZenVerticalTabsManager._hasSetSingleToolbar || isBlankPageURL(newBrowser.currentURI?.spec))) {
          let selectURL = () => {
            if (this._asyncTabSwitching) {
              // Set _awaitingSetURI flag to suppress popup notification

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -945,7 +945,10 @@ class nsZenWorkspaces {
       delete this._initialTab;
     }
 
-    const openOnStartup = Services.prefs.getBoolPref("zen.urlbar.open-on-startup", true);
+    const openOnStartup = Services.prefs.getBoolPref(
+      "zen.urlbar.open-on-startup",
+      true
+    );
     showed &&= openOnStartup;
     initialTabWasEmpty &&= openOnStartup;
 

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -875,10 +875,12 @@ class nsZenWorkspaces {
     };
 
     let removedEmptyTab = false;
+    let initialTabWasEmpty = false;
     if (
       this._initialTab &&
       !(this._initialTab._shouldRemove && this._initialTab._veryPossiblyEmpty)
     ) {
+      initialTabWasEmpty = !!this._initialTab._veryPossiblyEmpty;
       gBrowser.selectedTab = this._initialTab;
       this.moveTabToWorkspace(this._initialTab, this.activeWorkspace);
       gBrowser.moveTabTo(this._initialTab, {
@@ -944,6 +946,7 @@ class nsZenWorkspaces {
     }
 
     showed &&= Services.prefs.getBoolPref("zen.urlbar.open-on-startup", true);
+    initialTabWasEmpty &&= Services.prefs.getBoolPref("zen.urlbar.open-on-startup", true);
 
     // Wait for the next event loop to ensure that the startup focus logic by
     // firefox has finished doing it's thing.
@@ -951,7 +954,9 @@ class nsZenWorkspaces {
       setTimeout(() => {
         if (gZenVerticalTabsManager._canReplaceNewTab && showed) {
           BrowserCommands.openTab();
-        } else if (!showed) {
+        } else if (showed || initialTabWasEmpty) {
+          openLocation();
+        } else {
           gBrowser.selectedBrowser.focus();
         }
       });

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -945,8 +945,9 @@ class nsZenWorkspaces {
       delete this._initialTab;
     }
 
-    showed &&= Services.prefs.getBoolPref("zen.urlbar.open-on-startup", true);
-    initialTabWasEmpty &&= Services.prefs.getBoolPref("zen.urlbar.open-on-startup", true);
+    const openOnStartup = Services.prefs.getBoolPref("zen.urlbar.open-on-startup", true);
+    showed &&= openOnStartup;
+    initialTabWasEmpty &&= openOnStartup;
 
     // Wait for the next event loop to ensure that the startup focus logic by
     // firefox has finished doing it's thing.


### PR DESCRIPTION
Fixes #12112

When zen.urlbar.replace-newtab=false, opening a new window or new tab no longer auto-focused the URL bar.

- New window (Ctrl+N): selectStartPage() never called openLocation() because the `showed` flag is only set on the _tabToRemoveForEmpty path, which requires replace-newtab=true. Fix: track initialTabWasEmpty separately and use it to call openLocation().

- New tab (Ctrl+T): PR #13002 added && !_hasSetSingleToolbar to _adjustFocusAfterTabSwitch to prevent focus-stealing on tab switches, but this also blocked focus for new blank tabs. Fix: allow focus when the tab URL is a blank page (isBlankPageURL).