### PR TITLE
no-bug: Add focus indicators to space creation form (gh-13550)

### DIFF
--- a/src/zen/spaces/create-workspace-form.css
+++ b/src/zen/spaces/create-workspace-form.css
@@ -138,6 +138,11 @@ zen-workspace-creation {
           margin-left: auto;
           min-width: unset !important;
           border-radius: 6px;
+
+          &:focus-visible {
+            outline: 2px solid var(--zen-colors-border-contrast);
+            outline-offset: 2px;
+          }
         }
       }
 
@@ -152,6 +157,11 @@ zen-workspace-creation {
 
         &:hover {
           background-color: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));
+        }
+
+        &:focus-visible {
+          outline: 2px solid var(--zen-colors-border-contrast);
+          outline-offset: 2px;
         }
       }
 


### PR DESCRIPTION
## Summary

The container profile picker and the theme picker in the Create Workspace flow both set `appearance: none` without a replacement focus style, so they were invisible when tabbed to via keyboard. This adds a `:focus-visible` outline using the existing `--zen-colors-border-contrast` token, matching the pattern used in `zen-split-group.inc.css`.

Affected elements:
- `.zen-workspace-creation-profile` (container picker)
- `.zen-workspace-creation-edit-theme-button` (theme picker)

## Demo

https://github.com/user-attachments/assets/503d8bad-27db-4906-9f7b-08945c422396



