### PR TITLE
gh-13941: Fixed boost button viable when non-effective, CSS part

### DIFF
--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -542,8 +542,7 @@
     margin: 0;
 
     &[disabled] {
-      opacity: 0.5;
-      pointer-events: none;
+      visibility: hidden;
     }
   }
 }

--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -540,6 +540,11 @@
 
   & toolbarbutton {
     margin: 0;
+
+    &[disabled] {
+      opacity: 0.5;
+      pointer-events: none;
+    }
   }
 }
 


### PR DESCRIPTION
In PR #13953, I thought there is a CSS rule for disabled buttons to prevent them from pressed.
Turns out, there is, but only applies on this area 
<img width="231" height="47" alt="image" src="https://github.com/user-attachments/assets/a09c8f89-010a-4812-b65a-deaddef8caff" />

So in this PR, same rules are added to this part
<img width="231" height="41" alt="image" src="https://github.com/user-attachments/assets/e7e6418d-a39e-4579-88d2-4124123f4430" />

