### PR TITLE
gh-7094: Fixed topbar dropping down when titlebar is enabled

### DIFF
--- a/src/zen/common/styles/zen-browser-container.css
+++ b/src/zen/common/styles/zen-browser-container.css
@@ -43,7 +43,7 @@
   }
 
   /* stylelint-disable-next-line media-query-no-invalid */
-  @media (not -moz-pref("zen.view.shift-down-site-on-hover")) and (not ((-moz-pref("zen.view.experimental-no-window-controls") or (not -moz-pref("zen.view.hide-window-controls"))) and -moz-pref("zen.view.use-single-toolbar"))) {
+  @media (not -moz-pref("zen.view.shift-down-site-on-hover")) and (not ((-moz-pref("zen.view.experimental-no-window-controls") or (not -moz-pref("zen.view.hide-window-controls")) or (not -moz-pref("browser.tabs.inTitlebar"))) and -moz-pref("zen.view.use-single-toolbar"))) {
     .browserSidebarContainer:is(.deck-selected, [zen-split="true"]) .browserContainer {
       transition: margin var(--zen-hidden-toolbar-transition);
 

--- a/src/zen/tabs/zen-tabs/vertical-tabs-topbar.inc.css
+++ b/src/zen/tabs/zen-tabs/vertical-tabs-topbar.inc.css
@@ -31,7 +31,7 @@ z-index: 1;
 %include ../../compact-mode/windows-captions-fix-default.inc.css
   }
 
-  @media -moz-pref('zen.view.experimental-no-window-controls') {
+  @media -moz-pref('zen.view.experimental-no-window-controls') or (not -moz-pref("browser.tabs.inTitlebar")) {
     :root:not([zen-has-bookmarks]) & {
       max-height: 0 !important;
       overflow: hidden;


### PR DESCRIPTION
From #7094 , we need to prevent topbar pulling down when hovering if following criterias are all meet:
1. Titlebar is enabled
2. Bookmark bar is disabled
3. In compact mode
4. Only sidebar layout

Thanks to previous effort, we already have a similar mechanism when `zen.view.experimental-no-window-controls`  is `true`. And firefox also has a pref reflecting the status of titlebar (`browser.tabs.inTitlebar`)

So, to tap in that existing mechanism, this PR puts a conditonal judgement that either `zen.view.experimental-no-window-controls` or `browser.tabs.inTitlebar` can achieve same effect.

However, since I only tested the changes on Windows, I don't know if it will lead to same result in MAC OS or linux.