### PR TITLE
no-bug: fix SIGNMAR path in Sign MAR step to point at binary not directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -512,7 +512,7 @@ jobs:
 
       - name: Sign MAR files
         env:
-          SIGNMAR: ${{ github.workspace }}/signmar-linux-x86_64
+          SIGNMAR: ${{ github.workspace }}/signmar-linux-x86_64/signmar
           ZEN_MAR_SIGNING_PASSWORD: ${{ secrets.ZEN_MAR_SIGNING_PASSWORD }}
           ZEN_SIGNING_CERT_PEM_BASE64: ${{ secrets.ZEN_SIGNING_CERT_PEM_BASE64 }}
           ZEN_SIGNING_PRIVATE_KEY_PEM_BASE64: ${{ secrets.ZEN_SIGNING_PRIVATE_KEY_PEM_BASE64 }}


### PR DESCRIPTION
## Summary

The current `dev` twilight build fails at the `Sign MAR files` step with:

```
Error: signmar not found at /home/runner/_work/desktop/desktop/signmar-linux-x86_64. Build the engine first.
```

(see run [24212281387](https://github.com/zen-browser/desktop/actions/runs/24212281387) and the currently in-progress run [24217940668](https://github.com/zen-browser/desktop/actions/runs/24217940668), which is on track to hit the same wall once it reaches that step.)

Root cause: the blanket `Download artifact` step at [`build.yml:493`](https://github.com/zen-browser/desktop/blob/dev/.github/workflows/build.yml#L493-L494) uses `actions/download-artifact@v4` with no `name:`, so each artifact is extracted into a subdirectory named after the artifact. That means the `signmar-linux-x86_64` artifact (whose contents is just the `signmar` binary) lands at `${{ github.workspace }}/signmar-linux-x86_64/signmar`.

The `SIGNMAR` env at `build.yml:515` was pointing at `${{ github.workspace }}/signmar-linux-x86_64` — the directory, not the file inside it — so the `[ ! -f "$SIGNMAR" ]` check in `scripts/mar_sign.sh`'s `sign_mars()` correctly fails.

## Fix

One-line: append `/signmar` so `SIGNMAR` resolves to the actual binary.

```diff
-          SIGNMAR: ${{ github.workspace }}/signmar-linux-x86_64
+          SIGNMAR: ${{ github.workspace }}/signmar-linux-x86_64/signmar
```

## Notes

- Related to GHSA-qpj9-m8jc-mw6q — unblocks the twilight MAR signing pipeline that @mr-cheffy wired up in the security-fork PR.
- The dedicated `Download signmar-linux-x86_64 from artifacts` step at L508-L511 is now technically redundant with the blanket download, but left in place for this PR to keep the change minimal and scoped. Happy to follow up with a cleanup PR if preferred.

## Test plan

- [ ] Next twilight scheduled release run reaches the `Sign MAR files` step
- [ ] `bash scripts/mar_sign.sh -s` finds `signmar` and signs the per-arch MAR files
- [ ] Resulting `macos.mar` / `linux-*.mar` / `windows-*.mar` have `num_signatures >= 1` at header offset 16