### PR TITLE
fix: restore missing pin tab shortcut

### DIFF
--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -832,7 +832,7 @@ class nsZenKeyboardShortcutsLoader {
 }
 
 class nsZenKeyboardShortcutsVersioner {
-  static LATEST_KBS_VERSION = 18;
+  static LATEST_KBS_VERSION = 19;
 
   constructor() {}
 
@@ -1226,6 +1226,24 @@ class nsZenKeyboardShortcutsVersioner {
           "zen-workspace-shortcut-create"
         )
       );
+    }
+
+    if (version < 19) {
+      // Migrate from version 18 to 19.
+      // Restore the pin/unpin tab shortcut if older data missed the v10 migration.
+      if (!data.find(s => s.getID() == "zen-toggle-pin-tab")) {
+        data.push(
+          new KeyShortcut(
+            "zen-toggle-pin-tab",
+            "D",
+            "",
+            ZEN_OTHER_SHORTCUTS_GROUP,
+            nsKeyShortcutModifiers.fromObject({ accel: true, shift: true }),
+            "cmd_zenTogglePinTab",
+            "zen-toggle-pin-tab-shortcut"
+          )
+        );
+      }
     }
 
     return data;


### PR DESCRIPTION
## Summary
- Bump the keyboard shortcut schema version to 19
- Add a migration that restores the pin/unpin tab shortcut when saved shortcut data missed the old v10 migration
- Keep the existing default binding: Accel+Shift+D

Fixes #4504

## Testing
- node --check src/zen/kbs/ZenKeyboardShortcuts.mjs
- git diff --check

## Notes
- npm test could not run in this shallow checkout because engine/testing/mochitest/ignorePrefs.json is missing.
- npm run lint could not run in this shallow checkout because the engine directory is missing.