### PR TITLE
gh-8643: Fix stuck sidebar in compact mode after DnD exception

### DIFF
--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -1139,6 +1139,12 @@
       const dt = event.dataTransfer;
       const draggedTab = dt.mozGetDataAt(TAB_DROP_TYPE, 0);
       let ownerGlobal = draggedTab?.ownerGlobal;
+      // Release the compact-mode drag latch up front so the sidebar can
+      // collapse on mouseleave again even if any step below throws (e.g.
+      // super.handle_dragend hitting a stale tab after an upstream drop
+      // failure). Otherwise _isTabBeingDragged stays true until restart and
+      // the sidebar pins open. See gh-8643.
+      delete ownerGlobal?.gZenCompactModeManager?._isTabBeingDragged;
       draggedTab.style.visibility = "";
       let thisFromGlobal = ownerGlobal?.gBrowser.tabContainer.tabDragAndDrop;
       let currentEssenialContainer =
@@ -1172,7 +1178,6 @@
         thisFromGlobal._tempDragImageParent.remove();
         delete thisFromGlobal._tempDragImageParent;
       }
-      delete ownerGlobal.gZenCompactModeManager._isTabBeingDragged;
       if (dt.dropEffect !== "move") {
         ownerGlobal.gZenCompactModeManager._clearAllHoverStates();
       }


### PR DESCRIPTION
## Why

Closes #8643.

In compact mode the sidebar randomly stops auto-collapsing on mouse leave after ~1h of use and stays pinned open until restart. Reported reliably on macOS, intermittently elsewhere.

Root cause: `gZenCompactModeManager._isTabBeingDragged` is the latch that keeps the sidebar expanded during a drag. It's set in `startTabDrag` and cleared at the very *end* of `handle_dragend`. If any step inside `handle_dragend` throws — most commonly `super.handle_dragend` after an upstream drop failure like `adoptTab` hitting a null `linkedBrowser` — the delete never runs. The mouseleave path in `ZenCompactMode.mjs:830` then early-returns forever because the flag is still truthy, and the sidebar stays pinned open until the process restarts.

## What

One-line fix: move the `delete gZenCompactModeManager._isTabBeingDragged` to the top of `handle_dragend` (with optional chaining to survive a null owner global). Now the latch is released before anything that could throw runs, so the sidebar can always collapse on the next mouseleave — regardless of whether later cleanup succeeds.

## Test plan

- [ ] Launch Zen, enable compact mode with auto-hide sidebar.
- [ ] Drag a tab within the sidebar, drop it — sidebar collapses on mouseleave (no regression).
- [ ] Drag a tab across workspaces — workspace still switches, sidebar still collapses.
- [ ] Drag a tab out to create a new window — adoption still works, sidebar still collapses.
- [ ] Synthetic repro: throw from `super.handle_dragend` (e.g. monkey-patch to throw, or reproduce the `linkedBrowser is null` / `children.at(...)` condition from #8643) — confirm the sidebar still collapses on mouseleave after the failed drag.
- [ ] Long-session check: after a known bad drag error fires, hover out of the sidebar — it collapses.