### PR TITLE
no-bug: `contain` of `.zen-glance-sidebar-container` too strict

### DIFF
--- a/src/zen/glance/zen-glance.css
+++ b/src/zen/glance/zen-glance.css
@@ -10,7 +10,7 @@
   z-index: 999;
 
   will-change: transform, opacity;
-  contain: content;
+  contain: layout style;
 
   top: 15px;
   padding: 12px;


### PR DESCRIPTION
The confirm button was cut off due to

https://github.com/zen-browser/desktop/blob/0199e256d68d62bc6b7926792601f5fa5cc405b1/src/zen/glance/zen-glance.css#L13

<img width="551" height="518" alt="image" src="https://github.com/user-attachments/assets/d5eba075-b1f0-4572-9a3c-2c9d7d7f4c31" />
