### PR TITLE
gh-13518: Fix oversized extension popup panel on Wayland

### DIFF
--- a/src/external-patches/firefox/gh-13518_extension_popup_resize_panel.patch
+++ b/src/external-patches/firefox/gh-13518_extension_popup_resize_panel.patch
@@ -1,0 +1,49 @@
+# See https://github.com/zen-browser/desktop/issues/13518
+#
+# Browser-action extension popups (which use ViewPopup with fixedWidth=false)
+# rely on `viewNode.customRectGetter` to tell panelmultiview how tall the
+# subview should be:
+#
+#     this.viewNode.customRectGetter = () => {
+#       return { height: this.lastCalculatedInViewHeight || this.viewHeight };
+#     };
+#
+# `viewHeight` is captured once during `attach()` from
+# `viewNode.getBoundingClientRect().height`. On Wayland compositors with
+# fractional scaling (e.g. Hyprland), and in Zen's single-toolbar layouts where
+# the panelview is reparented into a freshly created `customizationui-widget-
+# panel`, that one-shot measurement can land on an inflated value before the
+# popup HTML reports its real intrinsic size. After that, the popup browser
+# itself is resized correctly via `resizeBrowser`, but the surrounding panel
+# never shrinks because `customRectGetter` keeps returning the stale
+# `viewHeight`. The result is a small popup floating in a tall, mostly-empty
+# panel, with the bottom of the popup unclickable.
+#
+# `resizeBrowser` already updates `lastCalculatedInViewHeight` for the
+# `fixedWidth=true` branch but forgets to do it for the `fixedWidth=false`
+# branch (which is the default for `browser_action` popups). Mirror that same
+# update so `customRectGetter` always reports the up-to-date popup height and
+# panelmultiview lets the panel shrink to fit.
+#
+# This is a temporary external patch. Once it lands upstream in Firefox the
+# corresponding section of this patch will start failing to apply and the
+# patch should be removed (per src/external-patches/firefox/README.md).
+diff --git a/browser/components/extensions/ExtensionPopups.sys.mjs b/browser/components/extensions/ExtensionPopups.sys.mjs
+--- a/browser/components/extensions/ExtensionPopups.sys.mjs
++++ b/browser/components/extensions/ExtensionPopups.sys.mjs
+@@ -416,10 +416,15 @@
+     } else {
+       this.browser.style.width = `${width}px`;
+       this.browser.style.minWidth = `${width}px`;
+       this.browser.style.height = `${height}px`;
+       this.browser.style.minHeight = `${height}px`;
++
++      // Mirror the fixedWidth branch so `customRectGetter` reports the
++      // up-to-date popup height instead of the stale `viewHeight` that was
++      // captured once during `attach()`. See gh-13518.
++      this.lastCalculatedInViewHeight = height;
+     }
+ 
+     let event = new this.window.CustomEvent("WebExtPopupResized", { detail });
+     this.browser.dispatchEvent(event);
+   }


### PR DESCRIPTION
Closes #13518.

## What was happening

Browser-action extension popups were rendering inside a panel that was much taller than the popup HTML's intrinsic size, leaving a large empty area below the popup content. The bottom rows of the popup were either visually cut off or, more often, "spilled out of the window" with clicks falling through to the page below.

Reproduced reliably on Hyprland (Wayland + fractional scale) on Arch Linux with Vimium and Bitwarden when extensions are pinned to the URL bar / overflow row.

## Root cause

In `browser/components/extensions/ExtensionPopups.sys.mjs`, `ViewPopup` exposes the panel's height to `panelmultiview` via:

```js
this.viewNode.customRectGetter = () => {
  return { height: this.lastCalculatedInViewHeight || this.viewHeight };
};
```

`viewHeight` is captured **once** during `attach()` from `viewNode.getBoundingClientRect().height`. Then `resizeBrowser({ width, height })` is called every time the popup HTML reports its intrinsic size and is supposed to keep `lastCalculatedInViewHeight` in sync — but it only does so in the `fixedWidth=true` branch:

```js
resizeBrowser({ width, height, detail }) {
  if (this.fixedWidth) {
    // ...
    this.lastCalculatedInViewHeight = Math.max(height, this.viewHeight);
  } else {
    this.browser.style.width  = `${width}px`;
    this.browser.style.minWidth  = `${width}px`;
    this.browser.style.height = `${height}px`;
    this.browser.style.minHeight = `${height}px`;
    // <-- nothing updates lastCalculatedInViewHeight here
  }
  // ...
}
```

`browser_action` popups always go through the `fixedWidth=false` branch, so `lastCalculatedInViewHeight` stays `undefined` for the entire lifetime of the popup. `customRectGetter` falls back to the stale `viewHeight`. On Wayland with fractional scaling, and especially in our single-toolbar layouts where the panelview is reparented into a freshly created `customizationui-widget-panel` (per gh-13535), that one-shot measurement happens at a layout state where the panelview is much taller than the popup actually needs — the panel never gets to shrink. The internal `<browser>` is sized correctly via `style.height`, but the panel chrome around it is locked open.

## Fix

Mirror the `fixedWidth=true` branch in the `else`:

```js
this.lastCalculatedInViewHeight = height;
```

Now `customRectGetter` reports the up-to-date popup height, panelmultiview lets the panel shrink to fit on the next layout pass, and the brief "flash of oversized panel" some users saw on the URL-bar path also goes away.

Shipped as a temporary `src/external-patches/firefox/` patch — per the README in that directory it should be dropped once the equivalent change lands upstream in `mozilla-central`.

## Verification

- Patch applies cleanly against `FIREFOX_150_0_2_RELEASE/browser/components/extensions/ExtensionPopups.sys.mjs`.
- Built locally on Arch Linux + Hyprland (Wayland), fractional scaling.
- Confirmed Vimium and Bitwarden popups now render at their natural size on both the URL-bar path and the overflow path. No more empty area, no more passthrough clicks, and no more "starts oversized then snaps" flash on first open.


## Screenshots

After:
<img width="2562" height="1620" alt="image" src="https://github.com/user-attachments/assets/ae9173f0-8eba-48bf-aadc-9487a950abf8" />

Before:
<img width="2666" height="1308" alt="Image" src="https://github.com/user-attachments/assets/57af82ec-17c4-49aa-88f1-4ad159803ec2" />