### PR TITLE
no-bug: Submit workspace creation form on Enter and cancel on Escape

### DIFF
--- a/src/zen/glance/zen-glance.css
+++ b/src/zen/glance/zen-glance.css
@@ -83,6 +83,7 @@
       & label {
         max-width: 4rem;
         margin-left: 8px;
+        color: white;
       }
 
       & image {

--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -158,6 +158,18 @@ class nsZenWorkspaceCreation extends MozXULElement {
       }
     });
 
+    // Bound on the root so Esc works regardless of which child has focus
+    // (name input, icon picker trigger, profile button, primary button).
+    // Open popups consume Esc before it reaches us, so the emoji/profile
+    // pickers still close as expected.
+    this.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        this.cancelButton.doCommand();
+      }
+    });
+
     this.inputIcon.addEventListener("command", this.onIconCommand.bind(this));
 
     this.profilesPopup = this.querySelector(

--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -148,6 +148,16 @@ class nsZenWorkspaceCreation extends MozXULElement {
       this.createButton.disabled = !this.inputName.value.trim();
     });
 
+    this.inputName.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!this.createButton.disabled) {
+          this.createButton.doCommand();
+        }
+      }
+    });
+
     this.inputIcon.addEventListener("command", this.onIconCommand.bind(this));
 
     this.profilesPopup = this.querySelector(

--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -148,7 +148,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
       this.createButton.disabled = !this.inputName.value.trim();
     });
 
-    this.inputName.addEventListener("keydown", (event) => {
+    this.inputName.addEventListener("keydown", event => {
       if (event.key === "Enter") {
         event.preventDefault();
         event.stopPropagation();
@@ -162,7 +162,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
     // (name input, icon picker trigger, profile button, primary button).
     // Open popups consume Esc before it reaches us, so the emoji/profile
     // pickers still close as expected.
-    this.addEventListener("keydown", (event) => {
+    this.addEventListener("keydown", event => {
       if (event.key === "Escape") {
         event.preventDefault();
         event.stopPropagation();


### PR DESCRIPTION
- Submit the workspace creation form on **Enter** when the name field is non-empty.
- Cancel the form on **Escape**, bound on the component root so it fires regardless of which child (name input, icon picker trigger, profile button, footer buttons) has focus. Open popups still consume Escape first, so the emoji picker and profile popup close normally.
- Paint macOS ⏎ / ESC keyboard-hint badges on the Create and Cancel buttons via `::after`, mirroring the convention already used on XUL `<dialog>` accept/cancel buttons in `zen-buttons.css`. The ⏎ badge hides via `:not(:disabled)` while the Create button is disabled, so there's no affordance for a key that wouldn't do anything.
- Apply symmetric inline padding on both buttons so their labels stay visually centered against the full button width; the absolutely-positioned badges sit over the reserved right slot.

Closes https://github.com/zen-browser/desktop/discussions/13360

## Demo

https://github.com/user-attachments/assets/f2b7ca4c-f8c0-4898-a97c-bf004977c2ee
