### PR TITLE
gh-7094: Fix webcontent shift when bookmark bar pulled down in the presence of title bar

### DIFF
--- a/src/zen/common/styles/zen-browser-container.css
+++ b/src/zen/common/styles/zen-browser-container.css
@@ -43,7 +43,7 @@
   }
 
   /* stylelint-disable-next-line media-query-no-invalid */
-  @media (not -moz-pref("zen.view.shift-down-site-on-hover")) and (not ((-moz-pref("zen.view.experimental-no-window-controls") or (not -moz-pref("zen.view.hide-window-controls")) or (not -moz-pref("browser.tabs.inTitlebar"))) and -moz-pref("zen.view.use-single-toolbar"))) {
+  @media (not -moz-pref("zen.view.shift-down-site-on-hover")) {
     .browserSidebarContainer:is(.deck-selected, [zen-split="true"]) .browserContainer {
       transition: margin var(--zen-hidden-toolbar-transition);
 
@@ -57,6 +57,12 @@
 
         :root:not([zen-single-toolbar="true"]) & {
           --margin-top-fix: calc(-1 * var(--zen-toolbar-height-with-bookmarks) + var(--zen-element-separation));
+        }
+
+        @media -moz-pref("zen.view.experimental-no-window-controls") or (not -moz-pref("zen.view.hide-window-controls")) or (not -moz-pref("browser.tabs.inTitlebar")) {
+          :root:not([zen-has-bookmarks="true"])[zen-single-toolbar="true"] & {
+            --margin-top-fix: 0px;
+          }
         }
 
         margin-top: var(--margin-top-fix);


### PR DESCRIPTION
Per https://github.com/zen-browser/desktop/pull/13468#pullrequestreview-4191276729 , handling the timing of webcontent shift with bookmark bar in mind