### PR TITLE
Fast tab switching by scrolling

### DIFF
--- a/prefs/zen/zen.yaml
+++ b/prefs/zen/zen.yaml
@@ -52,3 +52,6 @@
 
 - name: zen.tabs.ctrl-tab.ignore-pending-tabs
   value: false
+
+- name: zen.tabs.scroll-switcher.enabled
+  value: false

--- a/src/browser/base/content/zen-assets.jar.inc.mn
+++ b/src/browser/base/content/zen-assets.jar.inc.mn
@@ -9,6 +9,7 @@
 #include ../../../zen/mods/jar.inc.mn
 #include ../../../zen/spaces/jar.inc.mn
 #include ../../../zen/tabs/jar.inc.mn
+#include ../../../zen/tab-switcher/jar.inc.mn
 #include ../../../zen/kbs/jar.inc.mn
 #include ../../../zen/glance/jar.inc.mn
 #include ../../../zen/folders/jar.inc.mn

--- a/src/zen/common/ZenPreloadedScripts.js
+++ b/src/zen/common/ZenPreloadedScripts.js
@@ -25,6 +25,7 @@
     "chrome://browser/content/zen-components/ZenPinnedTabManager.mjs",
     "chrome://browser/content/zen-components/ZenViewSplitter.mjs",
     "chrome://browser/content/zen-components/ZenFolders.mjs",
+    "chrome://browser/content/zen-components/ZenScrollTabSwitcher.mjs",
     "chrome://browser/content/zen-components/ZenEmojiPicker.mjs",
     "chrome://browser/content/zen-components/ZenLiveFoldersUI.mjs",
     "chrome://browser/content/zen-components/ZenDownloadAnimation.mjs",

--- a/src/zen/tab-switcher/ZenScrollTabSwitcher.css
+++ b/src/zen/tab-switcher/ZenScrollTabSwitcher.css
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#zen-scroll-tab-switcher {
+  position: fixed;
+  z-index: 2147483647;
+  top: 8.5vh;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(760px, calc(100vw - 96px));
+  max-height: min(360px, calc(100vh - 140px));
+  overflow: hidden;
+  box-sizing: border-box;
+  padding: 8px;
+  color: #f4f4f5;
+  background: rgba(14, 15, 18, 0.97);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 12px;
+  box-shadow: 0 18px 52px rgba(0, 0, 0, 0.34);
+  font: menu;
+  backdrop-filter: blur(24px);
+}
+
+#zen-scroll-tab-switcher .zen-scroll-tab-switcher-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 344px;
+  overflow: hidden;
+}
+
+#zen-scroll-tab-switcher .zen-scroll-tab-switcher-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-height: 50px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  color: #d8d8df;
+  user-select: none;
+}
+
+#zen-scroll-tab-switcher .zen-scroll-tab-switcher-item.selected {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.105);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+#zen-scroll-tab-switcher .zen-scroll-tab-switcher-item.selected::before {
+  position: absolute;
+  top: 10px;
+  bottom: 10px;
+  left: 0;
+  width: 3px;
+  border-radius: 999px;
+  background: #6ee7d8;
+  content: "";
+}
+
+#zen-scroll-tab-switcher .zen-scroll-tab-switcher-favicon {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  object-fit: contain;
+}
+
+#zen-scroll-tab-switcher .zen-scroll-tab-switcher-copy {
+  min-width: 0;
+}
+
+#zen-scroll-tab-switcher .zen-scroll-tab-switcher-title,
+#zen-scroll-tab-switcher .zen-scroll-tab-switcher-url {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#zen-scroll-tab-switcher .zen-scroll-tab-switcher-title {
+  color: #f4f4f5;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 18px;
+}
+
+#zen-scroll-tab-switcher .zen-scroll-tab-switcher-url {
+  color: #a5a7b0;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+}
+
+#zen-scroll-tab-switcher .zen-scroll-tab-switcher-active {
+  color: #6ee7d8;
+  font-size: 11px;
+  font-weight: 700;
+}

