### PR TITLE
fix: #11155 multiple inconsistancies with private window theme

### DIFF
--- a/src/zen/common/styles/zen-theme.css
+++ b/src/zen/common/styles/zen-theme.css
@@ -227,17 +227,21 @@
 
   --toolbar-field-color: var(--toolbox-textcolor) !important;
 
-  &[zen-private-window='true'][zen-dark-private-windows='true'] {
-    --zen-main-browser-background: color-mix(in srgb, rgb(11, 10, 11) 90%, var(--zen-themed-toolbar-bg-transparent));
-    --zen-main-browser-background-toolbar: var(--zen-main-browser-background);
-    --zen-primary-color: rgb(11, 10, 11) !important;
-    /* Make sure its in sync with getToolbarColor */
-    --toolbox-textcolor: rgba(255, 255, 255, 0.8) !important;
-    --toolbar-color-scheme: dark !important;
+  @media -moz-pref("browser.theme.dark-private-windows") {
+    &[zen-private-window='true'] {
+      --zen-main-browser-background: color-mix(in srgb, rgb(11, 10, 11) 90%, var(--zen-themed-toolbar-bg-transparent));
+      --zen-main-browser-background-toolbar: var(--zen-main-browser-background);
+      --zen-primary-color: rgb(11, 10, 11) !important;
+      /* Make sure its in sync with getToolbarColor */
+      --toolbox-textcolor: rgba(255, 255, 255, 0.8) !important;
+      --toolbar-color-scheme: dark !important;
+    }
   }
 
-  &[zen-private-window='true'][zen-dark-private-windows='false'] {
-    --toolbar-color-scheme: light !important;
+  @media not -moz-pref("browser.theme.dark-private-windows") {
+    &[zen-private-window='true'] {
+      --toolbar-color-scheme: light !important;
+    }
   }
 
   &[zen-unsynced-window='true'] {
@@ -329,14 +333,24 @@
       }
     }
 
-    :root[privatebrowsingmode='temporary'][zen-dark-private-windows='true'] &,
-    &[privatebrowsingmode='temporary'][zen-dark-private-windows='true'] {
+    @media -moz-pref("browser.theme.dark-private-windows") {
+      :root[privatebrowsingmode='temporary'] &,
+      &[privatebrowsingmode='temporary'] {
 %include schemes/dark.inc.css
+      }
     }
 
-    :root[privatebrowsingmode='temporary'][zen-dark-private-windows='false'] &,
-    &[privatebrowsingmode='temporary'][zen-dark-private-windows='false'] {
+    @media not -moz-pref("browser.theme.dark-private-windows") {
+      :root[privatebrowsingmode='temporary'] &,
+      &[privatebrowsingmode='temporary'] {
 %include schemes/light.inc.css
+      }
+    }
+  }
+
+  &[privatebrowsingmode='temporary'] #tabbrowser-tabpanels browser[type='content'] {
+    @media not -moz-pref("browser.theme.dark-private-windows") {
+      color-scheme: light dark !important;
     }
   }
 

--- a/src/zen/common/styles/zen-theme.css
+++ b/src/zen/common/styles/zen-theme.css
@@ -241,6 +241,14 @@
   @media not -moz-pref("browser.theme.dark-private-windows") {
     &[zen-private-window='true'] {
       --toolbar-color-scheme: light !important;
+      @media (-moz-system-dark-theme) {
+        --zen-main-browser-background: color-mix(in srgb, rgb(11, 10, 11) 90%, var(--zen-themed-toolbar-bg-transparent));
+        --zen-main-browser-background-toolbar: var(--zen-main-browser-background);
+        --zen-primary-color: rgb(11, 10, 11) !important;
+        /* Make sure its in sync with getToolbarColor */
+        --toolbox-textcolor: rgba(255, 255, 255, 0.8) !important;
+        --toolbar-color-scheme: dark !important;
+      }
     }
   }
 
@@ -344,6 +352,9 @@
       :root[privatebrowsingmode='temporary'] &,
       &[privatebrowsingmode='temporary'] {
 %include schemes/light.inc.css
+        @media (-moz-system-dark-theme) {
+%include schemes/dark.inc.css
+        }
       }
     }
   }

--- a/src/zen/common/styles/zen-theme.css
+++ b/src/zen/common/styles/zen-theme.css
@@ -227,13 +227,17 @@
 
   --toolbar-field-color: var(--toolbox-textcolor) !important;
 
