### PR TITLE
gh-10746: Fix SMAuthorizedClients wrong Team ID

### DIFF
--- a/src/build/moz-configure/update-programs-configure.patch
+++ b/src/build/moz-configure/update-programs-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/build/moz.configure/update-programs.configure b/build/moz.configure/update-programs.configure
+index d87fd6dd35b1211a7ef8f64c2e2af18b91dc1f43..e6691d50e6b2ee05828a25b2dc3cb71895ff6bd7 100644
+--- a/build/moz.configure/update-programs.configure
++++ b/build/moz.configure/update-programs.configure
+@@ -73,7 +73,7 @@ def mac_prod_requirements_string(identifier):
+         f'identifier "{identifier}" and anchor apple generic and '
+         "certificate 1[field.1.2.840.113635.100.6.2.6] and "
+         "certificate leaf[field.1.2.840.113635.100.6.1.13] and "
+-        'certificate leaf[subject.OU] = "43AQ936H96"'
++        'certificate leaf[subject.OU] = "9V5K9TP787"'
+     )
+ 
+ 


### PR DESCRIPTION
## Summary

Corrects the `SMAuthorizedClients` Team ID in `mac_prod_requirements_string()` — currently points to Mozilla's `43AQ936H96` instead of Zen's `9V5K9TP787`. This string is compiled into `MOZ_SMAUTHORIZEDCLIENTS_REQUIREMENTS` and used by the macOS elevated updater to verify allowed clients via their code signing requirements.

This matches the Team ID Zen already uses in `src/security/mac/hardenedruntime/production/firefox-browser-xml.patch` for `com.apple.application-identifier`.

The two certificate OIDs (`1.2.840.113635.100.6.2.6` and `1.2.840.113635.100.6.1.13`) are Apple's Developer ID intermediate + application chain OIDs and are unchanged for any Developer ID-signed app — only the `subject.OU` (Team ID) is org-specific.

## Changes

- Add `src/build/moz-configure/update-programs-configure.patch` (one-line change in `mac_prod_requirements_string`)

## Test plan

- [ ] Build succeeds with patch applied
- [ ] Compiled `MOZ_SMAUTHORIZEDCLIENTS_REQUIREMENTS` references `9V5K9TP787`