### PR TITLE
Fix unbound shortcuts writing key="undefined" to the keyset

### DIFF
--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -316,6 +316,14 @@ class KeyShortcut {
   #reserved = false;
   #internal = false;
 
+  static #normalizeKey(key) {
+    return (key ?? "").toLowerCase();
+  }
+
+  static #normalizeKeycode(keycode) {
+    return keycode ?? "";
+  }
+
   constructor(
     id,
     key,
@@ -329,8 +337,8 @@ class KeyShortcut {
     internal = false
   ) {
     this.#id = id;
-    this.#key = key?.toLowerCase();
-    this.#keycode = keycode;
+    this.#key = KeyShortcut.#normalizeKey(key);
+    this.#keycode = KeyShortcut.#normalizeKeycode(keycode);
 
     if (!window.VALID_SHORTCUT_GROUPS.includes(group)) {
       throw new Error("Illegal group value: " + group);
@@ -373,8 +381,8 @@ class KeyShortcut {
   static #parseFromJSON(json) {
     return new KeyShortcut(
       json.id,
-      json.key,
-      json.keycode,
+      json.key ?? "",
+      json.keycode ?? "",
       json.group,
       nsKeyShortcutModifiers.parseFromJSON(json.modifiers),
       json.action,
@@ -547,8 +555,8 @@ class KeyShortcut {
   toJSONForm() {
     return {
       id: this.#id,
-      key: this.#key,
-      keycode: this.#keycode,
+      key: this.#key ?? "",
+      keycode: this.#keycode ?? "",
       group: this.#group,
       l10nId: this.#l10nId,
       modifiers: this.#modifiers.toJSONString(),
@@ -628,6 +636,16 @@ class KeyShortcut {
     this.#key = "";
     this.#keycode = "";
     this.#modifiers = new nsKeyShortcutModifiers(false, false, false, false);
+  }
+
+  /**
+   * Repair shortcuts whose unbound state was persisted without a "key" field and
+   * later applied as the literal string "undefined" in the keyset (#13902).
+   */
+  repairMalformedUnboundKey() {
+    if (this.#key === "undefined") {
+      this.clearKeybind();
+    }
   }
 
   setNewBinding(shortcut) {
@@ -848,7 +866,7 @@ class nsZenKeyboardShortcutsLoader {
 }
 
 class nsZenKeyboardShortcutsVersioner {
-  static LATEST_KBS_VERSION = 19;
+  static LATEST_KBS_VERSION = 20;
 
   constructor() {}
 
@@ -1226,6 +1244,14 @@ class nsZenKeyboardShortcutsVersioner {
           "zen-duplicate-tab-shortcut"
         )
       );
+      // Firefox's key_duplicateTab has no default binding; keep it unbound now
+      // that cmd_zenDuplicateTab is the Zen-managed duplicate-tab action.
+      for (let shortcut of data) {
+        if (shortcut.getID() == "key_duplicateTab") {
+          shortcut.shouldBeEmpty = true;
+          break;
+        }
+      }
     }
 
     if (version < 18) {
@@ -1252,6 +1278,19 @@ class nsZenKeyboardShortcutsVersioner {
           shortcut.shouldBeEmpty = true;
           shortcut.setDisabled(true);
           break;
+        }
+      }
+    }
+
+    if (version < 20) {
+      // Migrate from version 19 to 20.
+      // Unbound shortcuts saved without a "key" field were applied as key="undefined"
+      // in the keyset, which Gecko mis-matched as bare "u" (see #13902).
+      for (let shortcut of data) {
+        shortcut.repairMalformedUnboundKey();
+        if (shortcut.getID() == "key_duplicateTab") {
+          shortcut.shouldBeEmpty = true;
+          shortcut.setDisabled(true);
         }
       }
     }
@@ -1418,7 +1457,7 @@ window.gZenKeyboardShortcutsManager = {
       keyset.innerHTML = "";
 
       for (let key of this._currentShortcutList) {
-        if (key.isInternal()) {
+        if (key.isInternal() || key.isEmpty()) {
           continue;
         }
         let child = key.toXHTMLElement(browser);

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -1284,14 +1284,11 @@ class nsZenKeyboardShortcutsVersioner {
 
     if (version < 20) {
       // Migrate from version 19 to 20.
-      // Unbound shortcuts saved without a "key" field were applied as key="undefined"
-      // in the keyset, which Gecko mis-matched as bare "u" (see #13902).
+      // v19 clears key_duplicateTab, but other unbound shortcuts may still have
+      // been applied as key="undefined" (see #13902). Repair any that persisted
+      // the literal string before parse/apply normalization.
       for (let shortcut of data) {
         shortcut.repairMalformedUnboundKey();
-        if (shortcut.getID() == "key_duplicateTab") {
-          shortcut.shouldBeEmpty = true;
-          shortcut.setDisabled(true);
-        }
       }
     }
 


### PR DESCRIPTION
Fixes #13902

## Problem

When a shortcut has no `key` in `zen-keyboard-shortcuts.json`, Zen CKS leaves `#key` as `undefined`. On apply, `setAttribute("key", undefined)` stringifies to the literal **`key="undefined"`** in XUL. With no modifiers, Gecko mis-matches bare **`u`** (first character of `"undefined"`), firing commands like `Browser:DuplicateTab`.

## Fix

**Runtime (parse / save / apply):**
- Normalize missing/null `key` and `keycode` to `""` on parse and in the constructor
- Always serialize `"key": ""` in `toJSONForm()` (never omit the field)
- Skip `isEmpty()` shortcuts in `_applyShortcuts()` so unbound commands are not inserted into `zenKeyset`

**Migrations:**
- **v17** (retroactive for future 16→17 migrators): clear `key_duplicateTab` when `zen-duplicate-tab` is added, since Firefox's entry has no default binding
- **v19** (unchanged): disable `key_duplicateTab` in favour of `cmd_zenDuplicateTab`
- **v20** (new): run `repairMalformedUnboundKey()` on all shortcuts (clears literal `"undefined"` keys) and re-apply `key_duplicateTab` unbind/disable

`replaceWithChild()` on `dev` already avoids setting an empty `key` attribute; this completes the fix for the parse/save/apply/migrate path.

## Test plan

- [ ] Profile at CKS v18 with `key_duplicateTab` missing `key` field → upgrade runs v19+v20 → no `<key key="undefined">` in `zenKeyset`
- [ ] Profile at CKS v19 with corrupted bindings → v20 repair clears literal `"undefined"` keys
- [ ] Bare `u` on a normal page does not duplicate the tab
- [ ] Bound shortcuts (e.g. `accel+u` view source) still work
- [ ] Keyboard shortcut settings can still bind/unbind Duplicate Tab via `zen-duplicate-tab`