### PR TITLE
no-bug: Add configurable keyboard shortcut to create a new workspace

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -321,6 +321,7 @@ zen-workspace-shortcut-switch-9 = Switch to Workspace 9
 zen-workspace-shortcut-switch-10 = Switch to Workspace 10
 zen-workspace-shortcut-forward = Forward Workspace
 zen-workspace-shortcut-backward = Backward Workspace
+zen-workspace-shortcut-create = Create New Workspace
 zen-sidebar-shortcut-toggle = Toggle Sidebar's Width
 zen-pinned-tab-shortcut-reset = Reset Pinned Tab to Pinned URL
 zen-split-view-shortcut-grid = Toggle Split View Grid

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -832,7 +832,7 @@ class nsZenKeyboardShortcutsLoader {
 }
 
 class nsZenKeyboardShortcutsVersioner {
-  static LATEST_KBS_VERSION = 17;
+  static LATEST_KBS_VERSION = 18;
 
   constructor() {}
 
@@ -1208,6 +1208,22 @@ class nsZenKeyboardShortcutsVersioner {
           nsKeyShortcutModifiers.fromObject({}),
           "cmd_zenDuplicateTab",
           "zen-duplicate-tab-shortcut"
+        )
+      );
+    }
+
+    if (version < 18) {
+      // Migrate from version 17 to 18.
+      // Add shortcut to Create New Workspace (unbound by default)
+      data.push(
+        new KeyShortcut(
+          "zen-workspace-create",
+          "",
+          "",
+          ZEN_WORKSPACE_SHORTCUTS_GROUP,
+          nsKeyShortcutModifiers.fromObject({}),
+          "cmd_zenOpenWorkspaceCreation",
+          "zen-workspace-shortcut-create"
         )
       );
     }


### PR DESCRIPTION
Implements the feature requested in discussion [#13361](https://github.com/zen-browser/desktop/discussions/13361).

## Summary

Adds a **Create New Workspace** entry to `about:preferences` → Keyboard Shortcuts → Workspaces, alongside the existing *Forward Workspace* / *Backward Workspace* bindings. The shortcut fires the same `cmd_zenOpenWorkspaceCreation` command that the **+** button in the workspace switcher already dispatches, so it opens the identical new-workspace dialog.

The shortcut is unbound by default (like `zen-duplicate-tab`) to avoid conflicts — users pick their own binding.

## Changes

- **`src/zen/kbs/ZenKeyboardShortcuts.mjs`** — Bumped `LATEST_KBS_VERSION` from 17 to 18 and added a `version < 18` migration block that pushes a new `KeyShortcut("zen-workspace-create", …, "cmd_zenOpenWorkspaceCreation", "zen-workspace-shortcut-create")` into the `ZEN_WORKSPACE_SHORTCUTS_GROUP`. Follows the existing pattern (`zen-duplicate-tab` at v17, `zen-new-unsynced-window` at v15, etc.) — new shortcuts live in the migration only, not in `zenGetDefaultShortcuts()`, so fresh profiles (v0→18) and upgraded profiles (v17→18) both end up with a single entry.
- **`locales/en-US/browser/browser/preferences/zen-preferences.ftl`** — Added `zen-workspace-shortcut-create = Create New Workspace`.

No new command definition or dispatch handler is needed — `cmd_zenOpenWorkspaceCreation` was already registered in `zen-commands.inc.xhtml` and already has a handler in `zen-sets.js` that invokes `gZenWorkspaces.openWorkspaceCreation(event)`.

## Test plan

- [x] Fresh profile (version 0) — migration cascade runs v0→18, shortcut appears exactly once in the Workspaces group (verified in build log: `Zen CKS: Migrating shortcuts from version 0 to 18`)
- [x] **v17 → v18 upgrade path verified in isolation.** Seeded a throwaway profile with a realistic 134-entry shortcuts JSON (stripped of any `zen-workspace-create`) and pinned `zen.keyboard.shortcuts.version=17` via `user.js`. Launch log showed `Zen CKS: Migrating shortcuts from version 17 to 18` (i.e. only the v18 block ran); post-launch JSON had exactly one `zen-workspace-create` entry, unbound, with `action=cmd_zenOpenWorkspaceCreation` and `group=zen-workspace`. Pre-existing entries were untouched.
- [x] Binding the shortcut and pressing it opens the new-workspace dialog, identical to clicking the **+** button
- [x] Unbinding the shortcut leaves the row present but the key no longer triggers
- [x] No conflict with the existing `ZEN_WORKSPACE_SHORTCUTS_GROUP` entries (Forward / Backward / Switch-1..10 / Close All Unpinned Tabs)

## Demo


https://github.com/user-attachments/assets/483cb39e-bcfd-415e-bc1d-24d907e7edc8

