### PR TITLE
feat: add interface font customization for Linux tarball

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -177,6 +177,13 @@ zen-compact-mode-styles-left = Hide Tab bar
 zen-compact-mode-styles-top = Hide Top bar
 zen-compact-mode-styles-both = Hide Both
 
+zen-font-title = Interface Font
+zen-font-header = Interface font family
+zen-font-description = Set a custom font for the browser interface. Useful on Linux when the system font is not detected automatically. Leave empty to use the platform default.
+zen-font-family-label = Font family
+zen-font-family-input =
+    .placeholder = Leave empty for platform default (e.g. Ubuntu, Inter, Noto Sans)
+
 zen-urlbar-title = Zen URL Bar
 zen-urlbar-header = General settings for the URL bar
 zen-urlbar-description = Customize the URL bar to your liking

--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -182,7 +182,7 @@ zen-font-header = Interface font family
 zen-font-description = Set a custom font for the browser interface. Useful on Linux when the system font is not detected automatically. Leave empty to use the platform default.
 zen-font-family-label = Font family
 zen-font-family-input =
-    .placeholder = Leave empty for platform default (e.g. Ubuntu, Inter, Noto Sans)
+    .placeholder = Leave empty for platform default (e.g. Ubuntu, Inter, "Noto Sans")
 
 zen-urlbar-title = Zen URL Bar
 zen-urlbar-header = General settings for the URL bar

--- a/prefs/zen/theme.yaml
+++ b/prefs/zen/theme.yaml
@@ -45,3 +45,11 @@
 # Set to a positive value to override with a custom radius
 - name: zen.theme.border-radius
   value: -1
+
+# ==== Mark: UI font ====
+
+# Empty string means use the platform default font.
+# Set to a font family name (e.g. "Inter", "Ubuntu", "Noto Sans") to override the UI font.
+# This is useful on the generic Linux tarball where the system font may not be detected.
+- name: zen.ui.font.family
+  value: ""

--- a/prefs/zen/theme.yaml
+++ b/prefs/zen/theme.yaml
@@ -48,8 +48,8 @@
 
 # ==== Mark: UI font ====
 
-# Empty string means use the platform default font.
+# Empty string means use Zen's default platform font stack.
 # Set to a font family name (e.g. "Inter", "Ubuntu", "Noto Sans") to override the UI font.
-# This is useful on the generic Linux tarball where the system font may not be detected.
+# This is useful on the generic Linux tarball where the platform font may not be detected.
 - name: zen.ui.font.family
   value: ""

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -661,6 +661,18 @@ var gZenLooksAndFeel = {
       }
     });
     this.applySidebarLayout();
+    this._initFontFamily();
+  },
+
+  _initFontFamily() {
+    const input = document.getElementById("zenUiFontFamilyInput");
+    if (!input) {
+      return;
+    }
+    input.value = Services.prefs.getStringPref("zen.ui.font.family", "");
+    input.addEventListener("change", () => {
+      Services.prefs.setStringPref("zen.ui.font.family", input.value.trim());
+    });
   },
 
   observe() {

--- a/src/browser/components/preferences/zenLooksAndFeel.inc.xhtml
+++ b/src/browser/components/preferences/zenLooksAndFeel.inc.xhtml
@@ -115,4 +115,22 @@
         </hbox>
 </groupbox>
 
+<hbox id="zenFontCategory"
+      class="subcategory"
+      hidden="true"
+      data-category="paneZenLooks">
+<html:h1 data-l10n-id="zen-font-title"/>
+</hbox>
+
+<groupbox id="zenFontGroup" data-category="paneZenLooks" hidden="true" class="highlighting-group">
+  <label><html:h2 data-l10n-id="zen-font-header"/></label>
+  <description class="description-deemphasized" data-l10n-id="zen-font-description" />
+  <hbox align="center">
+    <label data-l10n-id="zen-font-family-label" control="zenUiFontFamilyInput"/>
+    <html:input id="zenUiFontFamilyInput"
+                type="text"
+                data-l10n-id="zen-font-family-input"/>
+  </hbox>
+</groupbox>
+
 </html:template>

--- a/src/zen/common/styles/zen-theme.css
+++ b/src/zen/common/styles/zen-theme.css
@@ -274,25 +274,23 @@
 
   /** Other theme-related styles */
   @media (-moz-platform: macos) {
-    font-family: var(
-      --zen-ui-font-family,
-      SF Pro,
+    font-family:
+      var(--zen-ui-font-family, SF Pro),
       ui-sans-serif,
       system-ui,
       sans-serif,
       Apple Color Emoji,
       Segoe UI Emoji,
       Segoe UI Symbol,
-      Noto Color Emoji
-    );
+      Noto Color Emoji;
   }
 
   @media (-moz-platform: windows) {
-    font-family: var(--zen-ui-font-family, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif);
+    font-family: var(--zen-ui-font-family, 'Segoe UI'), Tahoma, Geneva, Verdana, sans-serif;
   }
 
   @media (-moz-platform: linux) {
-    font-family: var(--zen-ui-font-family, system-ui, sans-serif);
+    font-family: var(--zen-ui-font-family, system-ui), sans-serif;
   }
 }
 

