### PR TITLE
fix: Hide appcontent navbar strip in compact + single-toolbar mode

### DIFF
--- a/src/zen/compact-mode/sidebar.inc.css
+++ b/src/zen/compact-mode/sidebar.inc.css
@@ -47,8 +47,8 @@
     margin-left: calc(var(--zen-element-separation) - 3px) !important;
   }
 
-  &[zen-single-toolbar='true']:not([zen-has-bookmarks]) {
-    #zen-appcontent-navbar-wrapper:not([should-hide='true']):not([zen-has-hover]):not([has-popup-menu]):not([zen-compact-mode-active]):not([flash-popup]) {
+  &[zen-single-toolbar='true'] {
+    #zen-appcontent-navbar-wrapper:not([zen-has-hover]):not([has-popup-menu]):not([zen-compact-mode-active]):not([flash-popup]) {
       height: 0;
       min-height: 0;
       overflow: hidden;

--- a/src/zen/compact-mode/sidebar.inc.css
+++ b/src/zen/compact-mode/sidebar.inc.css
@@ -47,6 +47,15 @@
     margin-left: calc(var(--zen-element-separation) - 3px) !important;
   }
 
+  &[zen-single-toolbar='true']:not([zen-has-bookmarks]) {
+    #zen-appcontent-navbar-wrapper:not([should-hide='true']):not([zen-has-hover]):not([has-popup-menu]):not([zen-compact-mode-active]):not([flash-popup]) {
+      height: 0;
+      min-height: 0;
+      overflow: hidden;
+      pointer-events: none;
+    }
+  }
+
   #navigator-toolbox {
     --zen-toolbox-max-width: 74px !important;
     --zen-compact-float: var(--zen-element-separation);


### PR DESCRIPTION
## Summary

- In compact mode with `zen.view.use-single-toolbar = true`, the `#zen-appcontent-navbar-wrapper` remains visible as a thin strip (~8px) even though the sidebar is hidden and it contains no visible content.
- Adds a CSS rule to collapse the wrapper to zero height when compact mode is active and the sidebar is not expanded/hovered.

## Steps to reproduce

1. Enable compact mode
2. Enable single-toolbar mode (`zen.view.use-single-toolbar = true`)
3. Move the cursor away from the sidebar so it hides
4. A thin horizontal strip is visible at the top of the content area

## Fix

Targets `#zen-appcontent-navbar-wrapper` in the `:not([zen-compact-animating])` block inside `sidebar.inc.css`. Collapses it when it has none of the "active" attributes (`zen-has-hover`, `has-popup-menu`, `zen-compact-mode-active`, `flash-popup`).

Fixes #7094