### PR TITLE
gh-12241: fix skip startup bookmark toolbar invalidation when no workspace bookmarks exist

### DIFF
--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -2469,8 +2469,14 @@ class nsZenWorkspaces {
       }
     }
 
-    // Reset bookmarks
-    this.#invalidateBookmarkContainers();
+    // Avoid forcing a startup toolbar rebuild when there are no
+    // workspace-specific bookmark assignments to apply.
+    const hasWorkspaceBookmarks = !!Object.keys(
+      this._workspaceBookmarksCache?.bookmarks || {}
+    ).length;
+    if (!onInit || hasWorkspaceBookmarks) {
+      this.#invalidateBookmarkContainers();
+    }
 
     // Update workspace indicator
     await this.updateWorkspaceIndicator(workspace, this.workspaceIndicator);


### PR DESCRIPTION
Issue: https://github.com/zen-browser/desktop/issues/12241

## Summary

This fixes a Zen-specific issue where opening a second window could make the first bookmarks bar item disappear from the new window's bookmarks toolbar UI.

In the reported repro, the missing bookmark was also set as the homepage, but the proven root cause was not homepage mutation or bookmark deletion.

## Root cause

Zen restores workspace state on second-window startup and always runs:

- `restoreWorkspacesFromSessionStore(...)`
- `changeWorkspace(activeWorkspace, { onInit: true })`

That startup workspace path unconditionally called `#invalidateBookmarkContainers()`, which forced a bookmarks toolbar rebuild.

For the affected profile:

- the bookmark still existed in `moz_bookmarks`
- `browser.startup.homepage` was unchanged
- `zen_bookmarks_workspaces` was empty

So the issue was a Zen-only toolbar rebuild problem, not a Places deletion problem.

## Fix

Skip the startup bookmark-toolbar invalidation when there are no workspace-specific bookmark assignments in the cache.

This keeps the existing behavior for:

- normal workspace switches
- explicit workspace bookmark updates
- profiles that actually use workspace-specific bookmark assignments

## Why this is safe

The change is limited to the Zen startup workspace-init path and only affects the empty workspace-bookmark-cache case.

It does not change:

- bookmark storage
- homepage prefs
- session restore structure
- window sync tab behavior
- Firefox upstream behavior outside the Zen-specific hook

## Notes

The repro happened with the homepage URL also being the first bookmarks bar item, but the code-backed cause is broader: a redundant Zen bookmarks-toolbar rebuild during second-window startup.