### PR TITLE
fix(tabs): honor pinned close behavior in Places tab

### DIFF
--- a/src/browser/components/places/content/places-js.patch
+++ b/src/browser/components/places/content/places-js.patch
@@ -1,0 +1,35 @@
+diff --git a/browser/components/places/content/places.js b/browser/components/places/content/places.js
+--- a/browser/components/places/content/places.js
++++ b/browser/components/places/content/places.js
+@@ -276,6 +276,21 @@ var PlacesOrganizer = {
+ 
+   QueryInterface: ChromeUtils.generateQI([]),
+ 
++  _handleZenPinnedTabCloseShortcut(event) {
++    const browser =
++      window.browsingContext?.embedderElement ??
++      window.docShell?.chromeEventHandler;
++    const browserWindow = browser?.ownerGlobal;
++    const tab = browserWindow?.gBrowser?.getTabForBrowser(browser);
++
++    if (!tab?.pinned || !browserWindow?.gZenPinnedTabManager?.enabled) {
++      return false;
++    }
++
++    browserWindow.gZenPinnedTabManager.onCloseTabShortcut(event, tab);
++    return true;
++  },
++
+   handleEvent: function PO_handleEvent(event) {
+     switch (event.type) {
+       case "load":
+@@ -318,6 +333,9 @@ var PlacesOrganizer = {
+             this.forward();
+             break;
+           case "OrganizerCommand:CloseWindow":
++            if (this._handleZenPinnedTabCloseShortcut(event)) {
++              break;
++            }
+             window.close();
+             break;
+         }

--- a/src/zen/tests/pinned/browser.toml
+++ b/src/zen/tests/pinned/browser.toml
@@ -15,6 +15,8 @@ prefs = ["zen.workspaces.separate-essentials=false"]
 
 ["browser_pinned_nounload_reset.js"]
 
+["browser_pinned_places_close_shortcut.js"]
+
 ["browser_pinned_reset_button.js"]
 
 ["browser_pinned_reset_noswitch.js"]

--- a/src/zen/tests/pinned/browser_pinned_places_close_shortcut.js
+++ b/src/zen/tests/pinned/browser_pinned_places_close_shortcut.js
@@ -1,0 +1,49 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_Pinned_Places_Close_Shortcut_Behavior() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.pinned-tab-manager.close-shortcut-behavior", "switch"]],
+  });
+
+  const otherTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.com/"
+  );
+  const placesTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "chrome://browser/content/places/places.xhtml"
+  );
+
+  try {
+    gBrowser.pinTab(placesTab);
+    gBrowser.selectedTab = placesTab;
+
+    await SpecialPowers.spawn(placesTab.linkedBrowser, [], () => {
+      content.document
+        .getElementById("OrganizerCommand:CloseWindow")
+        .doCommand();
+    });
+
+    await TestUtils.waitForCondition(
+      () => gBrowser.selectedTab !== placesTab,
+      "Pinned Places tab close command switched away from the tab"
+    );
+
+    ok(!placesTab.closing, "The pinned Places tab should remain open");
+    is(
+      gBrowser.selectedTab,
+      otherTab,
+      "The close shortcut behavior should switch to the next tab"
+    );
+  } finally {
+    if (!placesTab.closing) {
+      await BrowserTestUtils.removeTab(placesTab);
+    }
+    if (!otherTab.closing) {
+      await BrowserTestUtils.removeTab(otherTab);
+    }
+  }
+});


### PR DESCRIPTION

  ## Summary

  - Patch Places organizer close handling so an embedded pinned `places.xhtml` tab delegates to Zen's pinned-tab close
  shortcut manager instead of calling `window.close()` directly.
  - Keep standalone Places organizer windows unchanged.
  - Add a pinned-tab browser test covering `OrganizerCommand:CloseWindow` with the close behavior set to `switch`.

  ## Root Cause

  `chrome://browser/content/places/places.xhtml` owns a separate `OrganizerCommand:CloseWindow` command. When loaded inside
  a browser tab, that command calls `window.close()` directly, bypassing `gZenPinnedTabManager.onCloseTabShortcut()`. As a
  result, pinned or essential Places tabs do not honor `zen.pinned-tab-manager.close-shortcut-behavior`.

  ## Testing

  - `node --check src/zen/tests/pinned/browser_pinned_places_close_shortcut.js`
  - `git diff --check`
  - Verified `src/browser/components/places/content/places-js.patch` applies to current upstream `places.js` with `git apply
  --check`.
  - Applied the patch to a temporary upstream `places.js` copy and ran `node --check` on the patched file.

  `npm run lint -- ...` could not run because the generated Firefox `engine/` directory is not present.

  Fixes #12353