### PR TITLE
gh-13642: fix unexpected sidebar width increase in compact mode

### DIFF
--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -1510,7 +1510,7 @@ window.gZenVerticalTabsManager = {
       this.navigatorToolbox.after(splitter);
       window.dispatchEvent(new Event("resize"));
       if (!isCompactMode) {
-        gZenCompactModeManager.getAndApplySidebarWidth();
+        gZenCompactModeManager.getAndApplySidebarWidth({});
       }
       gZenUIManager.updateTabsToolbar();
       this.rebuildURLBarMenus();

--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -219,7 +219,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
           document.getElementById("nav-bar").style.visibility = "collapse";
         }
         this.style.visibility = "visible";
-        gZenCompactModeManager.getAndApplySidebarWidth();
+        gZenCompactModeManager.getAndApplySidebarWidth({});
         this.resolveInitialized();
         let animation = gZenUIManager.motion.animate(
           this.elementsToAnimate,


### PR DESCRIPTION
`getAndApplySidebarWidth()` does handle this case but in the condition it requires the event.
```
      if (
        event &&
        shouldRecalculate &&
        sidebarExpanded &&
        !gZenVerticalTabsManager._hadSidebarCollapse
      ) {
        return;
      }
```
If the function does not return here then it makes the `--zen-sidebar-width` = `--actual-zen-sidebar-width` which adds the padding's width to the sidebar.

I don't know if not passing event in the function was intentional, but this seems to fix the issue.

fixes: #13642