### PR TITLE
fix(kbs): restore missing pin tab shortcut

### DIFF
--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -832,7 +832,7 @@ class nsZenKeyboardShortcutsLoader {
 }
 
 class nsZenKeyboardShortcutsVersioner {
-  static LATEST_KBS_VERSION = 18;
+  static LATEST_KBS_VERSION = 19;
 
   constructor() {}
 
@@ -1226,6 +1226,25 @@ class nsZenKeyboardShortcutsVersioner {
           "zen-workspace-shortcut-create"
         )
       );
+    }
+
+    if (version < 19) {
+      // Migrate from version 18 to 19.
+      // Ensure profiles that missed the version 10 migration still show
+      // Toggle Pin Tab in settings.
+      if (!data.find(shortcut => shortcut.getID() == "zen-toggle-pin-tab")) {
+        data.push(
+          new KeyShortcut(
+            "zen-toggle-pin-tab",
+            "D",
+            "",
+            ZEN_OTHER_SHORTCUTS_GROUP,
+            nsKeyShortcutModifiers.fromObject({ accel: true, shift: true }),
+            "cmd_zenTogglePinTab",
+            "zen-toggle-pin-tab-shortcut"
+          )
+        );
+      }
     }
 
     return data;


### PR DESCRIPTION

  ## Summary

  - Bump the Zen keyboard shortcut schema version from 18 to 19.
  - Add a guarded migration that restores the `zen-toggle-pin-tab` shortcut when it is missing from an existing profile.
  - Reuse the existing `cmd_zenTogglePinTab` command and `zen-toggle-pin-tab-shortcut` label so the shortcut appears again
  in Settings > Keyboard Shortcuts.

  ## Root Cause

  The Toggle Pin Tab shortcut was added in an earlier migration, but profiles that reached the latest shortcut version while
  missing that entry had no later repair path. `fillDefaultIfNotPresent()` only backfills shortcuts from
  `zenGetDefaultShortcuts()`, and the pin-tab shortcut is migration-added rather than part of that default list.

  ## Testing

  - `node --check src/zen/kbs/ZenKeyboardShortcuts.mjs`
  - `git diff --check`
  - Static verification that the latest keyboard shortcut version is 19 and the migration is guarded against duplicate `zen-
  toggle-pin-tab` entries.

  `npm run lint -- src/zen/kbs/ZenKeyboardShortcuts.mjs` could not run in this shallow checkout because the generated/
  downloaded Firefox `engine` directory is not present.

  Fixes #4504