### PR TITLE
fix: Use CanvasText for tab preview panel text color

### DIFF
--- a/src/zen/common/styles/zen-popup.css
+++ b/src/zen/common/styles/zen-popup.css
@@ -428,3 +428,7 @@ menuseparator {
 #window-modal-dialog {
   inset: 0;
 }
+
+#tab-preview-panel {
+  color: CanvasText;
+}


### PR DESCRIPTION
## Summary

- Tab hover preview text (title + URL) renders invisible on light color schemes because `--text-color-deemphasized` inherits `currentColor` from the panel's dark-themed paint context, producing white text against a light panel background.
- Adds `color: CanvasText` on `#tab-preview-panel` so text color always matches the system foreground color regardless of inherited paint context.

## Steps to reproduce

1. Enable a light color scheme / light system theme
2. Hover over any tab in the sidebar
3. Tab preview popup appears — title/URL text is white-on-white (invisible)

## Fix

One rule in `zen-popup.css`:

```css
#tab-preview-panel {
  color: CanvasText;
}
```

`CanvasText` is a CSS system color that resolves to the system's foreground text color, adapting correctly to both light and dark themes without hardcoding a value.

Fixes #12410