### PR TITLE
feat(folders): Add zen.folders.new-tabs-in-folder to open new tabs in current folder

### DIFF
--- a/prefs/zen/folders.yaml
+++ b/prefs/zen/folders.yaml
@@ -13,3 +13,6 @@
 
 - name: zen.folders.owned-tabs-in-folder
   value: false
+
+- name: zen.folders.new-tabs-in-folder
+  value: false

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -397,6 +397,18 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
   on_TabOpen(event) {
     const tab = event.target;
     const group = tab.group;
+    if (
+      Services.prefs.getBoolPref("zen.folders.new-tabs-in-folder")
+      && !group?.isZenFolder
+      && !tab.owner
+    ) {
+      const activeFolder = gBrowser.selectedTab?.group;
+      if (activeFolder?.isZenFolder) {
+        gBrowser.pinTab(tab);
+        activeFolder.addTabs([tab]);
+        return;
+      }
+    }
     if (!group?.isZenFolder || tab.pinned) {
       return;
     }

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -398,26 +398,27 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     const tab = event.target;
     const group = tab.group;
     if (
-      Services.prefs.getBoolPref("zen.folders.new-tabs-in-folder")
-      && !group?.isZenFolder
-      && !tab.owner
+      Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder") &&
+      group?.isZenFolder &&
+      !tab.pinned
     ) {
-      const activeFolder = gBrowser.selectedTab?.group;
-      if (activeFolder?.isZenFolder) {
-        gBrowser.pinTab(tab);
-        activeFolder.addTabs([tab]);
-        return;
-      }
-    }
-    if (!group?.isZenFolder || tab.pinned) {
-      return;
-    }
-    // Edge case: In occations where we add a tab with an ownerTab
-    // inside a folder, the tab gets added into the folder in an
-    // unpinned state. We need to pin it and re-add it into the folder.
-    if (Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder")) {
+      // Edge case: In occations where we add a tab with an ownerTab
+      // inside a folder, the tab gets added into the folder in an
+      // unpinned state. We need to pin it and re-add it into the folder.
       gBrowser.pinTab(tab);
       group.addTabs([tab]);
+      return;
+    }
+    const activeFolder = gBrowser.selectedTab?.group;
+    if (
+      Services.prefs.getBoolPref("zen.folders.new-tabs-in-folder") &&
+      !group?.isZenFolder &&
+      !tab.owner &&
+      activeFolder?.isZenFolder &&
+      !activeFolder?.isLiveFolder &&
+      !activeFolder?.hasAttribute("split-view-group")
+    ) {
+      activeFolder.addTabs([tab]);
     }
   }
 

--- a/src/zen/tests/folders/browser.toml
+++ b/src/zen/tests/folders/browser.toml
@@ -26,6 +26,8 @@ support-files = [
 
 ["browser_folder_multiselected.js"]
 
+["browser_folder_new_tabs.js"]
+
 ["browser_folder_owner_tabs.js"]
 
 ["browser_folder_reset_button.js"]

--- a/src/zen/tests/folders/browser_folder_new_tabs.js
+++ b/src/zen/tests/folders/browser_folder_new_tabs.js
@@ -1,0 +1,91 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_New_Tab_Inside_Folder() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.folders.new-tabs-in-folder", true]],
+  });
+  const selectedTab = gBrowser.selectedTab;
+  const tab = BrowserTestUtils.addTab(gBrowser, "about:blank");
+  const folder = await gZenFolders.createFolder([tab], {
+    renameFolder: false,
+  });
+  gBrowser.selectedTab = tab;
+  const triggeringPrincipal = Services.scriptSecurityManager.getSystemPrincipal();
+
+  const newTab = gBrowser.addTab("https://example.com", {
+    inBackground: true,
+    triggeringPrincipal,
+  });
+
+  /* eslint-disable mozilla/no-arbitrary-setTimeout */
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  Assert.equal(folder.tabs.length, 3, "New tab was added to the folder");
+  Assert.equal(newTab.group, folder, "New tab is in the folder group");
+
+  gBrowser.selectedTab = selectedTab;
+  await removeFolder(folder);
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_New_Tab_Not_Inside_Folder_When_Pref_Disabled() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.folders.new-tabs-in-folder", false]],
+  });
+  const selectedTab = gBrowser.selectedTab;
+  const tab = BrowserTestUtils.addTab(gBrowser, "about:blank");
+  const folder = await gZenFolders.createFolder([tab], {
+    renameFolder: false,
+  });
+  gBrowser.selectedTab = tab;
+  const triggeringPrincipal = Services.scriptSecurityManager.getSystemPrincipal();
+
+  const newTab = gBrowser.addTab("https://example.com", {
+    inBackground: true,
+    triggeringPrincipal,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  Assert.equal(folder.tabs.length, 2, "New tab was not added to the folder");
+  ok(!newTab.group, "New tab should not be in any group");
+
+  gBrowser.selectedTab = selectedTab;
+  BrowserTestUtils.removeTab(newTab);
+  await removeFolder(folder);
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_Owned_Tab_Not_Captured_By_New_Tabs_In_Folder() {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["zen.folders.new-tabs-in-folder", true],
+      ["zen.folders.owned-tabs-in-folder", false],
+    ],
+  });
+  const selectedTab = gBrowser.selectedTab;
+  const tab = BrowserTestUtils.addTab(gBrowser, "about:blank");
+  const folder = await gZenFolders.createFolder([tab], {
+    renameFolder: false,
+  });
+  gBrowser.selectedTab = tab;
+
+  const newTab = gBrowser.addTab("https://example.com", {
+    relatedToCurrent: true,
+    ownerTab: tab,
+    triggeringPrincipal,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  Assert.equal(folder.tabs.length, 2, "Owned tab was not captured by new-tabs-in-folder");
+  ok(!newTab.group, "Owned tab should not be in any group");
+
+  gBrowser.selectedTab = selectedTab;
+  BrowserTestUtils.removeTab(newTab);
+  await removeFolder(folder);
+  await SpecialPowers.popPrefEnv();
+});


### PR DESCRIPTION
Adds a new `zen.folders.new-tabs-in-folder` preference. When enabled, new tabs via Ctrl + T will open under the currently open tab's parent folder. This saves having to continually move new tabs into the desired folder.

Relevant discussion: #13669