### PR TITLE
feat: add 'Open Link in Folder...' context menu item for links

### DIFF
--- a/locales/en-US/browser/browser/zen-vertical-tabs.ftl
+++ b/locales/en-US/browser/browser/zen-vertical-tabs.ftl
@@ -27,6 +27,10 @@ zen-toolbar-context-new-folder =
     .label = New Folder
     .accesskey = N
 
+zen-open-link-in-folder =
+    .label = Open Link in Folder...
+    .accesskey = F
+
 sidebar-zen-expand =
   .label = Expand Sidebar
 

--- a/src/browser/base/content/nsContextMenu-sys-mjs.patch
+++ b/src/browser/base/content/nsContextMenu-sys-mjs.patch
@@ -1,13 +1,14 @@
 diff --git a/browser/base/content/nsContextMenu.sys.mjs b/browser/base/content/nsContextMenu.sys.mjs
-index 97cb36e2ed48d00454e169fb0470b47ac994b883..1811a92885620c8a916937f467ebb7d0eb0d3a0e 100644
+index 97cb36e2ed48d00454e169fb0470b47ac994b883..c5a8eb6b812c2c1455fe75f2aa56c9425db88e6f 100644
 --- a/browser/base/content/nsContextMenu.sys.mjs
 +++ b/browser/base/content/nsContextMenu.sys.mjs
-@@ -369,6 +369,9 @@ export class nsContextMenu {
+@@ -369,6 +369,10 @@ export class nsContextMenu {
      this.initTextFragmentItems();
      this.pdfjsContextMenu.initItems();
  
 +    this.showItem("context-zenSplitLink", this.onLink && !this.onMailtoLink && !this.onTelLink);
-+    this.showItem("context-zenOpenLinkInGlance", this.onLink && !this.onMailtoLink && !this.onTelLink); 
++    this.showItem("context-zenOpenLinkInGlance", this.onLink && !this.onMailtoLink && !this.onTelLink);
++    this.showItem("context-zenOpenLinkInFolder", this.onLink && !this.onMailtoLink && !this.onTelLink);
 +
      this.showHideSeparators(aXulMenu);
      if (!aXulMenu.showHideSeparators) {

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -53,6 +53,7 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
   #animationCount = 0;
 
   init() {
+    this.#initLinkContextMenu();
     this.#foldersEnabled = !gZenWorkspaces.privateWindowOrDisabled;
 
     if (!this.#foldersEnabled) {
@@ -299,6 +300,79 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
         ? gBrowser.selectedTabs
         : [TabContextMenu.contextTab];
       group.addTabs(tabs);
+    });
+  }
+
+  #initLinkContextMenu() {
+    const menu = window.MozXULElement.parseXULToFragment(`
+      <menu id="context-zenOpenLinkInFolder" data-l10n-id="zen-open-link-in-folder" hidden="true">
+        <menupopup>
+        </menupopup>
+      </menu>
+    `);
+    document.getElementById("context-sep-open").before(menu);
+
+    const linkFolderMenu = document.getElementById("context-zenOpenLinkInFolder");
+    const popup = linkFolderMenu.querySelector("menupopup");
+
+    popup.addEventListener("popupshowing", () => {
+      if (!this.#foldersEnabled) {
+        return;
+      }
+      const groups = gBrowser.tabGroups.filter(group => {
+        const isZenFolder = group?.isZenFolder;
+        const isLiveFolder = group?.isLiveFolder;
+        const spaceId = group?.getAttribute("zen-workspace-id");
+        if (
+          !isZenFolder ||
+          isLiveFolder ||
+          spaceId !== gZenWorkspaces.activeWorkspace
+        ) {
+          return false;
+        }
+        return true;
+      });
+      for (const group of groups) {
+        const icon = group.iconURL;
+        const menuItem = document.createXULElement("menuitem");
+        menuItem.setAttribute("label", group.label);
+        menuItem.classList.add("context-zen-link-open-in-folder-item");
+        if (icon) {
+          menuItem.setAttribute("image", icon);
+        }
+        menuItem._group = group;
+        popup.appendChild(menuItem);
+      }
+    });
+
+    popup.addEventListener("popuphidden", () => {
+      const items = popup.querySelectorAll(
+        ".context-zen-link-open-in-folder-item"
+      );
+      for (const item of items) {
+        delete item._group;
+        item.remove();
+      }
+    });
+
+    popup.addEventListener("command", event => {
+      if (
+        !event.target.classList.contains("context-zen-link-open-in-folder-item")
+      ) {
+        return;
+      }
+      const group = event.target._group;
+      if (!group) {
+        return;
+      }
+      const url = gContextMenu.linkURL;
+      if (!url) {
+        return;
+      }
+      const newTab = gBrowser.addTab(url, {
+        triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
+      });
+      group.addTabs([newTab]);
     });
   }
 


### PR DESCRIPTION
Adds a 'Open Link in Folder...' submenu to the link right-click context menu, listing all Zen folders in the active workspace. Selecting a folder opens the link in a new background tab and adds it to that folder.