### PR TITLE
no-bug: add --space command line flag to open a link in a specific workspace

### DIFF
--- a/src/browser/components/BrowserContentHandler-sys-mjs.patch
+++ b/src/browser/components/BrowserContentHandler-sys-mjs.patch
@@ -2,7 +2,7 @@ diff --git a/browser/components/BrowserContentHandler.sys.mjs b/browser/componen
 index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09814422bf 100644
 --- a/browser/components/BrowserContentHandler.sys.mjs
 +++ b/browser/components/BrowserContentHandler.sys.mjs
-@@ -603,6 +603,88 @@ nsBrowserContentHandler.prototype = {
+@@ -603,6 +603,67 @@ nsBrowserContentHandler.prototype = {
        }
      }
  
@@ -30,29 +30,6 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
 +    try {
 +      let zenWorkspaceParam = cmdLine.handleFlagWithParam("zen-workspace", false);
 +      if (zenWorkspaceParam) {
-+        let zenWorkspaceURL = null;
-+        try {
-+          zenWorkspaceURL = cmdLine.handleFlagWithParam("url", false);
-+        } catch (e) {}
-+        if (zenWorkspaceURL === null) {
-+          for (let i = cmdLine.length - 1; i >= 0; i--) {
-+            const arg = cmdLine.getArgument(i);
-+            if (arg && arg[0] != "-") {
-+              zenWorkspaceURL = arg;
-+              cmdLine.removeArguments(i, i);
-+              break;
-+            }
-+          }
-+        }
-+        let uri = null;
-+        let principal = null;
-+        if (zenWorkspaceURL !== null) {
-+          const resolved = resolveURIInternal(cmdLine, zenWorkspaceURL);
-+          if (shouldLoadURI(resolved.uri)) {
-+            uri = resolved.uri;
-+            principal = resolved.principal;
-+          }
-+        }
 +        let targetWin = Services.wm.getMostRecentWindow("navigator:browser");
 +        if (
 +          !targetWin?.gZenWorkspaces?.workspaceEnabled ||
@@ -70,16 +47,18 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
 +          }
 +        }
 +        if (targetWin) {
-+          targetWin.gZenWorkspaces.openLinkInWorkspaceFromCommandLine(
-+            zenWorkspaceParam,
-+            uri ? uri.spec : null
++          targetWin.gZenWorkspaces.changeWorkspaceFromCommandLine(
++            zenWorkspaceParam
 +          );
-+          targetWin.focus();
++          cmdLine.preventDefault = true;
 +        } else {
-+          let win = openBrowserWindow(cmdLine, principal, uri ? uri.spec : null);
-+          win._zenInitialWorkspace = zenWorkspaceParam;
++          // Cold start: stash the workspace so the first window that
++          // restores picks it up, and let normal startup open that window.
++          Services.prefs.setStringPref(
++            "zen.workspaces.cmdline-initial-workspace",
++            zenWorkspaceParam
++          );
 +        }
-+        cmdLine.preventDefault = true;
 +      }
 +    } catch (e) {
 +      if (e.result != Cr.NS_ERROR_INVALID_ARG) {
@@ -91,12 +70,12 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
      var searchParam = cmdLine.handleFlagWithParam("search", false);
      if (searchParam) {
        doSearch(searchParam, cmdLine);
-@@ -672,6 +754,8 @@ nsBrowserContentHandler.prototype = {
+@@ -672,6 +733,8 @@ nsBrowserContentHandler.prototype = {
        "  --new-window <url> Open <url> in a new window.\n" +
        "  --new-tab <url>    Open <url> in a new tab.\n" +
        "  --private-window [<url>] Open <url> in a new private window.\n";
 +    info += "  --blank-window [<url>]  Open the new blank window.\n";
-+    info += "  --zen-workspace <space> [<url>]  Open <url> in the workspace with the given name or UUID.\n";
++    info += "  --zen-workspace <space>  Switch to the workspace with the given name or UUID.\n";
      if (AppConstants.platform == "win") {
        info += "  --preferences      Open Options dialog.\n";
      } else {

--- a/src/browser/components/BrowserContentHandler-sys-mjs.patch
+++ b/src/browser/components/BrowserContentHandler-sys-mjs.patch
@@ -28,7 +28,7 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
 +    }
 +
 +    try {
-+      let zenWorkspaceParam = cmdLine.handleFlagWithParam("zen-workspace", false);
++      let zenWorkspaceParam = cmdLine.handleFlagWithParam("space", false);
 +      if (zenWorkspaceParam) {
 +        let targetWin = lazy.BrowserWindowTracker.getTopWindow({
 +          private: false,
@@ -42,7 +42,7 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
 +            zenWorkspaceParam
 +          );
 +        } else {
-+          // Cold start: stash the workspace so the first window that
++          // Cold start: stash the space so the first window that
 +          // restores picks it up, and let normal startup open that window.
 +          Services.prefs.setStringPref(
 +            "zen.workspaces.cmdline-initial-workspace",
@@ -65,7 +65,7 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
        "  --new-tab <url>    Open <url> in a new tab.\n" +
        "  --private-window [<url>] Open <url> in a new private window.\n";
 +    info += "  --blank-window [<url>]  Open the new blank window.\n";
-+    info += "  --zen-workspace <space>  Switch to the workspace with the given name or UUID.\n";
++    info += "  --space <space>  Switch to the space with the given name or UUID.\n";
      if (AppConstants.platform == "win") {
        info += "  --preferences      Open Options dialog.\n";
      } else {

--- a/src/browser/components/BrowserContentHandler-sys-mjs.patch
+++ b/src/browser/components/BrowserContentHandler-sys-mjs.patch
@@ -2,7 +2,7 @@ diff --git a/browser/components/BrowserContentHandler.sys.mjs b/browser/componen
 index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09814422bf 100644
 --- a/browser/components/BrowserContentHandler.sys.mjs
 +++ b/browser/components/BrowserContentHandler.sys.mjs
-@@ -603,6 +603,28 @@ nsBrowserContentHandler.prototype = {
+@@ -603,6 +603,88 @@ nsBrowserContentHandler.prototype = {
        }
      }
  
@@ -27,15 +27,76 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
 +      }
 +    }
 +
++    try {
++      let zenWorkspaceParam = cmdLine.handleFlagWithParam("zen-workspace", false);
++      if (zenWorkspaceParam !== null) {
++        let zenWorkspaceURL = null;
++        try {
++          zenWorkspaceURL = cmdLine.handleFlagWithParam("url", false);
++        } catch (e) {}
++        if (zenWorkspaceURL === null) {
++          for (let i = cmdLine.length - 1; i >= 0; i--) {
++            const arg = cmdLine.getArgument(i);
++            if (arg && arg[0] != "-") {
++              zenWorkspaceURL = arg;
++              cmdLine.removeArguments(i, i);
++              break;
++            }
++          }
++        }
++        let uri = null;
++        let principal = null;
++        if (zenWorkspaceURL !== null) {
++          const resolved = resolveURIInternal(cmdLine, zenWorkspaceURL);
++          if (shouldLoadURI(resolved.uri)) {
++            uri = resolved.uri;
++            principal = resolved.principal;
++          }
++        }
++        let targetWin = Services.wm.getMostRecentWindow("navigator:browser");
++        if (
++          !targetWin?.gZenWorkspaces?.workspaceEnabled ||
++          targetWin.gZenWorkspaces.isPrivateWindow
++        ) {
++          targetWin = null;
++          for (const win of Services.wm.getEnumerator("navigator:browser")) {
++            if (
++              !win.closed &&
++              win.gZenWorkspaces?.workspaceEnabled &&
++              !win.gZenWorkspaces.isPrivateWindow
++            ) {
++              targetWin = win;
++            }
++          }
++        }
++        if (targetWin) {
++          targetWin.gZenWorkspaces.openLinkInWorkspaceFromCommandLine(
++            zenWorkspaceParam,
++            uri ? uri.spec : null
++          );
++          targetWin.focus();
++        } else {
++          let win = openBrowserWindow(cmdLine, principal, uri ? uri.spec : null);
++          win._zenInitialWorkspace = zenWorkspaceParam;
++        }
++        cmdLine.preventDefault = true;
++      }
++    } catch (e) {
++      if (e.result != Cr.NS_ERROR_INVALID_ARG) {
++        throw e;
++      }
++    }
++
 +
      var searchParam = cmdLine.handleFlagWithParam("search", false);
      if (searchParam) {
        doSearch(searchParam, cmdLine);
-@@ -672,6 +694,7 @@ nsBrowserContentHandler.prototype = {
+@@ -672,6 +754,8 @@ nsBrowserContentHandler.prototype = {
        "  --new-window <url> Open <url> in a new window.\n" +
        "  --new-tab <url>    Open <url> in a new tab.\n" +
        "  --private-window [<url>] Open <url> in a new private window.\n";
 +    info += "  --blank-window [<url>]  Open the new blank window.\n";
++    info += "  --zen-workspace <space> [<url>]  Open <url> in the workspace with the given name or UUID.\n";
      if (AppConstants.platform == "win") {
        info += "  --preferences      Open Options dialog.\n";
      } else {

--- a/src/browser/components/BrowserContentHandler-sys-mjs.patch
+++ b/src/browser/components/BrowserContentHandler-sys-mjs.patch
@@ -38,9 +38,9 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
 +          targetWin?.gZenWorkspaces &&
 +          !targetWin.gZenWorkspaces.privateWindowOrDisabled
 +        ) {
-+          targetWin.gZenWorkspaces.changeWorkspaceFromCommandLine(
-+            zenWorkspaceParam
-+          );
++          targetWin.gZenWorkspaces
++            .changeWorkspaceFromCommandLine(zenWorkspaceParam)
++            .catch(console.error);
 +        } else {
 +          // Cold start: stash the space so the first window that
 +          // restores picks it up, and let normal startup open that window.

--- a/src/browser/components/BrowserContentHandler-sys-mjs.patch
+++ b/src/browser/components/BrowserContentHandler-sys-mjs.patch
@@ -2,7 +2,7 @@ diff --git a/browser/components/BrowserContentHandler.sys.mjs b/browser/componen
 index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09814422bf 100644
 --- a/browser/components/BrowserContentHandler.sys.mjs
 +++ b/browser/components/BrowserContentHandler.sys.mjs
-@@ -603,6 +603,67 @@ nsBrowserContentHandler.prototype = {
+@@ -603,6 +603,57 @@ nsBrowserContentHandler.prototype = {
        }
      }
  
@@ -30,27 +30,17 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
 +    try {
 +      let zenWorkspaceParam = cmdLine.handleFlagWithParam("zen-workspace", false);
 +      if (zenWorkspaceParam) {
-+        let targetWin = Services.wm.getMostRecentWindow("navigator:browser");
++        let targetWin = lazy.BrowserWindowTracker.getTopWindow({
++          private: false,
++          allowPopups: false,
++        });
 +        if (
-+          !targetWin?.gZenWorkspaces?.workspaceEnabled ||
-+          targetWin.gZenWorkspaces.isPrivateWindow
++          targetWin?.gZenWorkspaces &&
++          !targetWin.gZenWorkspaces.privateWindowOrDisabled
 +        ) {
-+          targetWin = null;
-+          for (const win of Services.wm.getEnumerator("navigator:browser")) {
-+            if (
-+              !win.closed &&
-+              win.gZenWorkspaces?.workspaceEnabled &&
-+              !win.gZenWorkspaces.isPrivateWindow
-+            ) {
-+              targetWin = win;
-+            }
-+          }
-+        }
-+        if (targetWin) {
 +          targetWin.gZenWorkspaces.changeWorkspaceFromCommandLine(
 +            zenWorkspaceParam
 +          );
-+          cmdLine.preventDefault = true;
 +        } else {
 +          // Cold start: stash the workspace so the first window that
 +          // restores picks it up, and let normal startup open that window.
@@ -70,7 +60,7 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
      var searchParam = cmdLine.handleFlagWithParam("search", false);
      if (searchParam) {
        doSearch(searchParam, cmdLine);
-@@ -672,6 +733,8 @@ nsBrowserContentHandler.prototype = {
+@@ -672,6 +723,8 @@ nsBrowserContentHandler.prototype = {
        "  --new-window <url> Open <url> in a new window.\n" +
        "  --new-tab <url>    Open <url> in a new tab.\n" +
        "  --private-window [<url>] Open <url> in a new private window.\n";

--- a/src/browser/components/BrowserContentHandler-sys-mjs.patch
+++ b/src/browser/components/BrowserContentHandler-sys-mjs.patch
@@ -29,7 +29,7 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
 +
 +    try {
 +      let zenWorkspaceParam = cmdLine.handleFlagWithParam("zen-workspace", false);
-+      if (zenWorkspaceParam !== null) {
++      if (zenWorkspaceParam) {
 +        let zenWorkspaceURL = null;
 +        try {
 +          zenWorkspaceURL = cmdLine.handleFlagWithParam("url", false);

--- a/src/browser/components/BrowserContentHandler-sys-mjs.patch
+++ b/src/browser/components/BrowserContentHandler-sys-mjs.patch
@@ -2,7 +2,7 @@ diff --git a/browser/components/BrowserContentHandler.sys.mjs b/browser/componen
 index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09814422bf 100644
 --- a/browser/components/BrowserContentHandler.sys.mjs
 +++ b/browser/components/BrowserContentHandler.sys.mjs
-@@ -603,6 +603,57 @@ nsBrowserContentHandler.prototype = {
+@@ -603,6 +603,61 @@ nsBrowserContentHandler.prototype = {
        }
      }
  
@@ -41,6 +41,10 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
 +          targetWin.gZenWorkspaces
 +            .changeWorkspaceFromCommandLine(zenWorkspaceParam)
 +            .catch(console.error);
++          targetWin.focus();
++          if (!cmdLine.length) {
++            cmdLine.preventDefault = true;
++          }
 +        } else {
 +          // Cold start: stash the space so the first window that
 +          // restores picks it up, and let normal startup open that window.
@@ -60,12 +64,12 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
      var searchParam = cmdLine.handleFlagWithParam("search", false);
      if (searchParam) {
        doSearch(searchParam, cmdLine);
-@@ -672,6 +723,8 @@ nsBrowserContentHandler.prototype = {
+@@ -672,6 +727,8 @@ nsBrowserContentHandler.prototype = {
        "  --new-window <url> Open <url> in a new window.\n" +
        "  --new-tab <url>    Open <url> in a new tab.\n" +
        "  --private-window [<url>] Open <url> in a new private window.\n";
 +    info += "  --blank-window [<url>]  Open the new blank window.\n";
-+    info += "  --space <space>  Switch to the space with the given name or UUID.\n";
++    info += "  --space <space> [<url>]  Switch to the space with the given name or UUID, and open <url> in it if given.\n";
      if (AppConstants.platform == "win") {
        info += "  --preferences      Open Options dialog.\n";
      } else {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -675,6 +675,25 @@ class nsZenWorkspaces {
     }
   }
 
+  resolveWorkspaceFromString(value) {
+    if (!value) {
+      return null;
+    }
+    try {
+      const workspaces = this.getWorkspaces();
+      return (
+        workspaces.find(workspace => workspace.uuid === value) ||
+        workspaces.find(
+          workspace =>
+            workspace.name?.toLowerCase() === value.toLowerCase()
+        ) ||
+        null
+      );
+    } catch {
+      return null;
+    }
+  }
+
   getWorkspaces(lieToMe = false) {
     if (lieToMe) {
       const { ZenSessionStore } = ChromeUtils.importESModule(
@@ -738,6 +757,17 @@ class nsZenWorkspaces {
       : [this.#createWorkspaceData("Space", undefined)];
     this.activeWorkspace =
       aWinData.activeZenSpace || this._workspaceCache[0].uuid;
+    if (window._zenInitialWorkspace) {
+      // Set by the `--zen-workspace` command line flag when the window
+      // was opened, see BrowserContentHandler.sys.mjs.
+      const initialWorkspace = this.resolveWorkspaceFromString(
+        window._zenInitialWorkspace
+      );
+      if (initialWorkspace) {
+        this.activeWorkspace = initialWorkspace.uuid;
+      }
+      delete window._zenInitialWorkspace;
+    }
     let promise = this.#initializeWorkspaces();
     for (const workspace of spacesFromStore) {
       const element = this.workspaceElement(workspace.uuid);
@@ -1615,6 +1645,32 @@ class nsZenWorkspaces {
   async changeWorkspaceWithID(workspaceID, ...args) {
     const workspace = this.getWorkspaceFromId(workspaceID);
     return await this.changeWorkspace(workspace, ...args);
+  }
+
+  /**
+   * Handles the `--zen-workspace` command line flag for an already running
+   * browser: switches to the given workspace (name or UUID) and optionally
+   * opens a URL inside of it.
+   *
+   * @param {string} workspaceMatch - The workspace UUID or name to switch to
+   * @param {string|null} url - The URL to open in the workspace, if any
+   */
+  async openLinkInWorkspaceFromCommandLine(workspaceMatch, url = null) {
+    await this.promiseInitialized;
+    const workspace = this.resolveWorkspaceFromString(workspaceMatch);
+    if (workspace && workspace.uuid !== this.activeWorkspace) {
+      await this.changeWorkspaceWithID(workspace.uuid);
+    }
+    if (!url) {
+      return;
+    }
+    const tab = gBrowser.addTrustedTab(url, {
+      inBackground: false,
+    });
+    if (workspace) {
+      this.moveTabToWorkspace(tab, workspace.uuid);
+    }
+    gBrowser.selectedTab = tab;
   }
 
   async changeWorkspace(workspace, ...args) {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -757,14 +757,17 @@ class nsZenWorkspaces {
       : [this.#createWorkspaceData("Space", undefined)];
     this.activeWorkspace =
       aWinData.activeZenSpace || this._workspaceCache[0].uuid;
-    const cmdLineWorkspace = Services.prefs.getStringPref(
-      "zen.workspaces.cmdline-initial-workspace",
-      ""
-    );
+    const cmdLineWorkspace = this.privateWindowOrDisabled
+      ? ""
+      : Services.prefs.getStringPref(
+          "zen.workspaces.cmdline-initial-workspace",
+          ""
+        );
     if (cmdLineWorkspace) {
       // Set by the `--space` command line flag on a cold start,
-      // see BrowserContentHandler.sys.mjs. Consumed by the first window
-      // that restores its workspaces.
+      // see BrowserContentHandler.sys.mjs. Consumed by the first syncing
+      // window that restores its workspaces; private and unsynced windows
+      // must not eat the pref.
       Services.prefs.clearUserPref("zen.workspaces.cmdline-initial-workspace");
       const initialWorkspace = this.resolveWorkspaceFromString(cmdLineWorkspace);
       if (initialWorkspace) {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -757,16 +757,19 @@ class nsZenWorkspaces {
       : [this.#createWorkspaceData("Space", undefined)];
     this.activeWorkspace =
       aWinData.activeZenSpace || this._workspaceCache[0].uuid;
-    if (window._zenInitialWorkspace) {
-      // Set by the `--zen-workspace` command line flag when the window
-      // was opened, see BrowserContentHandler.sys.mjs.
-      const initialWorkspace = this.resolveWorkspaceFromString(
-        window._zenInitialWorkspace
-      );
+    const cmdLineWorkspace = Services.prefs.getStringPref(
+      "zen.workspaces.cmdline-initial-workspace",
+      ""
+    );
+    if (cmdLineWorkspace) {
+      // Set by the `--zen-workspace` command line flag on a cold start,
+      // see BrowserContentHandler.sys.mjs. Consumed by the first window
+      // that restores its workspaces.
+      Services.prefs.clearUserPref("zen.workspaces.cmdline-initial-workspace");
+      const initialWorkspace = this.resolveWorkspaceFromString(cmdLineWorkspace);
       if (initialWorkspace) {
         this.activeWorkspace = initialWorkspace.uuid;
       }
-      delete window._zenInitialWorkspace;
     }
     let promise = this.#initializeWorkspaces();
     for (const workspace of spacesFromStore) {
@@ -1649,28 +1652,16 @@ class nsZenWorkspaces {
 
   /**
    * Handles the `--zen-workspace` command line flag for an already running
-   * browser: switches to the given workspace (name or UUID) and optionally
-   * opens a URL inside of it.
+   * browser: switches to the workspace matching the given name or UUID.
    *
    * @param {string} workspaceMatch - The workspace UUID or name to switch to
-   * @param {string|null} url - The URL to open in the workspace, if any
    */
-  async openLinkInWorkspaceFromCommandLine(workspaceMatch, url = null) {
+  async changeWorkspaceFromCommandLine(workspaceMatch) {
     await this.promiseInitialized;
     const workspace = this.resolveWorkspaceFromString(workspaceMatch);
     if (workspace && workspace.uuid !== this.activeWorkspace) {
       await this.changeWorkspaceWithID(workspace.uuid);
     }
-    if (!url) {
-      return;
-    }
-    const tab = gBrowser.addTrustedTab(url, {
-      inBackground: false,
-    });
-    if (workspace) {
-      this.moveTabToWorkspace(tab, workspace.uuid);
-    }
-    gBrowser.selectedTab = tab;
   }
 
   async changeWorkspace(workspace, ...args) {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -762,7 +762,7 @@ class nsZenWorkspaces {
       ""
     );
     if (cmdLineWorkspace) {
-      // Set by the `--zen-workspace` command line flag on a cold start,
+      // Set by the `--space` command line flag on a cold start,
       // see BrowserContentHandler.sys.mjs. Consumed by the first window
       // that restores its workspaces.
       Services.prefs.clearUserPref("zen.workspaces.cmdline-initial-workspace");
@@ -1651,7 +1651,7 @@ class nsZenWorkspaces {
   }
 
   /**
-   * Handles the `--zen-workspace` command line flag for an already running
+   * Handles the `--space` command line flag for an already running
    * browser: switches to the workspace matching the given name or UUID.
    *
    * @param {string} workspaceMatch - The workspace UUID or name to switch to

--- a/src/zen/tests/spaces/browser.toml
+++ b/src/zen/tests/spaces/browser.toml
@@ -20,6 +20,8 @@ support-files = [
 
 ["browser_issue_9900.js"]
 
+["browser_open_link_in_workspace_cmdline.js"]
+
 ["browser_overflow_scrollbox.js"]
 
 ["browser_private_mode.js"]

--- a/src/zen/tests/spaces/browser.toml
+++ b/src/zen/tests/spaces/browser.toml
@@ -20,7 +20,7 @@ support-files = [
 
 ["browser_issue_9900.js"]
 
-["browser_open_link_in_workspace_cmdline.js"]
+["browser_zen_workspace_cmdline.js"]
 
 ["browser_overflow_scrollbox.js"]
 

--- a/src/zen/tests/spaces/browser_open_link_in_workspace_cmdline.js
+++ b/src/zen/tests/spaces/browser_open_link_in_workspace_cmdline.js
@@ -1,0 +1,105 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_resolve_workspace_from_string() {
+  const originalWorkspaceUUID = gZenWorkspaces.activeWorkspace;
+  await gZenWorkspaces.createAndSaveWorkspace("Cmdline Space");
+  const created = gZenWorkspaces
+    .getWorkspaces()
+    .find(workspace => workspace.name === "Cmdline Space");
+  Assert.ok(created, "The new workspace should exist.");
+
+  Assert.strictEqual(
+    gZenWorkspaces.resolveWorkspaceFromString(created.uuid)?.uuid,
+    created.uuid,
+    "Workspaces should resolve by UUID."
+  );
+  Assert.strictEqual(
+    gZenWorkspaces.resolveWorkspaceFromString("cmdline space")?.uuid,
+    created.uuid,
+    "Workspaces should resolve by name, case-insensitively."
+  );
+  Assert.strictEqual(
+    gZenWorkspaces.resolveWorkspaceFromString("does-not-exist"),
+    null,
+    "Unknown workspaces should resolve to null."
+  );
+  Assert.strictEqual(
+    gZenWorkspaces.resolveWorkspaceFromString(null),
+    null,
+    "Empty values should resolve to null."
+  );
+
+  await gZenWorkspaces.removeWorkspace(created.uuid);
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    originalWorkspaceUUID,
+    "We should be back on the original workspace."
+  );
+});
+
+add_task(async function test_open_link_in_workspace_from_command_line() {
+  const originalWorkspaceUUID = gZenWorkspaces.activeWorkspace;
+  await gZenWorkspaces.createAndSaveWorkspace("Cmdline Target");
+  const target = gZenWorkspaces
+    .getWorkspaces()
+    .find(workspace => workspace.name === "Cmdline Target");
+  Assert.ok(target, "The target workspace should exist.");
+
+  await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    originalWorkspaceUUID,
+    "We should start from the original workspace."
+  );
+
+  await gZenWorkspaces.openLinkInWorkspaceFromCommandLine(
+    "Cmdline Target",
+    "https://example.com/"
+  );
+
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    target.uuid,
+    "The command line flag should switch to the target workspace."
+  );
+  const tab = gBrowser.selectedTab;
+  Assert.strictEqual(
+    tab.getAttribute("zen-workspace-id"),
+    target.uuid,
+    "The opened tab should belong to the target workspace."
+  );
+
+  BrowserTestUtils.removeTab(tab);
+  await gZenWorkspaces.removeWorkspace(target.uuid);
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    originalWorkspaceUUID,
+    "We should be back on the original workspace."
+  );
+});
+
+add_task(async function test_open_link_with_unknown_workspace() {
+  const originalWorkspaceUUID = gZenWorkspaces.activeWorkspace;
+
+  await gZenWorkspaces.openLinkInWorkspaceFromCommandLine(
+    "does-not-exist",
+    "https://example.com/"
+  );
+
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    originalWorkspaceUUID,
+    "An unknown workspace should not switch spaces."
+  );
+  const tab = gBrowser.selectedTab;
+  Assert.strictEqual(
+    tab.getAttribute("zen-workspace-id"),
+    originalWorkspaceUUID,
+    "The tab should open in the active workspace as a fallback."
+  );
+
+  BrowserTestUtils.removeTab(tab);
+});

--- a/src/zen/tests/spaces/browser_zen_workspace_cmdline.js
+++ b/src/zen/tests/spaces/browser_zen_workspace_cmdline.js
@@ -40,7 +40,7 @@ add_task(async function test_resolve_workspace_from_string() {
   );
 });
 
-add_task(async function test_open_link_in_workspace_from_command_line() {
+add_task(async function test_change_workspace_from_command_line() {
   const originalWorkspaceUUID = gZenWorkspaces.activeWorkspace;
   await gZenWorkspaces.createAndSaveWorkspace("Cmdline Target");
   const target = gZenWorkspaces
@@ -55,24 +55,24 @@ add_task(async function test_open_link_in_workspace_from_command_line() {
     "We should start from the original workspace."
   );
 
-  await gZenWorkspaces.openLinkInWorkspaceFromCommandLine(
-    "Cmdline Target",
-    "https://example.com/"
-  );
-
+  // Matching by name is case-insensitive.
+  await gZenWorkspaces.changeWorkspaceFromCommandLine("cmdline target");
   Assert.strictEqual(
     gZenWorkspaces.activeWorkspace,
     target.uuid,
     "The command line flag should switch to the target workspace."
   );
-  const tab = gBrowser.selectedTab;
+
+  await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+  // Matching by UUID also works.
+  await gZenWorkspaces.changeWorkspaceFromCommandLine(target.uuid);
   Assert.strictEqual(
-    tab.getAttribute("zen-workspace-id"),
+    gZenWorkspaces.activeWorkspace,
     target.uuid,
-    "The opened tab should belong to the target workspace."
+    "The command line flag should switch to the target workspace by UUID."
   );
 
-  BrowserTestUtils.removeTab(tab);
+  await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
   await gZenWorkspaces.removeWorkspace(target.uuid);
   Assert.strictEqual(
     gZenWorkspaces.activeWorkspace,
@@ -81,25 +81,14 @@ add_task(async function test_open_link_in_workspace_from_command_line() {
   );
 });
 
-add_task(async function test_open_link_with_unknown_workspace() {
+add_task(async function test_unknown_workspace_does_not_switch() {
   const originalWorkspaceUUID = gZenWorkspaces.activeWorkspace;
 
-  await gZenWorkspaces.openLinkInWorkspaceFromCommandLine(
-    "does-not-exist",
-    "https://example.com/"
-  );
+  await gZenWorkspaces.changeWorkspaceFromCommandLine("does-not-exist");
 
   Assert.strictEqual(
     gZenWorkspaces.activeWorkspace,
     originalWorkspaceUUID,
     "An unknown workspace should not switch spaces."
   );
-  const tab = gBrowser.selectedTab;
-  Assert.strictEqual(
-    tab.getAttribute("zen-workspace-id"),
-    originalWorkspaceUUID,
-    "The tab should open in the active workspace as a fallback."
-  );
-
-  BrowserTestUtils.removeTab(tab);
 });

--- a/src/zen/tests/spaces/browser_zen_workspace_cmdline.js
+++ b/src/zen/tests/spaces/browser_zen_workspace_cmdline.js
@@ -104,3 +104,82 @@ add_task(async function test_unknown_workspace_does_not_switch() {
     "An unknown workspace should not switch spaces."
   );
 });
+
+add_task(async function test_initial_workspace_pref_consumed_on_restore() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.testing.enabled", false]],
+  });
+  const originalWorkspaceUUID = gZenWorkspaces.activeWorkspace;
+  await gZenWorkspaces.createAndSaveWorkspace("Cmdline Cold Start");
+  const target = gZenWorkspaces
+    .getWorkspaces()
+    .find(workspace => workspace.name === "Cmdline Cold Start");
+  Assert.ok(target, "The target workspace should exist.");
+  registerCleanupFunction(async () => {
+    Services.prefs.clearUserPref("zen.workspaces.cmdline-initial-workspace");
+    if (gZenWorkspaces.getWorkspaceFromId(target.uuid)) {
+      await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+      await gZenWorkspaces.removeWorkspace(target.uuid);
+    }
+  });
+
+  // Simulates the pref stashed by `--space` on a cold start, see
+  // BrowserContentHandler.sys.mjs.
+  Services.prefs.setStringPref(
+    "zen.workspaces.cmdline-initial-workspace",
+    "cmdline cold start"
+  );
+
+  const newWindow = await BrowserTestUtils.openNewBrowserWindow();
+  await newWindow.gZenWorkspaces.promiseInitialized;
+
+  Assert.strictEqual(
+    newWindow.gZenWorkspaces.activeWorkspace,
+    target.uuid,
+    "The restored window should start on the requested workspace."
+  );
+  Assert.strictEqual(
+    Services.prefs.getStringPref(
+      "zen.workspaces.cmdline-initial-workspace",
+      ""
+    ),
+    "",
+    "The pref should be consumed by the restored window."
+  );
+
+  await BrowserTestUtils.closeWindow(newWindow);
+  await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+  await gZenWorkspaces.removeWorkspace(target.uuid);
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_initial_workspace_pref_survives_private_window() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.testing.enabled", false]],
+  });
+  Services.prefs.setStringPref(
+    "zen.workspaces.cmdline-initial-workspace",
+    "does-not-matter"
+  );
+  registerCleanupFunction(() => {
+    Services.prefs.clearUserPref("zen.workspaces.cmdline-initial-workspace");
+  });
+
+  const privateWindow = await BrowserTestUtils.openNewBrowserWindow({
+    private: true,
+  });
+  await privateWindow.gZenWorkspaces.promiseInitialized;
+
+  Assert.strictEqual(
+    Services.prefs.getStringPref(
+      "zen.workspaces.cmdline-initial-workspace",
+      ""
+    ),
+    "does-not-matter",
+    "A private window should not consume the initial workspace pref."
+  );
+
+  await BrowserTestUtils.closeWindow(privateWindow);
+  Services.prefs.clearUserPref("zen.workspaces.cmdline-initial-workspace");
+  await SpecialPowers.popPrefEnv();
+});

--- a/src/zen/tests/spaces/browser_zen_workspace_cmdline.js
+++ b/src/zen/tests/spaces/browser_zen_workspace_cmdline.js
@@ -10,6 +10,12 @@ add_task(async function test_resolve_workspace_from_string() {
     .getWorkspaces()
     .find(workspace => workspace.name === "Cmdline Space");
   Assert.ok(created, "The new workspace should exist.");
+  registerCleanupFunction(async () => {
+    if (gZenWorkspaces.getWorkspaceFromId(created.uuid)) {
+      await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+      await gZenWorkspaces.removeWorkspace(created.uuid);
+    }
+  });
 
   Assert.strictEqual(
     gZenWorkspaces.resolveWorkspaceFromString(created.uuid)?.uuid,
@@ -47,6 +53,12 @@ add_task(async function test_change_workspace_from_command_line() {
     .getWorkspaces()
     .find(workspace => workspace.name === "Cmdline Target");
   Assert.ok(target, "The target workspace should exist.");
+  registerCleanupFunction(async () => {
+    if (gZenWorkspaces.getWorkspaceFromId(target.uuid)) {
+      await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+      await gZenWorkspaces.removeWorkspace(target.uuid);
+    }
+  });
 
   await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
   Assert.strictEqual(


### PR DESCRIPTION
Adds a `--space <space>` command line flag that switches to the workspace matching the given name (case-insensitive) or UUID:

    zen --space work
    zen --space "Space Name"
    zen --space c2d1e574-3f04-4bd5-9721-2e6dd7f1adf9 # uuid of workspace


Behavior:
- Browser running: delegates to `gZenWorkspaces.changeWorkspaceFromCommandLine` in the most recent non-private window, which switches to the matching workspace.
- Cold start: the workspace is stashed in the `zen.workspaces.cmdline-initial-workspace` pref, which is consumed (and cleared) by the first window that restores its workspaces, so the browser starts on the requested space.
- Unknown workspace: no-op — the active workspace stays unchanged.
- When used together with a url invocation, the url would open in the specified space. 

Implementation: extends the `BrowserContentHandler.sys.mjs` patch (same pattern as the existing `--blank-window` flag) and adds `resolveWorkspaceFromString` / `changeWorkspaceFromCommandLine` to `ZenSpaceManager`. Includes mochitests covering name/UUID resolution, workspace switching, and the unknown-workspace no-op.
When used together with a url invocation, the url would open in the specified space. 

Useful for OS shortcuts and scripting, e.g. a `.desktop` entry per workspace.

Disclaimer: this was written by Claude, I reviewed and tested the code myself.
