### PR TITLE
gh-12142: Clear pending attribute on synced tabs

### DIFF
--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -1353,6 +1353,9 @@ class nsZenWindowSync {
         _forZenEmptyTab: tab.hasAttribute("zen-empty-tab"),
       });
       newTab.id = tab.id;
+      if (!tab.hasAttribute("pending")) {
+        newTab.removeAttribute("pending");
+      }
       this.#syncItemWithOriginal(
         tab,
         newTab,


### PR DESCRIPTION
## Summary

- When tabs are synced between windows via `ZenWindowSync`, new placeholder tabs are always created with the `pending` attribute, causing them to appear as unloaded even when the source tab is already loaded.
- Adds a check in `on_TabOpen` to remove the `pending` attribute from the synced tab if the source tab does not have it.

## Steps to reproduce

1. Open a tab with a loaded page in one window
2. Open a second Zen window
3. The tab appears in the second window as pending/unloaded even though the source is loaded

## Fix

In `ZenWindowSync.sys.mjs`, `on_TabOpen`:

```js
if (!tab.hasAttribute("pending")) {
  newTab.removeAttribute("pending");
}
```

Fixes #12142