### PR TITLE
feat: detect pinned-tab URL fragment changes (opt-in pref)

### DIFF
--- a/prefs/zen/workspaces.yaml
+++ b/prefs/zen/workspaces.yaml
@@ -54,5 +54,8 @@
 - name: zen.pinned-tab-manager.restore-pinned-tabs-to-pinned-url
   value: false
 
+- name: zen.pinned-tab-manager.detect-fragment-changes
+  value: false
+
 - name: zen.pinned-tab-manager.close-shortcut-behavior
   value: reset-unload-switch

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -21,6 +21,12 @@ class ZenPinnedTabsObserver {
     );
     XPCOMUtils.defineLazyPreferenceGetter(
       lazy,
+      "zenPinnedTabDetectFragmentChanges",
+      "zen.pinned-tab-manager.detect-fragment-changes",
+      false
+    );
+    XPCOMUtils.defineLazyPreferenceGetter(
+      lazy,
       "zenPinnedTabCloseShortcutBehavior",
       "zen.pinned-tab-manager.close-shortcut-behavior",
       "switch"
@@ -854,9 +860,13 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     ) {
       return;
     }
-    // Remove # and ? from the URL
-    const pinUrl = tab._zenPinnedInitialState.entry.url.split("#")[0];
-    const currentUrl = location.split("#")[0];
+    // Remove the fragment from the URL before comparing, unless the user has
+    // opted in to treating fragment changes as a deviation from the pinned URL.
+    const stripFragment = !lazy.zenPinnedTabDetectFragmentChanges;
+    const pinUrl = stripFragment
+      ? tab._zenPinnedInitialState.entry.url.split("#")[0]
+      : tab._zenPinnedInitialState.entry.url;
+    const currentUrl = stripFragment ? location.split("#")[0] : location;
     // Add an indicator that the pin has been changed
     if (
       Services.io.newURI(currentUrl).spec === Services.io.newURI(pinUrl).spec

--- a/src/zen/tests/pinned/browser.toml
+++ b/src/zen/tests/pinned/browser.toml
@@ -7,6 +7,8 @@ prefs = ["zen.workspaces.separate-essentials=false"]
 
 ["browser_issue_8726.js"]
 
+["browser_issue_13939.js"]
+
 ["browser_pinned_changed.js"]
 
 ["browser_pinned_close.js"]

--- a/src/zen/tests/pinned/browser_issue_13939.js
+++ b/src/zen/tests/pinned/browser_issue_13939.js
@@ -1,0 +1,65 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Issue #13939: when "zen.pinned-tab-manager.detect-fragment-changes" is
+// enabled, a pinned tab should treat a URL fragment change as a deviation from
+// its pinned URL (showing "Back to pinned URL"). When disabled (the default),
+// the fragment is stripped before comparing, so a fragment-only change is not
+// treated as a deviation.
+
+async function pinAndNavigate(detectFragmentChanges) {
+  let result;
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      [
+        "zen.pinned-tab-manager.detect-fragment-changes",
+        detectFragmentChanges,
+      ],
+    ],
+  });
+
+  await BrowserTestUtils.withNewTab(
+    { gBrowser, url: "https://example.com/#a" },
+    async browser => {
+      const tab = gBrowser.getTabForBrowser(browser);
+      gBrowser.pinTab(tab);
+      ok(tab.pinned, "The tab should be pinned after calling gBrowser.pinTab()");
+
+      await gBrowser.TabStateFlusher.flush(browser);
+      await new Promise(r => setTimeout(r, 500));
+
+      const locationChanged = BrowserTestUtils.waitForLocationChange(
+        gBrowser,
+        "https://example.com/#b"
+      );
+      BrowserTestUtils.startLoadingURIString(browser, "https://example.com/#b");
+      await locationChanged;
+      await new Promise(r => setTimeout(r, 500));
+
+      result = tab.hasAttribute("zen-pinned-changed");
+    }
+  );
+
+  await SpecialPowers.popPrefEnv();
+  return result;
+}
+
+add_task(async function test_fragment_change_detected_when_enabled() {
+  const changed = await pinAndNavigate(true);
+  ok(
+    changed,
+    "With detect-fragment-changes enabled, a fragment change should mark the " +
+      "pinned tab as changed"
+  );
+});
+
+add_task(async function test_fragment_change_ignored_by_default() {
+  const changed = await pinAndNavigate(false);
+  ok(
+    !changed,
+    "With detect-fragment-changes disabled (default), a fragment-only change " +
+      "should not mark the pinned tab as changed"
+  );
+});


### PR DESCRIPTION
Closes #13939 

Adds an opt-in preference, `zen.pinned-tab-manager.detect-fragment-changes` (default `false`), so a pinned tab treats a URL fragment change (e.g. ".../#inbox" -> ".../#starred") as a deviation from its pinned URL and shows "Back to pinned URL". Helpful for fragment-routed SPAs like Gmail.

Default `false` keeps today's behavior (fragment stripped before comparison). When enabled, the fragment is kept in the `onLocationChange` comparison (only the detection changes). Stored pinned target and pin-reset are untouched.

Scoped to fragments only. Despite the old `// Remove # and ? from the URL` comment, the code only ever stripped the fragment. Query strings (`?`) already count as a change, so no query behavior is altered.

Test: `browser_issue_13939.js` covers both states (on -> detected, off -> ignored).

---

*Implemented with Claude Code (https://claude.com/claude-code); reviewed, tested, and submitted by me.*