### PR TITLE
gh-13027: Fix window-sync jam that left synced tabs blank in new windows

### DIFF
--- a/src/zen/sessionstore/ZenSessionManager.sys.mjs
+++ b/src/zen/sessionstore/ZenSessionManager.sys.mjs
@@ -737,6 +737,54 @@ export class nsZenSessionManager {
     return tabData && !(tabData.zenIsEmpty && !tabData.groupId);
   }
 
+  /**
+   * Removes trailing "about:blank" entries from a tab's saved session history.
+   *
+   * When a tab's contents are swapped to another window, ZenWindowSync loads
+   * "about:blank" into the now-empty browser so Firefox isn't left with an
+   * unloaded-but-selected tab. That "about:blank" can get persisted as the
+   * tab's active session entry; when such state is later restored (most visibly
+   * into a newly opened window, which is cloned from saved state), the tab would
+   * open on the blank artifact and show an empty "New Tab" instead of the page
+   * it was actually displaying. This strips the trailing artifact so the tab
+   * restores onto its real last entry, as long as a real entry exists to fall
+   * back to. See gh-13027.
+   *
+   * @param {object} aTabData - The tab state object to sanitize.
+   * @returns {object} The original object when there is nothing to strip, or a
+   *   shallow copy with the trailing "about:blank" entries removed and the
+   *   index clamped onto a real entry.
+   */
+  #stripBlankSwapArtifact(aTabData) {
+    const entries = aTabData?.entries;
+    if (!Array.isArray(entries) || entries.length < 2) {
+      return aTabData;
+    }
+    const isBlank = entry => !entry?.url || entry.url === "about:blank";
+    // Leave genuinely blank tabs alone: there's no real entry to fall back to.
+    if (entries.every(isBlank)) {
+      return aTabData;
+    }
+    let lastReal = entries.length - 1;
+    while (lastReal > 0 && isBlank(entries[lastReal])) {
+      lastReal--;
+    }
+    if (lastReal === entries.length - 1) {
+      // No trailing "about:blank" artifact to remove.
+      return aTabData;
+    }
+    const newEntries = entries.slice(0, lastReal + 1);
+    // Session history indices are 1-based. Only trust an integer index (so a
+    // missing, NaN, or non-integer value falls back to the last entry), then
+    // clamp into [1, newEntries.length] so it can never point before the first
+    // entry or past the trimmed list.
+    let index = Number.isInteger(aTabData.index)
+      ? aTabData.index
+      : newEntries.length;
+    index = Math.min(Math.max(index, 1), newEntries.length);
+    return { ...aTabData, entries: newEntries, index };
+  }
+
   #collectUsedTabsFromWindows(aStateWindows) {
     const tabIdRelationMap = new Map();
     for (const window of aStateWindows) {
@@ -756,7 +804,12 @@ export class nsZenSessionManager {
         }
       }
     }
