### PR TITLE
fix: Harden native macOS popover against use-after-free on app activation (gh-13294)

### DIFF
--- a/src/external-patches/firefox/native_macos_popovers.patch
+++ b/src/external-patches/firefox/native_macos_popovers.patch
@@ -327,6 +327,9 @@ diff --git a/widget/cocoa/nsCocoaWindow.mm b/widget/cocoa/nsCocoaWindow.mm
 +      nsCocoaUtils::CocoaRectToGeckoRectDevPix(windowFrame, backingScale);
 +
 +  nsPresContext* presContext = aPopupFrame->PresContext();
++  if (!presContext) {
++    return;
++  }
 +  mozilla::CSSIntPoint cssPos =
 +      presContext->DevPixelsToIntCSSPixels(devPixRect.TopLeft());
 +
@@ -347,7 +350,20 @@ diff --git a/widget/cocoa/nsCocoaWindow.mm b/widget/cocoa/nsCocoaWindow.mm
        NS_OBJC_END_TRY_IGNORE_BLOCK;
 +      if (ShouldShowAsNSPopover()) {
 +        nsMenuPopupFrame* popupFrame = GetPopupFrame();
-+        if (nativeParentWindow) {
++        // Re-fetch the parent window pointer.  The value captured at the
++        // top of Show() can become stale when the parent widget is torn
++        // down during macOS activation-notification dispatch (see
++        // gh-13194, gh-13294).
++        NSWindow* popoverParent = mParent
++            ? (NSWindow*)mParent->GetNativeData(NS_NATIVE_WINDOW)
++            : nil;
++        NSView* parentView =
++            popoverParent ? [popoverParent contentView] : nil;
++        bool popoverShown = false;
++        if (popoverParent && parentView && popupFrame &&
++            popupFrame->PresContext() &&
++            popupFrame->PresContext()->DeviceContext()) {
++          NS_OBJC_BEGIN_TRY_IGNORE_BLOCK;
 +          NSRectEdge preferredEdge =
 +              AlignmentPositionToNSRectEdge(popupFrame->GetAlignmentPosition());
 +          nsRect anchorRectAppUnits = popupFrame->GetUntransformedAnchorRect();
@@ -360,20 +376,10 @@ diff --git a/widget/cocoa/nsCocoaWindow.mm b/widget/cocoa/nsCocoaWindow.mm
 +                  mozilla::LayoutDeviceRect::FromAppUnits(anchorRectAppUnits,
 +                                                          appUnitsPerDevPixel) /
 +                  desktopToLayoutScale);
-+          // Taking the now correctly scaled anchor rect and turning it into a
-+          // gecko rect this accounts for the y-axis inversion that cocoa needs,
-+          // as the origin is in the bottom left. This rect is in screen space
 +          NSRect cocoaScreenRect =
 +              nsCocoaUtils::GeckoRectToCocoaRect(popupAnchorRectScaled);
-+          // We take the screen space rect and convert it to window space
-+          // coordinates, as NSPopover requires the coordinates to be in view
-+          // space and inside the view. If the coordinates are outside our view,
-+          // the popover will fail silently
 +          NSRect windowRect =
-+              [nativeParentWindow convertRectFromScreen:cocoaScreenRect];
-+          NSView* parentView = [nativeParentWindow contentView];
-+          // We take the window space rect and convert it to view space for the
-+          // specific parent view
++              [popoverParent convertRectFromScreen:cocoaScreenRect];
 +          NSRect positioningRect = [parentView convertRect:windowRect
 +                                                  fromView:nil];
 +          BOOL shouldHideAnchor = NO;
@@ -386,8 +392,18 @@ diff --git a/widget/cocoa/nsCocoaWindow.mm b/widget/cocoa/nsCocoaWindow.mm
 +                                             preferredEdge:preferredEdge
 +                                              hiddenAnchor:shouldHideAnchor];
 +          SyncPopoverBounds([(PopupWindow*)mWindow popover], popupFrame);
++          popoverShown = [(PopupWindow*)mWindow popover].shown;
++          NS_OBJC_END_TRY_IGNORE_BLOCK;
 +        }
