### PR TITLE
gh-8309: Fix moving essential tabs to new window

### DIFF
--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -832,17 +832,57 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..87f41c8583c26f364530def5bd5d8333
          aTab.selected ||
          aTab.closing ||
          // Tabs that are sharing the screen, microphone or camera cannot be hidden.
-@@ -6834,7 +7037,8 @@
+@@ -6834,7 +7037,48 @@
       * @param {object} [aOptions={}]
       *   Key-value pairs that will be serialized into the features string.
       */
 -    replaceTabWithWindow(aTab, aOptions = {}) {
++    #normalizeDuplicatedEssentialTab(tab) {
++      tab.removeAttribute("zen-essential");
++      tab.removeAttribute("zenDefaultUserContextId");
++      if (tab.pinned) {
++        tab.ownerGlobal.gBrowser.unpinTab(tab);
++      }
++    }
++
++    async #duplicateEssentialTab(tab) {
++      const duplicatedTab = this.duplicateTab(tab, true, {
++        tabIndex: tab._tPos + 1,
++      });
++      this.#normalizeDuplicatedEssentialTab(duplicatedTab);
++
++      return new Promise(resolve => {
++        const onRestored = () => {
++          this.#normalizeDuplicatedEssentialTab(duplicatedTab);
++          resolve(duplicatedTab);
++        };
++
++        duplicatedTab.addEventListener("SSTabRestored", onRestored, {
++          once: true,
++        });
++      });
++    }
++
 +    replaceTabWithWindow(aTab, aOptions = {}, zenForceSync = false) {
 +      if (!this.isTab(aTab)) return; // TODO: Handle tab groups
++      if (
++        !zenForceSync &&
++        aTab.hasAttribute("zen-essential")
++      ) {
++        this.#duplicateEssentialTab(aTab).then(
++          duplicatedTab => {
++            if (duplicatedTab) {
++              this.replaceTabWithWindow(duplicatedTab, aOptions);
++            }
++          },
++          error => Cu.reportError(error)
++        );
++        return null;
++      }
        if (this.tabs.length == 1) {
          return null;
        }
-@@ -6851,7 +7055,7 @@
+@@ -6851,7 +7101,7 @@
        // tell a new window to take the "dropped" tab
        let args = Cc["@mozilla.org/array;1"].createInstance(Ci.nsIMutableArray);
        args.appendElement(aTab.splitview ?? aTab);
@@ -851,7 +891,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..87f41c8583c26f364530def5bd5d8333
          private: PrivateBrowsingUtils.isWindowPrivate(window),
          features: Object.entries(aOptions)
            .map(([key, value]) => `${key}=${value}`)
-@@ -6859,6 +7063,8 @@
+@@ -6859,6 +7109,8 @@
          openerWindow: window,
          args,
        });
@@ -860,10 +900,47 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..87f41c8583c26f364530def5bd5d8333
      }
  
      /**
-@@ -6971,7 +7177,7 @@
-      *   `true` if element is a `<tab-group>`
-      */
-     isTabGroup(element) {
+@@ -6880,10 +7132,35 @@
+        elements = [contextTab.splitview ?? contextTab];
+      }
+
+-      if (this.tabs.length == elements.length) {
++      const containsEssentialTab = elements.some(
++        element => this.isTab(element) && element.hasAttribute("zen-essential")
++      );
++      if (this.tabs.length == elements.length && !containsEssentialTab) {
+         return null;
+       }
+
++      if (containsEssentialTab) {
++        Promise.all(
++          elements.map(element =>
++            this.isTab(element) && element.hasAttribute("zen-essential")
++              ? this.#duplicateEssentialTab(element)
++              : element
++          )
++        ).then(
++          duplicatedElements => {
++            if (duplicatedElements.every(Boolean)) {
++              this.#replaceTabsWithWindow(duplicatedElements, aOptions);
++            }
++          },
++          error => Cu.reportError(error)
++        );
++        return null;
++      }
++
++      return this.#replaceTabsWithWindow(elements, aOptions);
++    }
++
++    #replaceTabsWithWindow(elements, aOptions) {
+       if (elements.length == 1) {
+         return this.replaceTabWithWindow(elements[0], aOptions);
+       }
+@@ -6971,7 +7248,7 @@
+     *   `true` if element is a `<tab-group>`
+     */
+    isTabGroup(element) {
 -      return !!(element?.tagName == "tab-group");
 +      return !!(element?.tagName == "tab-group" || element?.tagName == "zen-folder");
      }
