### PR TITLE
gh-10594: Change conditional for triggering padding bump

### DIFF
--- a/src/zen/common/zenThemeModifier.js
+++ b/src/zen/common/zenThemeModifier.js
@@ -168,17 +168,17 @@
         document.documentElement.setAttribute("zen-no-padding", true);
       } else {
         document.documentElement.removeAttribute("zen-no-padding");
-        if (domFullscreen) {
-          const selectedBrowser = gBrowser.selectedBrowser;
-          selectedBrowser.style.paddingRight = "0.5px";
-          window.addEventListener(
-            "MozAfterPaint",
-            () => {
-              selectedBrowser.style.paddingRight = "";
-            },
-            { once: true }
-          );
-        }
+      }
+      if (domFullscreen) {
+        const selectedBrowser = gBrowser.selectedBrowser;
+        selectedBrowser.style.paddingRight = "0.5px";
+        window.addEventListener(
+          "MozAfterPaint",
+          () => {
+            selectedBrowser.style.paddingRight = "";
+          },
+          { once: true }
+        );
       }
     },
 


### PR DESCRIPTION
Intended to fix video controls going off-screen when in compact mode: #10594 

Tested to no longer overflow with:
- Compact mode enabled & disabled
- `zen.theme.content-element-separation` set to 8 (default) & 0 (to remove borders)