### PR TITLE
fix: persist custom tab icons across sessions for favicon-less tabs

### DIFF
--- a/src/browser/components/sessionstore/SessionStore-sys-mjs.patch
+++ b/src/browser/components/sessionstore/SessionStore-sys-mjs.patch
@@ -310,8 +310,9 @@ index 3bebeb70e1a88aefb3ef4bc2114bd85b0d8d1e51..5414adeca242f00bff98c5e41de74f33
 +    if (typeof tabData.zenStaticLabel === "string") {
 +      tab.zenStaticLabel = tabData.zenStaticLabel;
 +    }
-+    if (tabData.zenHasStaticIcon && tabData.image) {
-+      tab.zenStaticIcon = tabData.image;
++    const restoredIcon = tabData.zenStaticIconURL || (tabData.zenHasStaticIcon && tabData.image);
++    if (restoredIcon) {
++      tab.zenStaticIcon = restoredIcon;
 +    }
 +    if (tabData.zenDefaultUserContextId) {
 +      tab.setAttribute("zenDefaultUserContextId", true);

--- a/src/browser/components/sessionstore/TabState-sys-mjs.patch
+++ b/src/browser/components/sessionstore/TabState-sys-mjs.patch
@@ -15,6 +15,7 @@ index eb24c3ffdd2cfb33379aca993af5171fdb91ac2c..15d3fbff397df23f112355e22ca5dba5
 +    tabData.zenIsEmpty = tab.hasAttribute("zen-empty-tab");
 +    tabData.zenStaticLabel = tab.zenStaticLabel;
 +    tabData.zenHasStaticIcon = !!tab.zenStaticIcon;
++    tabData.zenStaticIconURL = tab.zenStaticIcon || undefined;
 +    tabData.zenGlanceId = tab.getAttribute("glance-id");
 +    tabData.zenIsGlance = tab.hasAttribute("zen-glance-tab");
 +    tabData._zenPinnedInitialState = tab._zenPinnedInitialState;

--- a/src/zen/common/modules/ZenSessionStore.mjs
+++ b/src/zen/common/modules/ZenSessionStore.mjs
@@ -27,8 +27,9 @@ class ZenSessionStore extends nsZenPreloadedFeature {
     if (typeof tabData.zenStaticLabel === "string") {
       tab.zenStaticLabel = tabData.zenStaticLabel;
     }
-    if (tabData.zenHasStaticIcon && tabData.image) {
-      tab.zenStaticIcon = tabData.image;
+    const restoredIcon = tabData.zenStaticIconURL || (tabData.zenHasStaticIcon && tabData.image);
+    if (restoredIcon) {
+      tab.zenStaticIcon = restoredIcon;
     }
     if (tabData.zenEssential) {
       tab.setAttribute("zen-essential", "true");

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -604,7 +604,8 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
             }
             gBrowser.setIcon(tab, icon);
             lazy.TabStateCache.update(tab.permanentKey, {
-              image: null,
+              zenStaticIconURL: icon || undefined,
+              zenHasStaticIcon: !!icon,
             });
           },
         });


### PR DESCRIPTION
Fixes #13020

## Problem

Custom icons set on tabs without favicons were occasionally discarded after restarting the browser. The root cause was a save/restore mismatch:

- When a custom icon was set, `TabStateCache.update({ image: null })` explicitly cleared the image field in the session cache
- Both restore paths checked `zenHasStaticIcon && tabData.image` — this condition always evaluated to false since `image` was null
- Tabs with real favicons were unaffected because Firefox's async favicon service would later overwrite the null; favicon-less tabs never received such a write

## Fix

- Added a dedicated `zenStaticIconURL` field to the session state so the icon URL is saved independently of `tabData.image`
- Updated both restore paths to prefer `zenStaticIconURL` with fallback to the old `image`-based path for backward compatibility with existing sessions
- Replaced the `image: null` cache update with explicit `zenStaticIconURL` and `zenHasStaticIcon` fields to keep the cache consistent

## Files changed

- `src/browser/components/sessionstore/TabState-sys-mjs.patch`
- `src/browser/components/sessionstore/SessionStore-sys-mjs.patch`
- `src/zen/common/modules/ZenSessionStore.mjs`
- `src/zen/tabs/ZenPinnedTabManager.mjs`