### PR TITLE
feat: Add ZenDevUrlDetector for localhost/dev URL detection

### DIFF
--- a/src/zen/common/ZenPreloadedScripts.js
+++ b/src/zen/common/ZenPreloadedScripts.js
@@ -11,6 +11,7 @@
   ChromeUtils.importESModule("resource:///modules/zen/ZenSpaceManager.mjs", { global: "current" });
   ChromeUtils.importESModule("chrome://browser/content/zen-components/ZenCompactMode.mjs", { global: "current" });
   ChromeUtils.importESModule("chrome://browser/content/ZenUIManager.mjs", { global: "current" });
+  ChromeUtils.importESModule("chrome://browser/content/ZenDevUrlDetector.mjs", { global: "current" });
   ChromeUtils.importESModule("chrome://browser/content/zen-components/ZenMods.mjs", { global: "current" });
   ChromeUtils.importESModule("chrome://browser/content/zen-components/ZenKeyboardShortcuts.mjs", { global: "current" });
   ChromeUtils.importESModule("chrome://browser/content/zen-components/ZenSessionStore.mjs", { global: "current" });

--- a/src/zen/common/jar.inc.mn
+++ b/src/zen/common/jar.inc.mn
@@ -9,6 +9,7 @@
         content/browser/ZenStartup.mjs                                          (../../zen/common/modules/ZenStartup.mjs)
         content/browser/ZenUpdates.mjs                                          (../../zen/common/modules/ZenUpdates.mjs)
         content/browser/ZenUIManager.mjs                                        (../../zen/common/modules/ZenUIManager.mjs)
+        content/browser/ZenDevUrlDetector.mjs                                   (../../zen/common/modules/ZenDevUrlDetector.mjs)
         content/browser/zen-components/ZenCommonUtils.mjs                       (../../zen/common/modules/ZenCommonUtils.mjs)
         content/browser/zen-components/ZenSessionStore.mjs                      (../../zen/common/modules/ZenSessionStore.mjs)
         content/browser/zen-components/ZenHasPolyfill.mjs                       (../../zen/common/modules/ZenHasPolyfill.mjs)

--- a/src/zen/common/modules/ZenDevUrlDetector.mjs
+++ b/src/zen/common/modules/ZenDevUrlDetector.mjs
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/**
+ * ZenDevUrlDetector
+ *
+ * Detects when the active tab is on a local/development URL (localhost,
+ * 127.0.0.1, *.local, file://, etc.) and toggles the `zen-dev-url` attribute
+ * on the document element so CSS can style the browser chrome accordingly.
+ *
+ * Controlled by the "zen.urlbar.show-dev-indicator" preference (default: true).
+ *
+ * Inspiration: Arc Browser's DEV URL mode.
+ */
+
+const ZenDevUrlDetector = {
+  PREF: "zen.urlbar.show-dev-indicator",
+
+  // Exact hostnames that are always considered dev
+  _devHosts: new Set(["localhost", "127.0.0.1", "0.0.0.0", "[::1]"]),
+
+  // TLD suffixes that are always considered dev
+  _devTLDs: [".local", ".localhost", ".internal", ".test"],
+
+  get _enabled() {
+    return Services.prefs.getBoolPref(this.PREF, true);
+  },
+
+  init() {
+    // addTabsProgressListener fires for all tabs (active and background).
+    // onLocationChange will only update the UI when the changed tab is
+    // the currently selected one (isTopLevel + browser identity check).
+    gBrowser.addTabsProgressListener(this._progressListener);
+
+    // Detect switching between tabs — re-evaluate current URI
+    window.addEventListener("TabSelect", this);
+
+    // React to the pref being toggled at runtime
+    Services.prefs.addObserver(this.PREF, this);
+
+    // Run once on startup to set initial state
+    this._update();
+  },
+
+  observe(_subject, topic) {
+    if (topic === "nsPref:changed") {
+      this._update();
+    }
+  },
+
+  handleEvent(_event) {
+    this._update();
+  },
+
+  _isDevUri(uri) {
+    if (!uri) return false;
+    try {
+      const { scheme } = uri;
+
+      // file:// URLs are always local
+      if (scheme === "file") return true;
+
+      // Only check http/https; ignore about:, chrome:, etc.
+      if (scheme !== "http" && scheme !== "https") return false;
+
+      const host = uri.host ?? "";
+
+      if (this._devHosts.has(host)) return true;
+      if (this._devTLDs.some(tld => host.endsWith(tld))) return true;
+
+      return false;
+    } catch {
+      return false;
+    }
+  },
+
+  _update() {
+    const isDev = this._enabled && this._isDevUri(gBrowser.currentURI);
+    document.documentElement.toggleAttribute("zen-dev-url", isDev);
+  },
+
+  _progressListener: {
+    QueryInterface: ChromeUtils.generateQI(["nsIWebProgressListener"]),
+
+    // addTabsProgressListener prepends the browser element as the first arg.
+    onLocationChange(aBrowser, aWebProgress, _aRequest, aLocation) {
+      // Only react when the top-level frame of the *active* tab navigates.
+      if (aWebProgress.isTopLevel && aBrowser === gBrowser.selectedBrowser) {
+        const isDev =
+          ZenDevUrlDetector._enabled &&
+          ZenDevUrlDetector._isDevUri(aLocation);
+        document.documentElement.toggleAttribute("zen-dev-url", isDev);
+      }
+    },
+  },
+};
+
+window.gZenDevUrlDetector = ZenDevUrlDetector;

