### PR TITLE
Add GitLab live folders provider (cloud and self-hosted)

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -20,3 +20,5 @@ files:
     translation: browser/browser/preferences/zen-preferences.ftl
   - source: en-US/browser/browser/zen-folders.ftl
     translation: browser/browser/zen-folders.ftl
+  - source: en-US/browser/browser/zen-live-folders.ftl
+    translation: browser/browser/zen-live-folders.ftl

--- a/docs/live-folders-specs.md
+++ b/docs/live-folders-specs.md
@@ -52,6 +52,18 @@ interface LiveFolderProvider {
 - **Configuration**:
   - `username`: GitHub username.
 
+#### `GitlabLiveFolderProvider`
+
+- **Description**: Updates live folder contents from a GitLab user's Merge Requests or Issues.
+- **Hosts**: Works with `gitlab.com` and self-hosted instances. The host is auto-detected from the active tab when the folder is created (falls back to `gitlab.com`).
+- **Authentication**:
+  - **Cookie-first**: relies on the user's existing GitLab session cookies, just like `GithubLiveFolderProvider`. No prompt and no setup for the common case.
+  - **Personal Access Token (fallback)**: when cookies are not enough (typical for some self-hosted instances behind SSO), the user can set a PAT via the folder's context menu. The token must have at least the `read_api` scope. It is stored in the Firefox Login Manager (encrypted by the platform), keyed by host, and never written to `zen-live-folders.jsonlz4`.
+- **Endpoints used** (REST v4, `GET`):
+  - `https://{host}/api/v4/merge_requests?scope=assigned_to_me|created_by_me&state=opened`
+  - `https://{host}/api/v4/merge_requests?reviewer_username=__me__&state=opened` (for "Review Requests")
+  - `https://{host}/api/v4/issues?scope=assigned_to_me|created_by_me&state=opened`
+
 #### `RestAPILiveFolderProvider`
 
 - **Description**: Updates live folder contents from a REST API endpoint.

--- a/locales/en-US/browser/browser/zen-live-folders.ftl
+++ b/locales/en-US/browser/browser/zen-live-folders.ftl
@@ -115,6 +115,11 @@ zen-live-folder-gitlab-option-review-requested =
 zen-live-folder-gitlab-option-instance =
     .label = Instance: { $host }
 
+zen-live-folder-gitlab-option-change-instance =
+    .label = Change Instance…
+
+zen-live-folder-gitlab-prompt-instance = GitLab instance host (e.g. gitlab.com or forge.example.org)
+
 zen-live-folder-gitlab-option-project-filter =
     .label = Projects
 

--- a/locales/en-US/browser/browser/zen-live-folders.ftl
+++ b/locales/en-US/browser/browser/zen-live-folders.ftl
@@ -120,6 +120,10 @@ zen-live-folder-gitlab-option-change-instance =
 
 zen-live-folder-gitlab-prompt-instance = GitLab instance host (e.g. gitlab.com or forge.example.org)
 
+zen-live-folder-gitlab-prompt-pat-title = GitLab access token
+
+zen-live-folder-gitlab-prompt-instance-title = GitLab instance
+
 zen-live-folder-gitlab-option-project-filter =
     .label = Projects
 

--- a/locales/en-US/browser/browser/zen-live-folders.ftl
+++ b/locales/en-US/browser/browser/zen-live-folders.ftl
@@ -97,5 +97,48 @@ zen-live-folder-github-issues =
 zen-live-folder-github-option-repo-list-note =
     .label = This list is generated based on your currently active pull requests.
 
+zen-live-folder-gitlab-merge-requests =
+    .label = GitLab Merge Requests
+
+zen-live-folder-gitlab-issues =
+    .label = GitLab Issues
+
+zen-live-folder-gitlab-option-author-self =
+    .label = Created by Me
+
+zen-live-folder-gitlab-option-assigned-self =
+    .label = Assigned to Me
+
+zen-live-folder-gitlab-option-review-requested =
+    .label = Review Requests
+
+zen-live-folder-gitlab-option-instance =
+    .label = Instance: { $host }
+
+zen-live-folder-gitlab-option-project-filter =
+    .label = Projects
+
+zen-live-folder-gitlab-option-project =
+    .label = { $project }
+
+zen-live-folder-gitlab-option-project-list-note =
+    .label = This list is generated based on your currently active items.
+
+zen-live-folder-gitlab-option-set-token =
+    .label = Set Access Token…
+
+zen-live-folder-gitlab-option-remove-token =
+    .label = Remove Access Token
+
+zen-live-folder-gitlab-no-auth =
+    .label = Not signed in to GitLab
+    .tooltiptext = Sign in to GitLab or set a personal access token.
+
+zen-live-folder-gitlab-no-filter =
+    .label = Filter is not set
+    .tooltiptext = No filter set, nothing will be fetched.
+
+zen-live-folder-gitlab-prompt-pat = Personal access token for { $host } (read_api scope minimum)
+
 zen-live-folders-promotion-title = Live Folder Created!
-zen-live-folders-promotion-description = Latest content from your RSS feeds or GitHub pull requests will appear here automatically.
+zen-live-folders-promotion-description = Latest content from your RSS feeds, GitHub or GitLab will appear here automatically.

--- a/src/browser/themes/shared/zen-icons/common/selectable/logo-gitlab.svg
+++ b/src/browser/themes/shared/zen-icons/common/selectable/logo-gitlab.svg
@@ -1,0 +1,1 @@
+<svg fill="context-fill" fill-opacity="context-fill-opacity" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg"><path d="M256 472 40 256l40-160 96 192 80-200 80 200 96-192 40 160z"/></svg>

--- a/src/browser/themes/shared/zen-icons/jar.inc.mn
+++ b/src/browser/themes/shared/zen-icons/jar.inc.mn
@@ -438,7 +438,7 @@
 *  skin/classic/browser/zen-icons/selectable/location.svg          (../shared/zen-icons/common/selectable/location.svg) 
 *  skin/classic/browser/zen-icons/selectable/lock-closed.svg          (../shared/zen-icons/common/selectable/lock-closed.svg) 
 *  skin/classic/browser/zen-icons/selectable/logo-github.svg          (../shared/zen-icons/common/selectable/logo-github.svg) 
-*  skin/classic/browser/zen-icons/selectable/logo-gitlab.svg          (../shared/zen-icons/common/selectable/logo-gitlab.svg) 
+   skin/classic/browser/zen-icons/selectable/logo-gitlab.svg          (../shared/zen-icons/common/selectable/logo-gitlab.svg)
 *  skin/classic/browser/zen-icons/selectable/logo-rss.svg          (../shared/zen-icons/common/selectable/logo-rss.svg) 
 *  skin/classic/browser/zen-icons/selectable/logo-usd.svg          (../shared/zen-icons/common/selectable/logo-usd.svg) 
 *  skin/classic/browser/zen-icons/selectable/mail.svg          (../shared/zen-icons/common/selectable/mail.svg) 

--- a/src/browser/themes/shared/zen-icons/jar.inc.mn
+++ b/src/browser/themes/shared/zen-icons/jar.inc.mn
@@ -438,6 +438,7 @@
 *  skin/classic/browser/zen-icons/selectable/location.svg          (../shared/zen-icons/common/selectable/location.svg) 
 *  skin/classic/browser/zen-icons/selectable/lock-closed.svg          (../shared/zen-icons/common/selectable/lock-closed.svg) 
 *  skin/classic/browser/zen-icons/selectable/logo-github.svg          (../shared/zen-icons/common/selectable/logo-github.svg) 
+*  skin/classic/browser/zen-icons/selectable/logo-gitlab.svg          (../shared/zen-icons/common/selectable/logo-gitlab.svg) 
 *  skin/classic/browser/zen-icons/selectable/logo-rss.svg          (../shared/zen-icons/common/selectable/logo-rss.svg) 
 *  skin/classic/browser/zen-icons/selectable/logo-usd.svg          (../shared/zen-icons/common/selectable/logo-usd.svg) 
 *  skin/classic/browser/zen-icons/selectable/mail.svg          (../shared/zen-icons/common/selectable/mail.svg) 

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -87,6 +87,14 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
              command="cmd_zenNewLiveFolder"
              image="chrome://browser/skin/zen-icons/selectable/logo-github.svg" />
            <menuitem
+             data-l10n-id="zen-live-folder-gitlab-merge-requests"
+             command="cmd_zenNewLiveFolder"
+             image="chrome://browser/skin/zen-icons/selectable/logo-gitlab.svg" />
+           <menuitem
+             data-l10n-id="zen-live-folder-gitlab-issues"
+             command="cmd_zenNewLiveFolder"
+             image="chrome://browser/skin/zen-icons/selectable/logo-gitlab.svg" />
+           <menuitem
              data-l10n-id="zen-live-folder-type-rss"
              command="cmd_zenNewLiveFolder"
              image="chrome://browser/skin/zen-icons/selectable/logo-rss.svg"/>

--- a/src/zen/live-folders/GitlabAuth.sys.mjs
+++ b/src/zen/live-folders/GitlabAuth.sys.mjs
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+const HTTP_REALM = "zen-live-folder-gitlab-pat";
+const USERNAME = "zen";
+
+function originForHost(host) {
+  return `https://${host}`;
+}
+
+function buildLoginInfo(host, token) {
+  return Cc["@mozilla.org/login-manager/loginInfo;1"]
+    .createInstance(Ci.nsILoginInfo)
+    .init(originForHost(host), null, HTTP_REALM, USERNAME, token, "", "");
+}
+
+export const GitlabAuth = {
+  async getToken(host) {
+    if (!host) {
+      return null;
+    }
+    const logins = await Services.logins.searchLoginsAsync({
+      origin: originForHost(host),
+      httpRealm: HTTP_REALM,
+    });
+    return logins[0]?.password ?? null;
+  },
+
+  async setToken(host, token) {
+    if (!host || !token) {
+      return;
+    }
+    await this.removeToken(host);
+    await Services.logins.addLoginAsync(buildLoginInfo(host, token));
+  },
+
+  async removeToken(host) {
+    if (!host) {
+      return;
+    }
+    const logins = await Services.logins.searchLoginsAsync({
+      origin: originForHost(host),
+      httpRealm: HTTP_REALM,
+    });
+    for (const login of logins) {
+      Services.logins.removeLogin(login);
+    }
+  },
+};

--- a/src/zen/live-folders/GitlabAuth.sys.mjs
+++ b/src/zen/live-folders/GitlabAuth.sys.mjs
@@ -10,9 +10,11 @@ function originForHost(host) {
 }
 
 function buildLoginInfo(host, token) {
-  return Cc["@mozilla.org/login-manager/loginInfo;1"]
-    .createInstance(Ci.nsILoginInfo)
-    .init(originForHost(host), null, HTTP_REALM, USERNAME, token, "", "");
+  const login = Cc["@mozilla.org/login-manager/loginInfo;1"].createInstance(
+    Ci.nsILoginInfo
+  );
+  login.init(originForHost(host), null, HTTP_REALM, USERNAME, token, "", "");
+  return login;
 }
 
 export const GitlabAuth = {

--- a/src/zen/live-folders/ZenLiveFoldersManager.sys.mjs
+++ b/src/zen/live-folders/ZenLiveFoldersManager.sys.mjs
@@ -148,6 +148,14 @@ class nsZenLiveFoldersManager {
             this.createFolder("github:issues");
             break;
           }
+          case "zen-live-folder-gitlab-merge-requests": {
+            this.createFolder("gitlab:merge-requests");
+            break;
+          }
+          case "zen-live-folder-gitlab-issues": {
+            this.createFolder("gitlab:issues");
+            break;
+          }
           case "zen-live-folder-type-rss": {
             this.createFolder("rss");
             break;
@@ -237,6 +245,15 @@ class nsZenLiveFoldersManager {
         icon = "chrome://browser/skin/zen-icons/selectable/logo-github.svg";
         break;
       }
+      case "gitlab": {
+        const [message] = await lazy.l10n.formatMessages([
+          { id: `zen-live-folder-gitlab-${providerType}` },
+        ]);
+
+        label = message.attributes[0].value;
+        icon = "chrome://browser/skin/zen-icons/selectable/logo-gitlab.svg";
+        break;
+      }
     }
 
     const folder = this.window.gZenFolders.createFolder([], {
@@ -251,11 +268,16 @@ class nsZenLiveFoldersManager {
       this.window.gZenFolders.setFolderUserIcon(folder, icon);
     }
 
+    const initialState = {
+      url,
+      type: providerType,
+    };
+    if (typeof ProviderClass.getDefaultHost === "function") {
+      initialState.host = ProviderClass.getDefaultHost(this.window);
+    }
+
     const config = {
-      state: this.#applyDefaultStateValues({
-        url,
-        type: providerType,
-      }),
+      state: this.#applyDefaultStateValues(initialState),
     };
 
     let liveFolder = new ProviderClass({

--- a/src/zen/live-folders/ZenLiveFoldersManager.sys.mjs
+++ b/src/zen/live-folders/ZenLiveFoldersManager.sys.mjs
@@ -27,6 +27,10 @@ const providers = [
     path: "resource:///modules/zen/GithubLiveFolder.sys.mjs",
     module: "nsGithubLiveFolderProvider",
   },
+  {
+    path: "resource:///modules/zen/GitlabLiveFolder.sys.mjs",
+    module: "nsGitlabLiveFolderProvider",
+  },
 ];
 
 class nsZenLiveFoldersManager {

--- a/src/zen/live-folders/moz.build
+++ b/src/zen/live-folders/moz.build
@@ -3,7 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 EXTRA_JS_MODULES.zen += [
+    "GitlabAuth.sys.mjs",
     "providers/GithubLiveFolder.sys.mjs",
+    "providers/GitlabLiveFolder.sys.mjs",
     "providers/RssLiveFolder.sys.mjs",
     "ZenLiveFolder.sys.mjs",
     "ZenLiveFoldersManager.sys.mjs",

--- a/src/zen/live-folders/providers/GitlabLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GitlabLiveFolder.sys.mjs
@@ -313,17 +313,15 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
   async #promptForToken() {
     const window = this.manager.window;
     const [promptText] = await lazy.l10n.formatValues([
-      { id: "zen-live-folder-gitlab-prompt-pat", args: { host: this.state.host } },
+      {
+        id: "zen-live-folder-gitlab-prompt-pat",
+        args: { host: this.state.host },
+      },
     ]);
     const input = { value: "" };
-    const ok = Services.prompt.prompt(
-      window,
-      promptText,
-      null,
-      input,
-      null,
-      { value: null }
-    );
+    const ok = Services.prompt.prompt(window, promptText, null, input, null, {
+      value: null,
+    });
     if (!ok) {
       return;
     }

--- a/src/zen/live-folders/providers/GitlabLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GitlabLiveFolder.sys.mjs
@@ -71,7 +71,7 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
     return headers;
   }
 
-  #buildScopeUrls() {
+  #buildScopeUrls(userId) {
     const isMergeRequest = this.state.type === "merge-requests";
     const scopes = [];
 
@@ -81,12 +81,20 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
     if (this.state.options.authorMe ?? false) {
       scopes.push({ scope: "created_by_me" });
     }
-    if (isMergeRequest && (this.state.options.reviewRequested ?? false)) {
-      // GitLab uses reviewer_username=__me__ rather than scope= for review-requested.
-      scopes.push({ scope: null, reviewer: true });
+    if (
+      isMergeRequest &&
+      (this.state.options.reviewRequested ?? false) &&
+      userId
+    ) {
+      // The /merge_requests endpoint defaults to scope=created_by_me on the
+      // server, so a reviewer filter without scope=all silently intersects to
+      // empty whenever the MR was opened by someone else (the common case for
+      // reviewers). Older GitLab versions also do not resolve __me__, so we
+      // pass the resolved numeric id instead.
+      scopes.push({ scope: "all", reviewerId: userId });
     }
 
-    return scopes.map(({ scope, reviewer }) => {
+    return scopes.map(({ scope, reviewerId }) => {
       const url = new URL(`${this.#apiBase}/${this.#resourcePath}`);
       url.searchParams.set("state", "opened");
       url.searchParams.set("per_page", "50");
@@ -95,11 +103,33 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
       if (scope) {
         url.searchParams.set("scope", scope);
       }
-      if (reviewer) {
-        url.searchParams.set("reviewer_username", "__me__");
+      if (reviewerId) {
+        url.searchParams.set("reviewer_id", String(reviewerId));
       }
       return url.href;
     });
+  }
+
+  async #fetchUserId() {
+    if (this.state.userId) {
+      return this.state.userId;
+    }
+    try {
+      const headers = await this.#buildHeaders();
+      const { text, status } = await this.fetch(`${this.#apiBase}/user`, {
+        headers,
+      });
+      if (status !== 200) {
+        return null;
+      }
+      const user = JSON.parse(text);
+      if (typeof user?.id === "number") {
+        this.state.userId = user.id;
+        this.requestSave();
+        return user.id;
+      }
+    } catch {}
+    return null;
   }
 
   async fetchItems() {
@@ -114,7 +144,11 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
       }
 
       const headers = await this.#buildHeaders();
-      const urls = this.#buildScopeUrls();
+      const reviewRequested =
+        this.state.type === "merge-requests" &&
+        (this.state.options.reviewRequested ?? false);
+      const userId = reviewRequested ? await this.#fetchUserId() : null;
+      const urls = this.#buildScopeUrls(userId);
 
       const responses = await Promise.all(
         urls.map(url => this.#fetchScope(url, headers))
@@ -330,7 +364,7 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
       },
     ]);
     const input = { value: "" };
-    const ok = Services.prompt.prompt(window, promptText, null, input, null, {
+    const ok = Services.prompt.prompt(window, "", promptText, input, null, {
       value: null,
     });
     if (!ok) {
@@ -350,7 +384,7 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
       "zen-live-folder-gitlab-prompt-instance",
     ]);
     const input = { value: this.state.host };
-    const ok = Services.prompt.prompt(window, promptText, null, input, null, {
+    const ok = Services.prompt.prompt(window, "", promptText, input, null, {
       value: null,
     });
     if (!ok) {
@@ -364,9 +398,11 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
       return false;
     }
     this.state.host = host;
-    // Switching instances invalidates the per-host project list.
+    // Switching instances invalidates the per-host project list and the
+    // cached numeric user id (it belongs to the previous host).
     this.state.projects = new Set();
     this.state.options.projectExcludes = new Set();
+    delete this.state.userId;
     return true;
   }
 

--- a/src/zen/live-folders/providers/GitlabLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GitlabLiveFolder.sys.mjs
@@ -357,16 +357,23 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
 
   async #promptForToken() {
     const window = this.manager.window;
-    const [promptText] = await lazy.l10n.formatValues([
+    const [title, promptText] = await lazy.l10n.formatValues([
+      "zen-live-folder-gitlab-prompt-pat-title",
       {
         id: "zen-live-folder-gitlab-prompt-pat",
         args: { host: this.state.host },
       },
     ]);
     const input = { value: "" };
-    const ok = Services.prompt.prompt(window, "", promptText, input, null, {
-      value: null,
-    });
+    // Use promptPassword so the PAT is masked while typing — it's a secret.
+    const ok = Services.prompt.promptPassword(
+      window,
+      title,
+      promptText,
+      input,
+      null,
+      { value: null }
+    );
     if (!ok) {
       return;
     }
@@ -380,11 +387,12 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
 
   async #promptForInstance() {
     const window = this.manager.window;
-    const [promptText] = await lazy.l10n.formatValues([
+    const [title, promptText] = await lazy.l10n.formatValues([
+      "zen-live-folder-gitlab-prompt-instance-title",
       "zen-live-folder-gitlab-prompt-instance",
     ]);
     const input = { value: this.state.host };
-    const ok = Services.prompt.prompt(window, "", promptText, input, null, {
+    const ok = Services.prompt.prompt(window, title, promptText, input, null, {
       value: null,
     });
     if (!ok) {

--- a/src/zen/live-folders/providers/GitlabLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GitlabLiveFolder.sys.mjs
@@ -1,0 +1,368 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { nsZenLiveFolderProvider } from "resource:///modules/zen/ZenLiveFolder.sys.mjs";
+
+const lazy = {};
+ChromeUtils.defineESModuleGetters(lazy, {
+  GitlabAuth: "resource:///modules/zen/GitlabAuth.sys.mjs",
+});
+
+ChromeUtils.defineLazyGetter(
+  lazy,
+  "l10n",
+  () => new Localization(["browser/zen-live-folders.ftl"])
+);
+
+const DEFAULT_HOST = "gitlab.com";
+const ICON_URL = "chrome://browser/skin/zen-icons/selectable/logo-gitlab.svg";
+
+// Best-effort heuristic: detect a GitLab instance from the active tab's URL.
+// Falls back to gitlab.com when nothing convincing is found.
+function looksLikeGitlabHost(host) {
+  if (!host) {
+    return false;
+  }
+  return host === "gitlab.com" || /(^|\.)gitlab\./i.test(host);
+}
+
+export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
+  static type = "gitlab";
+
+  static getDefaultHost(window) {
+    try {
+      const uri = window?.gBrowser?.selectedBrowser?.currentURI;
+      if (uri && (uri.scheme === "https" || uri.scheme === "http")) {
+        if (looksLikeGitlabHost(uri.host)) {
+          return uri.host;
+        }
+      }
+    } catch {}
+    return DEFAULT_HOST;
+  }
+
+  constructor({ id, state, manager }) {
+    super({ id, state, manager });
+
+    this.state.type = state.type;
+    this.state.host = state.host || DEFAULT_HOST;
+    this.state.options = state.options ?? {};
+    this.state.projects = new Set(state.projects ?? []);
+    this.state.options.projectExcludes = new Set(
+      state.options.projectExcludes ?? []
+    );
+  }
+
+  get #apiBase() {
+    return `https://${this.state.host}/api/v4`;
+  }
+
+  get #resourcePath() {
+    return this.state.type === "merge-requests" ? "merge_requests" : "issues";
+  }
+
+  async #buildHeaders() {
+    const headers = { Accept: "application/json" };
+    const token = await lazy.GitlabAuth.getToken(this.state.host);
+    if (token) {
+      headers["PRIVATE-TOKEN"] = token;
+    }
+    return headers;
+  }
+
+  #buildScopeUrls() {
+    const isMergeRequest = this.state.type === "merge-requests";
+    const scopes = [];
+
+    if (this.state.options.assignedMe ?? true) {
+      scopes.push({ scope: "assigned_to_me" });
+    }
+    if (this.state.options.authorMe ?? false) {
+      scopes.push({ scope: "created_by_me" });
+    }
+    if (isMergeRequest && (this.state.options.reviewRequested ?? false)) {
+      // GitLab uses reviewer_username=__me__ rather than scope= for review-requested.
+      scopes.push({ scope: null, reviewer: true });
+    }
+
+    return scopes.map(({ scope, reviewer }) => {
+      const url = new URL(`${this.#apiBase}/${this.#resourcePath}`);
+      url.searchParams.set("state", "opened");
+      url.searchParams.set("per_page", "50");
+      url.searchParams.set("order_by", "updated_at");
+      url.searchParams.set("sort", "desc");
+      if (scope) {
+        url.searchParams.set("scope", scope);
+      }
+      if (reviewer) {
+        url.searchParams.set("reviewer_username", "__me__");
+      }
+      return url.href;
+    });
+  }
+
+  async fetchItems() {
+    try {
+      const hasAnyFilterEnabled =
+        (this.state.options.authorMe ?? false) ||
+        (this.state.options.assignedMe ?? true) ||
+        (this.state.options.reviewRequested ?? false);
+
+      if (!hasAnyFilterEnabled) {
+        return "zen-live-folder-gitlab-no-filter";
+      }
+
+      const headers = await this.#buildHeaders();
+      const urls = this.#buildScopeUrls();
+
+      const responses = await Promise.all(
+        urls.map(url => this.#fetchScope(url, headers))
+      );
+
+      const combinedItems = new Map();
+      const combinedActiveProjects = new Set();
+
+      for (const response of responses) {
+        if (response.authError) {
+          return "zen-live-folder-gitlab-no-auth";
+        }
+        if (!response.items) {
+          continue;
+        }
+        for (const item of response.items) {
+          combinedItems.set(item.id, item);
+        }
+        for (const project of response.activeProjects) {
+          combinedActiveProjects.add(project);
+        }
+      }
+
+      this.state.projects = combinedActiveProjects;
+
+      const excluded = this.state.options.projectExcludes;
+      const items = Array.from(combinedItems.values()).filter(
+        item => !excluded.has(item.project)
+      );
+
+      return items;
+    } catch (error) {
+      console.error("Error fetching or parsing GitLab items:", error);
+      return "zen-live-folder-failed-fetch";
+    }
+  }
+
+  async #fetchScope(url, headers) {
+    const { text, status } = await this.fetch(url, { headers });
+
+    if (status === 401 || status === 403) {
+      return { authError: true };
+    }
+    if (status !== 200) {
+      return { items: [], activeProjects: new Set() };
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return { items: [], activeProjects: new Set() };
+    }
+
+    if (!Array.isArray(parsed)) {
+      return { items: [], activeProjects: new Set() };
+    }
+
+    const items = [];
+    const activeProjects = new Set();
+
+    for (const entry of parsed) {
+      const project = entry.references?.full
+        ? entry.references.full.split(/[#!]/)[0]
+        : "";
+      if (project) {
+        activeProjects.add(project);
+      }
+      const sigil = this.state.type === "merge-requests" ? "!" : "#";
+      items.push({
+        id: `${project}${sigil}${entry.iid}`,
+        title: entry.title,
+        subtitle: entry.author?.username ?? "",
+        icon: ICON_URL,
+        url: entry.web_url,
+        project,
+      });
+    }
+
+    return { items, activeProjects };
+  }
+
+  get options() {
+    const excluded = this.state.options.projectExcludes;
+    const projectOptions = Array.from(this.state.projects.union(excluded))
+      .sort((a, b) => a.localeCompare(b))
+      .map(project => ({
+        l10nId: "zen-live-folder-gitlab-option-project",
+        l10nArgs: { project },
+
+        key: "projectExclude",
+        value: project,
+
+        type: "checkbox",
+        checked: !excluded.has(project),
+      }));
+
+    if (projectOptions.length) {
+      projectOptions.push({ type: "separator" });
+    }
+
+    projectOptions.push({
+      l10nId: "zen-live-folder-gitlab-option-project-list-note",
+      disabled: true,
+    });
+
+    return [
+      {
+        l10nId: "zen-live-folder-gitlab-option-instance",
+        l10nArgs: { host: this.state.host },
+        disabled: true,
+      },
+      { type: "separator" },
+      {
+        l10nId: "zen-live-folder-gitlab-option-author-self",
+        key: "authorMe",
+        checked: this.state.options.authorMe ?? false,
+      },
+      {
+        l10nId: "zen-live-folder-gitlab-option-assigned-self",
+        key: "assignedMe",
+        checked: this.state.options.assignedMe ?? true,
+      },
+      {
+        l10nId: "zen-live-folder-gitlab-option-review-requested",
+        key: "reviewRequested",
+        checked: this.state.options.reviewRequested ?? false,
+        hidden: this.state.type === "issues",
+      },
+      { type: "separator" },
+      {
+        l10nId: "zen-live-folder-gitlab-option-project-filter",
+        key: "projectExclude",
+        options: projectOptions,
+        // 1 project + separator + note = 3 options, so we need at least 4 to enable the menu.
+        disabled: projectOptions.length < 4,
+      },
+      { type: "separator" },
+      {
+        l10nId: "zen-live-folder-gitlab-option-set-token",
+        key: "setToken",
+      },
+      {
+        l10nId: "zen-live-folder-gitlab-option-remove-token",
+        key: "removeToken",
+      },
+    ];
+  }
+
+  async onOptionTrigger(option) {
+    super.onOptionTrigger(option);
+
+    const key = option.getAttribute("option-key");
+    const checked = option.hasAttribute("checked");
+    if (!this.options.some(x => x.key === key)) {
+      return;
+    }
+
+    switch (key) {
+      case "projectExclude": {
+        const project = option.getAttribute("option-value");
+        if (!project) {
+          return;
+        }
+        const excluded = this.state.options.projectExcludes;
+        if (checked) {
+          excluded.delete(project);
+        } else {
+          excluded.add(project);
+        }
+        this.state.options.projectExcludes = excluded;
+        break;
+      }
+      case "setToken": {
+        await this.#promptForToken();
+        break;
+      }
+      case "removeToken": {
+        await lazy.GitlabAuth.removeToken(this.state.host);
+        break;
+      }
+      case "authorMe":
+      case "assignedMe":
+      case "reviewRequested": {
+        this.state.options[key] = checked;
+        break;
+      }
+      default:
+        return;
+    }
+
+    this.refresh();
+    this.requestSave();
+  }
+
+  async #promptForToken() {
+    const window = this.manager.window;
+    const [promptText] = await lazy.l10n.formatValues([
+      { id: "zen-live-folder-gitlab-prompt-pat", args: { host: this.state.host } },
+    ]);
+    const input = { value: "" };
+    const ok = Services.prompt.prompt(
+      window,
+      promptText,
+      null,
+      input,
+      null,
+      { value: null }
+    );
+    if (!ok) {
+      return;
+    }
+    const token = (input.value ?? "").trim();
+    if (token) {
+      await lazy.GitlabAuth.setToken(this.state.host, token);
+    } else {
+      await lazy.GitlabAuth.removeToken(this.state.host);
+    }
+  }
+
+  async onActionButtonClick(errorId) {
+    super.onActionButtonClick(errorId);
+
+    switch (errorId) {
+      case "zen-live-folder-gitlab-no-auth": {
+        const tab = this.manager.window.gBrowser.addTrustedTab(
+          `https://${this.state.host}/users/sign_in`
+        );
+        this.manager.window.gBrowser.selectedTab = tab;
+        break;
+      }
+      case "zen-live-folder-gitlab-no-filter": {
+        this.refresh();
+        break;
+      }
+    }
+  }
+
+  serialize() {
+    return {
+      state: {
+        ...this.state,
+        projects: Array.from(this.state.projects),
+        options: {
+          ...this.state.options,
+          projectExcludes: Array.from(this.state.options.projectExcludes),
+        },
+      },
+    };
+  }
+}

--- a/src/zen/live-folders/providers/GitlabLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GitlabLiveFolder.sys.mjs
@@ -227,6 +227,10 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
         l10nArgs: { host: this.state.host },
         disabled: true,
       },
+      {
+        l10nId: "zen-live-folder-gitlab-option-change-instance",
+        key: "changeInstance",
+      },
       { type: "separator" },
       {
         l10nId: "zen-live-folder-gitlab-option-author-self",
@@ -296,6 +300,13 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
         await lazy.GitlabAuth.removeToken(this.state.host);
         break;
       }
+      case "changeInstance": {
+        const changed = await this.#promptForInstance();
+        if (!changed) {
+          return;
+        }
+        break;
+      }
       case "authorMe":
       case "assignedMe":
       case "reviewRequested": {
@@ -331,6 +342,32 @@ export class nsGitlabLiveFolderProvider extends nsZenLiveFolderProvider {
     } else {
       await lazy.GitlabAuth.removeToken(this.state.host);
     }
+  }
+
+  async #promptForInstance() {
+    const window = this.manager.window;
+    const [promptText] = await lazy.l10n.formatValues([
+      "zen-live-folder-gitlab-prompt-instance",
+    ]);
+    const input = { value: this.state.host };
+    const ok = Services.prompt.prompt(window, promptText, null, input, null, {
+      value: null,
+    });
+    if (!ok) {
+      return false;
+    }
+    const host = (input.value ?? "")
+      .trim()
+      .replace(/^https?:\/\//, "")
+      .replace(/\/.*$/, "");
+    if (!host || host === this.state.host) {
+      return false;
+    }
+    this.state.host = host;
+    // Switching instances invalidates the per-host project list.
+    this.state.projects = new Set();
+    this.state.options.projectExcludes = new Set();
+    return true;
   }
 
   async onActionButtonClick(errorId) {

--- a/src/zen/tests/live-folders/browser.toml
+++ b/src/zen/tests/live-folders/browser.toml
@@ -6,6 +6,8 @@
 
 ["browser_github_live_folder.js"]
 
+["browser_gitlab_live_folder.js"]
+
 ["browser_live_folder.js"]
 
 ["browser_rss_live_folder.js"]

--- a/src/zen/tests/live-folders/browser_gitlab_live_folder.js
+++ b/src/zen/tests/live-folders/browser_gitlab_live_folder.js
@@ -70,7 +70,7 @@ add_task(async function test_fetch_url_assigned_to_me_default() {
 
 add_task(async function test_fetch_url_review_requested() {
   info(
-    "should issue a reviewer_username=__me__ query when reviewRequested is enabled"
+    "should resolve the user id and issue a reviewer_id+scope=all query when reviewRequested is enabled"
   );
 
   const sandbox = sinon.createSandbox();
@@ -79,13 +79,26 @@ add_task(async function test_fetch_url_review_requested() {
     reviewRequested: true,
   });
 
-  instance.fetch.resolves({ status: 200, text: "[]" });
+  instance.fetch.onFirstCall().resolves({
+    status: 200,
+    text: JSON.stringify({ id: 4242, username: "alice" }),
+  });
+  instance.fetch.onSecondCall().resolves({ status: 200, text: "[]" });
+
   await instance.fetchItems();
 
-  Assert.equal(instance.fetch.callCount, 1);
-  const url = new URL(instance.fetch.firstCall.args[0]);
-  Assert.equal(url.searchParams.get("reviewer_username"), "__me__");
-  Assert.equal(url.searchParams.get("scope"), null, "scope should not be set");
+  Assert.equal(
+    instance.fetch.callCount,
+    2,
+    "Should resolve the user then query MRs"
+  );
+  const userUrl = new URL(instance.fetch.firstCall.args[0]);
+  Assert.equal(userUrl.pathname, "/api/v4/user");
+
+  const url = new URL(instance.fetch.secondCall.args[0]);
+  Assert.equal(url.searchParams.get("reviewer_id"), "4242");
+  Assert.equal(url.searchParams.get("scope"), "all");
+  Assert.equal(url.searchParams.get("reviewer_username"), null);
 
   sandbox.restore();
 });

--- a/src/zen/tests/live-folders/browser_gitlab_live_folder.js
+++ b/src/zen/tests/live-folders/browser_gitlab_live_folder.js
@@ -11,7 +11,11 @@ ChromeUtils.defineESModuleGetters(this, {
 });
 
 function getGitlabProviderForTest(sandbox, customOptions = {}) {
-  const { type = "merge-requests", host = "gitlab.com", ...rest } = customOptions;
+  const {
+    type = "merge-requests",
+    host = "gitlab.com",
+    ...rest
+  } = customOptions;
   const defaultOptions = {
     authorMe: false,
     assignedMe: true,
@@ -185,7 +189,10 @@ add_task(async function test_json_parsing_into_items() {
   instance.fetch.resolves({ status: 200, text: payload });
   const items = await instance.fetchItems();
 
-  Assert.ok(Array.isArray(items), "fetchItems should return an array on success");
+  Assert.ok(
+    Array.isArray(items),
+    "fetchItems should return an array on success"
+  );
   Assert.equal(items.length, 2);
   Assert.equal(items[0].id, "group/project!42");
   Assert.equal(items[0].title, "Improve cache eviction");

--- a/src/zen/tests/live-folders/browser_gitlab_live_folder.js
+++ b/src/zen/tests/live-folders/browser_gitlab_live_folder.js
@@ -1,0 +1,246 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+ChromeUtils.defineESModuleGetters(this, {
+  sinon: "resource://testing-common/Sinon.sys.mjs",
+  nsGitlabLiveFolderProvider:
+    "resource:///modules/zen/GitlabLiveFolder.sys.mjs",
+  GitlabAuth: "resource:///modules/zen/GitlabAuth.sys.mjs",
+});
+
+function getGitlabProviderForTest(sandbox, customOptions = {}) {
+  const { type = "merge-requests", host = "gitlab.com", ...rest } = customOptions;
+  const defaultOptions = {
+    authorMe: false,
+    assignedMe: true,
+    reviewRequested: false,
+    ...rest,
+  };
+
+  const mockManager = {
+    saveState: sandbox.spy(),
+  };
+
+  const initialState = {
+    interval: 60,
+    lastFetched: 0,
+    type,
+    host,
+    options: defaultOptions,
+  };
+
+  const instance = new nsGitlabLiveFolderProvider({
+    id: "test-gitlab-folder",
+    state: initialState,
+    manager: mockManager,
+  });
+
+  sandbox.stub(instance, "fetch");
+  sandbox.stub(GitlabAuth, "getToken").resolves(null);
+  return instance;
+}
+
+add_task(async function test_fetch_url_assigned_to_me_default() {
+  info(
+    "should query the merge_requests endpoint with scope=assigned_to_me by default"
+  );
+
+  const sandbox = sinon.createSandbox();
+  const instance = getGitlabProviderForTest(sandbox);
+
+  instance.fetch.resolves({ status: 200, text: "[]" });
+  await instance.fetchItems();
+
+  Assert.ok(instance.fetch.calledOnce, "Fetch should be called once");
+  const fetchedUrl = new URL(instance.fetch.firstCall.args[0]);
+  Assert.equal(fetchedUrl.host, "gitlab.com");
+  Assert.equal(fetchedUrl.pathname, "/api/v4/merge_requests");
+  Assert.equal(fetchedUrl.searchParams.get("scope"), "assigned_to_me");
+  Assert.equal(fetchedUrl.searchParams.get("state"), "opened");
+  Assert.equal(fetchedUrl.searchParams.get("per_page"), "50");
+
+  sandbox.restore();
+});
+
+add_task(async function test_fetch_url_review_requested() {
+  info(
+    "should issue a reviewer_username=__me__ query when reviewRequested is enabled"
+  );
+
+  const sandbox = sinon.createSandbox();
+  const instance = getGitlabProviderForTest(sandbox, {
+    assignedMe: false,
+    reviewRequested: true,
+  });
+
+  instance.fetch.resolves({ status: 200, text: "[]" });
+  await instance.fetchItems();
+
+  Assert.equal(instance.fetch.callCount, 1);
+  const url = new URL(instance.fetch.firstCall.args[0]);
+  Assert.equal(url.searchParams.get("reviewer_username"), "__me__");
+  Assert.equal(url.searchParams.get("scope"), null, "scope should not be set");
+
+  sandbox.restore();
+});
+
+add_task(async function test_fetch_url_self_hosted_host() {
+  info("should respect a custom self-hosted host");
+
+  const sandbox = sinon.createSandbox();
+  const instance = getGitlabProviderForTest(sandbox, {
+    host: "gitlab.example.com",
+  });
+
+  instance.fetch.resolves({ status: 200, text: "[]" });
+  await instance.fetchItems();
+
+  const url = new URL(instance.fetch.firstCall.args[0]);
+  Assert.equal(url.host, "gitlab.example.com");
+  Assert.ok(url.pathname.startsWith("/api/v4/"));
+
+  sandbox.restore();
+});
+
+add_task(async function test_fetch_uses_issues_endpoint_when_type_is_issues() {
+  info("should hit /api/v4/issues when state.type is 'issues'");
+
+  const sandbox = sinon.createSandbox();
+  const instance = getGitlabProviderForTest(sandbox, { type: "issues" });
+
+  instance.fetch.resolves({ status: 200, text: "[]" });
+  await instance.fetchItems();
+
+  const url = new URL(instance.fetch.firstCall.args[0]);
+  Assert.equal(url.pathname, "/api/v4/issues");
+
+  sandbox.restore();
+});
+
+add_task(async function test_pat_header_injected_when_token_present() {
+  info(
+    "should inject PRIVATE-TOKEN header when GitlabAuth returns a token for the host"
+  );
+
+  const sandbox = sinon.createSandbox();
+  const instance = getGitlabProviderForTest(sandbox);
+  GitlabAuth.getToken.restore();
+  sandbox.stub(GitlabAuth, "getToken").resolves("glpat-deadbeef");
+
+  instance.fetch.resolves({ status: 200, text: "[]" });
+  await instance.fetchItems();
+
+  const opts = instance.fetch.firstCall.args[1];
+  Assert.ok(opts && opts.headers, "headers should be passed to fetch");
+  Assert.equal(opts.headers["PRIVATE-TOKEN"], "glpat-deadbeef");
+  Assert.equal(opts.headers.Accept, "application/json");
+
+  sandbox.restore();
+});
+
+add_task(async function test_pat_header_omitted_when_no_token() {
+  info("should not send PRIVATE-TOKEN header when there is no stored token");
+
+  const sandbox = sinon.createSandbox();
+  const instance = getGitlabProviderForTest(sandbox);
+
+  instance.fetch.resolves({ status: 200, text: "[]" });
+  await instance.fetchItems();
+
+  const opts = instance.fetch.firstCall.args[1];
+  Assert.ok(opts && opts.headers, "headers should be passed to fetch");
+  Assert.ok(
+    !("PRIVATE-TOKEN" in opts.headers),
+    "PRIVATE-TOKEN must be absent when no token is stored"
+  );
+
+  sandbox.restore();
+});
+
+add_task(async function test_json_parsing_into_items() {
+  info("should parse the JSON payload into FolderItem-shaped entries");
+
+  const sandbox = sinon.createSandbox();
+  const instance = getGitlabProviderForTest(sandbox);
+
+  const payload = JSON.stringify([
+    {
+      iid: 42,
+      title: "Improve cache eviction",
+      web_url: "https://gitlab.com/group/project/-/merge_requests/42",
+      author: { username: "alice" },
+      references: { full: "group/project!42" },
+    },
+    {
+      iid: 7,
+      title: "Fix flaky test",
+      web_url: "https://gitlab.com/group/other/-/merge_requests/7",
+      author: { username: "bob" },
+      references: { full: "group/other!7" },
+    },
+  ]);
+
+  instance.fetch.resolves({ status: 200, text: payload });
+  const items = await instance.fetchItems();
+
+  Assert.ok(Array.isArray(items), "fetchItems should return an array on success");
+  Assert.equal(items.length, 2);
+  Assert.equal(items[0].id, "group/project!42");
+  Assert.equal(items[0].title, "Improve cache eviction");
+  Assert.equal(items[0].subtitle, "alice");
+  Assert.equal(
+    items[0].url,
+    "https://gitlab.com/group/project/-/merge_requests/42"
+  );
+
+  sandbox.restore();
+});
+
+add_task(async function test_auth_error_status() {
+  info("should return the GitLab no-auth error id on 401/403");
+
+  for (const status of [401, 403]) {
+    const sandbox = sinon.createSandbox();
+    const instance = getGitlabProviderForTest(sandbox);
+    instance.fetch.resolves({ status, text: "" });
+
+    const result = await instance.fetchItems();
+    Assert.equal(result, "zen-live-folder-gitlab-no-auth");
+
+    sandbox.restore();
+  }
+});
+
+add_task(async function test_no_filter_enabled_returns_no_filter_error() {
+  info(
+    "should short-circuit with no-filter error when every scope option is off"
+  );
+
+  const sandbox = sinon.createSandbox();
+  const instance = getGitlabProviderForTest(sandbox, {
+    authorMe: false,
+    assignedMe: false,
+    reviewRequested: false,
+  });
+
+  const result = await instance.fetchItems();
+  Assert.equal(result, "zen-live-folder-gitlab-no-filter");
+  Assert.ok(instance.fetch.notCalled, "Fetch must not be called");
+
+  sandbox.restore();
+});
+
+add_task(async function test_network_error_returns_failed_fetch() {
+  info("should gracefully turn network errors into the failed-fetch id");
+
+  const sandbox = sinon.createSandbox();
+  const instance = getGitlabProviderForTest(sandbox);
+  instance.fetch.rejects(new Error("Network down"));
+
+  const result = await instance.fetchItems();
+  Assert.equal(result, "zen-live-folder-failed-fetch");
+
+  sandbox.restore();
+});


### PR DESCRIPTION
## Summary

  Adds **GitLab** as a third Live Folders provider, alongside GitHub and RSS, covering both **gitlab.com** and **self-hosted** instances (public or private). Built to address [discussion
  #12453](https://github.com/zen-browser/desktop/discussions/12453).

  ## What this PR does

  - Two new menu entries under **New Live Folder**: **GitLab Merge Requests** and **GitLab Issues**
  - New REST v4 provider `nsGitlabLiveFolderProvider` that mirrors the GitHub provider's contract
  - **Cookie-first auth**, falling back to a Personal Access Token stored in the **Firefox Login Manager** (encrypted, never written to `zen-live-folders.jsonlz4`)
  - **Auto-detection of the instance** from the active tab when the folder is created
  - **Change Instance…** menuitem to switch host after creation (needed for non-standard hosts like `code.company.com`)
  - Filters mirroring GitHub: `Created by Me`, `Assigned to Me`, `Review Requests` (uses `reviewer_id` + `scope=all` because older self-hosted versions don't resolve `__me__` and the endpoint defaults to
  `created_by_me`)
  - Per-project exclusion filter, list rebuilt on every fetch from the active items
  - New tanuki SVG icon, full Fluent strings (`zen-live-folder-gitlab-*`)
  - Mochitest coverage (URL construction, JSON parsing, PRIVATE-TOKEN injection, 401/403 → no-auth, no-filter, network error)
  - Drive-by fix: register `zen-live-folders.ftl` in `crowdin.yml` (it was never wired in, so all live-folder strings — GitHub, RSS, GitLab — were stuck in en-US for every other locale)
  - Drive-by spec doc: section in `docs/live-folders-specs.md`

 ## Screenshots

<img width="477" height="363" alt="Capture d’écran 2026-04-26 à 11 11 43" src="https://github.com/user-attachments/assets/be2094f4-4ebb-4c6f-9dc4-4a7d3062c902" />  

--------------------

<img width="552" height="400" alt="Capture d’écran 2026-04-26 à 11 10 18" src="https://github.com/user-attachments/assets/8f0d3d98-d032-4436-a987-89041b6c81cb" />  

------------------

<img width="470" height="330" alt="Capture d’écran 2026-04-26 à 11 12 56" src="https://github.com/user-attachments/assets/0b86c80f-707d-4c7f-844a-22d1b74007d4" />  

------------------

<img width="470" height="330" alt="Capture d’écran 2026-04-26 à 11 13 21" src="https://github.com/user-attachments/assets/45817083-bbda-4c87-9639-56255a0d457c" />  


  ## Notes for reviewers

  - Auth pattern (PAT in Login Manager) is inspired by #13044 but kept **scoped to GitLab** (`GitlabAuth.sys.mjs`) so it doesn't conflict if #13044 lands. A shared `Auth.sys.mjs` would be a sensible
  follow-up once #13044's design is final.
  - REST v4 was preferred over GraphQL (cf. closed #12579) because it stays GET-only, keeps the parent's `fetch()` signature untouched, and supports cookies natively.
  - PAT is masked in the prompt (`promptPassword`), never serialized in cleartext, and removed from Login Manager via the dedicated `Remove Access Token` menuitem.
  - The instance host is auto-detected via `getDefaultHost(window)` using a heuristic on the active tab's URL (`gitlab.com` or `(^|.)gitlab.`). Hosts that don't match (e.g. `code.company.com`) default to
  `gitlab.com`; the user changes them via `Change Instance…`. Switching instance invalidates the per-host cached `userId`.

  ## References

  - Discussion #12453 — feature request this PR addresses
  - PR #12579 — earlier closed attempt (GraphQL, abandoned by author); avoided its lacunae (no tests, GitHub strings reused, no self-hosted)
  - PR #13044 — in-progress GitHub Enterprise PR; provided the PAT-via-Login-Manager pattern this PR adapts