### PR TITLE
gh-8391: Prevent opening glance when selecting text in link (gh-14164)

### DIFF
--- a/src/zen/glance/actors/ZenGlanceChild.sys.mjs
+++ b/src/zen/glance/actors/ZenGlanceChild.sys.mjs
@@ -17,8 +17,14 @@ XPCOMUtils.defineLazyPreferenceGetter(
   true
 );
 
+// A small threshold to allow for minor mouse jitter during a normal click.
+// Anything beyond this is likely an intentional drag (like selecting text).
+const CLICK_DRAG_THRESHOLD_PX = 4;
+
 export class ZenGlanceChild extends JSWindowActorChild {
   #activationMethod;
+  #mouseDownX = null;
+  #mouseDownY = null;
 
   constructor() {
     super();
@@ -121,9 +127,23 @@ export class ZenGlanceChild extends JSWindowActorChild {
     // The problem is that at that stage we don't know the rect or even what
     // element has been clicked, so we send the data here.
     this.#sendClickDataToParent(node, event.target);
+
+    this.#mouseDownX = event.clientX;
+    this.#mouseDownY = event.clientY;
   }
 
   on_click(event) {
+    // If the user drags to select text inside a link, we shouldn't open glance.
+    if (this.#mouseDownX !== null && this.#mouseDownY !== null) {
+      const deltaX = Math.abs(event.clientX - this.#mouseDownX);
+      const deltaY = Math.abs(event.clientY - this.#mouseDownY);
+      this.#mouseDownX = null;
+      this.#mouseDownY = null;
+      if (deltaX > CLICK_DRAG_THRESHOLD_PX || deltaY > CLICK_DRAG_THRESHOLD_PX) {
+        return;
+      }
+    }
+
     const { node, href, principal } = this.#getTargetFromEvent(event);
     if (
       event.button !== 0 ||


### PR DESCRIPTION
Fixes #8391

This PR fixes the issue where selecting text inside a link (e.g., holding `Option` and dragging) unintentionally triggers the "Glance" preview.

Solution:
- Track the mouse coordinate on `mousedown`.
- Measure the movement delta (in pixels) on `click`.
- Introduce a standard drag threshold (`CLICK_DRAG_THRESHOLD_PX = 4`) to allow for minor mouse jitter during normal clicks.
- If the mouse moves more than 4 pixels between press and release, the event is treated as an intentional drag/text selection and Glance is not opened.


