### PR TITLE
fix: localize hardcoded Zen action strings

### DIFF
--- a/locales/en-US/browser/browser/zen-general.ftl
+++ b/locales/en-US/browser/browser/zen-general.ftl
@@ -77,8 +77,40 @@ zen-icons-picker-emoji =
   .label = Emojis
 zen-icons-picker-svg =
   .label = Icons
+zen-icons-picker-search =
+  .placeholder = Search emojis
 
 urlbar-search-mode-zen_actions = Actions
+zen-urlbar-action-toggle-compact-mode = Toggle Compact Mode
+zen-urlbar-action-open-theme-picker = Open Theme Picker
+zen-urlbar-action-new-split-view = New Split View
+zen-urlbar-action-new-folder = New Folder
+zen-urlbar-action-copy-current-url = Copy Current URL
+zen-urlbar-action-settings = Settings
+zen-urlbar-action-open-private-window = Open Private Window
+zen-urlbar-action-open-new-window = Open New Window
+zen-urlbar-action-new-blank-window = New Blank Window
+zen-urlbar-action-pin-tab = Pin Tab
+zen-urlbar-action-unpin-tab = Unpin Tab
+zen-urlbar-action-next-space = Next Space
+zen-urlbar-action-previous-space = Previous Space
+zen-urlbar-action-close-tab = Close Tab
+zen-urlbar-action-reload-tab = Reload Tab
+zen-urlbar-action-reload-tab-without-cache = Reload Tab Without Cache
+zen-urlbar-action-next-tab = Next Tab
+zen-urlbar-action-previous-tab = Previous Tab
+zen-urlbar-action-capture-screenshot = Capture Screenshot
+zen-urlbar-action-toggle-tabs-on-right = Toggle Tabs on right
+zen-urlbar-action-add-to-essentials = Add to Essentials
+zen-urlbar-action-remove-from-essentials = Remove from Essentials
+zen-urlbar-action-find-in-page = Find in Page
+zen-urlbar-action-manage-extensions = Manage Extensions
+zen-urlbar-action-switch-to-automatic-appearance = Switch to Automatic Appearance
+zen-urlbar-action-switch-to-light-mode = Switch to Light Mode
+zen-urlbar-action-switch-to-dark-mode = Switch to Dark Mode
+zen-urlbar-action-print = Print
+zen-urlbar-action-focus-on = Focus on
+zen-urlbar-action-extension = Extension
 zen-site-data-settings = Settings
 
 zen-generic-manage = Manage
@@ -150,4 +182,3 @@ zen-window-sync-migration-dialog-accept = Got It
 
 zen-appmenu-new-blank-window =
     .label = New blank window
-

--- a/src/browser/base/content/zen-panels/emojis-picker.inc
+++ b/src/browser/base/content/zen-panels/emojis-picker.inc
@@ -14,7 +14,7 @@
   <hbox id="PanelUI-zen-emojis-picker-pages">
     <vbox emojis="true">
       <hbox id="PanelUI-zen-emojis-picker-header">
-        <html:input type="search" id="PanelUI-zen-emojis-picker-search" placeholder="Search emojis" />
+        <html:input type="search" id="PanelUI-zen-emojis-picker-search" data-l10n-id="zen-icons-picker-search" />
       </hbox>
       <hbox id="PanelUI-zen-emojis-picker-list" />
     </vbox>

--- a/src/zen/urlbar/ZenUBActionsProvider.sys.mjs
+++ b/src/zen/urlbar/ZenUBActionsProvider.sys.mjs
@@ -27,6 +27,10 @@ ChromeUtils.defineESModuleGetters(lazy, {
   UrlUtils: "resource://gre/modules/UrlUtils.sys.mjs",
 });
 
