### PR TITLE
gh-13776: fix shortcut conflict detection failing with special keys

### DIFF
--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -44,6 +44,10 @@ const KEYCODE_MAP = {
   SCROLL_LOCK: "VK_SCROLL",
 };
 
+const REVERSE_KEYCODE_MAP = Object.fromEntries(
+  Object.entries(KEYCODE_MAP).map(([k, v]) => [v, k])
+);
+
 const defaultKeyboardGroups = {
   windowAndTabManagement: [
     "zen-window-new-shortcut",
@@ -1507,9 +1511,11 @@ window.gZenKeyboardShortcutsManager = {
         continue;
       }
 
+      const keyNameOrCode = targetShortcut.getKeyNameOrCode();
+      const key = REVERSE_KEYCODE_MAP[keyNameOrCode] ?? keyNameOrCode;
       if (
         targetShortcut.getModifiers().equals(modifiers) &&
-        targetShortcut.getKeyNameOrCode()?.toLowerCase() == realShortcut
+        key?.toLowerCase() == realShortcut
       ) {
         return {
           hasConflicts: true,


### PR DESCRIPTION
`getKeyNameOrCode()` returns the keycode as defined in the `KEYCODE_MAP` which will never match to the `realShortcut`.
Doing a reverse lookup in `KEYCODE_MAP` fixes the issue.
I created a `REVERSE_KEYCODE_MAP` to avoid an extra loop when doing a reverse lookup.

fixes: #13776 