### PR TITLE
Enable NVIDIA VSR overlay prefs on Windows

### DIFF
--- a/prefs/firefox/performance.yaml
+++ b/prefs/firefox/performance.yaml
@@ -17,3 +17,26 @@
   condition: "defined(XP_WIN) || defined(XP_DARWIN)"
   value: "@cond"
   mirror: once
+
+# NVIDIA RTX Video Super Resolution is officially supported on Windows 10/11.
+# Use Firefox/Gecko's existing DirectComposition video overlay path instead of
+# the RTX Video SDK, which NVIDIA currently documents for Windows 10/11 only.
+# Do not force-enable overlays; Firefox gfxInfo blocklists remain authoritative.
+# https://nvidia.custhelp.com/app/answers/detail/a_id/5448/~/rtx-video-faq
+# https://developer.nvidia.com/blog/enhancing-low-resolution-sdr-video-with-the-nvidia-rtx-video-sdk/
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1823135
+- name: gfx.webrender.overlay-vp-super-resolution
+  condition: "defined(XP_WIN)"
+  value: true
+
+- name: gfx.webrender.dcomp-video-hw-overlay-win
+  condition: "defined(XP_WIN)"
+  value: true
+
+- name: gfx.webrender.dcomp-video-vp-scaling-win
+  condition: "defined(XP_WIN)"
+  value: true
+
+- name: gfx.webrender.dcomp-video-sw-overlay-win
+  condition: "defined(XP_WIN)"
+  value: true


### PR DESCRIPTION
## What changed

This enables NVIDIA RTX Video Super Resolution through Gecko's existing DirectComposition video overlay path on Windows.

The patch turns on the prefs required for the existing Firefox/Gecko VSR integration:

- `gfx.webrender.overlay-vp-super-resolution`
- `gfx.webrender.dcomp-video-hw-overlay-win`
- `gfx.webrender.dcomp-video-vp-scaling-win`
- `gfx.webrender.dcomp-video-sw-overlay-win`

## Why

Firefox already has the VSR plumbing in the Windows video overlay path, including the NVIDIA video processor extension and the existing gfxInfo safeguards. Enabling those prefs lets Zen use that path instead of adding a separate upscaler or integrating the RTX Video SDK directly.

The prefs are Windows-only because NVIDIA currently documents RTX Video / VSR browser support for Windows 10/11. Linux and macOS are intentionally left unchanged until there is an official supported path for those platforms.

## Notes

This does not force-enable overlays and does not enable RTX Video HDR. Driver and hardware blocklists remain handled by Gecko/Mozilla's existing gfxInfo checks.

References:

- NVIDIA RTX Video FAQ: https://nvidia.custhelp.com/app/answers/detail/a_id/5448/~/rtx-video-faq
- NVIDIA RTX Video SDK blog: https://developer.nvidia.com/blog/enhancing-low-resolution-sdr-video-with-the-nvidia-rtx-video-sdk/
- Mozilla VSR tracking bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1823135

## Validation

- `npm run ffprefs`
- Checked that the generated prefs are guarded by `XP_WIN`