### PR TITLE
no-bug: add a "100%" size override value in boosts

### DIFF
--- a/src/zen/boosts/ZenBoostsEditor.mjs
+++ b/src/zen/boosts/ZenBoostsEditor.mjs
@@ -639,7 +639,7 @@ ${cssSelector} {
    * Handles the size toggle button press, cycling through size override options
    */
   onBoostSizePressed() {
-    if (this.currentBoostData.sizeOverride == 1) {
+    if (this.currentBoostData.sizeOverride == 0) {
       this.currentBoostData.sizeOverride = 1.1;
     } else if (this.currentBoostData.sizeOverride == 1.1) {
       this.currentBoostData.sizeOverride = 1.25;
@@ -649,6 +649,8 @@ ${cssSelector} {
       this.currentBoostData.sizeOverride = 0.9;
     } else if (this.currentBoostData.sizeOverride == 0.9) {
       this.currentBoostData.sizeOverride = 1;
+    } else if (this.currentBoostData.sizeOverride == 1) {
+      this.currentBoostData.sizeOverride = 0;
     }
 
     this.updateSizeButtonVisuals();
@@ -1120,7 +1122,7 @@ ${cssSelector} {
     const sizeValue = this.doc.getElementById("zen-boost-size-value");
 
     switch (this.currentBoostData.sizeOverride) {
-      case 1:
+      case 0:
         sizeButton.setAttribute("mode", "none");
         sizeText.style.display = "initial";
         sizeValue.style.display = "none";
@@ -1142,6 +1144,11 @@ ${cssSelector} {
         break;
       case 0.9:
         sizeButton.setAttribute("mode", "blue");
+        sizeText.style.display = "none";
+        sizeValue.style.display = "initial";
+        break;
+      case 1:
+        sizeButton.setAttribute("mode", "green");
         sizeText.style.display = "none";
         sizeValue.style.display = "initial";
         break;
@@ -1581,8 +1588,11 @@ ${cssSelector} {
     const gradient = this.doc.querySelector(".zen-boost-color-picker-gradient");
     const rect = gradient.getBoundingClientRect();
 
-    if (!this.currentBoostData.sizeOverride) {
-      this.currentBoostData.sizeOverride = 1;
+    if (
+      !this.currentBoostData.sizeOverride &&
+      this.currentBoostData.sizeOverride !== 0
+    ) {
+      this.currentBoostData.sizeOverride = 0;
     }
 
     if (

--- a/src/zen/boosts/ZenBoostsManager.sys.mjs
+++ b/src/zen/boosts/ZenBoostsManager.sys.mjs
@@ -137,7 +137,7 @@ class nsZenBoostsManager {
         autoTheme: false,
 
         textCaseOverride: "none",
-        sizeOverride: 1,
+        sizeOverride: 0,
 
         zapSelectors: [],
         customCSS: "",

--- a/src/zen/boosts/actors/ZenBoostsChild.sys.mjs
+++ b/src/zen/boosts/actors/ZenBoostsChild.sys.mjs
@@ -359,7 +359,7 @@ export class ZenBoostsChild extends JSWindowActorChild {
       if (
         boostData.sizeOverride &&
         isFinite(boostData.sizeOverride) &&
-        boostData.sizeOverride !== 1
+        boostData.sizeOverride !== 0
       ) {
         browsingContext.fullZoom = boostData.sizeOverride;
       }

--- a/src/zen/boosts/zen-boosts.css
+++ b/src/zen/boosts/zen-boosts.css
@@ -627,6 +627,11 @@ body {
   --mod-button-c1: light-dark(#6650fc, #5d56ca);
   --mod-button-c2: light-dark(#4125ff, #453aa9);
 }
+.mod-button[mode="green"] {
+  color: #e3e9e4;
+  --mod-button-c1: light-dark(#2dd75d, #187432);
+  --mod-button-c2: light-dark(#23a849, #0c3919);
+}
 .mod-button[mode] {
   background: linear-gradient(180deg, var(--mod-button-c1) 0%, var(--mod-button-c2) 100%) border-box;
   transition:


### PR DESCRIPTION
Adds a new "100%" size override value in boosts. I think a lot of people has their default zoom set to something else other than "100%", so they might need it sometimes.

This is how the colos look:

Light mode
<img width="96" height="55" alt="image" src="https://github.com/user-attachments/assets/980bed63-5c1b-44d9-8c28-1f16bb157076" />

Dark mode
<img width="102" height="55" alt="image" src="https://github.com/user-attachments/assets/a8a44f73-2f09-4570-b543-f86d98210ba0" />
