### PR TITLE
add: Space Overview dashboard (PoC)

### DIFF
--- a/locales/en-US/browser/browser/zen-vertical-tabs.ftl
+++ b/locales/en-US/browser/browser/zen-vertical-tabs.ftl
@@ -26,6 +26,10 @@ zen-toolbar-context-new-folder =
 sidebar-zen-expand =
   .label = Expand Sidebar
 
+zen-overview-button =
+  .label = Space Overview
+  .tooltiptext = Space Overview
+
 sidebar-zen-create-new =
   .label = Create New...
 

--- a/locales/en-US/browser/browser/zen-workspaces.ftl
+++ b/locales/en-US/browser/browser/zen-workspaces.ftl
@@ -98,3 +98,24 @@ zen-panel-ui-workspaces-change-forward =
 
 zen-panel-ui-workspaces-change-back =
     .label = Previous Space
+
+zen-space-overview-title = Space Overview
+zen-space-overview-search =
+    .placeholder = Search tabs\u2026
+zen-space-overview-tab-count =
+    { $count ->
+        [one] { $count } tab
+       *[other] { $count } tabs
+    }
+zen-space-overview-bookmarks = Bookmarks
+zen-space-overview-empty = No tabs in this space
+zen-space-overview-new-space = + New Space
+zen-space-overview-more-tabs = and { $count } more\u2026
+zen-space-overview-error = Open this page from within Zen Browser
+zen-space-overview-create-space = Create Space
+zen-space-overview-delete-space =
+    .title = Delete Space
+zen-space-overview-close-tab =
+    .title = Close tab
+zen-space-overview-rename-placeholder =
+    .placeholder = Space name

--- a/src/browser/base/content/zen-commands.inc.xhtml
+++ b/src/browser/base/content/zen-commands.inc.xhtml
@@ -50,6 +50,7 @@
   <command id="cmd_zenPinnedTabResetNoTab" />
 
   <command id="cmd_zenToggleSidebar" />
+  <command id="cmd_zenOpenSpaceOverview" />
 
   <command id="cmd_zenCopyCurrentURL" />
   <command id="cmd_zenCopyCurrentURLMarkdown" />

--- a/src/browser/base/content/zen-sidebar-icons.inc.xhtml
+++ b/src/browser/base/content/zen-sidebar-icons.inc.xhtml
@@ -14,6 +14,7 @@
   context="toolbar-context-menu"
   mode="icons">
   <toolbarbutton removable="true" class="chromeclass-toolbar-additional toolbarbutton-1 zen-sidebar-action-button" id="zen-expand-sidebar-button" command="cmd_zenToggleSidebar" data-l10n-id="sidebar-zen-expand"></toolbarbutton>
+  <toolbarbutton removable="true" class="chromeclass-toolbar-additional toolbarbutton-1 zen-sidebar-action-button" id="zen-overview-button" command="cmd_zenOpenSpaceOverview" data-l10n-id="zen-overview-button"></toolbarbutton>
   <zen-workspace-icons id="zen-workspaces-button" overflows="false" removable="false"></zen-workspace-icons>
   <toolbarbutton removable="true" class="chromeclass-toolbar-additional toolbarbutton-1 zen-sidebar-action-button" id="zen-create-new-button" context="zenCreateNewPopup" data-l10n-id="sidebar-zen-create-new"></toolbarbutton>
 </toolbar>

--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -411,6 +411,10 @@
   list-style-image: url("expand-sidebar.svg") !important;
 }
 
+#zen-overview-button {
+  list-style-image: url("selectable/grid-2x2.svg") !important;
+}
+
 .panel-header > .subviewbutton-back,
 #PanelUI-zen-gradient-generator-color-page-left {
   list-style-image: url("arrow-left.svg") !important;

