### PR TITLE
gh-14070: clear shortcut editing state on blur

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -945,6 +945,7 @@ var gZenCKSSettings = {
       });
 
       input.addEventListener("blur", (event) => {
+        this._currentActionID = null;
         const target = event.target;
         target.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-editing`);
         if (!this._hasSafed) {
@@ -1049,6 +1050,7 @@ var gZenCKSSettings = {
       input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-not-set`);
       input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-editing`);
       this._latestValidKey = null;
+      this._currentActionID = null;
       return;
     } else if (shortcut == "Escape" && !modifiersActive) {
       const { hasConflicts, conflictShortcut } = gZenKeyboardShortcutsManager.checkForConflicts(


### PR DESCRIPTION
## Summary

Fixes keyboard input being swallowed after cancelling a conflicting shortcut assignment with Escape.

When leaving a shortcut input, the visual editing state was removed, but the internal `_currentActionID` state could remain set. This meant later keyboard events, such as typing in the Settings search bar, could still be treated as shortcut-editing input.

This change clears `_currentActionID` when a shortcut input loses focus, and also clears it when cancelling shortcut editing with Tab.

## Related issue

Fixes #14070

## Validation

- Ran `git diff --check`
- Manual validation recommended:
  1. Open Settings → Keyboard Shortcuts
  2. Start editing a shortcut
  3. Enter a shortcut that conflicts with an existing one
  4. Press Escape
  5. Click the Find in Settings search bar
  6. Confirm typed characters are entered normally