-+        return;
++        if (popoverShown) {
++          return;
++        }
++        // Parent is gone or partially torn down — close any lingering
++        // popover and fall through to normal popup display logic.
++        if ([mWindow isKindOfClass:[PopupWindow class]] &&
++            [(PopupWindow*)mWindow usePopover]) {
++          [(PopupWindow*)mWindow closePopover];
++        }
 +      }
        // If our popup window is a non-native context menu, tell the OS (and
        // other programs) that a menu has opened.  This is how the OS knows to
@@ -445,11 +461,10 @@ diff --git a/widget/cocoa/nsCocoaWindow.mm b/widget/cocoa/nsCocoaWindow.mm
    // the wrong place, leading to a visual jump.
    [mWindow setFrame:newFrame display:YES];
  
-+  if (ShouldUseNSPopover() && [(PopupWindow*)mWindow usePopover]) {
++  if (ShouldUseNSPopover() &&
++      [mWindow isKindOfClass:[PopupWindow class]] &&
++      [(PopupWindow*)mWindow usePopover]) {
 +    [(PopupWindow*)mWindow updatePopoverContent];
-+    // A popover won't resize by setting the frame
-+    // as it's size is calculated based on the content size
-+    // Therefor the content size has to be changed as well
 +    NSSize contentSize = NSMakeSize(aWidth, aHeight);
 +    [[(PopupWindow*)mWindow popover] setContentSize:contentSize];
 +    SyncPopoverBounds([(PopupWindow*)mWindow popover], GetPopupFrame());
@@ -535,7 +550,7 @@ diff --git a/widget/cocoa/nsCocoaWindow.mm b/widget/cocoa/nsCocoaWindow.mm
 +                    preferredEdge:(NSRectEdge)preferredEdge
 +                     hiddenAnchor:(BOOL)hiddenAnchor {
 +  NS_OBJC_BEGIN_TRY_IGNORE_BLOCK;
-+  if (!mPopover) {
++  if (!mPopover || !positioningView || !positioningView.window) {
 +    return;
 +  }
 +
@@ -560,7 +575,9 @@ diff --git a/widget/cocoa/nsCocoaWindow.mm b/widget/cocoa/nsCocoaWindow.mm
 +  }
 +
 +  NSWindow* popoverWindow = mPopover.contentViewController.view.window;
-+  [popoverWindow setAcceptsMouseMovedEvents:YES];
++  if (popoverWindow) {
++    [popoverWindow setAcceptsMouseMovedEvents:YES];
++  }
 +
 +  NS_OBJC_END_TRY_IGNORE_BLOCK;
 +}


### PR DESCRIPTION
## Summary

Fix use-after-free crash (EXC_BAD_ACCESS / SIGSEGV) in nsCocoaWindow::Show() when macOS sends activation notifications and the parent window has been destroyed. The crash occurs in convertRectFromScreen: on a stale nativeParentWindow pointer during _NXShowKeyAndMain → _handleActivatedEvent notification dispatch. Multiple users report identical crash stacks on Apple Silicon Macs (#13194, #13294).

## Changes

- Re-fetch parent pointer before popover positioning instead of using the potentially stale value captured at the top of Show()
- Validate parent window, contentView, popupFrame, PresContext, and DeviceContext before entering the popover code path
- Wrap ObjC calls in try/catch (NS_OBJC_BEGIN_TRY_IGNORE_BLOCK) and use popover.shown to confirm success — on failure, fall through to normal popup logic
- Add null guards in showPopoverRelativeToRect: (positioningView, popoverWindow) and SyncPopoverBounds (PresContext)
- Add isKindOfClass guard before PopupWindow cast in the Resize path

Closes #13294
Related: #13194