### PR TITLE
gh-13796: Tab order reversed when dragging multiple tabs

### DIFF
--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -667,7 +667,6 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     let newIndex = dropIndex;
     let fromDifferentWindow = false;
     let ownedTabs = Array.from(movingTabs || draggedTab)
-      .reverse()
       .map(tab => {
         if (!gBrowser.isTab(tab)) {
           return tab;


### PR DESCRIPTION
## Summary

When dragging multiple tabs from one folder to another (or outside a folder), the tabs were appearing in reversed order. 

## Root Cause

The bug was in `src/zen/tabs/ZenPinnedTabManager.mjs` in the `moveToAnotherTabContainerIfNecessary` function. The code was calling `.reverse()` on the `movingTabs` array:

```javascript
let ownedTabs = Array.from(movingTabs || draggedTab)
  .reverse()  // This was reversing the tab order
  .map(tab => {
```

This `.reverse()` was originally added to handle adopting tabs from a different window (to avoid multiple tab-switches), but it was also being applied to tabs being moved within the same window, causing the order reversal bug.

## Fix

Removed the unnecessary `.reverse()` call. The correct tab order is now preserved when dropping tabs.

**File changed:** `src/zen/tabs/ZenPinnedTabManager.mjs`

**Lines changed:** Line 670 - removed `.reverse()`

## Testing

The issue can be reproduced by:
1. Creating a folder
2. Opening multiple tabs
3. Selecting multiple tabs
4. Dragging the selected tabs to the folder
5. Observing that tabs appear in reversed order

After the fix, tabs maintain their original order when dropped.

Fixes: zen-browser/desktop#13796