### PR TITLE
gh-13747: Fixed space icons overflow being inaccessible

### DIFF
--- a/src/zen/spaces/ZenSpaceIcons.mjs
+++ b/src/zen/spaces/ZenSpaceIcons.mjs
@@ -15,12 +15,12 @@ class nsZenWorkspaceIcons extends MozXULElement {
 
     this.initDragAndDrop();
     this.addEventListener("mouseover", e => {
-      if (this.isReorderMode) {
+      if (e.shiftKey || this.isReorderMode) {
         return;
       }
       const target = e.target.closest("toolbarbutton[zen-workspace-id]");
       if (target) {
-        this.scrollLeft = target.offsetLeft - 10;
+        target.scrollIntoView({ behavior: "smooth", inline: "nearest" });
       }
     });
   }
@@ -178,7 +178,7 @@ class nsZenWorkspaceIcons extends MozXULElement {
       return;
     }
     buttons[selected].setAttribute("active", true);
-    this.scrollLeft = buttons[selected].offsetLeft - 10;
+    buttons[selected].scrollIntoView({ behavior: "smooth", inline: "nearest" });
     this.setAttribute("selected", selected);
   }
 

--- a/src/zen/spaces/zen-workspaces.css
+++ b/src/zen/spaces/zen-workspaces.css
@@ -41,6 +41,7 @@
     fill-opacity: 0.6;
     -moz-context-properties: fill-opacity, fill;
     fill: currentColor;
+    scroll-margin: 0 20px;
 
     & .zen-workspace-icon {
       pointer-events: none;
@@ -105,7 +106,7 @@
 
   &[icons-overflow] {
     gap: 0 !important;
-    justify-content: center;
+    justify-content: safe center;
 
     & toolbarbutton {
       margin: 0;

--- a/src/zen/spaces/zen-workspaces.css
+++ b/src/zen/spaces/zen-workspaces.css
@@ -20,7 +20,6 @@
     display: none !important;
   }
 
-  border-radius: var(--button-border-radius) !important;
   background: transparent;
   appearance: unset !important;
   height: fit-content;


### PR DESCRIPTION
Fixes #13747 

## The root cause
It was the `justify-content: center`. 
I mean, It worked fine, but whenever the icons overflowed the flexbox was pushing the leftmost items into a negative position. Since the `scrollLeft` bottoms out at 0, those icons get trapped, you simply couldn't reach any icon with a position < 0.

## The solution
I only switched to `justify-content: safe center`, since it maintains everything centralized and uses the flex-start when there's negative positions.

## Other things done
The `safe center` worked, but the scrolling still felt a bit off. The manual offset (`this.scrollLeft = target.offsetLeft - 10;`) was creating an overly smooth walking to the right, making horizontal scrolling to the left feel very slow and rigid. So I did some additional tweaks:
- Replaced the manual offset calculation by scrollIntoView method;
- Added a 20px scroll-margin so the next icon is revealed smoothly;
- Added an exception for the Shift key in case anyone navigates the Spaces with Shift + Scroll.

## Tests
- Tested standard mouse hover and switching;
- Tested with an XP-Pen graphic tablet (it worked and it felt really good!).

<img width="314" height="174" alt="overflow_test" src="https://github.com/user-attachments/assets/fa7c9ab3-fb40-4986-b1d1-1d78926d5aac" />
