### PR TITLE
feat: add about:config pref to reserve specific keyboard shortcuts from page override

### DIFF
--- a/prefs/firefox/browser.yaml
+++ b/prefs/firefox/browser.yaml
@@ -63,6 +63,9 @@
   locked: true
   value: false
 
+- name: zen.keyboard.shortcuts.reserved
+  value: ""
+
 - name: browser.tabs.closeWindowWithLastTab
   value: false
 

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -452,8 +452,8 @@ class KeyShortcut {
     if (this.#disabled) {
       key.setAttribute("disabled", this.#disabled);
     }
-    if (this.#reserved) {
-      key.setAttribute("reserved", this.#reserved);
+    if (this.#reserved || this.#isReservedByPref()) {
+      key.setAttribute("reserved", "true");
     }
     if (this.#internal) {
       key.setAttribute("internal", this.#internal);
@@ -521,6 +521,14 @@ class KeyShortcut {
 
   isReserved() {
     return this.#reserved;
+  }
+
+  #isReservedByPref() {
+    const reserved = Services.prefs.getStringPref("zen.keyboard.shortcuts.reserved", "");
+    if (!reserved) {
+      return false;
+    }
+    return reserved.split(",").map(s => s.trim()).includes(this.#id);
   }
 
   isInternal() {


### PR DESCRIPTION
## Problem

This addresses #8894 — web pages (GitHub, TikTok, Google Docs, etc.) can intercept Zen's keyboard shortcuts before the browser handles them. The most common example: GitHub's "Copy raw file" button registers `data-hotkey="Meta+Shift+C"`, which steals Zen's Copy URL shortcut on file-view pages.

Firefox already has a mechanism for this — the `reserved` attribute on `<key>` elements. Shortcuts like Cmd+Q, Cmd+W, and Cmd+T are marked `reserved="true"` so pages can't override them. But none of Zen's custom shortcuts use this attribute, so they're all vulnerable to page-level interception.

## Approach

Rather than hardcoding `reserved="true"` on specific shortcuts (which is what #10422 attempted before being closed), this PR introduces a new `about:config` pref — `zen.keyboard.shortcuts.reserved` — that accepts a comma-separated list of shortcut IDs. Any shortcut ID in this list gets `reserved="true"` set on its `<key>` element at build time.

For example, setting the pref to `zen-copy-url,zen-copy-url-markdown` reserves just the Copy URL shortcuts from page override.

**Why a pref instead of a hardcoded change:**
- Default value is `""` (empty string), so this changes nothing for existing users
- Power users who are affected by #8894 can selectively reserve the shortcuts that conflict with their most-used sites
- It's granular — you can reserve just the shortcuts that are causing problems, rather than an all-or-nothing approach
- It sidesteps the web compatibility concern (Firefox intentionally leaves most shortcuts unprotected so pages can use them) by making it opt-in

## Changes

- **`prefs/firefox/browser.yaml`** — added `zen.keyboard.shortcuts.reserved` pref with empty string default
- **`src/zen/kbs/ZenKeyboardShortcuts.mjs`** — added `#isReservedByPref()` method to `KeyShortcut` class, called during `<key>` element creation. If the shortcut's ID is in the pref's comma-separated list, `reserved="true"` is set on the element.

## Testing

Tested locally on macOS with a dev build:
- Set `zen.keyboard.shortcuts.reserved` to `zen-copy-url,zen-copy-url-markdown` in `about:config`
- Restarted the browser
- Navigated to a GitHub file-view page (which registers `Meta+Shift+C` via `data-hotkey`)
- Cmd+Shift+C correctly copied the page URL (toast notification appeared, clipboard had the URL — not the raw file content)
- Verified Cmd+Shift+C still works on pages without conflicting hotkeys
- Verified Cmd+Shift+Alt+C (markdown copy) also works correctly
- With the pref set to `""`, behavior is unchanged from current — GitHub's hotkey takes priority as before

## Future considerations

- Currently requires a browser restart for pref changes to take effect (the pref is read when `<key>` elements are built during startup). A pref observer that triggers `_applyShortcuts()` on change could be added to make it live — happy to add that if it would help, but wanted to keep the diff small for now.
- Could also be surfaced in the Keyboard Shortcuts settings UI as a per-shortcut toggle, though that's a larger change.