### PR TITLE
gh-13941: Fixed boost button viable when non-effective

### DIFF
--- a/src/zen/urlbar/ZenSiteDataPanel.sys.mjs
+++ b/src/zen/urlbar/ZenSiteDataPanel.sys.mjs
@@ -251,9 +251,6 @@ export class nsZenSiteDataPanel {
     if (!canBoostSite) {
       boostButton.removeAttribute("boosting");
       boostButton.setAttribute("disabled", "true");
-    }
-
-    if (!canBoostSite) {
       return;
     }
 

--- a/src/zen/urlbar/ZenSiteDataPanel.sys.mjs
+++ b/src/zen/urlbar/ZenSiteDataPanel.sys.mjs
@@ -250,11 +250,14 @@ export class nsZenSiteDataPanel {
     const boostButton = this.document.getElementById("zen-site-data-boost");
     if (!canBoostSite) {
       boostButton.removeAttribute("boosting");
+      boostButton.setAttribute("disabled", "true");
     }
 
     if (!canBoostSite) {
       return;
     }
+
+    boostButton.removeAttribute("disabled");
 
     if (lazy.gZenBoostsManager.registeredBoostForDomain(domain)) {
       boostButton.setAttribute("boosting", "true");


### PR DESCRIPTION
This PR attempts to adds an attribute `disabled="true"` to boost button when uri is not legit for boost.
The button would then become dimmed and not interactable to cursor based on existing CSS rules.

Fix #13941 