-  &[zen-private-window='true'] {
+  &[zen-private-window='true'][zen-dark-private-windows='true'] {
     --zen-main-browser-background: color-mix(in srgb, rgb(11, 10, 11) 90%, var(--zen-themed-toolbar-bg-transparent));
     --zen-main-browser-background-toolbar: var(--zen-main-browser-background);
     --zen-primary-color: rgb(11, 10, 11) !important;
     /* Make sure its in sync with getToolbarColor */
     --toolbox-textcolor: rgba(255, 255, 255, 0.8) !important;
     --toolbar-color-scheme: dark !important;
+  }
+
+  &[zen-private-window='true'][zen-dark-private-windows='false'] {
+    --toolbar-color-scheme: light !important;
   }
 
   &[zen-unsynced-window='true'] {
@@ -325,9 +329,14 @@
       }
     }
 
-    :root[privatebrowsingmode='temporary'] &,
-    &[privatebrowsingmode='temporary'] {
+    :root[privatebrowsingmode='temporary'][zen-dark-private-windows='true'] &,
+    &[privatebrowsingmode='temporary'][zen-dark-private-windows='true'] {
 %include schemes/dark.inc.css
+    }
+
+    :root[privatebrowsingmode='temporary'][zen-dark-private-windows='false'] &,
+    &[privatebrowsingmode='temporary'][zen-dark-private-windows='false'] {
+%include schemes/light.inc.css
     }
   }
 

--- a/src/zen/spaces/ZenGradientGenerator.mjs
+++ b/src/zen/spaces/ZenGradientGenerator.mjs
@@ -926,9 +926,9 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
             {
               left: existingDot.element.style.left
                 ? [
-                    existingDot.element.style.left,
-                    `${dotPosition.position.x}px`,
-                  ]
+                  existingDot.element.style.left,
+                  `${dotPosition.position.x}px`,
+                ]
                 : `${dotPosition.position.x}px`,
               top: existingDot.element.style.top
                 ? [existingDot.element.style.top, `${dotPosition.position.y}px`]