-    return Array.from(tabIdRelationMap.values());
+    // Strip the "about:blank" swap artifact so saved state (and any window
+    // cloned from it) restores onto the real page rather than a blank tab.
+    // See gh-13027.
+    return Array.from(tabIdRelationMap.values()).map(tabData =>
+      this.#stripBlankSwapArtifact(tabData)
+    );
   }
 
   /**
@@ -815,6 +868,13 @@ export class nsZenSessionManager {
       aWindowData.splitViewData = sidebar.splitViewData;
       aWindowData.groups = sidebar.groups;
     }
+
+    // Heal any tabs whose saved state was left parked on an "about:blank" swap
+    // artifact so they restore onto their real page instead of a blank "New
+    // Tab" (covers sessions saved before this fix). See gh-13027.
+    aWindowData.tabs = (aWindowData.tabs || []).map(tabData =>
+      this.#stripBlankSwapArtifact(tabData)
+    );
 
     // Folders are always pinned, so we dont need to check for the pinned state here.
     aWindowData.folders = sidebar.folders;

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -200,6 +200,25 @@ class nsZenWindowSync {
   }
 
   /**
+   * Returns whether a tab currently holds live page contents that could be
+   * handed off to a synced tab in another window, as opposed to the
+   * "about:blank" placeholder ZenWindowSync loads into a browser whose contents
+   * were swapped out.
+   *
+   * Only "about:blank" is treated as non-live: it is the specific artifact this
+   * swap flow produces, so a tab showing any other URI -- a normal page, or
+   * even another "about:" page -- is considered to hold live contents.
+   *
+   * @param {MozTabbrowserTab} aTab - The tab to check.
+   * @returns {boolean} True unless the tab has no current URI or is showing
+   *   "about:blank".
+   */
+  #hasLiveContent(aTab) {
+    const spec = aTab?.linkedBrowser?.currentURI?.spec;
+    return !!(spec && spec !== "about:blank");
+  }
+
+  /**
    * Called when a browser window is about to be shown.
    * Adds event listeners for the specified events.
    *
@@ -1154,12 +1173,23 @@ class nsZenWindowSync {
         aWindow,
         selectedTab.id
       );
+      // gh-13027: decide the swap from what each tab actually holds, not just
+      // from the (sometimes stale) _zenContentsVisible flag. Only pull contents
+      // in when this tab is blank AND another window genuinely holds the live
+      // page; never swap a page out of a tab that already shows it, and clear a
+      // stale "owner" flag that points at a blank tab.
+      const selHasContent = this.#hasLiveContent(selectedTab);
+      const otherHasContent = this.#hasLiveContent(otherSelectedTab);
       selectedTab._zenContentsVisible = true;
-      if (otherSelectedTab) {
+      if (otherSelectedTab && !selHasContent && otherHasContent) {
         delete otherSelectedTab._zenContentsVisible;
         promises.push(
           this.#swapBrowserDocShellsAsync(selectedTab, otherSelectedTab)
         );
+      } else if (otherSelectedTab && !otherHasContent && !selHasContent) {
+        // The flagged owner is blank too (stale bookkeeping): nothing to pull,
+        // so clear the stale flag and let this tab restore its own contents.
+        delete otherSelectedTab._zenContentsVisible;
       }
     }
     await Promise.all(promises);
@@ -1500,10 +1530,17 @@ class nsZenWindowSync {
     window.addEventListener("TabSelect", onTabSelect, { once: true });
     // eslint-disable-next-line no-async-promise-executor
     this.#docShellSwitchPromise = new Promise(async resolve => {
-      await this.#onTabSwitchOrWindowFocus(window);
-      window.removeEventListener("TabSelect", onTabSelect);
-      resolve();
-      this.#docShellSwitchPromise = null;
+      // gh-13027: always clear #docShellSwitchPromise, even if the swap throws,
+      // so a single failed swap can't permanently jam window-sync.
+      try {
+        await this.#onTabSwitchOrWindowFocus(window);
+      } catch (e) {
+        console.error("ZenWindowSync on_focus error:", e);
+      } finally {
+        window.removeEventListener("TabSelect", onTabSelect);
+        resolve();
+        this.#docShellSwitchPromise = null;
+      }
     });
   }
 
@@ -1520,10 +1557,17 @@ class nsZenWindowSync {
     }
     // eslint-disable-next-line no-async-promise-executor
     this.#docShellSwitchPromise = new Promise(async resolve => {
-      await promise;
-      await this.#onTabSwitchOrWindowFocus(tab.ownerGlobal, previousTab);
-      resolve();
-      this.#docShellSwitchPromise = null;
+      // gh-13027: always clear #docShellSwitchPromise, even if the swap throws,
+      // so a single failed swap can't permanently jam window-sync.
+      try {
+        await promise;
+        await this.#onTabSwitchOrWindowFocus(tab.ownerGlobal, previousTab);
+      } catch (e) {
+        console.error("ZenWindowSync on_TabSelect error:", e);
+      } finally {
+        resolve();
+        this.#docShellSwitchPromise = null;
+      }
     });
   }
 
@@ -1540,8 +1584,15 @@ class nsZenWindowSync {
       this.#moveAllActiveTabsToOtherWindowsForClose(window);
     } catch (e) {
       console.error(`Error moving active tabs to other windows on close:`, e);
+    } finally {
+      // gh-13027: clear #docShellSwitchPromise after the close-time hand-off.
+      // If left set, the field stays a (resolved but truthy) promise forever,
+      // so every later on_TabSelect/on_focus hits `if (this.#docShellSwitchPromise)
+      // return;` and is skipped -- permanently jamming window-sync after the
+      // first window close and leaving synced tabs stuck on "New Tab".
+      resolve();
+      this.#docShellSwitchPromise = null;
     }
-    resolve();
   }
 
   on_WindowCloseAndBrowserFlushed(aBrowsers) {


### PR DESCRIPTION
## Summary

Fixes #13027. With synced tabs spanning two windows, closing one window, opening a new window, and selecting a synced tab left it stuck on a blank `about:blank` "New Tab" instead of loading the page it was actually showing. Restored 2-window sessions were fine; only a window-close-then-open jammed it.

## Root cause

In `ZenWindowSync.sys.mjs`, `on_SSWindowClosing` set `#docShellSwitchPromise` to serialize the close-time tab hand-off and resolved it, but never reset it to `null`. A resolved promise is still truthy, so after any window close every subsequent `on_TabSelect` / `on_focus` hit `if (this.#docShellSwitchPromise) return;` and bailed — the cross-window content swap (`#onTabSwitchOrWindowFocus`) never ran again, leaving synced tabs blank.

## Changes

**`ZenWindowSync.sys.mjs`**
- Clear `#docShellSwitchPromise` in a `finally` in `on_SSWindowClosing` (the actual bug), and wrap the swaps in `on_focus` / `on_TabSelect` in `try/finally` so a thrown swap can't re-jam the field.
- Add `#hasLiveContent(tab)` and decide the swap from each tab's live `currentURI` rather than the stale `_zenContentsVisible` flag: only pull contents in when the selected tab is blank **and** another window genuinely holds the live page; never swap a page out of a tab that already shows it; clear a stale owner flag pointing at a blank tab.

**`ZenSessionManager.sys.mjs`**
- Add `#stripBlankSwapArtifact(tabData)` to drop a trailing `about:blank` swap artifact (clamping `index`), applied when collecting tabs for save/new-window and when restoring window data, so saved or cloned session state heals onto the real page (also covers sessions saved before this fix).

## Test plan

- [x] Verified against the #13027 repro on a patched 1.20.1b release build (omni.ja injection): close one window, open a new window, select a synced tab — it now loads the real page instead of a blank "New Tab".
- [x] `./mach lint zen` passes — **0 errors**; eslint + `@zen-browser/prettier` report **0 problems / 0 fixed** on both changed files. (The only `mach lint zen` warning is a pre-existing `test-manifest-toml` note in `zen/tests/mochitests/sandbox/browser.toml`, untouched by this change; the skipped `cargo-audit` / `clang-format` linters are C++/Rust-only and need a full build toolchain.)
