### PR TITLE
gh-13857: Use Zen icon for share toolbar button

### DIFF
--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -435,6 +435,7 @@
 }
 
 #zen-copy-current-url-button,
+#share-tab-button,
 #zen-site-data-header-share {
   list-style-image: url("share.svg");
 }


### PR DESCRIPTION
Fixes #13857.

This updates the toolbar share button to use Zen's shared icon set instead of the upstream Firefox asset. The downloads button already points at the Zen icon set, so this keeps the two toolbar icons visually consistent.

Validation:
- Checked that `share-tab-button` is the Firefox toolbar share button id.
- Confirmed the repo lint script requires the generated `engine` checkout, which is not present in this clone.
