### PR TITLE
gh-13095: restore multi-select highlight for split-view tabs

### DIFF
--- a/src/zen/split-view/zen-split-group.inc.css
+++ b/src/zen/split-view/zen-split-group.inc.css
@@ -104,7 +104,8 @@ tab-group[split-view-group] {
       }
     }
 
-    tab-group[split-view-group]:where([hasactivetab]) & {
+    tab-group[split-view-group]:where([hasactivetab]) &,
+    &:has(> tab:is([multiselected])) {
       background-color: var(--tab-selected-bgcolor);
       box-shadow: var(--tab-selected-shadow);
 


### PR DESCRIPTION
Fixes #13095.

The selector change in fe19b44 replaced the :has(multiselected) match with [hasactivetab], which only fires when the active tab is inside the split group. Multi-selecting tabs without the split tab in the initial selection dropped the highlight.

Added the multiselected path back as a union so both cases get the selected styling.