+ChromeUtils.defineLazyGetter(lazy, "l10n", () => {
+  return new Localization(["browser/zen-general.ftl"]);
+});
+
 XPCOMUtils.defineLazyPreferenceGetter(
   lazy,
   "enabledPref",
@@ -183,6 +187,7 @@ export class ZenUrlbarProviderGlobalActions extends UrlbarProvider {
           ?.style.getPropertyValue("--zen-primary-color");
         actions.push({
           label: "Focus on",
+          l10nId: "zen-urlbar-action-focus-on",
           extraPayload: {
             workspaceId: workspace.uuid,
             prettyName: workspace.name,
@@ -216,6 +221,7 @@ export class ZenUrlbarProviderGlobalActions extends UrlbarProvider {
         return {
           icon: "chrome://browser/skin/zen-icons/extension.svg",
           label: "Extension",
+          l10nId: "zen-urlbar-action-extension",
           commandId: `zen:extension-${addon.id}`,
           extraPayload: {
             extensionId: addon.id,
@@ -237,6 +243,20 @@ export class ZenUrlbarProviderGlobalActions extends UrlbarProvider {
       .concat(await this.#getExtensionActions(window));
   }
 
+  async #localizeActions(actions) {
+    const actionsWithL10n = actions.filter(action => action.l10nId);
+    const messages = await lazy.l10n.formatValues(
+      actionsWithL10n.map(action => ({ id: action.l10nId }))
+    );
+    const labels = new Map(
+      actionsWithL10n.map((action, index) => [action, messages[index]])
+    );
+    return actions.map(action => ({
+      ...action,
+      label: labels.get(action) || action.label,
+    }));
+  }
+
   /**
    * Starts a search query amongst the available global actions.
    *
@@ -249,8 +269,9 @@ export class ZenUrlbarProviderGlobalActions extends UrlbarProvider {
     const actions = isWorkspaceSearch
       ? this.#getWorkspaceActions(window)
       : await this.#getAvailableActions(window);
+    const localizedActions = await this.#localizeActions(actions);
     let results = [];
-    for (let action of actions) {
+    for (let action of localizedActions) {
       if (isPrefixed && query.length < 1) {
         results.push({ action, score: 100 });
         continue;

--- a/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
+++ b/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
@@ -20,51 +20,61 @@ function isNotEmptyTab(window) {
 const globalActionsTemplate = [
   {
     label: "Toggle Compact Mode",
+    l10nId: "zen-urlbar-action-toggle-compact-mode",
     command: "cmd_zenCompactModeToggle",
     icon: "chrome://browser/skin/zen-icons/sidebar.svg",
   },
   {
     label: "Open Theme Picker",
+    l10nId: "zen-urlbar-action-open-theme-picker",
     command: "cmd_zenOpenZenThemePicker",
     icon: "chrome://browser/skin/zen-icons/edit-theme.svg",
   },
   {
     label: "New Split View",
+    l10nId: "zen-urlbar-action-new-split-view",
     command: "cmd_zenNewEmptySplit",
     icon: "chrome://browser/skin/zen-icons/split.svg",
   },
   {
     label: "New Folder",
+    l10nId: "zen-urlbar-action-new-folder",
     command: "cmd_zenOpenFolderCreation",
     icon: "chrome://browser/skin/zen-icons/folder.svg",
   },
   {
     label: "Copy Current URL",
+    l10nId: "zen-urlbar-action-copy-current-url",
     command: "cmd_zenCopyCurrentURL",
     icon: "chrome://browser/skin/zen-icons/link.svg",
   },
   {
     label: "Settings",
+    l10nId: "zen-urlbar-action-settings",
     command: window => window.openPreferences(),
     icon: "chrome://browser/skin/zen-icons/settings.svg",
   },
   {
     label: "Open Private Window",
+    l10nId: "zen-urlbar-action-open-private-window",
     command: "Tools:PrivateBrowsing",
     icon: "chrome://browser/skin/zen-icons/private-window.svg",
   },
   {
     label: "Open New Window",
+    l10nId: "zen-urlbar-action-open-new-window",
     command: "cmd_newNavigator",
     icon: "chrome://browser/skin/zen-icons/window.svg",
   },
   {
     label: "New Blank Window",
+    l10nId: "zen-urlbar-action-new-blank-window",
     command: "cmd_zenNewNavigatorUnsynced",
     icon: "chrome://browser/skin/zen-icons/window.svg",
   },
   {
     label: "Pin Tab",
+    l10nId: "zen-urlbar-action-pin-tab",
     command: "cmd_zenTogglePinTab",
     icon: "chrome://browser/skin/zen-icons/pin.svg",
     isAvailable: window => {
@@ -74,6 +84,7 @@ const globalActionsTemplate = [
   },
   {
     label: "Unpin Tab",
+    l10nId: "zen-urlbar-action-unpin-tab",
     command: "cmd_zenTogglePinTab",
     icon: "chrome://browser/skin/zen-icons/unpin.svg",
     isAvailable: window => {
@@ -83,6 +94,7 @@ const globalActionsTemplate = [
   },
   {
     label: "Next Space",
+    l10nId: "zen-urlbar-action-next-space",
     command: "cmd_zenWorkspaceForward",
     icon: "chrome://browser/skin/zen-icons/forward.svg",
     isAvailable: window => {
@@ -91,6 +103,7 @@ const globalActionsTemplate = [
   },
   {
     label: "Previous Space",
+    l10nId: "zen-urlbar-action-previous-space",
     command: "cmd_zenWorkspaceBackward",
     icon: "chrome://browser/skin/zen-icons/back.svg",
     isAvailable: window => {
@@ -100,6 +113,7 @@ const globalActionsTemplate = [
   },
   {
     label: "Close Tab",
+    l10nId: "zen-urlbar-action-close-tab",
     command: "cmd_close",
     icon: "chrome://browser/skin/zen-icons/close.svg",
     isAvailable: window => {
@@ -108,26 +122,31 @@ const globalActionsTemplate = [
   },
   {
     label: "Reload Tab",
+    l10nId: "zen-urlbar-action-reload-tab",
     command: "Browser:Reload",
     icon: "chrome://browser/skin/zen-icons/reload.svg",
   },
   {
     label: "Reload Tab Without Cache",
+    l10nId: "zen-urlbar-action-reload-tab-without-cache",
     command: "Browser:ReloadSkipCache",
     icon: "chrome://browser/skin/zen-icons/reload.svg",
   },
   {
     label: "Next Tab",
+    l10nId: "zen-urlbar-action-next-tab",
     command: "Browser:NextTab",
     icon: "chrome://browser/skin/zen-icons/forward.svg",
   },
   {
     label: "Previous Tab",
+    l10nId: "zen-urlbar-action-previous-tab",
     command: "Browser:PrevTab",
     icon: "chrome://browser/skin/zen-icons/back.svg",
   },
   {
     label: "Capture Screenshot",
+    l10nId: "zen-urlbar-action-capture-screenshot",
     command: "Browser:Screenshot",
     icon: "chrome://browser/skin/zen-icons/screenshot.svg",
     isAvailable: window => {
@@ -136,11 +155,13 @@ const globalActionsTemplate = [
   },
   {
     label: "Toggle Tabs on right",
+    l10nId: "zen-urlbar-action-toggle-tabs-on-right",
     command: "cmd_zenToggleTabsOnRight",
     icon: "chrome://browser/skin/zen-icons/sidebars-right.svg",
   },
   {
     label: "Add to Essentials",
+    l10nId: "zen-urlbar-action-add-to-essentials",
     command: window =>
       window.gZenPinnedTabManager.addToEssentials(window.gBrowser.selectedTab),
     isAvailable: window => {
@@ -154,6 +175,7 @@ const globalActionsTemplate = [
   },
   {
     label: "Remove from Essentials",
+    l10nId: "zen-urlbar-action-remove-from-essentials",
     command: window =>
       window.gZenPinnedTabManager.removeEssentials(window.gBrowser.selectedTab),
     isAvailable: window =>
@@ -162,6 +184,7 @@ const globalActionsTemplate = [
   },
   {
     label: "Find in Page",
+    l10nId: "zen-urlbar-action-find-in-page",
     command: "cmd_find",
     icon: "chrome://browser/skin/zen-icons/search-page.svg",
     isAvailable: window => {
@@ -170,11 +193,13 @@ const globalActionsTemplate = [
   },
   {
     label: "Manage Extensions",
+    l10nId: "zen-urlbar-action-manage-extensions",
     command: "Tools:Addons",
     icon: "chrome://browser/skin/zen-icons/extension.svg",
   },
   {
     label: "Switch to Automatic Appearance",
+    l10nId: "zen-urlbar-action-switch-to-automatic-appearance",
     command: () => Services.prefs.setIntPref("zen.view.window.scheme", 2),
     icon: "chrome://browser/skin/zen-icons/sparkles.svg",
     isAvailable: () => {
@@ -183,6 +208,7 @@ const globalActionsTemplate = [
   },
   {
     label: "Switch to Light Mode",
+    l10nId: "zen-urlbar-action-switch-to-light-mode",
     command: () => Services.prefs.setIntPref("zen.view.window.scheme", 1),
     icon: "chrome://browser/skin/zen-icons/face-sun.svg",
     isAvailable: () => {
@@ -191,6 +217,7 @@ const globalActionsTemplate = [
   },
   {
     label: "Switch to Dark Mode",
+    l10nId: "zen-urlbar-action-switch-to-dark-mode",
     command: () => Services.prefs.setIntPref("zen.view.window.scheme", 0),
     icon: "chrome://browser/skin/zen-icons/moon-stars.svg",
     isAvailable: () => {
@@ -199,6 +226,7 @@ const globalActionsTemplate = [
   },
   {
     label: "Print",
+    l10nId: "zen-urlbar-action-print",
     command: "cmd_print",
     icon: "chrome://browser/skin/zen-icons/print.svg",
     isAvailable: window => {


### PR DESCRIPTION
## Summary
- Add Fluent strings for Zen URL bar global actions so they can sync to Crowdin
- Localize workspace and extension action prefixes in the Zen actions provider
- Replace the hardcoded emoji search placeholder with a Fluent ID

Fixes #10749

## Testing
- node --check src/zen/urlbar/ZenUBActionsProvider.sys.mjs
- node --check src/zen/urlbar/ZenUBGlobalActions.sys.mjs
- git diff --check

## Notes
- npm test could not run in this shallow checkout because engine/testing/mochitest/ignorePrefs.json is missing.
- npm run lint could not run in this shallow checkout because the engine directory is missing.