### PR TITLE
fix: extension popup panel height on fractional scaling

### DIFF
--- a/src/browser/components/extensions/ExtensionPopups-sys-mjs.patch
+++ b/src/browser/components/extensions/ExtensionPopups-sys-mjs.patch
@@ -1,12 +1,8 @@
-# https://github.com/zen-browser/desktop/issues/13518
-# Update `lastCalculatedInViewHeight` in the fixedWidth=false branch of
-# `resizeBrowser` so the panel shrinks to the actual popup height.
 diff --git a/browser/components/extensions/ExtensionPopups.sys.mjs b/browser/components/extensions/ExtensionPopups.sys.mjs
+index 1cd35175507bd442aae6857e65015cfed00058e3..376377629e9732b292085ba94309e47cc53ee2ef 100644
 --- a/browser/components/extensions/ExtensionPopups.sys.mjs
 +++ b/browser/components/extensions/ExtensionPopups.sys.mjs
-@@ -416,10 +416,12 @@
-     } else {
-       this.browser.style.width = `${width}px`;
+@@ -418,6 +418,8 @@ export class BasePopup {
        this.browser.style.minWidth = `${width}px`;
        this.browser.style.height = `${height}px`;
        this.browser.style.minHeight = `${height}px`;
@@ -15,5 +11,3 @@ diff --git a/browser/components/extensions/ExtensionPopups.sys.mjs b/browser/com
      }
  
      let event = new this.window.CustomEvent("WebExtPopupResized", { detail });
-     this.browser.dispatchEvent(event);
-   }

--- a/src/browser/components/extensions/ExtensionPopups-sys-mjs.patch
+++ b/src/browser/components/extensions/ExtensionPopups-sys-mjs.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/extensions/ExtensionPopups.sys.mjs b/browser/components/extensions/ExtensionPopups.sys.mjs
-index 1cd35175507bd442aae6857e65015cfed00058e3..376377629e9732b292085ba94309e47cc53ee2ef 100644
+index 1cd35175507bd442aae6857e65015cfed00058e3..c7f9c5a4de05cfa476b89137798061ce36ef2f40 100644
 --- a/browser/components/extensions/ExtensionPopups.sys.mjs
 +++ b/browser/components/extensions/ExtensionPopups.sys.mjs
 @@ -418,6 +418,8 @@ export class BasePopup {
@@ -7,7 +7,7 @@ index 1cd35175507bd442aae6857e65015cfed00058e3..376377629e9732b292085ba94309e47c
        this.browser.style.height = `${height}px`;
        this.browser.style.minHeight = `${height}px`;
 +
-+      this.lastCalculatedInViewHeight = height;
++      this.lastCalculatedInViewHeight = Math.max(height, this.viewHeight);
      }
  
      let event = new this.window.CustomEvent("WebExtPopupResized", { detail });

--- a/src/external-patches/firefox/gh-13518_extension_popup_resize_panel.patch
+++ b/src/external-patches/firefox/gh-13518_extension_popup_resize_panel.patch
@@ -1,46 +1,16 @@
-# See https://github.com/zen-browser/desktop/issues/13518
-#
-# Browser-action extension popups (which use ViewPopup with fixedWidth=false)
-# rely on `viewNode.customRectGetter` to tell panelmultiview how tall the
-# subview should be:
-#
-#     this.viewNode.customRectGetter = () => {
-#       return { height: this.lastCalculatedInViewHeight || this.viewHeight };
-#     };
-#
-# `viewHeight` is captured once during `attach()` from
-# `viewNode.getBoundingClientRect().height`. On Wayland compositors with
-# fractional scaling (e.g. Hyprland), and in Zen's single-toolbar layouts where
-# the panelview is reparented into a freshly created `customizationui-widget-
-# panel`, that one-shot measurement can land on an inflated value before the
-# popup HTML reports its real intrinsic size. After that, the popup browser
-# itself is resized correctly via `resizeBrowser`, but the surrounding panel
-# never shrinks because `customRectGetter` keeps returning the stale
-# `viewHeight`. The result is a small popup floating in a tall, mostly-empty
-# panel, with the bottom of the popup unclickable.
-#
-# `resizeBrowser` already updates `lastCalculatedInViewHeight` for the
-# `fixedWidth=true` branch but forgets to do it for the `fixedWidth=false`
-# branch (which is the default for `browser_action` popups). Mirror that same
-# update so `customRectGetter` always reports the up-to-date popup height and
-# panelmultiview lets the panel shrink to fit.
-#
-# This is a temporary external patch. Once it lands upstream in Firefox the
-# corresponding section of this patch will start failing to apply and the
-# patch should be removed (per src/external-patches/firefox/README.md).
+# https://github.com/zen-browser/desktop/issues/13518
+# Update `lastCalculatedInViewHeight` in the fixedWidth=false branch of
+# `resizeBrowser` so the panel shrinks to the actual popup height.
 diff --git a/browser/components/extensions/ExtensionPopups.sys.mjs b/browser/components/extensions/ExtensionPopups.sys.mjs
 --- a/browser/components/extensions/ExtensionPopups.sys.mjs
 +++ b/browser/components/extensions/ExtensionPopups.sys.mjs