--- a/src/zen/tab-switcher/ZenScrollTabSwitcher.mjs
+++ b/src/zen/tab-switcher/ZenScrollTabSwitcher.mjs
@@ -1,0 +1,282 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { nsZenDOMOperatedFeature } from "chrome://browser/content/zen-components/ZenCommonUtils.mjs";
+
+const FEATURE_PREF = "zen.tabs.scroll-switcher.enabled";
+const STYLE_URL =
+  "chrome://browser/content/zen-components/ZenScrollTabSwitcher.css";
+const WHEEL_THRESHOLD = 18;
+const WHEEL_LOCK_MS = 90;
+
+class ZenScrollTabSwitcher extends nsZenDOMOperatedFeature {
+  #state = {
+    open: false,
+    panel: null,
+    list: null,
+    originalTab: null,
+    wheelDelta: 0,
+    wheelTimer: null,
+    listeners: [],
+  };
+
+  init() {
+    if (!Services.prefs.getBoolPref(FEATURE_PREF, false)) {
+      return;
+    }
+
+    window.addEventListener("keydown", this.#onGlobalKeydown, {
+      capture: true,
+    });
+    window.addEventListener("unload", this.#destroy, { once: true });
+  }
+
+  #isAltX(event) {
+    return (
+      event.altKey &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.shiftKey &&
+      event.code === "KeyX"
+    );
+  }
+
+  #onGlobalKeydown = event => {
+    if (!this.#isAltX(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    this.#state.open ? this.#commit() : this.#open();
+  };
+
+  #open() {
+    if (!gBrowser?.tabs?.length) {
+      return;
+    }
+
+    this.#installStyles();
+    this.#state.originalTab = gBrowser.selectedTab;
+    this.#state.panel = this.#htmlElement("div");
+    this.#state.panel.id = "zen-scroll-tab-switcher";
+    this.#state.list = this.#htmlElement("div", "zen-scroll-tab-switcher-list");
+    this.#state.panel.append(this.#state.list);
+    document.documentElement.append(this.#state.panel);
+    this.#state.open = true;
+    this.#render();
+
+    this.#addSessionListener(window, "wheel", this.#onWheel, {
+      capture: true,
+      passive: false,
+    });
+    this.#addSessionListener(window, "keydown", this.#onSessionKeydown, {
+      capture: true,
+    });
+    this.#addSessionListener(window, "unload", this.#onUnload, { once: true });
+  }
+
+  #commit() {
+    this.#close({ restore: false });
+  }
+
+  #cancel() {
+    this.#close({ restore: true });
+  }
+
+  #close({ restore }) {
+    if (!this.#state.open) {
+      return;
+    }
+
+    const originalTab = this.#state.originalTab;
+    this.#state.open = false;
+    this.#removeSessionListeners();
+    this.#state.panel?.remove();
+    this.#state.panel = null;
+    this.#state.list = null;
+    this.#state.originalTab = null;
+    this.#state.wheelDelta = 0;
+
+    if (restore && originalTab && !originalTab.closing) {
+      gBrowser.selectedTab = originalTab;
+    }
+  }
+
+  #destroy = () => {
+    window.removeEventListener("keydown", this.#onGlobalKeydown, {
+      capture: true,
+    });
+    this.#close({ restore: false });
+  };
+
+  #onUnload = () => {
+    this.#close({ restore: false });
+  };
+
+  #onSessionKeydown = event => {
+    if (!this.#state.open) {
+      return;
+    }
+
+    if (this.#isAltX(event) || event.key === "Enter") {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      this.#commit();
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      this.#cancel();
+    }
+  };
+
+  #onWheel = event => {
+    if (!this.#state.open) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    this.#state.wheelDelta += event.deltaY;
+
+    if (
+      this.#state.wheelTimer ||
+      Math.abs(this.#state.wheelDelta) < WHEEL_THRESHOLD
+    ) {
+      return;
+    }
+
+    const direction = this.#state.wheelDelta > 0 ? -1 : 1;
+    this.#state.wheelDelta = 0;
+    try {
+      gBrowser.tabContainer.advanceSelectedTab(direction, true);
+      this.#syncSelection();
+    } catch (error) {
+      console.error("[ZenScrollTabSwitcher] Failed to switch tabs:", error);
+      this.#close({ restore: false });
+      return;
+    }
+
+    this.#state.wheelTimer = setTimeout(() => {
+      this.#state.wheelTimer = null;
+    }, WHEEL_LOCK_MS);
+  };
+
+  #syncSelection() {
+    this.#render();
+    this.#state.list
+      ?.querySelector(".zen-scroll-tab-switcher-item.selected")
+      ?.scrollIntoView({ block: "center" });
+  }
+
+  #render() {
+    if (!this.#state.list) {
+      return;
+    }
+
+    this.#state.list.textContent = "";
+
+    for (const tab of this.#visibleTabs()) {
+      const item = this.#htmlElement(
+        "div",
+        `zen-scroll-tab-switcher-item${
+          tab === gBrowser.selectedTab ? " selected" : ""
+        }`
+      );
+
+      const icon = this.#htmlElement("img", "zen-scroll-tab-switcher-favicon");
+      icon.setAttribute("alt", "");
+      icon.setAttribute(
+        "src",
+        tab.getAttribute("image") || "chrome://branding/content/icon32.png"
+      );
+
+      const copy = this.#htmlElement("div", "zen-scroll-tab-switcher-copy");
+      const title = this.#htmlElement("div", "zen-scroll-tab-switcher-title");
+      title.textContent = tab.label || "Untitled tab";
+      const url = this.#htmlElement("div", "zen-scroll-tab-switcher-url");
+      url.textContent = this.#tabUrlLabel(tab);
+      copy.append(title, url);
+
+      item.append(icon, copy);
+      if (tab === gBrowser.selectedTab) {
+        const active = this.#htmlElement("div", "zen-scroll-tab-switcher-active");
+        active.textContent = "Active";
+        item.append(active);
+      }
+      item.addEventListener("click", () => {
+        gBrowser.selectedTab = tab;
+        this.#commit();
+      });
+      this.#state.list.append(item);
+    }
+  }
+
+  #visibleTabs() {
+    return Array.from(gBrowser.tabs).filter(tab => !tab.hidden && !tab.closing);
+  }
+
+  #tabUrlLabel(tab) {
+    const url =
+      tab.linkedBrowser?.currentURI?.displaySpec ||
+      tab.linkedBrowser?.currentURI?.spec ||
+      "";
+
+    if (!url) {
+      return "";
+    }
+
+    try {
+      const { hostname } = new URL(url);
+      return hostname.replace(/^www\./, "") || url;
+    } catch {
+      return url;
+    }
+  }
+
+  #addSessionListener(target, type, handler, options) {
+    target.addEventListener(type, handler, options);
+    this.#state.listeners.push({ target, type, handler, options });
+  }
+
+  #removeSessionListeners() {
+    for (const listener of this.#state.listeners.splice(0)) {
+      listener.target.removeEventListener(
+        listener.type,
+        listener.handler,
+        listener.options
+      );
+    }
+
+    if (this.#state.wheelTimer) {
+      clearTimeout(this.#state.wheelTimer);
+      this.#state.wheelTimer = null;
+    }
+  }
+
+  #htmlElement(tag, className) {
+    const element = document.createElementNS("http://www.w3.org/1999/xhtml", tag);
+    if (className) {
+      element.className = className;
+    }
+    return element;
+  }
+
+  #installStyles() {
+    if (document.getElementById("zen-scroll-tab-switcher-style")) {
+      return;
+    }
+
+    const link = this.#htmlElement("link");
+    link.id = "zen-scroll-tab-switcher-style";
+    link.setAttribute("rel", "stylesheet");
+    link.setAttribute("href", STYLE_URL);
+    document.documentElement.append(link);
+  }
+}
+
+window.gZenScrollTabSwitcher = new ZenScrollTabSwitcher();

