### PR TITLE
fix: Add changes to the zapping feature, c=boosts, b=no-bug

### DIFF
--- a/src/zen/boosts/ZenZapDissolve.sys.mjs
+++ b/src/zen/boosts/ZenZapDissolve.sys.mjs
@@ -154,6 +154,8 @@ void main() {
   #hasTriggered = false;
   #rafId = null;
 
+  #onComplete = null;
+
   /**
    * @param {Document} document Webpage document
    */
@@ -482,11 +484,13 @@ void main() {
    *
    * @param {Element} element The element to dissolve
    */
-  dissolve(element) {
+  dissolve(element, onComplete) {
     if (!this.#initialized || this.#hasTriggered || !element) {
       return;
     }
     this.#hasTriggered = true;
+
+    this.#onComplete = onComplete;
 
     const rect = element.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) {
@@ -580,6 +584,11 @@ void main() {
     if (this.#rafId) {
       this.window.cancelAnimationFrame(this.#rafId);
       this.#rafId = null;
+    }
+
+    if(this.#onComplete){
+      this.#onComplete();
+      this.#onComplete = null;
     }
   }
 

--- a/src/zen/boosts/ZenZapOverlayChild.sys.mjs
+++ b/src/zen/boosts/ZenZapOverlayChild.sys.mjs
@@ -192,13 +192,21 @@ export class ZapOverlay {
         counter++;
 
         this.#getNextDissolveEffect().then(dissolve => {
-          dissolve.dissolve(element);
+          dissolve.dissolve(element, () => {
+            this.zenBoostsChild.addZapSelector(cssPath);
+            this.onZapUpdate();
+
+            this.window.requestAnimationFrame(() => {
+              element.style.visibility = 'initial';
+            });
+          });
+          element.style.visibility = 'hidden';
         });
       });
+    } else {
+      this.zenBoostsChild.addZapSelector(cssPath);
+      this.onZapUpdate();
     }
-
-    this.zenBoostsChild.addZapSelector(cssPath);
-    this.onZapUpdate();
   }
 
   /**


### PR DESCRIPTION
I've added a fix for the zapping which will now only set the display to none of a zapped element after the dissolve animation is fully complete.

I also plan on looking forward to fixing the color invalidation issue, which is not done yet.