### PR TITLE
gh-13923: fix empty keyboard shortcut label caused by `key_duplicateTab`

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -825,6 +825,7 @@ var zenIgnoreKeyboardShortcutIDs = [
   "key_enterFullScreen_compat",
   "key_exitFullScreen_old",
   "key_exitFullScreen_compat",
+  "key_duplicateTab",
 ];
 
 var zenIgnoreKeyboardShortcutL10n = [


### PR DESCRIPTION
fixes: #13923 

didn't add `key_duplicateTab` in `zenIgnoreKeyboardShortcutIDs` in #13856 PR