### PR TITLE
Linux: add .deb packaging and desktop integration helper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -438,6 +438,48 @@ jobs:
           name: zen-${{ matrix.arch }}.AppImage.zsync
           path: ./dist/zen-${{ matrix.arch }}.AppImage.zsync
 
+  deb:
+    name: DEB build - Linux ${{ matrix.arch }}
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+    needs: [linux, build-data]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install dpkg-dev desktop-file-utils
+
+      - name: Download Linux build
+        uses: actions/download-artifact@v4
+        with:
+          name: zen.linux-${{ matrix.arch }}.tar.xz
+
+      - name: Build Debian package
+        run: |
+          set -eux
+          bash scripts/build-deb.sh \
+            --archive zen.linux-${{ matrix.arch }}.tar.xz \
+            --arch ${{ matrix.arch }} \
+            --version ${{ needs.build-data.outputs.version }} \
+            --brand ${{ inputs.update_branch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 5
+          name: zen-${{ matrix.arch }}.deb
+          path: ./dist/*.deb
+
   stop-self-hosted:
     runs-on: ubuntu-latest
     needs: [windows-step-3, linux]
@@ -476,6 +518,7 @@ jobs:
         check-release,
         mac-uni,
         appimage,
+        deb,
         source,
         stop-self-hosted,
       ]
@@ -559,6 +602,8 @@ jobs:
             ./zen.source.tar.zst/*
             ./zen.linux-x86_64.tar.xz/*
             ./zen.linux-aarch64.tar.xz/*
+            ./zen-x86_64.deb/*
+            ./zen-aarch64.deb/*
             ./zen-x86_64.AppImage/*
             ./zen-x86_64.AppImage.zsync/*
             ./zen-aarch64.AppImage/*
@@ -596,6 +641,8 @@ jobs:
             ./zen.source.tar.zst/*
             ./zen.linux-x86_64.tar.xz/*
             ./zen.linux-aarch64.tar.xz/*
+            ./zen-x86_64.deb/*
+            ./zen-aarch64.deb/*
             ./zen-x86_64.AppImage/*
             ./zen-x86_64.AppImage.zsync/*
             ./zen-aarch64.AppImage/*

--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ If you'd like to report a bug, please do so on our [GitHub Issues page](https://
 
 Zen is an open-source project, and we welcome contributions from the community! Please take a look at the [contribution guidelines](./docs/contribute.md) before getting started!
 
+### Linux (Ubuntu) install quality
+
+If you're using the unpacked Linux archive and want proper launcher/taskbar support:
+
+1. Extract the Zen archive so you have a folder containing the `zen` executable.
+2. Run:
+
+  `bash scripts/install-linux-desktop-entry.sh --zen-dir /path/to/zen`
+
+This installs a user-level desktop entry and icon so Zen shows correctly in launchers and can be pinned to the dock/taskbar.
+
+For release automation, this repository now also builds Debian packages (`.deb`) for `x86_64` and `aarch64` in CI and publishes them as release artifacts.
+
 #### Partners
 
 Thanks to all the partners of Zen for their support and contributions:

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Build a Debian package from a Zen Linux archive.
+
+Usage:
+  scripts/build-deb.sh --archive <zen.linux-ARCH.tar.xz> --arch <x86_64|aarch64> --version <version> [--brand <release|twilight>] [--out-dir <dir>]
+EOF
+}
+
+ARCHIVE=""
+ARCH=""
+VERSION=""
+BRAND="release"
+OUT_DIR="dist"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --archive)
+      ARCHIVE="$2"
+      shift 2
+      ;;
+    --arch)
+      ARCH="$2"
+      shift 2
+      ;;
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --brand)
+      BRAND="$2"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$ARCHIVE" || -z "$ARCH" || -z "$VERSION" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$ARCHIVE" ]]; then
+  echo "Archive not found: $ARCHIVE" >&2
+  exit 1
+fi
+
+case "$ARCH" in
+  x86_64)
+    DEB_ARCH="amd64"
+    ;;
+  aarch64)
+    DEB_ARCH="arm64"
+    ;;
+  *)
+    echo "Unsupported arch: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+case "$BRAND" in
+  release)
+    PKG_NAME="zen-browser"
+    APP_NAME="Zen Browser"
+    BIN_NAME="zen"
+    DESKTOP_ID="zen"
+    WM_CLASS="zen"
+    ;;
+  twilight)
+    PKG_NAME="zen-twilight"
+    APP_NAME="Zen Twilight"
+    BIN_NAME="zen-twilight"
+    DESKTOP_ID="zen-twilight"
+    WM_CLASS="zen-twilight"
+    ;;
+  *)
+    echo "Unsupported brand: $BRAND" >&2
+    exit 1
+    ;;
+esac
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+STAGE_ROOT="$WORKDIR/stage"
+SRC_ROOT="$WORKDIR/src"
+OPT_DIR="$STAGE_ROOT/opt/$PKG_NAME"
+DEBIAN_DIR="$STAGE_ROOT/DEBIAN"
+
+mkdir -p "$SRC_ROOT" "$OPT_DIR" "$DEBIAN_DIR"
+tar -xf "$ARCHIVE" -C "$SRC_ROOT"
+
+if [[ ! -d "$SRC_ROOT/zen" ]]; then
+  echo "Expected top-level 'zen' directory in archive." >&2
+  exit 1
+fi
+
+cp -a "$SRC_ROOT/zen/." "$OPT_DIR/"
+
+mkdir -p "$STAGE_ROOT/usr/bin"
+ln -s "/opt/$PKG_NAME/zen" "$STAGE_ROOT/usr/bin/$BIN_NAME"
+
+mkdir -p "$STAGE_ROOT/usr/share/applications"
+cat > "$STAGE_ROOT/usr/share/applications/$DESKTOP_ID.desktop" <<EOF
+[Desktop Entry]
+Name=$APP_NAME
+Comment=Experience tranquillity while browsing the web without people tracking you!
+Exec=$BIN_NAME %u
+Icon=$DESKTOP_ID
+Type=Application
+MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;application/x-xpinstall;application/pdf;application/json;
+StartupWMClass=$WM_CLASS
+Categories=Network;WebBrowser;
+StartupNotify=true
+Terminal=false
+X-MultipleArgs=false
+Keywords=Internet;WWW;Browser;Web;Explorer;
+Actions=new-window;new-blank-window;new-private-window;profilemanager;
+
+[Desktop Action new-window]
+Name=Open a New Window
+Exec=$BIN_NAME %u
+
+[Desktop Action new-blank-window]
+Name=Open a New Blank Window
+Exec=$BIN_NAME --blank-window %u
+
+[Desktop Action new-private-window]
+Name=Open a New Private Window
+Exec=$BIN_NAME --private-window %u
+
+[Desktop Action profilemanager]
+Name=Open the Profile Manager
+Exec=$BIN_NAME --ProfileManager %u
+EOF
+
+for size in 16 22 24 32 48 64 128 256 512; do
+  mkdir -p "$STAGE_ROOT/usr/share/icons/hicolor/${size}x${size}/apps"
+  cp "configs/branding/$BRAND/logo${size}.png" "$STAGE_ROOT/usr/share/icons/hicolor/${size}x${size}/apps/$DESKTOP_ID.png"
+done
+
+cat > "$DEBIAN_DIR/control" <<EOF
+Package: $PKG_NAME
+Version: $VERSION
+Section: web
+Priority: optional
+Architecture: $DEB_ARCH
+Maintainer: Zen OSS Team <support@zen-browser.app>
+Depends: libasound2, libdbus-1-3, libgtk-3-0
+Recommends: libcanberra0
+Description: $APP_NAME
+ Zen is a Firefox-based browser focused on productivity and privacy.
+EOF
+
+cat > "$DEBIAN_DIR/postinst" <<'EOF'
+#!/usr/bin/env bash
+set -e
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database -q || true
+fi
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -q /usr/share/icons/hicolor || true
+fi
+EOF
+
+cat > "$DEBIAN_DIR/postrm" <<'EOF'
+#!/usr/bin/env bash
+set -e
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database -q || true
+fi
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -q /usr/share/icons/hicolor || true
+fi
+EOF
+
+chmod 755 "$DEBIAN_DIR/postinst" "$DEBIAN_DIR/postrm"
+
+mkdir -p "$OUT_DIR"
+OUT_FILE="$OUT_DIR/${PKG_NAME}_${VERSION}_${DEB_ARCH}.deb"
+dpkg-deb --build --root-owner-group "$STAGE_ROOT" "$OUT_FILE"
+
+echo "Created $OUT_FILE"

--- a/scripts/install-linux-desktop-entry.sh
+++ b/scripts/install-linux-desktop-entry.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Install a user-local desktop launcher and icon for an unpacked Zen build.
+
+Usage:
+  scripts/install-linux-desktop-entry.sh --zen-dir <path-to-unpacked-zen-folder> [--brand <release|twilight>]
+EOF
+}
+
+ZEN_DIR=""
+BRAND="release"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --zen-dir)
+      ZEN_DIR="$2"
+      shift 2
+      ;;
+    --brand)
+      BRAND="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$ZEN_DIR" ]]; then
+  usage
+  exit 1
+fi
+
+ZEN_DIR="$(readlink -f "$ZEN_DIR")"
+ZEN_BIN="$ZEN_DIR/zen"
+if [[ ! -x "$ZEN_BIN" ]]; then
+  echo "Could not find executable at: $ZEN_BIN" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$BRAND" in
+  release)
+    APP_NAME="Zen Browser"
+    DESKTOP_ID="zen"
+    WM_CLASS="zen"
+    ;;
+  twilight)
+    APP_NAME="Zen Twilight"
+    DESKTOP_ID="zen-twilight"
+    WM_CLASS="zen-twilight"
+    ;;
+  *)
+    echo "Unsupported brand: $BRAND" >&2
+    exit 1
+    ;;
+esac
+
+ICON_CANDIDATES=(
+  "$ZEN_DIR/browser/chrome/icons/default/default128.png"
+  "$SCRIPT_DIR/../configs/branding/$BRAND/logo128.png"
+)
+
+ICON_SRC=""
+for candidate in "${ICON_CANDIDATES[@]}"; do
+  if [[ -f "$candidate" ]]; then
+    ICON_SRC="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$ICON_SRC" ]]; then
+  echo "Could not find an icon source. Checked:" >&2
+  printf '  - %s\n' "${ICON_CANDIDATES[@]}" >&2
+  exit 1
+fi
+
+APP_DIR="$HOME/.local/share/applications"
+ICON_DIR="$HOME/.local/share/icons/hicolor/128x128/apps"
+DESKTOP_FILE="$APP_DIR/$DESKTOP_ID.desktop"
+ICON_TARGET="$ICON_DIR/$DESKTOP_ID.png"
+
+mkdir -p "$APP_DIR" "$ICON_DIR"
+cp "$ICON_SRC" "$ICON_TARGET"
+
+cat > "$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Name=$APP_NAME
+Comment=Experience tranquillity while browsing the web without people tracking you!
+Exec=$ZEN_BIN %u
+Icon=$DESKTOP_ID
+Type=Application
+MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;application/x-xpinstall;application/pdf;application/json;
+StartupWMClass=$WM_CLASS
+Categories=Network;WebBrowser;
+StartupNotify=true
+Terminal=false
+X-MultipleArgs=false
+Keywords=Internet;WWW;Browser;Web;Explorer;
+Actions=new-window;new-blank-window;new-private-window;profilemanager;
+
+[Desktop Action new-window]
+Name=Open a New Window
+Exec=$ZEN_BIN %u
+
+[Desktop Action new-blank-window]
+Name=Open a New Blank Window
+Exec=$ZEN_BIN --blank-window %u
+
+[Desktop Action new-private-window]
+Name=Open a New Private Window
+Exec=$ZEN_BIN --private-window %u
+
+[Desktop Action profilemanager]
+Name=Open the Profile Manager
+Exec=$ZEN_BIN --ProfileManager %u
+EOF
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database "$APP_DIR" || true
+fi
+
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -q "$HOME/.local/share/icons/hicolor" || true
+fi
+
+echo "Installed desktop entry: $DESKTOP_FILE"
+echo "Installed icon: $ICON_TARGET"
+echo "Search for '$APP_NAME' in your app launcher and pin it to the taskbar."


### PR DESCRIPTION
Adds a user-local desktop entry installer for unpacked Linux builds, plus a CI-built .deb package flow for Ubuntu.\n\nTesting:\n- Downloaded the official zen.linux-x86_64.tar.xz release artifact\n- Built dist/zen-browser_1.19.8b-test_amd64.deb\n- Installed it with apt\n- Launched zen successfully and confirmed it was running\n\nNotes:\n- The .deb repackages the existing Linux tarball into a standard Debian layout\n- This is intended to make Zen behave like a normal installed app on Ubuntu