### PR TITLE
no-bug: Check Prettier formatting with Husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "lint-staged": {
-    "**/*": ""
+    "*": "prettier --check --cache"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The way lint-staged is currently set up does nothing. This change will make lint-staged check the prettier formatting before every commit. At some point, you may want to start running `npm run lint` in the pre-commit hook as well, but considering that I couldn't get that to work just yet, I haven't added that in this pull request. (The reason I don't use `--write` with prettier is so that it doesn't start formatting files that are marked as improperly formatted simply because no one put it in `.prettierignore`, scenarios like that are why the formatting should be done by the developer.)