--- a/src/zen/common/modules/ZenStartup.mjs
+++ b/src/zen/common/modules/ZenStartup.mjs
@@ -84,6 +84,7 @@ class ZenStartup {
       await SessionStore.promiseAllWindowsRestored;
       delete gZenUIManager.promiseInitialized;
       gZenCompactModeManager.init();
+      gZenDevUrlDetector.init();
       // Fix for https://github.com/zen-browser/desktop/issues/7605, specially in compact mode
       if (gURLBar.hasAttribute("breakout-extend")) {
         gURLBar.focus();

--- a/src/zen/common/styles/zen-omnibox.css
+++ b/src/zen/common/styles/zen-omnibox.css
@@ -719,3 +719,21 @@
     display: none !important;
   }
 }
+
+/* DEV URL mode — active when gZenDevUrlDetector detects a local/dev URL */
+:root[zen-dev-url] {
+  --zen-dev-url-color: #ff6b35;
+
+  & #urlbar-background {
+    outline: 1.5px solid var(--zen-dev-url-color) !important;
+    outline-offset: -1.5px;
+  }
+
+  & #urlbar:not([breakout-extend="true"]) #urlbar-background {
+    background-color: color-mix(
+      in srgb,
+      var(--zen-dev-url-color) 8%,
+      var(--toolbar-bgcolor)
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Added a dev URL indicator to the Zen URL bar, similar to what Arc Browser does when you're on a local dev server.

- Added a new `ZenDevUrlDetector` module that detects local/dev URLs (localhost, 127.0.0.1, `*.local`, `*.localhost`, `*.internal`, `*.test`, `file://`) and sets a `zen-dev-url` attribute on `<html>`
- Added CSS in `zen-omnibox.css` to show an orange outline and a slight background tint on the URL bar when the attribute is set
- Listens to tab switches and navigation in real time using `gBrowser.addTabsProgressListener`
- Can be turned off with the `zen.urlbar.show-dev-indicator` pref (default: `true`), changes apply right away without restarting

## Test plan

- [ ] Go to `localhost` or `127.0.0.1` and check that the URL bar gets an orange outline
- [ ] Go to `google.com` and check that the orange outline goes away
- [ ] Switch between a localhost tab and a regular tab and make sure the indicator updates correctly
- [ ] Set `zen.urlbar.show-dev-indicator = false` in `about:config` and check that the indicator disappears right away
- [ ] Check that `file://` URLs also trigger the indicator