@@ -1267,8 +1267,8 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
       const blendedAlpha = Math.min(
         1,
         opacity +
-          lazy.MIN_OPACITY +
-          colorToBlendOpacity * (1 - (opacity + lazy.MIN_OPACITY))
+        lazy.MIN_OPACITY +
+        colorToBlendOpacity * (1 - (opacity + lazy.MIN_OPACITY))
       );
       baseColor = this.blendColors(baseColor, colorToBlend, blendedAlpha * 100);
       if (!this.canBeTransparent) {
@@ -1387,8 +1387,10 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
   }
 
   shouldBeDarkMode(accentColor) {
-    if (PrivateBrowsingUtils.isWindowPrivate(window) && !Services.prefs.getBoolPref("browser.theme.dark-private-windows", true)) {
-      return false;
+    if (PrivateBrowsingUtils.isWindowPrivate(window)) {
+      if (Services.prefs.getBoolPref("browser.theme.dark-private-windows", true)) {
+        return true;
+      }
     }
     if (Services.prefs.getBoolPref("zen.theme.use-system-colors")) {
       return this.isDarkMode;

--- a/src/zen/spaces/ZenGradientGenerator.mjs
+++ b/src/zen/spaces/ZenGradientGenerator.mjs
@@ -928,9 +928,9 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
             {
               left: existingDot.element.style.left
                 ? [
-                  existingDot.element.style.left,
-                  `${dotPosition.position.x}px`,
-                ]
+                    existingDot.element.style.left,
+                    `${dotPosition.position.x}px`,
+                  ]
                 : `${dotPosition.position.x}px`,
               top: existingDot.element.style.top
                 ? [existingDot.element.style.top, `${dotPosition.position.y}px`]
@@ -1269,8 +1269,8 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
       const blendedAlpha = Math.min(
         1,
         opacity +
-        lazy.MIN_OPACITY +
-        colorToBlendOpacity * (1 - (opacity + lazy.MIN_OPACITY))
+          lazy.MIN_OPACITY +
+          colorToBlendOpacity * (1 - (opacity + lazy.MIN_OPACITY))
       );
       baseColor = this.blendColors(baseColor, colorToBlend, blendedAlpha * 100);
       if (!this.canBeTransparent) {

--- a/src/zen/spaces/ZenGradientGenerator.mjs
+++ b/src/zen/spaces/ZenGradientGenerator.mjs
@@ -1387,6 +1387,9 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
   }
 
   shouldBeDarkMode(accentColor) {
+    if (PrivateBrowsingUtils.isWindowPrivate(window) && !Services.prefs.getBoolPref("browser.theme.dark-private-windows", true)) {
+      return false;
+    }
     if (Services.prefs.getBoolPref("zen.theme.use-system-colors")) {
       return this.isDarkMode;
     }

--- a/src/zen/spaces/ZenGradientGenerator.mjs
+++ b/src/zen/spaces/ZenGradientGenerator.mjs
@@ -181,7 +181,9 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
 
   get isDarkMode() {
     if (PrivateBrowsingUtils.isWindowPrivate(window)) {
-      return Services.prefs.getBoolPref("browser.theme.dark-private-windows", true);
+      if (Services.prefs.getBoolPref("browser.theme.dark-private-windows", true)) {
+        return true;
+      }
     }
     switch (this.windowSchemeType) {
       case 0:

--- a/src/zen/spaces/ZenGradientGenerator.mjs
+++ b/src/zen/spaces/ZenGradientGenerator.mjs
@@ -181,7 +181,7 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
 
   get isDarkMode() {
     if (PrivateBrowsingUtils.isWindowPrivate(window)) {
-      return true;
+      return Services.prefs.getBoolPref("browser.theme.dark-private-windows", true);
     }
     switch (this.windowSchemeType) {
       case 0:

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -142,6 +142,7 @@ class nsZenWorkspaces {
 
     if (this.isPrivateWindow) {
       document.documentElement.setAttribute("zen-private-window", "true");
+      this.#initPrivateWindowTheme();
     }
 
     this.popupOpenHandler = this._popupOpenHandler.bind(this);
@@ -3408,6 +3409,26 @@ class nsZenWorkspaces {
     if (Services.prefs.getBoolPref("zen.tabs.close-window-with-empty")) {
       document.getElementById("cmd_closeWindow").doCommand();
     }
+  }
+
+  #initPrivateWindowTheme() {
+    const kDarkPrivateWindowsPref = "browser.theme.dark-private-windows";
+    const updateTheme = () => {
+      const isDark = Services.prefs.getBoolPref(kDarkPrivateWindowsPref, true);
+      document.documentElement.setAttribute(
+        "zen-dark-private-windows",
+        isDark ? "true" : "false"
+      );
+    };
+    Services.prefs.addObserver(kDarkPrivateWindowsPref, updateTheme);
+    updateTheme();
+    window.addEventListener(
+      "unload",
+      () => {
+        Services.prefs.removeObserver(kDarkPrivateWindowsPref, updateTheme);
+      },
+      { once: true }
+    );
   }
 }
 

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -142,7 +142,6 @@ class nsZenWorkspaces {
 
     if (this.isPrivateWindow) {
       document.documentElement.setAttribute("zen-private-window", "true");
-      this.#initPrivateWindowTheme();
     }
 
     this.popupOpenHandler = this._popupOpenHandler.bind(this);
@@ -3409,26 +3408,6 @@ class nsZenWorkspaces {
     if (Services.prefs.getBoolPref("zen.tabs.close-window-with-empty")) {
       document.getElementById("cmd_closeWindow").doCommand();
     }
-  }
-
-  #initPrivateWindowTheme() {
-    const kDarkPrivateWindowsPref = "browser.theme.dark-private-windows";
-    const updateTheme = () => {
-      const isDark = Services.prefs.getBoolPref(kDarkPrivateWindowsPref, true);
-      document.documentElement.setAttribute(
-        "zen-dark-private-windows",
-        isDark ? "true" : "false"
-      );
-    };
-    Services.prefs.addObserver(kDarkPrivateWindowsPref, updateTheme);
-    updateTheme();
-    window.addEventListener(
-      "unload",
-      () => {
-        Services.prefs.removeObserver(kDarkPrivateWindowsPref, updateTheme);
-      },
-      { once: true }
-    );
   }
 }
 


### PR DESCRIPTION
Targeting #11155: websites in private browing are always in dark theme when `browser.theme.dark-private-windows` is set to false.

- In `ZenGradientGenerator.mjs`, `isDarkMode` was hardcoded to return true whenever a window was private
    - changed to `return Services.prefs.getBoolPref("browser.theme.dark-private-windows", true);`
    - `shouldBeDarkMode` has a special case handling for private + `dark-private-windows` flag
- In `zen-theme.css`, the rules for private windows were hardcoded to always include `dark.inc.css`, and the css was not aware of the `browser.theme.dark-private-windows` flag
    - wrapped the code with `@media -moz-pref("browser.theme.dark-private-windows")`
    - added `color-scheme: light dark !important` for private windows

The default behavior (`browser.theme.dark-private-windows` is true) is not changed. When the flag is false, both the browser UI and the web content should follow system theme. The light theme comes from `schemes/light.inc.css`.