### PR TITLE
gh-9540: duplicated bookmarks on macOS window reopen

### DIFF
--- a/src/zen/common/modules/ZenStartup.mjs
+++ b/src/zen/common/modules/ZenStartup.mjs
@@ -100,7 +100,16 @@ class ZenStartup {
       delete this.promiseInitializedResolve;
 
       setTimeout(() => {
-        gZenWorkspaces._invalidateBookmarkContainers();
+        // Wait for the natural PlacesToolbar rebuild before invalidating, so
+        // the two async rebuilds don't interleave and duplicate bookmarks.
+        // promiseRebuilt() returns undefined when no rebuild is in flight.
+        const rebuilt =
+          document
+            .getElementById("PlacesToolbar")
+            ?._placesView?.promiseRebuilt() ?? Promise.resolve();
+        rebuilt
+          .catch(console.error)
+          .then(() => gZenWorkspaces._invalidateBookmarkContainers());
       });
     });
   }


### PR DESCRIPTION
## Summary

After closing the last browser window on macOS (which keeps the app alive in the dock) and reopening a window from the dock, the bookmarks toolbar would render its items twice (e.g. `A B C D` becomes `A B C D A B C D`).

## Steps to reproduce

1. On macOS, open Zen with the bookmarks toolbar visible and a few bookmarks on it.
2. Click the red traffic-light button to close the window (the app stays in the dock, as expected).
3. Click the Zen icon in the dock to open a new window.
4. Observe: bookmarks in the toolbar are duplicated. Repeating step 2–3 keeps duplicating them.


https://github.com/user-attachments/assets/70c1c506-40d7-49cb-bbbb-2717327fede5


## Root cause

On every window open, two `PlacesToolbar._rebuild()` runs race against each other:

1. The natural one Firefox triggers during `PlacesToolbar` construction (`result = …` → `containerOpen = true` → `invalidateContainer` → async `_rebuild`).
2. The explicit one Zen schedules in `ZenStartup.delayedStartupFinished` via `setTimeout(() => gZenWorkspaces._invalidateBookmarkContainers())` (added in gh-9540).

`_rebuild()` is async: it clears `_rootElt`, then `await`s `requestAnimationFrame` before inserting nodes. There is no lock between the two runs, so if the second invalidate fires inside the first one's `await` window, both end up appending the full child set — producing duplicates.

```
        time ───────────────────────────────────────────────────►

natural _rebuild  : [clear] [await rAF ─────────] [insert A B C D]
explicit invalidate:          │
                              ▼
                              [clear] [await rAF ─] [insert A B C D]
                                       ▲
                                       │ no lock / no queue
                                       │ both runs survive and both append

#PlacesToolbarItems final state: A B C D A B C D
```

If the explicit run had been serialized after the natural one, its `[clear]` would have wiped the first batch and only one set of items would remain.

### Why only when reopening from the dock?

- **Cold start** (first launch / Win / Linux close): Places queries and session restore are slow, so the natural `_rebuild` finishes long before our `setTimeout` callback runs. The two never overlap.
- **macOS dock reopen** (warm start): the process and Places DB are already hot, so the natural `_rebuild`'s `await` is much shorter and lines up exactly with our scheduled invalidate, causing the interleave.

macOS-specific because on Windows/Linux closing the last window kills the process, so every reopen is a cold start.

## Fix

Await `placesView.promiseRebuilt()` before calling `_invalidateBookmarkContainers()`, ensuring the natural rebuild has settled and the explicit invalidate runs cleanly.


## Notes

- This is the profile snapshot [cq7ys5nq.Temp.zip](https://github.com/user-attachments/files/28830542/cq7ys5nq.Temp.zip)
- Reproduced on macOS 1.21b (Firefox 151.0.4) (aarch64)