@@ -956,7 +1033,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..87f41c8583c26f364530def5bd5d8333
 +      if (!gZenFolders.canDropElement(element, targetElement)) {
 +        element = element.group;
 +      }
-+      if (!element.hasAttribute('zen-essential') && targetElement?.hasAttribute('zen-essential')) { 
++      if (!element.hasAttribute('zen-essential') && targetElement?.hasAttribute('zen-essential')) {
 +        targetElement = null;
 +        moveBefore = false;
 +      }

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -832,44 +832,18 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..87f41c8583c26f364530def5bd5d8333
          aTab.selected ||
          aTab.closing ||
          // Tabs that are sharing the screen, microphone or camera cannot be hidden.
-@@ -6834,7 +7037,48 @@
-      * @param {object} [aOptions={}]
-      *   Key-value pairs that will be serialized into the features string.
-      */
+@@ -6834,7 +7037,22 @@
+     * @param {object} [aOptions={}]
+     *   Key-value pairs that will be serialized into the features string.
+     */
 -    replaceTabWithWindow(aTab, aOptions = {}) {
-+    #normalizeDuplicatedEssentialTab(tab) {
-+      tab.removeAttribute("zen-essential");
-+      tab.removeAttribute("zenDefaultUserContextId");
-+      if (tab.pinned) {
-+        tab.ownerGlobal.gBrowser.unpinTab(tab);
-+      }
-+    }
-+
-+    async #duplicateEssentialTab(tab) {
-+      const duplicatedTab = this.duplicateTab(tab, true, {
-+        tabIndex: tab._tPos + 1,
-+      });
-+      this.#normalizeDuplicatedEssentialTab(duplicatedTab);
-+
-+      return new Promise(resolve => {
-+        const onRestored = () => {
-+          this.#normalizeDuplicatedEssentialTab(duplicatedTab);
-+          resolve(duplicatedTab);
-+        };
-+
-+        duplicatedTab.addEventListener("SSTabRestored", onRestored, {
-+          once: true,
-+        });
-+      });
-+    }
-+
 +    replaceTabWithWindow(aTab, aOptions = {}, zenForceSync = false) {
 +      if (!this.isTab(aTab)) return; // TODO: Handle tab groups
 +      if (
 +        !zenForceSync &&
 +        aTab.hasAttribute("zen-essential")
 +      ) {
-+        this.#duplicateEssentialTab(aTab).then(
++        gZenWorkspaces.duplicateEssentialTab(aTab).then(
 +          duplicatedTab => {
 +            if (duplicatedTab) {
 +              this.replaceTabWithWindow(duplicatedTab, aOptions);
@@ -882,7 +856,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..87f41c8583c26f364530def5bd5d8333
        if (this.tabs.length == 1) {
          return null;
        }
-@@ -6851,7 +7101,7 @@
+@@ -6851,7 +7075,7 @@
        // tell a new window to take the "dropped" tab
        let args = Cc["@mozilla.org/array;1"].createInstance(Ci.nsIMutableArray);
        args.appendElement(aTab.splitview ?? aTab);
@@ -891,7 +865,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..87f41c8583c26f364530def5bd5d8333
          private: PrivateBrowsingUtils.isWindowPrivate(window),
          features: Object.entries(aOptions)
            .map(([key, value]) => `${key}=${value}`)
-@@ -6859,6 +7109,8 @@
+@@ -6859,6 +7083,8 @@
          openerWindow: window,
          args,
        });
@@ -900,7 +874,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..87f41c8583c26f364530def5bd5d8333
      }
  
      /**
-@@ -6880,10 +7132,35 @@
+@@ -6880,10 +7106,35 @@
         elements = [contextTab.splitview ?? contextTab];
       }
 
@@ -916,7 +890,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..87f41c8583c26f364530def5bd5d8333
 +        Promise.all(
 +          elements.map(element =>
 +            this.isTab(element) && element.hasAttribute("zen-essential")
-+              ? this.#duplicateEssentialTab(element)
++              ? gZenWorkspaces.duplicateEssentialTab(element)
 +              : element
 +          )
 +        ).then(
@@ -937,7 +911,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..87f41c8583c26f364530def5bd5d8333
        if (elements.length == 1) {
          return this.replaceTabWithWindow(elements[0], aOptions);
        }
-@@ -6971,7 +7248,7 @@
+@@ -6971,7 +7247,7 @@
      *   `true` if element is a `<tab-group>`
      */
     isTabGroup(element) {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -426,6 +426,32 @@ class nsZenWorkspaces {
     return this.getEssentialsSection(this.getCurrentSpaceContainerId());
   }
 
+  normalizeDuplicatedEssentialTab(tab) {
+    tab.removeAttribute("zen-essential");
+    tab.removeAttribute("zenDefaultUserContextId");
+    if (tab.pinned) {
+      tab.ownerGlobal.gBrowser.unpinTab(tab);
+    }
+  }
+
+  async duplicateEssentialTab(tab) {
+    const duplicatedTab = tab.ownerGlobal.gBrowser.duplicateTab(tab, true, {
+      tabIndex: tab._tPos + 1,
+    });
+    this.normalizeDuplicatedEssentialTab(duplicatedTab);
+
+    return new Promise(resolve => {
+      const onRestored = () => {
+        this.normalizeDuplicatedEssentialTab(duplicatedTab);
+        resolve(duplicatedTab);
+      };
+
+      duplicatedTab.addEventListener("SSTabRestored", onRestored, {
+        once: true,
+      });
+    });
+  }
+
   #createWorkspaceTabsSection(workspace, tabs = []) {
     const workspaceWrapper = document.createXULElement("zen-workspace");
     const container = document.getElementById("tabbrowser-arrowscrollbox");

--- a/src/zen/tests/pinned/browser.toml
+++ b/src/zen/tests/pinned/browser.toml
@@ -7,6 +7,8 @@ prefs = ["zen.workspaces.separate-essentials=false"]
 
 ["browser_issue_8726.js"]
 
+["browser_essential_move_to_window.js"]
+
 ["browser_pinned_changed.js"]
 
 ["browser_pinned_close.js"]

--- a/src/zen/tests/pinned/browser_essential_move_to_window.js
+++ b/src/zen/tests/pinned/browser_essential_move_to_window.js
@@ -23,7 +23,7 @@ add_task(async function test_Move_Essential_Tab_To_Window_Duplicates() {
   const essentialCount = gBrowser._numZenEssentials;
   const newWindowPromise = BrowserTestUtils.waitForNewWindow();
   const openedWindow = gBrowser.replaceTabWithWindow(tab);
-  ok(openedWindow, "Moving an Essential tab opens a new window");
+  is(openedWindow, null, "Moving an Essential tab is deferred until restored");
 
   const newWindow = await newWindowPromise;
   await BrowserTestUtils.waitForCondition(
@@ -58,6 +58,137 @@ add_task(async function test_Move_Essential_Tab_To_Window_Duplicates() {
 
   await BrowserTestUtils.closeWindow(newWindow);
   await BrowserTestUtils.removeTab(tab);
+});
+
+add_task(async function test_Move_Essential_Waits_For_Duplicate_Restore() {
+  let newWindow;
+  let windowOpened = false;
+  const tab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    TEST_URL,
+    true
+  );
+  const duplicate = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.org/",
+    true
+  );
+
+  gZenPinnedTabManager.addToEssentials(tab);
+  const originalDuplicateTab = gBrowser.duplicateTab;
+  gBrowser.duplicateTab = () => duplicate;
+
+  try {
+    const newWindowPromise = BrowserTestUtils.waitForNewWindow().then(win => {
+      windowOpened = true;
+      return win;
+    });
+
+    gBrowser.replaceTabWithWindow(tab);
+    await TestUtils.waitForTick();
+    ok(!windowOpened, "The new window waits for the duplicate to restore");
+
+    duplicate.dispatchEvent(new CustomEvent("SSTabRestored"));
+    newWindow = await newWindowPromise;
+    is(
+      newWindow.gBrowser.selectedBrowser.currentURI.spec,
+      "https://example.org/",
+      "The restored duplicate is moved to the new window"
+    );
+  } finally {
+    gBrowser.duplicateTab = originalDuplicateTab;
+    if (newWindow && !newWindow.closed) {
+      await BrowserTestUtils.closeWindow(newWindow);
+    }
+    for (const candidate of [tab, duplicate]) {
+      if (candidate.isConnected && !candidate.closing) {
+        await BrowserTestUtils.removeTab(candidate);
+      }
+    }
+  }
+});
+
+add_task(async function test_Move_Multiple_Essentials_Waits_For_Restore() {
+  let newWindow;
+  let windowOpened = false;
+  const sourceTabs = [
+    await BrowserTestUtils.openNewForegroundTab(gBrowser, TEST_URL, true),
+    await BrowserTestUtils.openNewForegroundTab(
+      gBrowser,
+      "https://example.org/",
+      true
+    ),
+  ];
+  const duplicateTabs = [
+    await BrowserTestUtils.openNewForegroundTab(
+      gBrowser,
+      "https://example.net/",
+      true
+    ),
+    await BrowserTestUtils.openNewForegroundTab(
+      gBrowser,
+      "https://example.com/?duplicate=2",
+      true
+    ),
+  ];
+
+  for (const tab of sourceTabs) {
+    gZenPinnedTabManager.addToEssentials(tab);
+    gBrowser.addToMultiSelectedTabs(tab);
+  }
+
+  const duplicatesBySource = new Map(
+    sourceTabs.map((tab, index) => [tab, duplicateTabs[index]])
+  );
+  const originalDuplicateTab = gBrowser.duplicateTab;
+  gBrowser.duplicateTab = tab => duplicatesBySource.get(tab);
+
+  try {
+    const newWindowPromise = BrowserTestUtils.waitForNewWindow().then(win => {
+      windowOpened = true;
+      return win;
+    });
+
+    gBrowser.replaceTabsWithWindow(sourceTabs[0]);
+    duplicateTabs[0].dispatchEvent(new CustomEvent("SSTabRestored"));
+    await TestUtils.waitForTick();
+    ok(!windowOpened, "The new window waits for every duplicate to restore");
+
+    duplicateTabs[1].dispatchEvent(new CustomEvent("SSTabRestored"));
+    newWindow = await newWindowPromise;
+    const expectedURLs = [
+      "https://example.net/",
+      "https://example.com/?duplicate=2",
+    ];
+    await BrowserTestUtils.waitForCondition(
+      () =>
+        expectedURLs.every(url =>
+          newWindow.gBrowser.tabs.some(
+            tab => tab.linkedBrowser.currentURI.spec == url
+          )
+        ),
+      "All restored duplicates moved to the new window"
+    );
+
+    const movedURLs = newWindow.gBrowser.tabs
+      .map(tab => tab.linkedBrowser.currentURI.spec)
+      .filter(url => expectedURLs.includes(url));
+    Assert.deepEqual(
+      movedURLs,
+      expectedURLs,
+      "The restored duplicates keep their order and URLs"
+    );
+  } finally {
+    gBrowser.duplicateTab = originalDuplicateTab;
+    if (newWindow && !newWindow.closed) {
+      await BrowserTestUtils.closeWindow(newWindow);
+    }
+    for (const candidate of [...sourceTabs, ...duplicateTabs]) {
+      if (candidate.isConnected && !candidate.closing) {
+        await BrowserTestUtils.removeTab(candidate);
+      }
+    }
+  }
 });
 
 add_task(async function test_Forced_Sync_Moves_Essential_Tab() {

--- a/src/zen/tests/pinned/browser_essential_move_to_window.js
+++ b/src/zen/tests/pinned/browser_essential_move_to_window.js
@@ -1,0 +1,158 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const TEST_URL = "https://example.com/";
+
+function isInEssentialsContainer(tab) {
+  return !!tab.parentElement.closest(".zen-essentials-container");
+}
+
+add_task(async function test_Move_Essential_Tab_To_Window_Duplicates() {
+  const tab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    TEST_URL,
+    true
+  );
+
+  gZenPinnedTabManager.addToEssentials(tab);
+  ok(tab.hasAttribute("zen-essential"), "The original tab is essential");
+  ok(isInEssentialsContainer(tab), "The original tab is in Essentials");
+
+  const essentialCount = gBrowser._numZenEssentials;
+  const newWindowPromise = BrowserTestUtils.waitForNewWindow();
+  const openedWindow = gBrowser.replaceTabWithWindow(tab);
+  ok(openedWindow, "Moving an Essential tab opens a new window");
+
+  const newWindow = await newWindowPromise;
+  await BrowserTestUtils.waitForCondition(
+    () => newWindow.gBrowser.selectedBrowser.currentURI.spec == TEST_URL,
+    "The duplicated tab loaded in the new window"
+  );
+
+  const duplicatedTab = newWindow.gBrowser.selectedTab;
+  ok(
+    tab.hasAttribute("zen-essential"),
+    "The original tab remains marked as essential"
+  );
+  ok(
+    isInEssentialsContainer(tab),
+    "The original tab remains in the Essentials container"
+  );
+  is(
+    gBrowser._numZenEssentials,
+    essentialCount,
+    "The source window keeps the same number of Essentials"
+  );
+  ok(
+    !duplicatedTab.hasAttribute("zen-essential"),
+    "The new window receives a regular tab copy"
+  );
+  ok(!duplicatedTab.pinned, "The new window tab is not pinned");
+  is(
+    duplicatedTab.linkedBrowser.currentURI.spec,
+    TEST_URL,
+    "The new window tab keeps the original URL"
+  );
+
+  await BrowserTestUtils.closeWindow(newWindow);
+  await BrowserTestUtils.removeTab(tab);
+});
+
+add_task(async function test_Forced_Sync_Moves_Essential_Tab() {
+  let newWindow;
+  let duplicated = false;
+  const tab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    TEST_URL,
+    true
+  );
+
+  gZenPinnedTabManager.addToEssentials(tab);
+  ok(tab.hasAttribute("zen-essential"), "The original tab is essential");
+
+  const originalDuplicateTab = gBrowser.duplicateTab;
+  gBrowser.duplicateTab = (...args) => {
+    duplicated = true;
+    return originalDuplicateTab.apply(gBrowser, args);
+  };
+
+  try {
+    const newWindowPromise = BrowserTestUtils.waitForNewWindow();
+    const openedWindow = gBrowser.replaceTabWithWindow(
+      tab,
+      {},
+      /* zenForceSync = */ true
+    );
+    ok(openedWindow, "Forced sync opens a new window for the Essential tab");
+
+    newWindow = await newWindowPromise;
+    ok(!duplicated, "Forced sync does not duplicate an Essential tab");
+  } finally {
+    gBrowser.duplicateTab = originalDuplicateTab;
+
+    if (newWindow && !newWindow.closed) {
+      await BrowserTestUtils.closeWindow(newWindow);
+    }
+    for (const candidate of [...gBrowser.tabs]) {
+      if (
+        candidate.linkedBrowser.currentURI.spec == TEST_URL &&
+        !candidate.closing
+      ) {
+        await BrowserTestUtils.removeTab(candidate);
+      }
+    }
+  }
+});
+
+add_task(async function test_Move_Tab_Group_Label_To_Window_Still_Works() {
+  let newWindow;
+  const tab1 = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    TEST_URL,
+    true
+  );
+  const tab2 = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.org/",
+    true
+  );
+
+  try {
+    const group = gBrowser.addTabGroup([tab1, tab2], { insertBefore: tab1 });
+
+    const newWindowPromise = BrowserTestUtils.waitForNewWindow();
+    const openedWindow = gBrowser.replaceTabWithWindow(group.labelElement);
+    ok(openedWindow, "Moving a tab group label opens a new window");
+
+    newWindow = await newWindowPromise;
+    await BrowserTestUtils.waitForCondition(
+      () => newWindow.gBrowser.tabs.length >= 2,
+      "The grouped tabs moved to the new window"
+    );
+
+    is(
+      newWindow.gBrowser.tabs.length,
+      2,
+      "The new window receives both grouped tabs"
+    );
+  } finally {
+    if (newWindow && !newWindow.closed) {
+      await BrowserTestUtils.closeWindow(newWindow);
+    }
+    const blankTab = await BrowserTestUtils.openNewForegroundTab(
+      gBrowser,
+      "about:blank",
+      true
+    );
+    for (const tab of [...gBrowser.tabs]) {
+      if (tab == blankTab) {
+        continue;
+      }
+      if (tab.isConnected && !tab.closing) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});


### PR DESCRIPTION
Fixes #8309.

updates the move-to-new-window behavior for Essential tabs. For normal user moves, keeps the original Essential tab in place and opens a regular copy in the new window.

I also added coverage for the related edge cases that came up while testing this path.