### PR TITLE
fix: preserve Alt link text selection

### DIFF
--- a/prefs/zen/glance.yaml
+++ b/prefs/zen/glance.yaml
@@ -12,7 +12,7 @@
   value: true
 
 - name: zen.glance.activation-method
-  value: "alt" # ctrl, alt, shift
+  value: "ctrl" # ctrl, alt, shift
 
 - name: zen.glance.animation-duration
   value: 350 # in milliseconds


### PR DESCRIPTION
## Summary
- Change the default Glance activation modifier from Alt to Ctrl
- Align the shipped pref with the settings default and avoid intercepting Firefox's Alt/Option link text selection behavior


## Testing
- git diff --check

## Notes
- npm test could not run in this shallow checkout because engine/testing/mochitest/ignorePrefs.json is missing.
- npm run lint could not run in this shallow checkout because the engine directory is missing.