### PR TITLE
gh-14100: restore workspace routing for extension-opened tabs with explicit containers

### DIFF
--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -3005,7 +3005,8 @@ class nsZenWorkspaces {
 
     if (
       triggeringPrincipal &&
-      triggeringPrincipal.isAddonOrExpandedAddonPrincipal
+      triggeringPrincipal.isAddonOrExpandedAddonPrincipal &&
+      typeof userContextId === "undefined"
     ) {
       return [userContextId, false, undefined];
     }


### PR DESCRIPTION
The previous fix for the Grammarly sign-in issue (which bypassed container coercion for tabs opened by WebExtensions) broke extensions that explicitly target specific containers (such as 'Open external links in a container'). Those tabs opened in the active workspace instead of the workspace associated with the container.

This change refines the bypass condition to only apply when the extension does not specify a container (meaning default/No Container context is expected, i.e., userContextId is undefined). This preserves the Grammarly fix while restoring correct workspace switching for container-specific extension requests.