### PR TITLE
gh-10594: Repaint content on DOM fullscreen enter in compact borderless fullscreen (macOS notch)

### DIFF
--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -107,6 +107,17 @@ window.gZenCompactModeManager = {
         }
         this._setElementExpandAttribute(buttons, false);
       });
+
+      // Issue #10594: on a notched Mac in compact borderless fullscreen,
+      // entering DOM fullscreen (e.g. YouTube) leaves the content `<browser>`
+      // sized against stale viewport geometry, so the bottom ~notch-height of
+      // the video (progress bar / controls) sits below the visible screen.
+      // Force a layout flush + resize on the content area once the transition
+      // has started so the frame loader re-queries the safe viewport.
+      window.addEventListener(
+        "MozDOMFullscreen:Entered",
+        this._onMacDOMFullscreenEnter.bind(this)
+      );
     }
 
     SessionStore.promiseAllWindowsRestored.then(() => {
@@ -206,6 +217,38 @@ window.gZenCompactModeManager = {
     );
     // Always connect this observer, we need it even if compact mode is disabled
     ZenHasPolyfill.connectObserver(this.toolbarObserverId);
+  },
+
+  _onMacDOMFullscreenEnter() {
+    // Only the compact + native-fullscreen + borderless combination is affected.
+    if (
+      !this.preference ||
+      !document.documentElement.hasAttribute("inFullscreen") ||
+      !Services.prefs.getBoolPref("zen.view.borderless-fullscreen", true)
+    ) {
+      return;
+    }
+    // Wait two animation frames: one for the transition to start, one for the
+    // chrome to finish collapsing, then force a reflow + notify the content
+    // process so it re-measures against the real (post-notch) viewport.
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        const browser = gBrowser?.selectedBrowser;
+        if (!browser || !document.documentElement.hasAttribute("inDOMFullscreen")) {
+          return;
+        }
+        // Forces a synchronous layout flush on chrome.
+        void document.documentElement.getBoundingClientRect();
+        void browser.getBoundingClientRect();
+        // Nudge the frame loader so the content process resyncs its viewport.
+        try {
+          window.windowUtils.updateLayerTree();
+        } catch (e) {
+          // updateLayerTree is best-effort; swallow if unavailable.
+        }
+        window.dispatchEvent(new Event("resize"));
+      });
+    });
   },
 
   flashSidebarIfNecessary(aInstant = false) {


### PR DESCRIPTION
## Summary

Attempts to fix #10594 — on notched MacBooks, entering DOM fullscreen (e.g. fullscreen YouTube) while the browser is in compact mode + exclusive native fullscreen clips the bottom ~notch-height of the video content, hiding the progress bar and player controls.

Per @mr-cheffy's triage in the issue thread — *"we need to do one more re-paint when entering DOM fullscreen as compact mode seems to disable while entering fullscreen"* — this PR adds a macOS-only `MozDOMFullscreen:Entered` listener on `gZenCompactModeManager`. When the affected configuration is active (compact mode on, `[inFullscreen]` on the root, `zen.view.borderless-fullscreen` true), it waits two animation frames then:

1. Forces a synchronous chrome reflow (`getBoundingClientRect()` on root + selected browser).
2. Calls `windowUtils.updateLayerTree()` to nudge the compositor.
3. Dispatches a synthetic `resize` event so the content process re-queries the safe viewport.

Every other configuration early-returns, so there is no behavior change for non-macOS users, non-compact users, or users who have disabled borderless fullscreen.

### File touched
- `src/zen/compact-mode/ZenCompactMode.mjs` (+43 lines, no removals)

## ⚠️ Testing status — NEEDS VERIFICATION

I do **not** have access to a MacBook with a notch, which is the hardware the bug requires. This patch was written against the triage diagnosis and the existing codebase, but it has **not been built or run**. A reviewer (or any affected user) should:

1. Build the branch on a notched Mac.
2. Enable compact mode + borderless fullscreen.
3. Put the browser into exclusive (native) fullscreen.
4. Open a YouTube video and enter DOM fullscreen.
5. Confirm the progress bar / controls are visible.
6. Also verify the reproducer from [this comment](https://github.com/zen-browser/desktop/issues/10594#issuecomment-3439690006) (the standalone bug test page).

If the fix does not work, the diagnostic next step would be to log the frame loader's `browser.getBoundingClientRect()` before and after the two-rAF flush to see whether the post-flush rect matches the real safe viewport — if not, the repaint isn't the full story and we may need to toggle `--zen-element-separation` on `[inDOMFullscreen]`, or re-apply the safe-area inset during DOM fullscreen.

## Test plan

- [ ] Build on a notched MacBook (M1 Pro / M3 Air / M4 Pro have all been reported as affected).
- [ ] Confirm YouTube fullscreen controls render fully in compact borderless fullscreen.
- [ ] Confirm the bug-test page ([comment #3439690006](https://github.com/zen-browser/desktop/issues/10594#issuecomment-3439690006)) no longer clips its bottom marker.
- [ ] Confirm non-compact / non-fullscreen / non-macOS usage is unchanged (handler early-returns).
- [ ] Confirm exiting DOM fullscreen (handled separately via `flashSidebarIfNecessary`) still works.

Closes #10594 (pending verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)