### PR TITLE
fix: Intercept DOMWindowClose to prevent closing pinned Places tab on Ctrl+W

### DIFF
--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -253,22 +253,28 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
       cmdClose.addEventListener("command", this.onCloseTabShortcut.bind(this));
     }
 
-    gBrowser.addEventListener(
-      "DOMWindowClose",
-      (event) => {
-        let browser = event.target;
-        if (!browser.isRemoteBrowser) {
-          browser = event.target.docShell?.chromeEventHandler ?? browser;
-        }
-        const tab = gBrowser.getTabForBrowser(browser);
-        if (!tab?.pinned) {
-          return;
-        }
-        event.stopImmediatePropagation();
-        event.preventDefault();
-        this.onCloseTabShortcut(event, tab);
+    window.addEventListener(
+      "load",
+      () => {
+        gBrowser.addEventListener(
+          "DOMWindowClose",
+          (event) => {
+            let browser = event.target;
+            if (!browser.isRemoteBrowser) {
+              browser = event.target.docShell?.chromeEventHandler ?? browser;
+            }
+            const tab = gBrowser.getTabForBrowser(browser);
+            if (!tab?.pinned) {
+              return;
+            }
+            event.stopImmediatePropagation();
+            event.preventDefault();
+            this.onCloseTabShortcut(event, tab);
+          },
+          true
+        );
       },
-      true
+      { once: true }
     );
   }
 

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -252,6 +252,24 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     if (cmdClose) {
       cmdClose.addEventListener("command", this.onCloseTabShortcut.bind(this));
     }
+
+    gBrowser.addEventListener(
+      "DOMWindowClose",
+      (event) => {
+        let browser = event.target;
+        if (!browser.isRemoteBrowser) {
+          browser = event.target.docShell?.chromeEventHandler ?? browser;
+        }
+        const tab = gBrowser.getTabForBrowser(browser);
+        if (!tab?.pinned) {
+          return;
+        }
+        event.stopImmediatePropagation();
+        event.preventDefault();
+        this.onCloseTabShortcut(event, tab);
+      },
+      true
+    );
   }
 
   // eslint-disable-next-line complexity


### PR DESCRIPTION
## Summary

- The Places sidebar tab (`about:privatebrowsing` / bookmark manager) can be closed with Ctrl+W even when it's pinned, because `window.close()` dispatches a `DOMWindowClose` event that bypasses `cmd_close` (which already checks for pinned tabs).
- Adds a `DOMWindowClose` capture-phase listener on `gBrowser` to intercept and cancel the close event when the target tab is pinned.
- Also defers listener registration to `window load` to avoid a `gBrowser is undefined` crash (the parent `init()` runs at `DOMContentLoaded` before `gBrowser` is available).

## Steps to reproduce

1. Pin the Places/bookmarks sidebar tab
2. Focus it and press Ctrl+W
3. The tab closes despite being pinned

## Fix

In `ZenPinnedTabManager.mjs`, `_initClosePinnedTabShortcut()`:
- Wrap `gBrowser.addEventListener(...)` in `window.addEventListener("load", ..., { once: true })`
- Add `DOMWindowClose` handler that resolves the browser element for remote tabs and cancels the event if the tab is pinned

Fixes #12353