### PR TITLE
feat(folders): allow unpinned tabs in folders behind pref

### DIFF
--- a/prefs/zen/folders.yaml
+++ b/prefs/zen/folders.yaml
@@ -13,3 +13,13 @@
 
 - name: zen.folders.owned-tabs-in-folder
   value: false
+
+- name: zen.folders.allow-unpinned
+  value: false
+  # Allow creating folders that contain unpinned tabs in the regular
+  # tab area. When false (default), folders may only be created in the
+  # pinned area and any tab added to a folder is force-pinned. When
+  # true, right-clicking an unpinned tab creates a folder in the
+  # regular tab area whose members stay unpinned. This pref only
+  # governs creation — toggling it off does not retroactively pin
+  # existing unpinned folders.

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -1309,6 +1309,7 @@
       if (
         isTabGroupLabel(draggedTab) &&
         draggedTab.group?.isZenFolder &&
+        draggedTab.group?.pinned &&
         (((isTab(dropElement) ||
           dropElement.hasAttribute("split-view-group")) &&
           (!dropElement.pinned || dropElement.hasAttribute("zen-essential"))) ||

--- a/src/zen/folders/ZenFolder.mjs
+++ b/src/zen/folders/ZenFolder.mjs
@@ -68,7 +68,8 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
 
   connectedCallback() {
     super.connectedCallback();
-    this.labelElement.pinned = true;
+    this._isUnpinnedFolder = this.hasAttribute("zen-unpinned-folder");
+    this.labelElement.pinned = !this._isUnpinnedFolder;
     if (this.#initialized) {
       return;
     }
@@ -205,7 +206,7 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
   }
 
   get pinned() {
-    return this.isZenFolder;
+    return this.isZenFolder && !this._isUnpinnedFolder;
   }
 
   /**
@@ -215,7 +216,17 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
    * This no-op setter ensures compatibility with interfaces expecting a pinned property,
    * while preserving the invariant that ZenFolders cannot have their pinned state changed externally.
    */
-  set pinned(value) {}
+  set pinned(value) {
+    if (!Services.prefs.getBoolPref("zen.folders.allow-unpinned", false)) {
+      return; // legacy no-op behavior when pref is off
+    }
+    this._isUnpinnedFolder = !value;
+    if (value) {
+      this.removeAttribute("zen-unpinned-folder");
+    } else {
+      this.setAttribute("zen-unpinned-folder", "true");
+    }
+  }
 
   get iconURL() {
     return this.icon.querySelector("image")?.getAttribute("href") || "";

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -554,38 +554,63 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
   }
 
   createFolder(tabs = [], options = {}) {
+    const allowUnpinned = Services.prefs.getBoolPref(
+      "zen.folders.allow-unpinned",
+      false
+    );
+    const firstRealTab = tabs.find(t => !t.hasAttribute("zen-essential"));
+    const makeUnpinned =
+      allowUnpinned && firstRealTab && !firstRealTab.pinned;
+
     const filteredTabs = tabs
       .filter(tab => !tab.hasAttribute("zen-essential"))
       .map(tab => {
-        gBrowser.pinTab(tab);
+        if (!makeUnpinned) {
+          gBrowser.pinTab(tab);
+        }
         if (tab?.group?.hasAttribute("split-view-group")) {
           tab = tab.group;
         }
         return tab;
       });
 
-    const workspacePinned = gZenWorkspaces.workspaceElement(
-      options.workspaceId
-    )?.pinnedTabsContainer;
-    const pinnedContainer =
-      options.workspaceId && workspacePinned
-        ? workspacePinned
-        : gZenWorkspaces.pinnedTabsContainer;
-    const insertBefore =
-      options.insertBefore ||
-      pinnedContainer.querySelector(".pinned-tabs-container-separator");
+    let insertBefore;
+    if (makeUnpinned) {
+      const workspaceUnpinned = gZenWorkspaces.workspaceElement(
+        options.workspaceId
+      )?.tabsContainer;
+      const unpinnedContainer =
+        options.workspaceId && workspaceUnpinned
+          ? workspaceUnpinned
+          : gZenWorkspaces.activeWorkspaceStrip;
+      insertBefore = options.insertBefore || unpinnedContainer.firstChild;
+    } else {
+      const workspacePinned = gZenWorkspaces.workspaceElement(
+        options.workspaceId
+      )?.pinnedTabsContainer;
+      const pinnedContainer =
+        options.workspaceId && workspacePinned
+          ? workspacePinned
+          : gZenWorkspaces.pinnedTabsContainer;
+      insertBefore =
+        options.insertBefore ||
+        pinnedContainer.querySelector(".pinned-tabs-container-separator");
+    }
+
     const emptyTab = gBrowser.addTab("about:blank", {
       skipAnimation: true,
-      pinned: true,
+      pinned: !makeUnpinned,
       triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
       _forZenEmptyTab: true,
       createLazyBrowser: true,
     });
 
-    gBrowser.pinTab(emptyTab);
+    if (!makeUnpinned) {
+      gBrowser.pinTab(emptyTab);
+    }
     tabs = [emptyTab, ...filteredTabs];
 
-    const folder = this._createFolderNode(options);
+    const folder = this._createFolderNode({ ...options, pinned: !makeUnpinned });
 
     if (options.insertAfter) {
       options.insertAfter.after(folder);
@@ -620,6 +645,9 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     const folder = document.createXULElement("zen-folder", {
       is: "zen-folder",
     });
+    if (options.pinned === false) {
+      folder.setAttribute("zen-unpinned-folder", "true");
+    }
     let id = options.id;
     if (!id) {
       // Note: If this changes, make sure to also update the

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -330,7 +330,14 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
   on_TabOpen(event) {
     const tab = event.target;
     const group = tab.group;
-    if (!group?.isZenFolder || tab.pinned) {
+    if (!group?.isZenFolder) {
+      return;
+    }
+    // Unpinned folders accept unpinned tabs as-is. No force-pin.
+    if (group._isUnpinnedFolder) {
+      return;
+    }
+    if (tab.pinned) {
       return;
     }
     // Edge case: In occations where we add a tab with an ownerTab


### PR DESCRIPTION
## Summary

Adds `zen.folders.allow-unpinned` preference (default `false`). When enabled, folders may contain unpinned tabs in the regular tab area, not only pinned tabs.

- Right-click a **pinned** tab → pinned folder (unchanged behavior)
- Right-click an **unpinned** tab → folder created in regular tab area, tabs stay unpinned
- Existing folders stay pinned — the pref only affects newly created folders
- Toggling the pref off does not retroactively pin existing unpinned folders

Default is `false`, so existing users see zero behavior change.

## Changes

1. **`prefs/zen/folders.yaml`** — new `zen.folders.allow-unpinned` pref (default `false`)
2. **`src/zen/folders/ZenFolder.mjs`** — `pinned` getter/setter backed by `zen-unpinned-folder` attribute + `_isUnpinnedFolder` instance flag initialized in `connectedCallback`; label element pinned state conditioned
3. **`src/zen/folders/ZenFolders.mjs` (`createFolder`)** — compute `makeUnpinned` from first tab's state; skip `gBrowser.pinTab()` for unpinned; select unpinned workspace strip as insertion container; create sentinel empty tab with matching pinned state; pass `pinned: !makeUnpinned` to `_createFolderNode`
4. **`src/zen/folders/ZenFolders.mjs` (`_createFolderNode`)** — honor `options.pinned === false` by setting `zen-unpinned-folder` attribute before DOM attachment
5. **`src/zen/folders/ZenFolders.mjs` (`on_TabOpen`)** — short-circuit for `_isUnpinnedFolder` groups so unpinned tabs aren't force-pinned
6. **`src/zen/drag-and-drop/ZenDragAndDrop.js`** — condition `#applyDragoverIndicator` guard on `draggedTab.group?.pinned` so unpinned folders can be drag-reordered within the regular tab strip

## Session restore

No changes needed to `restoreDataFromSessionStore`. The method already passes `pinned: folderData.pinned` to `_createFolderNode`; with the attribute-based approach, unpinned folders restore naturally:
- `storeDataForSessionStore` serializes the correct `pinned: false` via the updated getter
- The sentinel empty tab is created unpinned, so Firefox's standard restore places it in the regular tab area
- `_createFolderNode` sets the `zen-unpinned-folder` attribute from the serialized data

## Design decisions

- **Only new folders can be unpinned** — no "convert pinned folder to unpinned" UI. The pinned/unpinned state is decided at creation time based on the right-clicked tab.
- **Pref governs creation only** — flipping the pref off doesn't retroactively pin existing unpinned folders, making it safe to toggle.
- **Attribute-based state** — `zen-unpinned-folder` element attribute is the source of truth, read in `connectedCallback`. This unifies both creation and restore paths through `_createFolderNode`.