--- a/src/zen/tab-switcher/jar.inc.mn
+++ b/src/zen/tab-switcher/jar.inc.mn
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+browser.jar:
+  content/browser/zen-components/ZenScrollTabSwitcher.mjs
+  content/browser/zen-components/ZenScrollTabSwitcher.css


### PR DESCRIPTION
## Summary

Sorry for the earlier rough PR attempt. I cleaned this up and changed the approach to lean on the native tabbox switching behavior instead of trying to recreate tab cycling manually.

This implementation is AI-generated/AI-assisted and intended as a draft UX prototype, not a final architecture claim.

Firefox/Zen already supports scroll-based tab switching when the pointer is over the tab list. This PR builds on that native behavior by adding a small keyboard-first Zen command mode around it: press `Alt+X` / `Option+X`, scroll anywhere in the window to live-preview tabs, then press `Alt+X` / `Option+X` or `Enter` to commit. `Escape` cancels and restores the original tab.

The reason I think this fits Zen is that it keeps tab browsing out of the way. You do not have to move your pointer to the tab list, open a heavy switcher, or break flow. It feels closer to a temporary command mode: enter it, skim tabs by scrolling, land where you want, and keep going.

## Behavior

- Disabled by default behind `zen.tabs.scroll-switcher.enabled`
- Uses `gBrowser.tabContainer.advanceSelectedTab(direction, true)` for tab switching
- Captures wheel/trackpad scrolling only while the switcher is open
- Supports scroll wheel and trackpad scrolling
- `Alt+X` / `Option+X` opens and commits
- `Enter` commits
- `Escape` restores the original tab
- No search UI in this draft

## Testing

- `node --check src/zen/tab-switcher/ZenScrollTabSwitcher.mjs`
- `git diff --check`

Manual testing:

- Enabled `zen.tabs.scroll-switcher.enabled`
- Opened the switcher with `Alt+X` / `Option+X`
- Scrolled through tabs with live preview
- Committed with `Alt+X` / `Option+X` and `Enter`
- Cancelled with `Escape`
- Verified normal scrolling resumes after closing
