### PR TITLE
fix: prevent detached popups from converting to NSPopover on macOS (f…

### DIFF
--- a/src/external-patches/firefox/native_macos_popovers.patch
+++ b/src/external-patches/firefox/native_macos_popovers.patch
@@ -428,10 +428,22 @@ diff --git a/widget/cocoa/nsCocoaWindow.mm b/widget/cocoa/nsCocoaWindow.mm
 +    return false;
 +  }
 +  nsMenuPopupFrame* popupFrame = GetPopupFrame();
-+  return [mWindow isKindOfClass:[PopupWindow class]] &&
-+         [(PopupWindow*)mWindow usePopover] && popupFrame &&
-+         popupFrame->ShouldFollowAnchor() &&
-+         !popupFrame->PopupElement().GetBoolAttr(nsGkAtoms::nonnativepopover);
++  if (![mWindow isKindOfClass:[PopupWindow class]] ||
++      ![(PopupWindow*)mWindow usePopover] || !popupFrame ||
++      !popupFrame->ShouldFollowAnchor() ||
++      popupFrame->PopupElement().GetBoolAttr(nsGkAtoms::nonnativepopover)) {
++    return false;
++  }
++
++  // Additional validation: ensure the anchor rect is valid and non-empty
++  // This prevents detached popups (like Shopify theme editor) from being
++  // converted to NSPopover when they shouldn't be
++  nsRect anchorRectAppUnits = popupFrame->GetUntransformedAnchorRect();
++  if (anchorRectAppUnits.IsEmpty()) {
++    return false;
++  }
++
++  return true;
 +}
 +
  TransparencyMode nsCocoaWindow::GetTransparencyMode() {


### PR DESCRIPTION
…ixes gh-XXXXX)

This fix adds an additional validation to the ShouldShowAsNSPopover() function to check that the anchor rect is valid and non-empty. This prevents detached popups (like Shopify theme editor windows) from being incorrectly converted to NSPopover, which would fail to display due to NSPopover's requirement that the anchor must be within the parent view.

- Add anchor rect validation in ShouldShowAsNSPopover()
- Prevents 'empty anchor' popups from using NSPopover
- Maintains NSPopover benefits for properly-anchored UI popups
- Fixes Shopify theme editor not opening on macOS