### PR TITLE
feat: add zen.theme.transparent-content for full native transparency

### DIFF
--- a/prefs/zen/theme.yaml
+++ b/prefs/zen/theme.yaml
@@ -39,6 +39,14 @@
 - name: zen.theme.hide-unified-extensions-button
   value: true
 
+# ==== Mark: transparency ====
+
+# Enables full transparency for web content areas, removing
+# the semi-transparent background overlay so the desktop or
+# wallpaper shows through transparent web pages cleanly.
+- name: zen.theme.transparent-content
+  value: false
+
 # ==== Mark: border radius ====
 
 # -1 will use platform-native values

--- a/src/zen/common/styles/zen-browser-container.css
+++ b/src/zen/common/styles/zen-browser-container.css
@@ -22,6 +22,16 @@
       }
     }
 
+    /* When full transparency is enabled via zen.theme.transparent-content,
+     * remove the semi-transparent overlay from transparent browser containers
+     * so the desktop wallpaper or background shows through cleanly. */
+    /* stylelint-disable-next-line media-query-no-invalid */
+    @media -moz-pref("zen.theme.transparent-content") {
+      & browser[type="content"][transparent="true"] {
+        background: none !important;
+      }
+    }
+
     /* stylelint-disable-next-line media-query-no-invalid */
     @media not -moz-pref("layout.css.prefers-color-scheme.content-override", 2) {
       & browser[type="content"] {

--- a/src/zen/common/styles/zen-browser-ui.css
+++ b/src/zen/common/styles/zen-browser-ui.css
@@ -104,6 +104,16 @@
   }
 }
 
+/* When full transparency is enabled, reduce the browser background
+ * overlay opacity so the window's native transparency effect (Mica,
+ * Acrylic, or compositor transparency on Linux) is more visible. */
+/* stylelint-disable-next-line media-query-no-invalid */
+@media -moz-pref("zen.theme.transparent-content") {
+  .zen-browser-generic-background::after {
+    opacity: calc(var(--zen-background-opacity) * 0.6) !important;
+  }
+}
+
 #zen-browser-background {
   /* This is conceptually a background, but putting this on a pseudo-element
     * avoids it from suppressing the chrome-content separator border, etc.


### PR DESCRIPTION
## Summary

Adds a new `about:config` preference **`zen.theme.transparent-content`** (default: `false`) that enables full transparency for web content areas.

### Problem

Currently, even when `browser.tabs.allow_transparent_browser` is enabled and a page declares itself transparent, Zen still renders a semi-transparent overlay (`rgba(255,255,255,0.4)` in light mode / `rgba(255,255,255,0.1)` in dark mode) over the content area. This prevents the desktop wallpaper from showing through cleanly.

Extensions like [Transparent Zen](https://github.com/frostybiscuit/transparent-zen) currently recommend users add a `userChrome.css` hack to work around this:

```css
& browser[transparent="true"] {
  background: none !important;
}
```

### Solution

This PR adds a native, preference-gated solution:

1. **`prefs/zen/theme.yaml`** — Registers the new `zen.theme.transparent-content` boolean preference (default: `false`)
2. **`src/zen/common/styles/zen-browser-container.css`** — When enabled, removes the semi-transparent background from `browser[transparent="true"]` containers
3. **`src/zen/common/styles/zen-browser-ui.css`** — Reduces the browser background overlay opacity by 40% so the native window transparency (Mica/Acrylic on Windows, compositor on Linux) is more visible

### How to test

1. Enable `browser.tabs.allow_transparent_browser` in `about:config`
2. Enable the appropriate platform transparency:
   - **Windows:** `widget.windows.mica` = `true`
   - **Linux:** `zen.widget.linux.transparency` = `true`
   - **macOS:** Works natively
3. Set `zen.theme.transparent-content` to `true`
4. Visit a website with the Transparent Zen extension or any page that sets transparent backgrounds
5. The desktop wallpaper should show through cleanly without the white overlay

### Before / After

- **Before:** Semi-transparent white overlay covers content area even on transparent pages
- **After:** Full transparency — desktop wallpaper visible through transparent web content

### Notes

- No existing behavior changes when the preference is `false` (default)
- Uses the existing `@media -moz-pref()` pattern already used throughout the codebase
- Addresses feedback from issue #12303 (transparency weirdness) and community requests