### PR TITLE
no-bug: bypass workspace container coercion for extension-opened tabs (gh-14001)

### DIFF
--- a/configs/windows/mozconfig
+++ b/configs/windows/mozconfig
@@ -9,6 +9,12 @@ if test "$ZEN_CROSS_COMPILING"; then
   export WINE="$(echo ~)/win-cross/wine/bin/wine"
   export WINEDEBUG=-all
 
+  # Force Wine to load the genuine Microsoft d3dcompiler_47.dll that ships next
+  # to fxc.exe in the Windows SDK instead of its built-in vkd3d reimplementation,
+  # whose HLSL front-end mishandles #include directives (emits an #hlsl_full_path
+  # marker it then fails to re-parse, breaking shader compilation).
+  export WINEDLLOVERRIDES="d3dcompiler_47=n"
+
   export MOZ_STUB_INSTALLER=1
   export MOZ_PKG_FORMAT=TAR
 
@@ -16,9 +22,9 @@ if test "$ZEN_CROSS_COMPILING"; then
   CROSS_COMPILE=1
 
   if test "$SURFER_COMPAT" = "aarch64"; then
-    export WIN32_REDIST_DIR="$(echo ~)/win-cross/vs2026/VC/Redist/MSVC/14.50.35710/arm64/Microsoft.VC145.CRT"
+    export WIN32_REDIST_DIR="$WINSYSROOT/VC/Redist/MSVC/14.50.35710/arm64/Microsoft.VC145.CRT"
   else
-    export WIN32_REDIST_DIR="$(echo ~)/win-cross/vs2026/VC/Redist/MSVC/14.50.35710/x64/Microsoft.VC145.CRT"
+    export WIN32_REDIST_DIR="$WINSYSROOT/VC/Redist/MSVC/14.50.35710/x64/Microsoft.VC145.CRT"
   fi
 fi
 

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -281,7 +281,7 @@ index 43fb79a3060e20f671ae6ffc26350c7abf497702..146b1559b8430773bd4ec173a8f4fe88
 +      let hasZenDefaultUserContextId = false;
 +      let zenForcedWorkspaceId = undefined;
 +      if (typeof gZenWorkspaces !== "undefined" && !_forZenEmptyTab) {
-+        [userContextId, hasZenDefaultUserContextId, zenForcedWorkspaceId] = gZenWorkspaces.getContextIdIfNeeded(userContextId, fromExternal);
++        [userContextId, hasZenDefaultUserContextId, zenForcedWorkspaceId] = gZenWorkspaces.getContextIdIfNeeded(userContextId, fromExternal, triggeringPrincipal);
 +      }
 +
        if (!UserInteraction.running("browser.tabs.opening", window)) {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -2979,8 +2979,15 @@ class nsZenWorkspaces {
 
   // Tab browser utilities
 
-  getContextIdIfNeeded(userContextId, fromExternal) {
+  getContextIdIfNeeded(userContextId, fromExternal, triggeringPrincipal) {
     if (!this.workspaceEnabled) {
+      return [userContextId, false, undefined];
+    }
+
+    if (
+      triggeringPrincipal &&
+      triggeringPrincipal.isAddonOrExpandedAddonPrincipal
+    ) {
       return [userContextId, false, undefined];
     }
 


### PR DESCRIPTION
When a WebExtension (e.g. Grammarly) opens a tab via browser.tabs.create() without specifying a cookieStoreId, it expects the tab to open in the default (No Container) context. Zen's workspace container logic was overriding this, forcing the tab into the active workspace's container. This broke extension sign-in flows because the extension's background script (running in container 0) couldn't access cookies set during login in the workspace container.

This change detects when triggeringPrincipal is an addon principal (isAddonOrExpandedAddonPrincipal) and skips the workspace container override, preserving the extension's intended container context.