### PR TITLE
Fix splitter bad position when sidebar open

### DIFF
--- a/src/browser/base/content/browser-box-inc-xhtml.patch
+++ b/src/browser/base/content/browser-box-inc-xhtml.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/base/content/browser-box.inc.xhtml b/browser/base/content/browser-box.inc.xhtml
-index d58fcdf99843d110b708f3fbf9fb317787fadfcf..cfc2aad902641609c3804e615c4cb66ce65299b7 100644
+index d58fcdf99843d110b708f3fbf9fb317787fadfcf..45ad1e28b31a4993e56dfce0f88f49f48f25f2de 100644
 --- a/browser/base/content/browser-box.inc.xhtml
 +++ b/browser/base/content/browser-box.inc.xhtml
 @@ -3,12 +3,22 @@
@@ -25,16 +25,20 @@ index d58fcdf99843d110b708f3fbf9fb317787fadfcf..cfc2aad902641609c3804e615c4cb66c
    <vbox id="sidebar-box" hidden="true" class="chromeclass-extrachrome">
      <box id="sidebar-header" align="center">
        <toolbarbutton id="sidebar-switcher-target" class="tabbable" aria-expanded="false">
-@@ -25,7 +35,7 @@
+@@ -25,8 +35,10 @@
      </stack>
    </vbox>
    <splitter id="sidebar-splitter" class="chromeclass-extrachrome sidebar-splitter" resizebefore="sibling" resizeafter="none" hidden="true"/>
 -  <tabbox id="tabbrowser-tabbox" flex="1" tabcontainer="tabbrowser-tabs">
+-    <tabpanels id="tabbrowser-tabpanels" flex="1" selectedIndex="0"/>
 +#include zen-tabbrowser-elements.inc.xhtml
-     <tabpanels id="tabbrowser-tabpanels" flex="1" selectedIndex="0"/>
++    <tabpanels id="tabbrowser-tabpanels" flex="1" selectedIndex="0">
++#include ../../../zen/split-view/zen-splitview-overlay.inc.xhtml
++    </tabpanels>
    </tabbox>
    <splitter id="ai-window-splitter" class="chromeclass-extrachrome sidebar-splitter" resizebefore="none" resizeafter="sibling" collapsed="true"/>
-@@ -34,3 +44,5 @@
+   <vbox id="ai-window-box" collapsed="true" class="chromeclass-extrachrome ai-window-right-sidebar">
+@@ -34,3 +46,5 @@
      </stack>
    </vbox>
  </hbox>

--- a/src/browser/base/content/zen-tabbrowser-elements.inc.xhtml
+++ b/src/browser/base/content/zen-tabbrowser-elements.inc.xhtml
@@ -4,5 +4,4 @@
 
 <vbox id="zen-toast-container" />
 
-#include ../../../zen/split-view/zen-splitview-overlay.inc.xhtml
 #include ../../../zen/glance/zen-glance.inc.xhtml

--- a/src/zen/common/styles/zen-browser-ui.css
+++ b/src/zen/common/styles/zen-browser-ui.css
@@ -277,6 +277,7 @@ body,
     position: absolute;
     top: 50%;
     left: 50%;
+    transform: translateX(-50%);
     opacity: 0;
     transition: opacity 0.1s ease-in-out;
     pointer-events: none;

--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -1721,7 +1721,7 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
         if (splitNode.direction === "column") {
           splitter.style.inset = `${100 - childRootPosition.bottom}% ${childRootPosition.right}% 0% ${childRootPosition.left}%`;
         } else {
-          splitter.style.inset = `${childRootPosition.top}% 0% ${childRootPosition.bottom}% ${100 - childRootPosition.right}%`;
+          splitter.style.inset = `${childRootPosition.top}% ${childRootPosition.right}% ${childRootPosition.bottom}% calc(${100 - childRootPosition.right}% - var(--zen-split-row-gap))`;
         }
       }
     });
@@ -1739,7 +1739,7 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     splitter.className = "zen-split-view-splitter";
     splitter.setAttribute("orient", orient);
     splitter.setAttribute("gridIdx", idx);
-    this.overlay.insertAdjacentElement("afterbegin", splitter);
+    this.tabBrowserPanel.appendChild(splitter);
 
     splitter.addEventListener("mousedown", this.handleSplitterMouseDown);
     return splitter;
@@ -1775,8 +1775,8 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
   }
 
   removeSplitters() {
-    [...this.overlay.children]
-      .filter(c => c.classList.contains("zen-split-view-splitter"))
+    this.tabBrowserPanel
+      .querySelectorAll(".zen-split-view-splitter")
       .forEach(s => s.remove());
     this._splitNodeToSplitters.clear();
   }

--- a/src/zen/split-view/zen-split-view.css
+++ b/src/zen/split-view/zen-split-view.css
@@ -116,6 +116,8 @@
   pointer-events: none;
   padding: inherit;
   inset: 0;
+  -moz-subtree-hidden-only-visually: 0;
+  z-index: 2;
 }
 
 #zen-splitview-overlay {


### PR DESCRIPTION
- Move `zen-splitview-overlay.inc.xhtml` into `tabpanels` element to handle correct drag-and-drop logic when sidebar is open
- Insert `zen-split-view-splitter` directly into `tabpanels` element for correct placement when sidebar is open
- Adjust inset calculation for `zen-split-view-splitter` to center in `tabpanels` element
- Add `translateX: calc(-50%)` to `::before` styles in order to properly center splitter

<img width="2559" height="1388" alt="image" src="https://github.com/user-attachments/assets/eba76843-fb52-40e5-be34-e2d108245f08" />