### PR TITLE
fix: compact sidebar on the right was covering the page scrollbar

### DIFF
--- a/prefs/zen/compact-mode.yaml
+++ b/prefs/zen/compact-mode.yaml
@@ -20,6 +20,9 @@
 - name: zen.view.compact.sidebar-keep-hover.duration
   value: 150
 
+- name: zen.view.compact.overlay-scrollbar-width
+  value: 15
+
 - name: zen.view.compact.animate-sidebar
   value: true
 

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -29,6 +29,13 @@ XPCOMUtils.defineLazyPreferenceGetter(
 
 XPCOMUtils.defineLazyPreferenceGetter(
   lazy,
+  "OVERLAY_SCROLLBAR_WIDTH",
+  "zen.view.compact.overlay-scrollbar-width",
+  15 // macOS overlay scrollbar interactive (thick) width in px
+);
+
+XPCOMUtils.defineLazyPreferenceGetter(
+  lazy,
   "COMPACT_MODE_SHOW_SIDEBAR_AND_TOOLBAR_ON_HOVER",
   "zen.view.compact.show-sidebar-and-toolbar-on-hover",
   true
@@ -42,6 +49,8 @@ window.gZenCompactModeManager = {
   _flashTimeouts: {},
   _eventListeners: [],
   _removeHoverFrames: {},
+  _pageScrollbarWidth: 0,
+  _scrollbarFadeTimeout: null,
 
   // Delay to avoid flickering when hovering over the sidebar
   HOVER_HACK_DELAY: Services.prefs.getIntPref(
@@ -112,6 +121,8 @@ window.gZenCompactModeManager = {
     SessionStore.promiseAllWindowsRestored.then(() => {
       this.preference = this._wasInCompactMode;
     });
+
+    this._initScrollbarTracking();
   },
 
   log(...args) {
@@ -833,6 +844,22 @@ window.gZenCompactModeManager = {
             return;
           }
 
+          // When the sidebar is on the right and a page scrollbar is visible,
+          // the shown position leaves a gap equal to the scrollbar width. If
+          // the cursor is in that gap (i.e. on the scrollbar), treat it as
+          // still hovering the sidebar so the sidebar doesn't hide.
+          if (
+            this.hoverableElements[i].screenEdge === "right" &&
+            this._pageScrollbarWidth > 0
+          ) {
+            if (
+              event.clientX >=
+              document.documentElement.clientWidth - this._pageScrollbarWidth
+            ) {
+              return;
+            }
+          }
+
           if (this.hoverableElements[i].keepHoverDuration) {
             this.flashElement(
               target,
@@ -987,6 +1014,69 @@ window.gZenCompactModeManager = {
       });
     }
     delete this._nextTimeWillBeActive;
+  },
+
+  // ---------------------------------------------------------------------------
+  // Page scrollbar tracking — keeps --zen-page-scrollbar-width in sync so the
+  // compact sidebar's shown position parks against the scrollbar's left edge.
+  // ---------------------------------------------------------------------------
+
+  _initScrollbarTracking() {
+    if (!this.sidebarIsOnRight) return;
+
+    // Measure whether the platform uses classic (layout-consuming) scrollbars.
+    // Returns 0 on macOS with overlay scrollbars, ~17 px on Windows/Linux.
+    const classicWidth = this._getClassicScrollbarWidth();
+    if (classicWidth > 0) {
+      // Classic scrollbars are always present when the page is scrollable —
+      // set the variable once and leave it.
+      this._applyScrollbarWidth(classicWidth);
+      return;
+    }
+
+    // Overlay scrollbars (macOS default): they appear during scrolling and
+    // fade out ~1 s after the last scroll input. Wheel events bubble from
+    // content to chrome in Firefox, so no frame script is needed.
+    window.addEventListener("wheel", () => this._onContentWheel(), {
+      passive: true,
+      capture: true,
+    });
+
+    // When the user switches tabs the new page may not be scrolling, so
+    // drop the gap immediately to avoid a stale gap on an idle page.
+    window.addEventListener("TabSelect", () => {
+      clearTimeout(this._scrollbarFadeTimeout);
+      this._applyScrollbarWidth(0);
+    });
+  },
+
+  _onContentWheel() {
+    this._applyScrollbarWidth(lazy.OVERLAY_SCROLLBAR_WIDTH);
+    clearTimeout(this._scrollbarFadeTimeout);
+    // macOS fades the scrollbar out roughly 1 s after scrolling stops.
+    this._scrollbarFadeTimeout = setTimeout(
+      () => this._applyScrollbarWidth(0),
+      1500
+    );
+  },
+
+  _getClassicScrollbarWidth() {
+    const div = document.createElement("div");
+    div.style.cssText =
+      "overflow-y:scroll;height:100px;width:100px;position:fixed;top:-9999px;visibility:hidden;";
+    document.documentElement.appendChild(div);
+    const w = div.offsetWidth - div.clientWidth;
+    div.remove();
+    return w;
+  },
+
+  _applyScrollbarWidth(width) {
+    if (this._pageScrollbarWidth === width) return;
+    this._pageScrollbarWidth = width;
+    document.documentElement.style.setProperty(
+      "--zen-page-scrollbar-width",
+      `${width}px`
+    );
   },
 };
 

--- a/src/zen/compact-mode/sidebar.inc.css
+++ b/src/zen/compact-mode/sidebar.inc.css
@@ -268,7 +268,13 @@
 
         left: calc(var(--zen-compact-float) / -2);
         :root[zen-right-side='true'] & {
-          right: calc(var(--zen-compact-float) / -2);
+          /* Park the shown sidebar against the left edge of the page scrollbar.
+             --zen-page-scrollbar-width is set dynamically by JS (0 when idle,
+             scrollbar width when active). env(scrollbar-inline-size) is the
+             correct fallback for classic scrollbars (Windows/Linux); on macOS
+             overlay scrollbars it resolves to 0, which is fine because JS
+             handles that case. */
+          right: var(--zen-page-scrollbar-width, env(scrollbar-inline-size, 0px));
           left: auto;
         }
       }


### PR DESCRIPTION
## What

When compact mode is enabled with the sidebar on the right side, the sidebar's shown position was `right: -4px` — extending past the window edge and completely covering the page scrollbar, making it unclickable and undraggable.

## How

The sidebar's shown position now parks against the left edge of the scrollbar instead of the window edge.

- **CSS**: `right` now uses `--zen-page-scrollbar-width` with `env(scrollbar-inline-size, 0px)` as fallback. On Windows/Linux, `env()` resolves to the real scrollbar width automatically. On macOS overlay scrollbars, it resolves to 0 and JS handles it.
- **JS**: `_initScrollbarTracking()` sets `--zen-page-scrollbar-width` on `:root`. For classic scrollbars (Windows/Linux) it measures once on init. For macOS overlay scrollbars, it listens to `wheel` events (which bubble from content to chrome) and fades the gap out ~1.5s after scrolling stops — matching the native overlay scrollbar fade timing. The gap width is configurable via `zen.view.compact.overlay-scrollbar-width` (default 15px).
- **Flicker fix**: `onLeave` now returns early if the cursor is within the scrollbar gap on the right edge, preventing the sidebar from rapidly hiding and re-showing when the user moves their cursor to the scrollbar.

All changes are gated on `sidebarIsOnRight` — no effect on left-side or non-compact layouts.

## Test

1. Enable compact mode, move sidebar to the right
2. Open a page with a scrollbar
3. Verify you can click and drag the scrollbar while the sidebar is shown