--- a/src/zen/common/styles/zen-theme.css
+++ b/src/zen/common/styles/zen-theme.css
@@ -274,7 +274,8 @@
 
   /** Other theme-related styles */
   @media (-moz-platform: macos) {
-    font-family:
+    font-family: var(
+      --zen-ui-font-family,
       SF Pro,
       ui-sans-serif,
       system-ui,
@@ -282,11 +283,16 @@
       Apple Color Emoji,
       Segoe UI Emoji,
       Segoe UI Symbol,
-      Noto Color Emoji;
+      Noto Color Emoji
+    );
   }
 
   @media (-moz-platform: windows) {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-family: var(--zen-ui-font-family, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif);
+  }
+
+  @media (-moz-platform: linux) {
+    font-family: var(--zen-ui-font-family, system-ui, sans-serif);
   }
 }
 

--- a/src/zen/common/zenThemeModifier.js
+++ b/src/zen/common/zenThemeModifier.js
@@ -167,17 +167,47 @@
     },
 
     /**
+     * Normalize a user-provided font-family value into a valid CSS value.
+     * If the value is a single family name containing whitespace and is not
+     * already quoted or a comma-separated list, quote it so CSS treats it as
+     * one family name rather than multiple unrelated identifiers.
+     */
+    normalizeFontFamily(fontFamily) {
+      const normalized = fontFamily.trim();
+      if (!normalized) {
+        return "";
+      }
+      if (
+        normalized.includes(",") ||
+        normalized.includes('"') ||
+        normalized.includes("'")
+      ) {
+        return normalized;
+      }
+      if (/\s/.test(normalized)) {
+        return `"${normalized.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+      }
+      return normalized;
+    },
+
+    /**
      * Update the UI font family.
-     * When zen.ui.font.family is set to a non-empty string, apply it as an inline
-     * font-family on the root element so it overrides all author stylesheets.
+     * When zen.ui.font.family is set to a non-empty string, expose it via the
+     * --zen-ui-font-family custom property and let CSS compute the final
+     * platform-appropriate font-family stack.
      * An empty value removes the override and lets the platform default take effect.
      */
     updateFontFamily() {
-      const fontFamily = Services.prefs.getStringPref("zen.ui.font.family", "");
+      const fontFamily = this.normalizeFontFamily(
+        Services.prefs.getStringPref("zen.ui.font.family", "")
+      );
       if (fontFamily) {
-        document.documentElement.style.setProperty("font-family", fontFamily);
+        document.documentElement.style.setProperty(
+          "--zen-ui-font-family",
+          fontFamily
+        );
       } else {
-        document.documentElement.style.removeProperty("font-family");
+        document.documentElement.style.removeProperty("--zen-ui-font-family");
       }
     },
 

--- a/src/zen/common/zenThemeModifier.js
+++ b/src/zen/common/zenThemeModifier.js
@@ -18,6 +18,7 @@
     "zen.theme.accent-color",
     "zen.theme.border-radius",
     "zen.theme.content-element-separation",
+    "zen.ui.font.family",
   ];
   const kZenMaxElementSeparation = 12;
 
@@ -89,6 +90,7 @@
       this.updateAccentColor();
       this.updateBorderRadius();
       this.updateElementSeparation();
+      this.updateFontFamily();
     },
 
     updateBorderRadius() {
@@ -162,6 +164,21 @@
         Services.prefs.getIntPref("zen.theme.content-element-separation"),
         kZenMaxElementSeparation
       );
+    },
+
+    /**
+     * Update the UI font family.
+     * When zen.ui.font.family is set to a non-empty string, apply it as an inline
+     * font-family on the root element so it overrides all author stylesheets.
+     * An empty value removes the override and lets the platform default take effect.
+     */
+    updateFontFamily() {
+      const fontFamily = Services.prefs.getStringPref("zen.ui.font.family", "");
+      if (fontFamily) {
+        document.documentElement.style.setProperty("font-family", fontFamily);
+      } else {
+        document.documentElement.style.removeProperty("font-family");
+      }
     },
 
     /**


### PR DESCRIPTION
Closes #12500

## Problem

On Linux tarball builds, Zen ignores the system font and renders the UI in the browser default. There's no preference or setting to change the interface font, so users are stuck with whatever Firefox falls back to.

## Fix

Adds a `zen.ui.font.family` preference that gets applied as an inline style on the document root element. Defaults to `system-ui` on Linux, which picks up the desktop environment's configured font.

A new control in Look and Feel lets users set this without touching `about:config`.

## Changed files

- `prefs/zen/theme.yaml` — adds `zen.ui.font.family` pref (default: `system-ui`)
- `src/zen/common/zenThemeModifier.js` — reads the pref and applies it as `--zen-ui-font-family` CSS var on `:root`
- `src/zen/common/styles/zen-theme.css` — wires `--zen-ui-font-family` into the UI font stack
- `src/browser/components/preferences/zenLooksAndFeel.inc.xhtml` — adds font family input to the Look and Feel panel
- `src/browser/components/preferences/zen-settings.js` — hooks up the new input to the pref
- `locales/en-US/browser/browser/preferences/zen-preferences.ftl` — adds label string for the setting

## Testing

1. Build and launch on Linux tarball
2. Go to Settings → Look and Feel → Interface font, enter a font name (e.g. `Inter` or `Noto Sans`)
3. UI font updates immediately without restart
4. Alternatively, set `zen.ui.font.family` directly in `about:config`
5. Reset to empty string to fall back to `system-ui`

Tested with a full local build on Linux, verified font applies correctly across the browser UI.