--- a/src/zen/common/zen-sets.js
+++ b/src/zen/common/zen-sets.js
@@ -56,6 +56,9 @@ document.addEventListener(
           case "cmd_zenToggleSidebar":
             gZenVerticalTabsManager.toggleExpand();
             break;
+          case "cmd_zenOpenSpaceOverview":
+            gZenWorkspaces.openSpaceOverview();
+            break;
           case "cmd_zenOpenZenThemePicker":
             gZenThemePicker.openThemePicker(event);
             break;

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -1463,6 +1463,45 @@ class nsZenWorkspaces {
     createForm.finishSetup();
   }
 
+  static OVERVIEW_URL =
+    "chrome://browser/content/zen-components/zen-space-overview.html";
+
+  openSpaceOverview() {
+    // Avoid a full Array.from allocation — break early once found.
+    for (const t of gBrowser.tabs) {
+      if (t.hasAttribute("zen-overview-tab")) {
+        gBrowser.selectedTab = t;
+        return;
+      }
+    }
+
+    // addTrustedTab returns the new tab synchronously, which avoids a race
+    // where gBrowser.selectedTab could point to a different tab if the user
+    // preference opens tabs in the background or a focus change races us.
+    const tab = gBrowser.addTrustedTab(nsZenWorkspaces.OVERVIEW_URL, {
+      triggeringPrincipal:
+        Services.scriptSecurityManager.getSystemPrincipal(),
+    });
+    gBrowser.selectedTab = tab;
+    tab.setAttribute("zen-overview-tab", "true");
+
+    // Place the tab in the essentials section so it is always visible in the
+    // pinned bar regardless of which space is active.
+    tab.setAttribute("zen-essential", "true");
+    tab.removeAttribute("zen-workspace-id");
+    if (!tab.pinned) {
+      gBrowser.pinTab(tab);
+    }
+    this.getEssentialsSection(tab).appendChild(tab);
+
+    document.documentElement.setAttribute("zen-overview-active", "true");
+  }
+
+  _updateOverviewTabActive() {
+    const isOverview = gBrowser.selectedTab?.hasAttribute("zen-overview-tab");
+    document.documentElement.toggleAttribute("zen-overview-active", isOverview);
+  }
+
   #unpinnedTabsInWorkspace(workspaceID) {
     return Array.from(this.allStoredTabs).filter(
       tab =>
@@ -2325,6 +2364,10 @@ class nsZenWorkspaces {
       return true; // Always show glance tabs
     }
 
+    if (tab.hasAttribute("zen-overview-tab")) {
+      return true; // Overview tab is always visible across all spaces
+    }
+
     // See https://github.com/zen-browser/desktop/issues/10666, we should never
     // show closing tabs and consider them as not part of any workspace. This will
     // invalidate the `lastSelectedTab[previousWorkspaceId]` logic in `_handleTabSelection`
@@ -2804,6 +2847,10 @@ class nsZenWorkspaces {
       return;
     }
 
+    if (tab.hasAttribute("zen-overview-tab")) {
+      return; // Overview tab workspace placement is managed by openSpaceOverview
+    }
+
     if (workspaceID) {
       if (
         tab.hasAttribute("change-workspace") &&
@@ -2845,6 +2892,7 @@ class nsZenWorkspaces {
   async onLocationChange(event) {
     let tab = event.target;
     this.#changeToEmptyTab();
+    this._updateOverviewTabActive();
     if (
       !this.workspaceEnabled ||
       this.#inChangingWorkspace ||
@@ -2862,6 +2910,21 @@ class nsZenWorkspaces {
     const isEssential = tab.getAttribute("zen-essential") === "true";
     if (tab.hasAttribute("zen-empty-tab")) {
       return;
+    }
+
+    if (tab.hasAttribute("zen-overview-tab")) {
+      // If the user navigated away from the overview page, clear the attribute
+      // so the URL bar is restored and workspace routing resumes normally.
+      const uri = tab.linkedBrowser?.currentURI?.spec;
+      if (uri && uri !== nsZenWorkspaces.OVERVIEW_URL) {
+        tab.removeAttribute("zen-overview-tab");
+        // zen-essential was set solely to keep the tab visible across spaces;
+        // reclaim normal workspace routing now that the URL has changed.
+        tab.removeAttribute("zen-essential");
+        document.documentElement.removeAttribute("zen-overview-active");
+      } else {
+        return; // Still on the overview page — no workspace switch needed
+      }
     }
 
     if (!isEssential) {

--- a/src/zen/spaces/jar.inc.mn
+++ b/src/zen/spaces/jar.inc.mn
@@ -3,5 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
         content/browser/zen-components/ZenSpaceBookmarksStorage.js              (../../zen/spaces/ZenSpaceBookmarksStorage.js)
+        content/browser/zen-components/zen-space-overview.html                  (../../zen/spaces/zen-space-overview.html)
+        content/browser/zen-components/zen-space-overview.css                   (../../zen/spaces/zen-space-overview.css)
+        content/browser/zen-components/zen-space-overview.js                    (../../zen/spaces/zen-space-overview.js)
 *       content/browser/zen-styles/zen-workspaces.css                           (../../zen/spaces/zen-workspaces.css)
         content/browser/zen-styles/zen-gradient-generator.css                   (../../zen/spaces/zen-gradient-generator.css)

--- a/src/zen/spaces/zen-space-overview.css
+++ b/src/zen/spaces/zen-space-overview.css
@@ -1,0 +1,686 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+:root {
+  --card-border-radius: 0.5rem;
+  --card-border: 1px solid var(--in-content-border-color, #ccc);
+  --card-bg: var(--in-content-box-background, #f9f9fb);
+  --card-header-bg: var(--in-content-box-background-odd, #ebebef);
+  --card-active-shadow: 0 0 0 3.5px hsla(from var(--in-content-primary-button-background, #0060df) h s l / 0.4);
+  --card-active-border: 1px solid var(--in-content-primary-button-background, #0060df);
+  --tab-hover-bg: var(--in-content-box-background-hover, #e0e0e6);
+  --text-color: var(--in-content-text-color, #15141a);
+  --text-muted: var(--in-content-deemphasized-text, #8f8f9d);
+  --border-color: var(--in-content-border-color, #ccc);
+  --gap: 1rem;
+  --gap-mini: 0.5rem;
+  --icon-btn-size: 20px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --card-bg: var(--in-content-box-background, #1c1b22);
+    --card-header-bg: var(--in-content-box-background-odd, #2b2a33);
+    --tab-hover-bg: var(--in-content-box-background-hover, #2b2a33);
+    --border-color: var(--in-content-border-color, #52525e);
+    --card-border: 1px solid var(--border-color);
+  }
+}
+
+/* Ensure [hidden] always wins even when element-level rules set display. */
+[hidden] {
+  display: none !important;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: var(--gap);
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  color: var(--text-color);
+  background: var(--in-content-page-background, #fff);
+  min-height: 100dvh;
+}
+
+/* ---- Header ---- */
+
+#overview-header {
+  display: flex;
+  align-items: center;
+  gap: var(--gap);
+  margin-bottom: var(--gap);
+  /* Never wrap — single solid toolbar row */
+  flex-wrap: nowrap;
+  min-width: 0;
+}
+
+#header-left {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.05em;
+  flex-shrink: 0;
+}
+
+#overview-title {
+  margin: 0;
+  font-size: 1.25em;
+  font-weight: 700;
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+#overview-subtitle {
+  margin: 0;
+  font-size: 0.88em;
+  font-weight: 500;
+  color: var(--text-color);
+  opacity: 0.6;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+}
+
+/* Right-hand toolbar: grows to fill remaining space, all items on one line */
+#header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-mini);
+  flex: 1;
+  justify-content: flex-end;
+  min-width: 0;
+  /* Do NOT wrap — keeps search + buttons on one line */
+  flex-wrap: nowrap;
+}
+
+#create-space-btn {
+  padding: 0.35em 0.85em;
+  border: none;
+  border-radius: 0.375rem;
+  background: var(--in-content-primary-button-background, #0060df);
+  color: var(--in-content-primary-button-text-color, #fff);
+  cursor: pointer;
+  font-size: 0.9em;
+  font-weight: 600;
+  white-space: nowrap;
+  flex-shrink: 0;
+  height: 2em;
+  line-height: 1;
+}
+
+#create-space-btn:hover {
+  background: var(--in-content-primary-button-background-hover, #0250bb);
+}
+
+/* Search grows but respects available space; shrinks before wrapping */
+#search-wrapper {
+  flex: 1 1 10em;
+  min-width: 0;
+  max-width: 24em;
+}
+
+#search {
+  width: 100%;
+  padding: 0.4em 0.7em;
+  border: var(--card-border);
+  border-radius: 0.375rem;
+  background: var(--card-bg);
+  color: var(--text-color);
+  font-size: 0.9em;
+  height: 2em;
+  outline-offset: 2px;
+}
+
+#refresh-btn {
+  padding: 0;
+  width: 2em;
+  height: 2em;
+  border: var(--card-border);
+  border-radius: 0.375rem;
+  background: var(--card-bg);
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: 1.1em;
+  line-height: 1;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#refresh-btn:hover {
+  background: var(--tab-hover-bg);
+}
+
+/* ---- Grid ---- */
+
+#grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  /* align-items: stretch (default) — cards in same row share height */
+  gap: var(--gap);
+}
+
+/* ---- Cards ---- */
+
+.space-card {
+  display: flex;
+  flex-direction: column;
+  border: var(--card-border);
+  border-radius: var(--card-border-radius);
+  /* Semi-transparent card — lets the page background show slightly through */
+  background: color-mix(in srgb, var(--card-bg) 80%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  max-height: 600px;
+  overflow: hidden;
+  transition: box-shadow 0.15s, border-color 0.15s, opacity 0.3s;
+}
+
+.space-card.is-active {
+  box-shadow: var(--card-active-shadow);
+  border: var(--card-active-border);
+}
+
+/* Theme: tint the whole card with a whisper of the space colour */
+.space-card.has-theme {
+  border-color: var(--space-primary-color, var(--border-color));
+  background: color-mix(in srgb, var(--space-primary-color, transparent) 10%, color-mix(in srgb, var(--card-bg) 80%, transparent));
+}
+
+/* Body of a themed card: slightly more opaque so tabs are readable */
+.space-card.has-theme .card-body {
+  background: color-mix(in srgb, var(--card-bg) 55%, transparent);
+}
+
+/* ---- Card header (STG-style: icon | input | count | actions) ---- */
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-mini);
+  padding: 0.5em 0.75em;
+  background: var(--card-header-bg);
+  border-bottom: var(--card-border);
+  border-radius: var(--card-border-radius) var(--card-border-radius) 0 0;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+  min-height: 2.6em;
+  /* Header is fully opaque relative to the card — carries the full theme gradient */
+  position: relative;
+}
+
+.card-header.has-theme {
+  background: var(--space-theme-gradient, var(--card-header-bg));
+}
+
+.card-header.has-theme.theme-dark {
+  color: #fff;
+}
+
+.card-header.has-theme.theme-dark .space-count {
+  color: rgba(255, 255, 255, 0.7);
+  background: rgba(0, 0, 0, 0.15);
+}
+
+.card-header.has-theme.theme-dark .space-icon {
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.4));
+}
+
+.card-header.has-theme.theme-dark .space-name {
+  color: #fff;
+  background: transparent;
+}
+
+.card-header.has-theme.theme-dark .space-name::placeholder {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.card-header.has-theme.theme-dark .card-action-btn {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.card-header.has-theme.theme-dark .card-action-btn:hover {
+  color: #fff;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+/* Hover only when not focused on the input */
+.card-header:not(:focus-within):hover {
+  filter: brightness(0.95);
+}
+
+.space-icon {
+  font-size: 1.2em;
+  line-height: 1;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
+.space-icon-img {
+  width: 1em;
+  height: 1em;
+  object-fit: contain;
+  /* Inherit theme-dark colour shift applied to the card header */
+  filter: var(--space-icon-filter, none);
+}
+
+.card-header.has-theme.theme-dark .space-icon-img {
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.4)) brightness(10);
+}
+
+/* Inline-editable space name (mirrors STG group-title input) */
+.space-name {
+  flex: 1;
+  font-weight: 600;
+  font-size: inherit;
+  font-family: inherit;
+  color: inherit;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.25rem;
+  padding: 0.1em 0.3em;
+  min-width: 0;
+  cursor: text;
+  outline: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.space-name:hover {
+  border-color: var(--border-color);
+  background: color-mix(in srgb, var(--card-bg) 60%, transparent);
+}
+
+.space-name:focus {
+  border-color: var(--in-content-primary-button-background, #0060df);
+  background: var(--card-bg);
+  cursor: text;
+  text-overflow: clip;
+  overflow: auto;
+}
+
+.space-count {
+  font-size: 0.8em;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--card-bg) 70%, transparent);
+  border-radius: 1em;
+  padding: 0.1em 0.55em;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+/* ---- Card action buttons ---- */
+
+.card-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.2em;
+  flex-shrink: 0;
+}
+
+.card-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--icon-btn-size);
+  height: var(--icon-btn-size);
+  padding: 0;
+  border: none;
+  border-radius: 0.25rem;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.8em;
+  line-height: 1;
+  visibility: visible;
+  opacity: 0.55;
+  transition: opacity 0.1s, background 0.1s, color 0.1s;
+}
+
+.card-header:hover .card-action-btn,
+.card-header:focus-within .card-action-btn {
+  opacity: 1;
+}
+
+.card-delete-btn {
+  color: var(--text-color);
+  opacity: 0.75;
+  font-size: 0.95em;
+  font-weight: 700;
+}
+
+.card-action-btn:hover {
+  background: color-mix(in srgb, currentColor 15%, transparent);
+}
+
+.card-delete-btn:hover {
+  color: var(--in-content-danger-button-background, #d70022);
+}
+
+/* ---- Card body ---- */
+
+.card-body {
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  padding: 0.25em 0;
+}
+
+/* ---- Tab list ---- */
+
+.tab-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tab-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.3em 0.75em;
+  cursor: pointer;
+  border-radius: 0.25rem;
+  margin: 0 0.25em;
+  height: 27px;
+}
+
+.tab-row:hover {
+  background: var(--tab-hover-bg);
+}
+
+.tab-row.is-active {
+  outline: 1px solid var(--in-content-primary-button-background, #0060df);
+  outline-offset: -1px;
+}
+
+/* ---- Favicon wrapper + loading state ---- */
+
+.tab-favicon-wrapper {
+  position: relative;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.tab-favicon {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+  display: block;
+}
+
+/* Pulsing loading spinner overlay on favicon */
+@keyframes zen-tab-loading-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.tab-loading-spinner {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 2px solid var(--in-content-primary-button-background, #0060df);
+  border-top-color: transparent;
+  animation: zen-tab-loading-spin 0.8s linear infinite;
+}
+
+@keyframes zen-tab-loading-spin {
+  to { transform: rotate(360deg); }
+}
+
+.tab-row.is-loading .tab-favicon {
+  opacity: 0.4;
+}
+
+.tab-title {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ---- Tab close button (STG pattern — visible on hover) ---- */
+
+.tab-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--icon-btn-size);
+  height: var(--icon-btn-size);
+  padding: 0;
+  border: none;
+  border-radius: 0.25rem;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.75em;
+  line-height: 1;
+  flex-shrink: 0;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.1s, background 0.1s, color 0.1s;
+}
+
+.tab-row:hover .tab-close,
+.tab-row:focus-within .tab-close {
+  visibility: visible;
+  opacity: 1;
+}
+
+.tab-close:hover {
+  background: color-mix(in srgb, var(--in-content-danger-button-background, #d70022) 15%, transparent);
+  color: var(--in-content-danger-button-background, #d70022);
+}
+
+.tab-row.is-dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+.space-card.drag-over {
+  box-shadow: 0 0 0 3.5px var(--in-content-primary-button-background, #0060df);
+  background: color-mix(in srgb, var(--in-content-primary-button-background) 8%, var(--card-bg));
+}
+
+.tab-more,
+.tab-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  cursor: default;
+  padding: 0.3em 0.75em;
+  font-size: 0.9em;
+  height: auto;
+}
+
+/* ---- Tree / File Explorer view ---- */
+
+.tree-group {
+  list-style: none;
+}
+
+.tree-group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.3em 0.75em;
+  cursor: pointer;
+  border-radius: 0.25rem;
+  margin: 0 0.25em;
+  user-select: none;
+  font-size: 0.92em;
+  font-weight: 600;
+}
+
+.tree-group-header:hover {
+  background: var(--tab-hover-bg);
+}
+
+.tree-group-header.has-group-color {
+  border-inline-start: 3px solid var(--group-color);
+}
+
+.tree-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
+  font-size: 0.6em;
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+  color: var(--text-muted);
+}
+
+.tree-expanded > .tree-group-header > .tree-chevron {
+  transform: rotate(90deg);
+}
+
+.tree-folder-icon::before {
+  content: "\1F4C1";
+  font-size: 0.95em;
+}
+
+.tree-expanded > .tree-group-header > .tree-folder-icon::before {
+  content: "\1F4C2";
+}
+
+.tree-group-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tree-group-count {
+  font-size: 0.75em;
+  font-weight: 400;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--card-bg) 70%, transparent);
+  border-radius: 1em;
+  padding: 0.1em 0.45em;
+  flex-shrink: 0;
+}
+
+.tree-children {
+  list-style: none;
+  margin: 0;
+  margin-inline-start: 1.3em;
+  padding: 0;
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 0.2s ease, opacity 0.15s ease;
+  border-inline-start: 1px solid var(--border-color);
+}
+
+.tree-expanded > .tree-children {
+  max-height: 9999px;
+  opacity: 1;
+}
+
+.tree-children .tree-group-header {
+  font-size: 0.88em;
+}
+
+/* ---- Bookmarks ---- */
+
+.bookmark-section {
+  border-top: var(--card-border);
+  flex-shrink: 0;
+}
+
+.bookmark-heading {
+  display: block;
+  padding: 0.4em 0.75em;
+  font-size: 0.82em;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.bookmark-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0.25em;
+}
+
+.bookmark-item {
+  padding: 0.2em 0.75em 0.2em 1.4em;
+}
+
+.bookmark-link {
+  color: var(--in-content-link-color, #0060df);
+  text-decoration: none;
+  font-size: 0.88em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.bookmark-link:hover {
+  text-decoration: underline;
+}
+
+/* ---- New Space card (STG "new group" dashed card) ---- */
+
+.new-space-card {
+  border: 2px dashed var(--border-color);
+  background: transparent;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  /* min-height so it looks intentional even when alone in a row */
+  min-height: 8em;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.new-space-card:hover .new-space-plus,
+.new-space-card:hover .new-space-label {
+  color: var(--text-color);
+}
+
+.new-space-card:hover {
+  background: color-mix(in srgb, var(--tab-hover-bg) 60%, transparent);
+}
+
+.new-space-plus {
+  font-size: 2.5em;
+  font-weight: 300;
+  line-height: 1;
+  color: var(--text-muted);
+  margin-bottom: 0.1em;
+}
+
+.new-space-label {
+  color: var(--text-muted);
+  font-size: 0.9em;
+}
+
+/* ---- Error state ---- */
+
+.error-state {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 4em;
+  color: var(--text-muted);
+  font-size: 1.1em;
+}

--- a/src/zen/spaces/zen-space-overview.html
+++ b/src/zen/spaces/zen-space-overview.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src chrome:; img-src chrome: moz-icon: data:; style-src chrome: 'unsafe-inline'; script-src chrome:; object-src 'none';"
+    />
+    <link rel="localization" href="browser/zen-workspaces.ftl" />
+    <link
+      rel="stylesheet"
+      href="chrome://browser/content/zen-components/zen-space-overview.css"
+    />
+    <title data-l10n-id="zen-space-overview-title"></title>
+  </head>
+  <body>
+    <header id="overview-header">
+      <div id="header-left">
+        <h1 id="overview-title" data-l10n-id="zen-space-overview-title"></h1>
+        <p id="overview-subtitle">Space dashboard</p>
+      </div>
+      <div id="header-actions">
+        <button
+          id="create-space-btn"
+          type="button"
+          data-l10n-id="zen-space-overview-create-space"
+        >Create Space</button>
+        <div id="search-wrapper">
+          <input
+            id="search"
+            type="search"
+            data-l10n-id="zen-space-overview-search"
+            autocomplete="off"
+            spellcheck="false"
+          />
+        </div>
+        <button id="refresh-btn" type="button" aria-label="Refresh">↻</button>
+      </div>
+    </header>
+    <div id="grid"></div>
+    <script src="chrome://browser/content/zen-components/zen-space-overview.js"></script>
+  </body>
+</html>

--- a/src/zen/spaces/zen-space-overview.js
+++ b/src/zen/spaces/zen-space-overview.js
@@ -1,0 +1,940 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const { PlacesUtils } = ChromeUtils.importESModule(
+  "resource://gre/modules/PlacesUtils.sys.mjs"
+);
+
+const LOG = (...args) => console.log("[ZenSpaceOverview]", ...args);
+const LOG_ERR = (...args) => console.error("[ZenSpaceOverview]", ...args);
+
+const TAB_CAP = 15;
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "about:", "chrome:"]);
+const FAVICON_PROTOCOLS = new Set([
+  "http:",
+  "https:",
+  "chrome:",
+  "moz-icon:",
+  "data:",
+]);
+
+let chromeWin = null;
+let _draggedTab = null;
+let _dragSourceWsId = null;
+
+// ---------------------------------------------------------------------------
+// Filter helpers (module-scope so buildGrid can re-apply after a rebuild)
+// ---------------------------------------------------------------------------
+
+function _showEl(el) { el.style.display = ""; }
+function _hideEl(el) { el.style.display = "none"; }
+
+// Recursively filter the tree, preserving group/folder structure.
+// A group is kept only when it has at least one matching descendant tab;
+// its children list is itself filtered the same way.
+function filterTreeNodes(nodes, q) {
+  const result = [];
+  for (const node of nodes) {
+    if (node.type === "tab") {
+      const title = (node.tab.label ?? "").toLowerCase();
+      const url =
+        (node.tab.linkedBrowser?.currentURI?.spec ?? "").toLowerCase();
+      if (title.includes(q) || url.includes(q)) result.push(node);
+    } else if (node.type === "group") {
+      const filteredChildren = filterTreeNodes(node.children, q);
+      if (filteredChildren.length) {
+        // Spread so the original node object is not mutated.
+        result.push({ ...node, children: filteredChildren, collapsed: false });
+      }
+    }
+  }
+  return result;
+}
+
+// Render a (possibly filtered) tree with no TAB_CAP — used during search so
+// every matching tab is shown regardless of how many there are.
+function renderFilteredNodes(nodes, list, workspaceId, depth = 0) {
+  for (const node of nodes) {
+    if (node.type === "tab") {
+      list.appendChild(buildTabRow(node.tab, workspaceId));
+    } else if (node.type === "group") {
+      list.appendChild(buildGroupNode(node, workspaceId, depth));
+    }
+  }
+}
+
+function applyFilter(q) {
+  for (const card of document.querySelectorAll(
+    ".space-card:not(.new-space-card)"
+  )) {
+    const body = card.querySelector(".card-body");
+    if (!body) continue;
+
+    if (!q) {
+      // Restore the original rendered list (with tree structure and TAB_CAP).
+      const currentList = body.querySelector(".tab-list");
+      if (card._zenOriginalTabList && currentList !== card._zenOriginalTabList) {
+        currentList.replaceWith(card._zenOriginalTabList);
+      }
+      // Release the height lock so the card can breathe freely again.
+      card.style.minHeight = "";
+      card._zenHeightLocked = false;
+      continue;
+    }
+
+    // Lock the card height before touching the DOM so the tile never collapses.
+    if (!card._zenHeightLocked) {
+      card.style.minHeight = card.offsetHeight + "px";
+      card._zenHeightLocked = true;
+    }
+
+    // Build a filtered tree preserving group/folder hierarchy.
+    const workspaceId = card.dataset.workspaceId;
+    const filteredNodes = filterTreeNodes(card._zenTreeNodes ?? [], q);
+    const newList = makeEl("ul", { class: "tab-list" });
+    if (filteredNodes.length) {
+      renderFilteredNodes(filteredNodes, newList, workspaceId);
+    } else {
+      newList.appendChild(buildEmptyRow());
+    }
+
+    // Swap in the filtered list.
+    const currentList = body.querySelector(".tab-list");
+    if (currentList) {
+      currentList.replaceWith(newList);
+    } else {
+      body.prepend(newList);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getChromeWindow() {
+  try {
+    return window.browsingContext?.topChromeWindow ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeURL(url) {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    return ALLOWED_PROTOCOLS.has(parsed.protocol) ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeFaviconURL(url) {
+  if (!url) return null;
+  try {
+    return FAVICON_PROTOCOLS.has(new URL(url).protocol) ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function makeEl(tag, attrs = {}) {
+  const el = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) {
+    el.setAttribute(k, v);
+  }
+  return el;
+}
+
+// ---------------------------------------------------------------------------
+// Favicon
+// ---------------------------------------------------------------------------
+
+function buildFavicon(tab) {
+  const img = makeEl("img", { class: "tab-favicon", alt: "", loading: "lazy" });
+
+  // Primary: tab.image (already sanitized browser favicon)
+  const src = sanitizeFaviconURL(tab.image);
+  if (src) {
+    img.src = src;
+    img.addEventListener("error", () => tryFaviconFallback(img, tab));
+    return img;
+  }
+
+  // Secondary: gBrowser.getIcon()
+  tryFaviconFallback(img, tab);
+  return img;
+}
+
+function tryFaviconFallback(img, tab) {
+  try {
+    const gBrowser = chromeWin?.gBrowser;
+    const iconUrl = gBrowser?.getIcon?.(tab);
+    if (iconUrl && sanitizeFaviconURL(iconUrl)) {
+      img.src = iconUrl;
+      img.addEventListener("error", () => useDefaultFavicon(img), {
+        once: true,
+      });
+      return;
+    }
+  } catch {
+    // fall through
+  }
+  useDefaultFavicon(img);
+}
+
+function useDefaultFavicon(img) {
+  img.src = "chrome://global/skin/icons/defaultFavicon.svg";
+}
+
+// ---------------------------------------------------------------------------
+// Tree builder — walks workspace containers preserving group/folder hierarchy
+// ---------------------------------------------------------------------------
+
+function buildWorkspaceTree(workspace) {
+  const { gZenWorkspaces, gBrowser } = chromeWin;
+  const wsElement = gZenWorkspaces.workspaceElement?.(workspace.uuid);
+  if (!wsElement) {
+    const allTabs = Array.from(gZenWorkspaces.allStoredTabs ?? []);
+    return allTabs
+      .filter(t => t.getAttribute("zen-workspace-id") === workspace.uuid)
+      .map(t => ({ type: "tab", tab: t }));
+  }
+
+  const nodes = [];
+  const containers = [wsElement.pinnedTabsContainer, wsElement.tabsContainer];
+  for (const container of containers) {
+    if (!container || container.hasAttribute("cloned")) continue;
+    walkContainer(container, nodes, gBrowser);
+  }
+  return nodes;
+}
+
+function walkContainer(container, nodes, gBrowser) {
+  for (const child of container.children) {
+    if (gBrowser.isTab(child)) {
+      nodes.push({ type: "tab", tab: child });
+      const glance = child.querySelector(".tabbrowser-tab[glance-id]");
+      if (glance) {
+        nodes.push({ type: "tab", tab: glance });
+      }
+    } else if (gBrowser.isTabGroup(child)) {
+      const children = [];
+      const groupContainer = child.groupContainer ?? child;
+      walkContainer(groupContainer, children, gBrowser);
+      nodes.push({
+        type: "group",
+        label: child.label || "",
+        color: child.color || null,
+        collapsed: child.collapsed ?? false,
+        group: child,
+        children,
+      });
+    }
+  }
+}
+
+function countTreeTabs(nodes) {
+  let count = 0;
+  for (const node of nodes) {
+    if (node.type === "tab") count++;
+    else if (node.type === "group") count += countTreeTabs(node.children);
+  }
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Shared tab removal helper
+// ---------------------------------------------------------------------------
+
+function removeTabFromCard(tab, card, workspaceId) {
+  chromeWin.gBrowser.removeTab(tab, { animate: true });
+
+  if (card && workspaceId) {
+    const workspace = chromeWin.gZenWorkspaces.getWorkspaceFromId(workspaceId);
+    if (workspace) {
+      const treeNodes = buildWorkspaceTree(workspace);
+      chromeWin.ZenWorkspaceBookmarksStorage.getBookmarkGuidsByWorkspace()
+        .then(byWorkspace => {
+          card.replaceWith(buildCard(workspace, treeNodes, byWorkspace));
+        })
+        .catch(() => {
+          card.replaceWith(buildCard(workspace, treeNodes, {}));
+        });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tab rows
+// ---------------------------------------------------------------------------
+
+function buildTabRow(tab, workspaceId) {
+  const row = makeEl("li", {
+    class: "tab-row",
+    role: "button",
+    tabindex: "0",
+  });
+  row.dataset.workspaceId = workspaceId;
+  row._zenTab = tab;
+
+  const isLoading = tab.getAttribute("busy") === "true" || tab.hasAttribute("busy");
+
+  if (chromeWin.gBrowser.selectedTab === tab) {
+    row.classList.add("is-active");
+  }
+  if (isLoading) {
+    row.classList.add("is-loading");
+  }
+
+  // Favicon wrapper with optional loading spinner
+  const faviconWrapper = makeEl("span", { class: "tab-favicon-wrapper" });
+  const favicon = buildFavicon(tab);
+  faviconWrapper.appendChild(favicon);
+
+  if (isLoading) {
+    const spinner = makeEl("span", { class: "tab-loading-spinner" });
+    faviconWrapper.appendChild(spinner);
+  }
+
+  const title = makeEl("span", { class: "tab-title" });
+  title.textContent = tab.label || "(Untitled)";
+
+  // Close button (STG pattern — visible on hover)
+  const closeBtn = makeEl("button", { class: "tab-close", type: "button" });
+  closeBtn.setAttribute("title", "");
+  document.l10n.setAttributes(closeBtn, "zen-space-overview-close-tab");
+  closeBtn.addEventListener("click", e => {
+    e.stopPropagation();
+    if (tab.closing) return;
+    const card = row.closest(".space-card");
+    const wsId = card?.dataset.workspaceId ?? workspaceId;
+    removeTabFromCard(tab, card, wsId);
+  });
+
+  row.appendChild(faviconWrapper);
+  row.appendChild(title);
+  row.appendChild(closeBtn);
+
+  if (!tab.hasAttribute("zen-essential")) {
+    row.setAttribute("draggable", "true");
+    row.addEventListener("dragstart", e => {
+      _draggedTab = tab;
+      _dragSourceWsId = workspaceId;
+      e.dataTransfer.setData("application/x-zen-tab-id", "1");
+      e.dataTransfer.effectAllowed = "move";
+      row.classList.add("is-dragging");
+    });
+    row.addEventListener("dragend", () => {
+      row.classList.remove("is-dragging");
+      _draggedTab = null;
+      _dragSourceWsId = null;
+    });
+  }
+
+  return row;
+}
+
+function buildGroupNode(groupNode, workspaceId, depth) {
+  const wrapper = makeEl("li", { class: "tree-group" });
+
+  const header = makeEl("div", {
+    class: "tree-group-header",
+    role: "button",
+    tabindex: "0",
+  });
+
+  const chevron = makeEl("span", { class: "tree-chevron" });
+  chevron.textContent = "\u25B6";
+
+  const folderIcon = makeEl("span", { class: "tree-folder-icon" });
+
+  const label = makeEl("span", { class: "tree-group-label" });
+  label.textContent = groupNode.label || "Group";
+
+  const count = makeEl("span", { class: "tree-group-count" });
+  const childTabCount = countTreeTabs(groupNode.children);
+  count.textContent = String(childTabCount);
+
+  if (groupNode.color) {
+    header.style.setProperty("--group-color", groupNode.color);
+    header.classList.add("has-group-color");
+  }
+
+  header.appendChild(chevron);
+  header.appendChild(folderIcon);
+  header.appendChild(label);
+  header.appendChild(count);
+
+  const childList = makeEl("ul", { class: "tree-children" });
+  renderTreeNodes(groupNode.children, childList, workspaceId, depth + 1);
+
+  wrapper.classList.add("tree-expanded");
+  header.addEventListener("click", e => {
+    e.stopPropagation();
+    wrapper.classList.toggle("tree-expanded");
+  });
+  header.addEventListener("keydown", e => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      wrapper.classList.toggle("tree-expanded");
+    }
+  });
+
+  wrapper.appendChild(header);
+  wrapper.appendChild(childList);
+  return wrapper;
+}
+
+function renderTreeNodes(nodes, list, workspaceId, depth) {
+  let tabsRendered = 0;
+  const isRoot = depth === 0;
+  const maxTabs = isRoot ? TAB_CAP : Infinity;
+
+  for (const node of nodes) {
+    if (node.type === "tab") {
+      if (tabsRendered >= maxTabs) continue;
+      list.appendChild(buildTabRow(node.tab, workspaceId));
+      tabsRendered++;
+    } else if (node.type === "group") {
+      list.appendChild(buildGroupNode(node, workspaceId, depth));
+    }
+  }
+
+  if (isRoot) {
+    const totalTabs = nodes.filter(n => n.type === "tab").length;
+    const remaining = totalTabs - tabsRendered;
+    if (remaining > 0) {
+      list.appendChild(buildMoreRow(remaining));
+    }
+  }
+}
+
+function buildMoreRow(remaining) {
+  const row = makeEl("li", { class: "tab-row tab-more" });
+  document.l10n.setAttributes(row, "zen-space-overview-more-tabs", {
+    count: remaining,
+  });
+  return row;
+}
+
+function buildEmptyRow() {
+  const row = makeEl("li", { class: "tab-empty" });
+  document.l10n.setAttributes(row, "zen-space-overview-empty");
+  return row;
+}
+
+// ---------------------------------------------------------------------------
+// Bookmarks (async)
+// ---------------------------------------------------------------------------
+
+async function buildBookmarkSection(workspace, byWorkspace) {
+  const section = makeEl("details", { class: "bookmark-section" });
+  const summary = makeEl("summary", { class: "bookmark-heading" });
+  document.l10n.setAttributes(summary, "zen-space-overview-bookmarks");
+  section.appendChild(summary);
+
+  try {
+    const guids = byWorkspace[workspace.uuid] ?? [];
+
+    if (!guids.length) {
+      section.hidden = true;
+      return section;
+    }
+
+    const items = await Promise.all(
+      guids.map(guid =>
+        PlacesUtils.bookmarks.fetch(guid).catch(() => null)
+      )
+    );
+
+    const list = makeEl("ul", { class: "bookmark-list" });
+    let added = 0;
+
+    for (const item of items) {
+      if (!item) continue;
+      const url = item.url?.href ?? "";
+      const safeURL = sanitizeURL(url);
+
+      const li = makeEl("li", { class: "bookmark-item" });
+      const a = makeEl("a", { class: "bookmark-link" });
+      if (safeURL) {
+        a.setAttribute("href", safeURL);
+      }
+      a.textContent = item.title || url || "(Bookmark)";
+
+      a.addEventListener("click", e => {
+        e.preventDefault();
+        if (!safeURL) return;
+        chromeWin.gZenWorkspaces
+          .changeWorkspaceWithID(workspace.uuid)
+          .then(() => {
+            chromeWin.gBrowser.addTrustedTab(safeURL, {
+              triggeringPrincipal:
+                Services.scriptSecurityManager.getSystemPrincipal(),
+            });
+          })
+          .catch(err => LOG_ERR("Bookmark navigation error:", err));
+      });
+
+      li.appendChild(a);
+      list.appendChild(li);
+      added++;
+    }
+
+    if (!added) {
+      section.hidden = true;
+      return section;
+    }
+
+    section.appendChild(list);
+  } catch (err) {
+    LOG_ERR("Bookmark section error:", err);
+    section.hidden = true;
+  }
+
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// Theme tinting
+// ---------------------------------------------------------------------------
+
+function applyThemeTint(card, workspace) {
+  try {
+    const picker = chromeWin.gZenThemePicker;
+    if (!picker?.getGradientForWorkspace) return;
+    const theme = picker.getGradientForWorkspace(workspace);
+    const header = card.querySelector(".card-header");
+    if (theme?.gradient && header) {
+      header.style.setProperty("--space-theme-gradient", theme.gradient);
+      header.classList.add("has-theme");
+      if (theme.isDarkMode) {
+        header.classList.add("theme-dark");
+      }
+    }
+    if (theme?.primaryColor) {
+      card.style.setProperty("--space-primary-color", theme.primaryColor);
+      card.classList.add("has-theme");
+    }
+  } catch {
+    // Cosmetic — ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Card builder
+// ---------------------------------------------------------------------------
+
+function buildCard(workspace, treeNodes, byWorkspace) {
+  const { gZenWorkspaces } = chromeWin;
+
+  const card = makeEl("section", {
+    class: "space-card",
+    "data-workspace-id": workspace.uuid,
+  });
+
+  if (gZenWorkspaces.activeWorkspace === workspace.uuid) {
+    card.classList.add("is-active");
+  }
+
+  const totalTabs = countTreeTabs(treeNodes);
+
+  // ---- Header (STG-style: icon | name-input | count | actions) ----
+  const header = makeEl("div", { class: "card-header" });
+  header.dataset.workspaceId = workspace.uuid;
+
+  const icon = makeEl("span", { class: "space-icon" });
+  const rawIcon = gZenWorkspaces.getWorkspaceIcon(workspace);
+  // getWorkspaceIcon returns either a plain emoji string or a chrome:// URL
+  // pointing to an SVG asset. Render URLs as <img> elements; anything else
+  // is an emoji and can be set directly as text.
+  if (rawIcon && (rawIcon.startsWith("chrome://") || rawIcon.startsWith("resource://"))) {
+    const iconImg = makeEl("img", {
+      src: rawIcon,
+      alt: workspace.name,
+      class: "space-icon-img",
+    });
+    icon.appendChild(iconImg);
+  } else {
+    icon.textContent = rawIcon;
+  }
+
+  // Inline-editable name input (mirrors STG group-title input)
+  const nameInput = makeEl("input", {
+    class: "space-name",
+    type: "text",
+    maxlength: "256",
+  });
+  nameInput.value = workspace.name;
+  document.l10n.setAttributes(nameInput, "zen-space-overview-rename-placeholder");
+
+  // Prevent drags while editing
+  nameInput.addEventListener("focus", () => {
+    card.removeAttribute("draggable");
+  });
+
+  // Save on blur
+  nameInput.addEventListener("blur", () => {
+    const newName = nameInput.value.trim();
+    if (newName && newName !== workspace.name) {
+      const updated = Object.assign({}, workspace, { name: newName });
+      try {
+        gZenWorkspaces.saveWorkspace(updated);
+        workspace.name = newName;
+      } catch (err) {
+        LOG_ERR("Failed to rename workspace:", err);
+        nameInput.value = workspace.name;
+      }
+    } else if (!newName) {
+      nameInput.value = workspace.name;
+    }
+  });
+
+  // Save on Enter, blur on Escape
+  nameInput.addEventListener("keydown", e => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      nameInput.blur();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      nameInput.value = workspace.name;
+      nameInput.blur();
+    }
+    e.stopPropagation();
+  });
+
+  // Click on name field should not switch workspace
+  nameInput.addEventListener("click", e => e.stopPropagation());
+
+  const count = makeEl("span", { class: "space-count" });
+  count.textContent = String(totalTabs);
+
+  // Action icons: delete
+  const actions = makeEl("div", { class: "card-actions" });
+
+  const deleteBtn = makeEl("button", { class: "card-action-btn card-delete-btn", type: "button" });
+  deleteBtn.textContent = "✕";
+  document.l10n.setAttributes(deleteBtn, "zen-space-overview-delete-space");
+  deleteBtn.addEventListener("click", async e => {
+    e.stopPropagation();
+    const workspaces = gZenWorkspaces.getWorkspaces();
+    if (workspaces.length <= 1) return; // prevent deleting last space
+    try {
+      const [title, body] = await document.l10n.formatValues([
+        { id: "zen-workspaces-delete-workspace-title" },
+        {
+          id: "zen-workspaces-delete-workspace-body",
+          args: { name: workspace.name },
+        },
+      ]);
+      if (Services.prompt.confirm(null, title, body)) {
+        await gZenWorkspaces.removeWorkspace(workspace.uuid);
+        buildGrid();
+      }
+    } catch (err) {
+      LOG_ERR("Failed to delete workspace:", err);
+    }
+  });
+
+  actions.appendChild(deleteBtn);
+
+  // Header click (not on input or actions) switches space
+  header.addEventListener("click", e => {
+    if (
+      e.target === nameInput ||
+      e.target === deleteBtn ||
+      actions.contains(e.target)
+    ) {
+      return;
+    }
+    const wsId = header.dataset.workspaceId;
+    if (wsId) {
+      Promise.resolve(
+        gZenWorkspaces.changeWorkspaceWithID(wsId)
+      ).catch(err => LOG_ERR("Space switch error:", err));
+    }
+  });
+  header.setAttribute("role", "button");
+  header.setAttribute("tabindex", "0");
+  header.addEventListener("keydown", e => {
+    if (e.key === "Enter" || e.key === " ") {
+      if (document.activeElement === nameInput) return;
+      const wsId = header.dataset.workspaceId;
+      if (wsId) {
+        Promise.resolve(
+          gZenWorkspaces.changeWorkspaceWithID(wsId)
+        ).catch(err => LOG_ERR("Space switch error:", err));
+      }
+    }
+  });
+
+  header.appendChild(icon);
+  header.appendChild(nameInput);
+  header.appendChild(count);
+  header.appendChild(actions);
+  card.appendChild(header);
+
+  // ---- Body — tree view ----
+  const body = makeEl("div", { class: "card-body" });
+  const list = makeEl("ul", { class: "tab-list" });
+
+  if (!treeNodes.length) {
+    list.appendChild(buildEmptyRow());
+  } else {
+    renderTreeNodes(treeNodes, list, workspace.uuid, 0);
+  }
+
+  body.appendChild(list);
+  card.appendChild(body);
+
+  // Store refs so applyFilter can re-render dynamically without a full rebuild.
+  card._zenTreeNodes = treeNodes;
+  card._zenOriginalTabList = list;
+
+  // Bookmark placeholder (filled async)
+  const placeholder = makeEl("div", { class: "bookmark-placeholder" });
+  card.appendChild(placeholder);
+  buildBookmarkSection(workspace, byWorkspace).then(section =>
+    placeholder.replaceWith(section)
+  );
+
+  // Theme tinting
+  applyThemeTint(card, workspace);
+
+  // Drop target — accept tab drags from other space cards
+  let _dragCounter = 0;
+  card.addEventListener("dragover", e => {
+    if (!_draggedTab || card.dataset.workspaceId === _dragSourceWsId) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+  });
+  card.addEventListener("dragenter", () => {
+    if (!_draggedTab || card.dataset.workspaceId === _dragSourceWsId) return;
+    if (++_dragCounter === 1) card.classList.add("drag-over");
+  });
+  card.addEventListener("dragleave", () => {
+    if (--_dragCounter <= 0) {
+      _dragCounter = 0;
+      card.classList.remove("drag-over");
+    }
+  });
+  card.addEventListener("drop", e => {
+    e.preventDefault();
+    card.classList.remove("drag-over");
+    _dragCounter = 0;
+    const targetWsId = card.dataset.workspaceId;
+    if (!_draggedTab || targetWsId === _dragSourceWsId) return;
+    chromeWin.gZenWorkspaces.moveTabToWorkspace(_draggedTab, targetWsId);
+    _draggedTab = null;
+    _dragSourceWsId = null;
+    buildGrid();
+  });
+
+  return card;
+}
+
+function buildNewSpaceCard() {
+  const card = makeEl("section", {
+    class: "space-card new-space-card",
+    role: "button",
+    tabindex: "0",
+  });
+
+  const plusIcon = makeEl("span", { class: "new-space-plus" });
+  plusIcon.textContent = "+";
+
+  const label = makeEl("span", { class: "new-space-label" });
+  label.textContent = "New Space";
+  document.l10n.setAttributes(label, "zen-space-overview-new-space");
+
+  card.appendChild(plusIcon);
+  card.appendChild(label);
+
+  const activate = () => chromeWin.gZenWorkspaces.openWorkspaceCreation();
+  card.addEventListener("click", activate);
+  card.addEventListener("keydown", e => {
+    if (e.key === "Enter" || e.key === " ") activate();
+  });
+
+  return card;
+}
+
+// ---------------------------------------------------------------------------
+// Grid builder
+// ---------------------------------------------------------------------------
+
+async function buildGrid() {
+  LOG("Building grid");
+  const grid = document.getElementById("grid");
+  grid.textContent = "";
+
+  if (!chromeWin) {
+    const err = makeEl("div", { class: "error-state" });
+    document.l10n.setAttributes(err, "zen-space-overview-error");
+    grid.appendChild(err);
+    return;
+  }
+
+  const { gZenWorkspaces, ZenWorkspaceBookmarksStorage } = chromeWin;
+  const workspaces = gZenWorkspaces.getWorkspaces();
+
+  let byWorkspace = {};
+  try {
+    byWorkspace =
+      await ZenWorkspaceBookmarksStorage.getBookmarkGuidsByWorkspace();
+  } catch (err) {
+    LOG_ERR("Failed to fetch bookmark guids:", err);
+  }
+
+  for (const workspace of workspaces) {
+    const treeNodes = buildWorkspaceTree(workspace);
+    grid.appendChild(buildCard(workspace, treeNodes, byWorkspace));
+  }
+
+  grid.appendChild(buildNewSpaceCard());
+  LOG("Grid built:", workspaces.length, "space(s)");
+
+  // Re-apply any active search so the filter survives a grid rebuild
+  // (e.g. when the tab regains focus and visibilitychange triggers a refresh).
+  const activeQuery = document.getElementById("search")?.value.trim().toLowerCase() ?? "";
+  if (activeQuery) applyFilter(activeQuery);
+}
+
+// ---------------------------------------------------------------------------
+// Event listeners
+// ---------------------------------------------------------------------------
+
+function attachListeners() {
+  const grid = document.getElementById("grid");
+
+  // Unified click handler for the grid (tab rows only — headers handled per-card)
+  grid.addEventListener("click", e => {
+    // Tab row click — switch space then select that tab
+    const row = e.target.closest(
+      ".tab-row:not(.tab-more):not(.tab-empty):not(.new-space-card)"
+    );
+    if (row?._zenTab && !row._zenTab.closing) {
+      // Don't activate if clicking the close button
+      if (e.target.closest(".tab-close")) return;
+      const wsId = row.dataset.workspaceId;
+      if (wsId) {
+        Promise.resolve(
+          chromeWin.gZenWorkspaces.changeWorkspaceWithID(wsId)
+        )
+          .then(() => {
+            chromeWin.gBrowser.selectedTab = row._zenTab;
+          })
+          .catch(err => LOG_ERR("Tab switch error:", err));
+      }
+      return;
+    }
+  });
+
+  // Middle-click on a tab row → close that tab
+  grid.addEventListener("auxclick", e => {
+    if (e.button !== 1) return;
+    const row = e.target.closest(
+      ".tab-row:not(.tab-more):not(.tab-empty)"
+    );
+    if (!row?._zenTab || row._zenTab.closing) return;
+    e.preventDefault();
+
+    const card = row.closest(".space-card");
+    const wsId = card?.dataset.workspaceId;
+    removeTabFromCard(row._zenTab, card, wsId);
+  });
+
+  // Keyboard activation for tab rows
+  grid.addEventListener("keydown", e => {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    const row = e.target.closest(
+      ".tab-row:not(.tab-more):not(.tab-empty)"
+    );
+    if (row?._zenTab && !row._zenTab.closing) {
+      row.click();
+    }
+  });
+
+  const searchEl = document.getElementById("search");
+
+  let _searchTimer = null;
+  searchEl.addEventListener("input", e => {
+    clearTimeout(_searchTimer);
+    _searchTimer = setTimeout(
+      () => applyFilter(e.target.value.trim().toLowerCase()),
+      120
+    );
+  });
+
+  // Inspired by the URL-bar workspace search shortcut approach: any printable
+  // key typed while the search bar is not already focused auto-redirects there
+  // so the user never needs to click the search input first.
+  document.addEventListener("keydown", e => {
+    // Let F3 and Escape always work regardless of focus.
+    if (e.key === "Escape") {
+      searchEl.value = "";
+      applyFilter("");
+      searchEl.blur();
+      return;
+    }
+    if (e.key === "F3") {
+      e.preventDefault();
+      searchEl.focus();
+      return;
+    }
+
+    // Skip modifier-only combos, function keys, and navigation keys.
+    if (e.key.length !== 1 || e.ctrlKey || e.metaKey || e.altKey) return;
+    // Don't steal focus from the rename input inside a card.
+    if (document.activeElement?.classList.contains("space-name")) return;
+    // Already focused — let keystrokes flow naturally.
+    if (document.activeElement === searchEl) return;
+
+    // Focus the search bar; the browser will insert the pressed character.
+    searchEl.focus();
+  });
+
+  // Refresh button
+  document.getElementById("refresh-btn").addEventListener("click", () => {
+    document.getElementById("search").value = "";
+    buildGrid();
+  });
+
+  // Create space button (toolbar)
+  const createBtn = document.getElementById("create-space-btn");
+  if (createBtn) {
+    createBtn.addEventListener("click", () => {
+      chromeWin.gZenWorkspaces.openWorkspaceCreation();
+    });
+  }
+
+  // Auto-refresh when tab regains focus
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      LOG("Tab regained focus — refreshing");
+      buildGrid();
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+document.addEventListener("DOMContentLoaded", () => {
+  LOG("Initializing");
+
+  chromeWin = getChromeWindow();
+  if (!chromeWin) {
+    LOG_ERR("topChromeWindow unavailable");
+  }
+
+  attachListeners();
+  buildGrid();
+});

--- a/src/zen/spaces/zen-workspaces.css
+++ b/src/zen/spaces/zen-workspaces.css
@@ -443,3 +443,16 @@ zen-workspace {
     transform: rotate(0deg);
   }
 }
+
+/* Hide the URL bar content when the Space Overview tab is active */
+:root[zen-overview-active] {
+  & #urlbar-input-container {
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  & #zen-overview-button {
+    opacity: 1 !important;
+    filter: none !important;
+  }
+}


### PR DESCRIPTION
Hi everyone! I've been using Zen Browser lately and I'm absolutely loving it. One thing I really miss from my previous workflow though is the overview I used to get from the [Simple Tab Groups](https://github.com/Drive4ik/simple-tab-groups) extension.

When you start having a ton of spaces, it's easy to lose track of where everything is. So I thought, why not try to bring that "Command Center" feel directly into Zen?

This is a Proof of Concept for a **Space Overview** dashboard. It's basically a bird's-eye view of everything you have open.

<img width="1728" height="1117" alt="space overview" src="https://github.com/user-attachments/assets/d640a5d0-6c76-4f8b-8fdc-fb6fd8076fd6" />


### ✨ What's in there right now:
- **Full Overview:** See all your workspaces and tabs in one grid.
- **Drag & Drop:** You can actually drag tabs between space cards to reorganize them on the fly.
- **Instant Search:** Just start typing to filter tabs across all your spaces (it's really fast!).
- **Workspace Tweaks:** Rename or delete spaces right from the card headers.
- **Zen Integration:** It picks up your space gradients/themes and even shows your bookmarks for each space.

I've tried to keep the UX familiar for anyone who has used STG before (hover to close buttons, middle-click to close, etc.).

### 📸 Preview
<!-- [IMAGE_PLACEHOLDER: You can drag and drop your 'space overview.png' here!] -->

### 🛠 Status
This is still a **PoC**! The UI definitely needs some love and polish, but the engine is there and working. I'm really looking forward to getting your comments and feedback to see how we can make this a first-class feature for Zen.

Thanks for the great browser!