### PR TITLE
no-bug: A few quality-of-life tweaks, take 2

### DIFF
--- a/configs/linux/mozconfig
+++ b/configs/linux/mozconfig
@@ -2,8 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Setting the compiler based on the existence of clang bin directory
-if test -d "$HOME/.mozbuild/clang/bin"; then
+# Setting the compiler based on the environment or existence of the clang
+# bin directory
+if test "$CC" && test "$CXX"; then
+    true
+elif test -d "$HOME/.mozbuild/clang/bin"; then
     export CC="$HOME/.mozbuild/clang/bin/clang"
     export CXX="$HOME/.mozbuild/clang/bin/clang++"
 else

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "python3 scripts/run_tests.py",
     "test:dbg": "python3 scripts/run_tests.py --jsdebugger --debug-on-failure",
     "test:gtest": "cd engine && ./mach gtest Zen*",
-    "ffprefs": "cd tools/ffprefs && cargo run --bin ffprefs -- ../../",
+    "ffprefs": "python3 scripts/run_cargo.py run --manifest-path tools/ffprefs/Cargo.toml --bin ffprefs -- prefs engine",
     "lc": "surfer license-check",
     "lc:fix": "surfer license-check --fix",
     "use-moz-src": "cd engine && ./mach use-moz-src",

--- a/scripts/run_cargo.py
+++ b/scripts/run_cargo.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+cargo = os.environ.get('CARGO', 'cargo')
+
+command = [cargo] + sys.argv[1:]
+
+try:
+  os.execvp(command[0], command)
+except OSError as e:
+  print(f"{sys.argv[0]}: '{command[0]}': {e}", file=sys.stderr)
+  if 'CARGO' in os.environ:
+    print('(CARGO environment variable is set)', file=sys.stderr)
+  sys.exit(1)

--- a/scripts/update_service_dumps.py
+++ b/scripts/update_service_dumps.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+import sys
 import json
 from json_with_comments import JSONWithCommentsDecoder
 
@@ -60,4 +61,6 @@ def main():
 
 
 if __name__ == "__main__":
+  if len(sys.argv) == 3:
+    _, DUMPS_FOLDER, ENGINE_DUMPS_FOLDER = sys.argv
   main()

--- a/tools/ffprefs/src/main.rs
+++ b/tools/ffprefs/src/main.rs
@@ -107,9 +107,9 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-const STATIC_PREFS: &str = "../engine/modules/libpref/init/zen-static-prefs.inc";
-const FIREFOX_PREFS: &str = "../engine/browser/app/profile/firefox.js";
-const DYNAMIC_PREFS: &str = "../engine/browser/app/profile/zen.js";
+const STATIC_PREFS: &str = "modules/libpref/init/zen-static-prefs.inc";
+const FIREFOX_PREFS: &str = "browser/app/profile/firefox.js";
+const DYNAMIC_PREFS: &str = "browser/app/profile/zen.js";
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct Preference {
@@ -122,12 +122,6 @@ struct Preference {
     mirror: Option<String>,
     locked: Option<bool>,
     sticky: Option<bool>,
-}
-
-fn get_config_path() -> PathBuf {
-    let mut path = env::current_dir().expect("Failed to get current directory");
-    path.push("prefs");
-    path
 }
 
 fn ordered_prefs(mut prefs: Vec<Preference>) -> Vec<Preference> {
@@ -153,11 +147,10 @@ fn get_prefs_files_recursively(dir: &PathBuf, files: &mut Vec<PathBuf>) {
     }
 }
 
-fn load_preferences() -> Vec<Preference> {
+fn load_preferences(prefs_path: &PathBuf) -> Vec<Preference> {
     let mut prefs = Vec::new();
-    let config_path = get_config_path();
     let mut pref_files = Vec::new();
-    get_prefs_files_recursively(&config_path, &mut pref_files);
+    get_prefs_files_recursively(&prefs_path, &mut pref_files);
     for file_path in pref_files {
         let content = fs::read_to_string(&file_path).expect("Failed to read file");
         let mut parsed_prefs: Vec<Preference> =
@@ -263,14 +256,9 @@ fn get_value(pref: &Preference) -> String {
     }
 }
 
-fn write_preferences(prefs: &[Preference]) {
-    let config_path = get_config_path();
-    if !config_path.exists() {
-        fs::create_dir_all(&config_path).expect("Failed to create prefs directory");
-    }
-
-    let static_prefs_path = config_path.join(STATIC_PREFS);
-    let dynamic_prefs_path = config_path.join(DYNAMIC_PREFS);
+fn write_preferences(engine_path: &PathBuf, prefs: &[Preference]) {
+    let static_prefs_path = engine_path.join(STATIC_PREFS);
+    let dynamic_prefs_path = engine_path.join(DYNAMIC_PREFS);
     println!(
         "Writing preferences to:\n  Static: {}\n  Dynamic: {}",
         static_prefs_path.display(),
@@ -300,10 +288,10 @@ fn write_preferences(prefs: &[Preference]) {
     fs::write(&dynamic_prefs_path, dynamic_content).expect("Failed to write dynamic prefs");
 }
 
-fn prepare_zen_prefs() {
+fn prepare_zen_prefs(engine_path: &PathBuf) {
     // Add `#include zen.js` to the bottom of the firefox.js file if it doesn't exist
     let line = "#include zen.js";
-    let firefox_prefs_path = get_config_path().join(FIREFOX_PREFS);
+    let firefox_prefs_path = engine_path.join(FIREFOX_PREFS);
     if let Ok(mut content) = fs::read_to_string(&firefox_prefs_path) {
         if !content.contains(line) {
             content.push_str(format!("\n{}\n", line).as_str());
@@ -351,15 +339,14 @@ fn expand_pref_values(prefs: &mut [Preference]) {
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let root_path = if args.len() > 1 {
-        PathBuf::from(&args[1])
-    } else {
-        env::current_dir().expect("Failed to get current directory")
-    };
-    env::set_current_dir(&root_path).expect("Failed to change directory");
+    if args.len() != 3 {
+        panic!("Must specify exactly two directories: prefs and engine");
+    }
+    let prefs_path  = PathBuf::from(&args[1]);
+    let engine_path = PathBuf::from(&args[2]);
 
-    prepare_zen_prefs();
-    let mut preferences = load_preferences();
+    prepare_zen_prefs(&engine_path);
+    let mut preferences = load_preferences(&prefs_path);
     expand_pref_values(&mut preferences);
-    write_preferences(&preferences);
+    write_preferences(&engine_path, &preferences);
 }


### PR DESCRIPTION
This should support `npm run import` on Windows. I looked into [run-script-os](https://www.npmjs.com/package/run-script-os), and a couple other approaches, but then figured it would be simpler to just call a small Python script that looks up the environment variable and calls `cargo`/`$CARGO` as appropriate.

Please give this a try, and let me know if you see any regressions.

----

`package.json`: Invoke `cargo(1)` through a Python script that honors the `CARGO` environment variable if set, and pass arguments to `ffprefs` using the new convention (see below)

`run_cargo.py`: Script to invoke `cargo(1)`, as a workaround for reading an environment variable in a `package.json` script in a cross-platform manner

`update_service_dumps.py`: Allow specifying `DUMPS_FOLDER` and `ENGINE_DUMPS_FOLDER` on the command line

`ffprefs/src/main.rs`: Allow specifying the `prefs` and `engine` dirs on the command line instead of hard-coding their locations relative to a common root dir