-@@ -416,10 +416,15 @@
+@@ -416,10 +416,12 @@
      } else {
        this.browser.style.width = `${width}px`;
        this.browser.style.minWidth = `${width}px`;
        this.browser.style.height = `${height}px`;
        this.browser.style.minHeight = `${height}px`;
 +
-+      // Mirror the fixedWidth branch so `customRectGetter` reports the
-+      // up-to-date popup height instead of the stale `viewHeight` that was
-+      // captured once during `attach()`. See gh-13518.
 +      this.lastCalculatedInViewHeight = height;
      }
  

--- a/src/external-patches/firefox/gh-13518_extension_popup_resize_panel.patch
+++ b/src/external-patches/firefox/gh-13518_extension_popup_resize_panel.patch
@@ -1,0 +1,49 @@
+# See https://github.com/zen-browser/desktop/issues/13518
+#
+# Browser-action extension popups (which use ViewPopup with fixedWidth=false)
+# rely on `viewNode.customRectGetter` to tell panelmultiview how tall the
+# subview should be:
+#
+#     this.viewNode.customRectGetter = () => {
+#       return { height: this.lastCalculatedInViewHeight || this.viewHeight };
+#     };
+#
+# `viewHeight` is captured once during `attach()` from
+# `viewNode.getBoundingClientRect().height`. On Wayland compositors with
+# fractional scaling (e.g. Hyprland), and in Zen's single-toolbar layouts where
+# the panelview is reparented into a freshly created `customizationui-widget-
+# panel`, that one-shot measurement can land on an inflated value before the
+# popup HTML reports its real intrinsic size. After that, the popup browser
+# itself is resized correctly via `resizeBrowser`, but the surrounding panel
+# never shrinks because `customRectGetter` keeps returning the stale
+# `viewHeight`. The result is a small popup floating in a tall, mostly-empty
+# panel, with the bottom of the popup unclickable.
+#
+# `resizeBrowser` already updates `lastCalculatedInViewHeight` for the
+# `fixedWidth=true` branch but forgets to do it for the `fixedWidth=false`
+# branch (which is the default for `browser_action` popups). Mirror that same
+# update so `customRectGetter` always reports the up-to-date popup height and
+# panelmultiview lets the panel shrink to fit.
+#
+# This is a temporary external patch. Once it lands upstream in Firefox the
+# corresponding section of this patch will start failing to apply and the
+# patch should be removed (per src/external-patches/firefox/README.md).
+diff --git a/browser/components/extensions/ExtensionPopups.sys.mjs b/browser/components/extensions/ExtensionPopups.sys.mjs
+--- a/browser/components/extensions/ExtensionPopups.sys.mjs
++++ b/browser/components/extensions/ExtensionPopups.sys.mjs
+@@ -416,10 +416,15 @@
+     } else {
+       this.browser.style.width = `${width}px`;
+       this.browser.style.minWidth = `${width}px`;
+       this.browser.style.height = `${height}px`;
+       this.browser.style.minHeight = `${height}px`;
++
++      // Mirror the fixedWidth branch so `customRectGetter` reports the
++      // up-to-date popup height instead of the stale `viewHeight` that was
++      // captured once during `attach()`. See gh-13518.
++      this.lastCalculatedInViewHeight = height;
+     }
+ 
+     let event = new this.window.CustomEvent("WebExtPopupResized", { detail });
+     this.browser.dispatchEvent(event);
+   }


### PR DESCRIPTION
Closes #13518 

After:
<img width="2562" height="1620" alt="image" src="https://github.com/user-attachments/assets/ae9173f0-8eba-48bf-aadc-9487a950abf8" />

Before:
<img width="2666" height="1308" alt="Image" src="https://github.com/user-attachments/assets/57af82ec-17c4-49aa-88f1-4ad159803ec2" />