### PR TITLE
fix(tabs): improve tab preview text contrast

### DIFF
--- a/src/zen/common/styles/zen-panel-ui.css
+++ b/src/zen/common/styles/zen-panel-ui.css
@@ -11,7 +11,10 @@ panel[type="arrow"]:not(#feature-callout) {
     -moz-default-appearance: menupopup;
     /* The blur behind doesn't blur all that much, add a semi-transparent
      * background to improve contrast */
-    --panel-background: light-dark(rgba(255, 255, 255, 0.5), rgba(0, 0, 0, 0.5)) !important;
+    --panel-background: light-dark(
+      rgba(255, 255, 255, 0.5),
+      rgba(0, 0, 0, 0.5)
+    ) !important;
 
     /* The mica rendering already adds a shadow and a border, so we
      * remove the one we add via CSS */
@@ -53,6 +56,17 @@ panel[type="arrow"]:not(#feature-callout) {
     &::part(content) {
       /* This shoudn't really be needed, but just in case */
       background-color: transparent !important;
+    }
+
+    &:where(#tab-preview-panel) {
+      --panel-color: MenuText !important;
+      --text-color-deemphasized: color-mix(
+        in srgb,
+        MenuText 65%,
+        transparent
+      ) !important;
+
+      color: MenuText !important;
     }
   }
 }


### PR DESCRIPTION

  ## Summary

  - Force the macOS tab preview panel foreground tokens to native menu text colors.
  - Keep the URI/deemphasized preview text readable by deriving it from `MenuText`.
  - Format the touched panel stylesheet with the repo Prettier config.

  ## Root Cause

  Zen's macOS arrow-panel styling makes panel backgrounds transparent for native popovers while the tab preview panel can
  inherit text colors from the browser theme. On a light native popover/page preview surface, that leaves the title and URI
  rendered as very light text, matching the screenshots in #12410.

  ## Testing

  - `git diff --check`
  - `npm exec -- prettier --check src/zen/common/styles/zen-panel-ui.css`

  `npm run lint -- src/zen/common/styles/zen-panel-ui.css` could not run in this checkout because the generated Firefox
  `engine/` directory is not present. The repo contribution docs note that `npm run init` creates that tree before full
  lint/build.

  Fixes #12410