### PR TITLE
fix: Reposition permission popup after compact mode sidebar expansion

### DIFF
--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -389,15 +389,16 @@ window.gZenUIManager = {
       );
       this.__currentPopup = showEvent.target;
       this.__currentPopupTrackElement = el;
-      el.addEventListener(
-        "transitionend",
-        () => {
-          if (typeof UpdatePopupNotificationsVisibility === "function") {
-            UpdatePopupNotificationsVisibility();
-          }
-        },
-        { once: true }
-      );
+      const onTransitionEnd = event => {
+        if (event.target !== el) {
+          return;
+        }
+        el.removeEventListener("transitionend", onTransitionEnd);
+        if (typeof UpdatePopupNotificationsVisibility === "function") {
+          UpdatePopupNotificationsVisibility();
+        }
+      };
+      el.addEventListener("transitionend", onTransitionEnd);
       break;
     }
   },

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -389,6 +389,15 @@ window.gZenUIManager = {
       );
       this.__currentPopup = showEvent.target;
       this.__currentPopupTrackElement = el;
+      el.addEventListener(
+        "transitionend",
+        () => {
+          if (typeof UpdatePopupNotificationsVisibility === "function") {
+            UpdatePopupNotificationsVisibility();
+          }
+        },
+        { once: true }
+      );
       break;
     }
   },

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -710,6 +710,17 @@ window.gZenCompactModeManager = {
         }
       }
       element.setAttribute(attr, "true");
+      if (element === this.sidebar) {
+        element.addEventListener(
+          "transitionend",
+          () => {
+            if (typeof UpdatePopupNotificationsVisibility === "function") {
+              UpdatePopupNotificationsVisibility();
+            }
+          },
+          { once: true }
+        );
+      }
       if (
         isToolbar &&
         ((gZenVerticalTabsManager._hasSetSingleToolbar &&

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -711,15 +711,16 @@ window.gZenCompactModeManager = {
       }
       element.setAttribute(attr, "true");
       if (element === this.sidebar) {
-        element.addEventListener(
-          "transitionend",
-          () => {
-            if (typeof UpdatePopupNotificationsVisibility === "function") {
-              UpdatePopupNotificationsVisibility();
-            }
-          },
-          { once: true }
-        );
+        const onSidebarTransitionEnd = event => {
+          if (event.target !== element) {
+            return;
+          }
+          element.removeEventListener("transitionend", onSidebarTransitionEnd);
+          if (typeof UpdatePopupNotificationsVisibility === "function") {
+            UpdatePopupNotificationsVisibility();
+          }
+        };
+        element.addEventListener("transitionend", onSidebarTransitionEnd);
       }
       if (
         isToolbar &&


### PR DESCRIPTION
## Summary

- In compact mode, permission doorhangers (camera, location, notifications, etc.) are mispositioned when they appear during or after the sidebar expansion animation — Firefox anchors them before the sidebar has finished moving, so they end up offset from the URL bar.
- Calls `UpdatePopupNotificationsVisibility()` after the sidebar `transitionend` in both the `onPopupShowing` path (ZenUIManager) and the `_setElementExpandAttribute` path (ZenCompactMode), so Firefox re-anchors queued doorhangers once the sidebar is in its final position.

## Steps to reproduce

1. Enable compact mode
2. Navigate to a site that requests a permission (e.g. camera)
3. Hover over the sidebar to expand it, then trigger the permission request
4. The doorhanger appears in the wrong position (offset from the URL bar)

## Fix

- `ZenUIManager.mjs` `onPopupShowing`: after calling `_setElementExpandAttribute`, attach a `transitionend` listener that calls `UpdatePopupNotificationsVisibility()`
- `ZenCompactMode.mjs` `_setElementExpandAttribute`: when the expanded element is the sidebar itself, attach the same `transitionend` listener

Fixes #13293