### PR TITLE
[codex] Add Zen Split Companion core patch

### DIFF
--- a/prefs/zen/split-view.yaml
+++ b/prefs/zen/split-view.yaml
@@ -22,3 +22,12 @@
 
 - name: zen.splitView.drag-over-split-threshold
   value: 40
+
+- name: zen.splitCompanion.enabled
+  value: false
+
+- name: zen.splitCompanion.pane.visible
+  value: false
+
+- name: zen.splitCompanion.rightWeb.visible
+  value: false

--- a/src/browser/base/content/browser-box-inc-xhtml.patch
+++ b/src/browser/base/content/browser-box-inc-xhtml.patch
@@ -25,7 +25,7 @@ index d58fcdf99843d110b708f3fbf9fb317787fadfcf..cfc2aad902641609c3804e615c4cb66c
    <vbox id="sidebar-box" hidden="true" class="chromeclass-extrachrome">
      <box id="sidebar-header" align="center">
        <toolbarbutton id="sidebar-switcher-target" class="tabbable" aria-expanded="false">
-@@ -25,7 +35,7 @@
+@@ -25,7 +35,8 @@
      </stack>
    </vbox>
    <splitter id="sidebar-splitter" class="chromeclass-extrachrome sidebar-splitter" resizebefore="sibling" resizeafter="none" hidden="true"/>
@@ -33,6 +33,7 @@ index d58fcdf99843d110b708f3fbf9fb317787fadfcf..cfc2aad902641609c3804e615c4cb66c
 +#include zen-tabbrowser-elements.inc.xhtml
      <tabpanels id="tabbrowser-tabpanels" flex="1" selectedIndex="0"/>
    </tabbox>
++  <vbox id="zen-split-companion-pane" hidden="true"/>
    <splitter id="ai-window-splitter" class="chromeclass-extrachrome sidebar-splitter" resizebefore="none" resizeafter="sibling" collapsed="true"/>
 @@ -34,3 +44,5 @@
      </stack>

--- a/src/zen/common/ZenPreloadedScripts.js
+++ b/src/zen/common/ZenPreloadedScripts.js
@@ -24,6 +24,7 @@
     "chrome://browser/content/zen-components/ZenGlanceManager.mjs",
     "chrome://browser/content/zen-components/ZenPinnedTabManager.mjs",
     "chrome://browser/content/zen-components/ZenViewSplitter.mjs",
+    "chrome://browser/content/zen-components/ZenSplitCompanionPane.mjs",
     "chrome://browser/content/zen-components/ZenFolders.mjs",
     "chrome://browser/content/zen-components/ZenEmojiPicker.mjs",
     "chrome://browser/content/zen-components/ZenLiveFoldersUI.mjs",

--- a/src/zen/split-view/ZenSplitCompanionPane.mjs
+++ b/src/zen/split-view/ZenSplitCompanionPane.mjs
@@ -1,0 +1,1024 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { nsZenDOMOperatedFeature } from "chrome://browser/content/zen-components/ZenCommonUtils.mjs";
+
+const kPrefs = {
+  enabled: "zen.splitCompanion.enabled",
+  paneVisible: "zen.splitCompanion.pane.visible",
+  rightWebVisible: "zen.splitCompanion.rightWeb.visible",
+};
+
+const kSplitActionFailedAttribute = "data-zen-split-action-failed";
+const kSplitActionErrorAttribute = "data-zen-split-action-error";
+const kRightWebVisibilityFailedAttribute =
+  "data-zen-right-web-visibility-failed";
+const kRightWebVisibilityErrorAttribute =
+  "data-zen-right-web-visibility-error";
+const kWorkspaceSwitchFailedAttribute = "data-zen-workspace-switch-failed";
+const kWorkspaceSwitchErrorAttribute = "data-zen-workspace-switch-error";
+
+export const ZEN_SPLIT_COMPANION_REFRESH_EVENTS = Object.freeze([
+  "TabOpen",
+  "TabClose",
+  "TabSelect",
+  "TabMove",
+  "TabAttrModified",
+  "TabPinned",
+  "TabUnpinned",
+  "DOMTitleChanged",
+  "ZenTabIconChanged",
+  "DOMAudioPlaybackStarted",
+  "DOMAudioPlaybackStopped",
+  "ZenWorkspacesUIUpdate",
+  "ZenWorkspaceDataChanged",
+]);
+
+function defaultBrowser() {
+  return typeof gBrowser == "undefined" ? null : gBrowser;
+}
+
+function defaultWorkspaceManager() {
+  return typeof gZenWorkspaces == "undefined" ? null : gZenWorkspaces;
+}
+
+function readAttribute(item, name) {
+  try {
+    return item?.getAttribute?.(name) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function hasAttribute(item, name) {
+  try {
+    return !!item?.hasAttribute?.(name);
+  } catch {
+    return false;
+  }
+}
+
+function readProperty(item, name, fallback = undefined) {
+  try {
+    return item == null ? fallback : item[name];
+  } catch {
+    return fallback;
+  }
+}
+
+function readNestedProperty(item, names, fallback = undefined) {
+  let value = item;
+  for (const name of names) {
+    value = readProperty(value, name);
+    if (value == null) {
+      return fallback;
+    }
+  }
+  return value;
+}
+
+function readBoolProperty(item, name) {
+  return !!readProperty(item, name, false);
+}
+
+function readString(value) {
+  return value == null ? "" : String(value);
+}
+
+function createCompanionElement(document, localName, className = "") {
+  const element =
+    typeof document.createXULElement == "function"
+      ? document.createXULElement(localName)
+      : document.createElement(localName);
+  if (className) {
+    element.classList.add(...className.split(" ").filter(Boolean));
+  }
+  return element;
+}
+
+function setLabelValue(label, value) {
+  const text = readString(value);
+  label.value = text;
+  label.setAttribute("value", text);
+}
+
+function setDataAttribute(element, name, value) {
+  const stringValue = readString(value);
+  if (stringValue) {
+    element.setAttribute(name, stringValue);
+  }
+}
+
+function setStateAttribute(element, name, value) {
+  element.toggleAttribute(name, !!value);
+}
+
+function clearSplitActionFailure(row) {
+  row.removeAttribute(kSplitActionFailedAttribute);
+  row.removeAttribute(kSplitActionErrorAttribute);
+}
+
+function markSplitActionFailure(row, reason) {
+  row.setAttribute(kSplitActionFailedAttribute, "true");
+  const error = readString(reason);
+  if (error) {
+    row.setAttribute(kSplitActionErrorAttribute, error);
+  } else {
+    row.removeAttribute(kSplitActionErrorAttribute);
+  }
+}
+
+function clearRightWebVisibilityFailure(host) {
+  host.removeAttribute(kRightWebVisibilityFailedAttribute);
+  host.removeAttribute(kRightWebVisibilityErrorAttribute);
+}
+
+function markRightWebVisibilityFailure(host, reason) {
+  host.setAttribute(kRightWebVisibilityFailedAttribute, "true");
+  const error = readString(reason);
+  if (error) {
+    host.setAttribute(kRightWebVisibilityErrorAttribute, error);
+  } else {
+    host.removeAttribute(kRightWebVisibilityErrorAttribute);
+  }
+}
+
+function clearWorkspaceSwitchFailure(row) {
+  row.removeAttribute(kWorkspaceSwitchFailedAttribute);
+  row.removeAttribute(kWorkspaceSwitchErrorAttribute);
+}
+
+function markWorkspaceSwitchFailure(row, reason) {
+  row.setAttribute(kWorkspaceSwitchFailedAttribute, "true");
+  const error = readString(reason);
+  if (error) {
+    row.setAttribute(kWorkspaceSwitchErrorAttribute, error);
+  } else {
+    row.removeAttribute(kWorkspaceSwitchErrorAttribute);
+  }
+}
+
+function findCompanionWorkspaceRow(target, host) {
+  for (let node = target; node && node !== host; node = node.parentNode) {
+    if (node.classList?.contains("zen-split-companion-workspace-row")) {
+      return node;
+    }
+  }
+  return null;
+}
+
+function findCompanionWorkspaceRowById(workspaceId, host) {
+  if (!workspaceId || !host) {
+    return null;
+  }
+
+  for (const row of host.querySelectorAll(
+    ".zen-split-companion-workspace-row"
+  )) {
+    if (readAttribute(row, "data-zen-workspace-id") === workspaceId) {
+      return row;
+    }
+  }
+  return null;
+}
+
+function findCompanionTabRow(target, host) {
+  for (let node = target; node && node !== host; node = node.parentNode) {
+    if (node.classList?.contains("zen-split-companion-tab-row")) {
+      return node;
+    }
+  }
+  return null;
+}
+
+function findLiveTabForCompanionRow(row, browser = defaultBrowser()) {
+  const tabId = readAttribute(row, "data-zen-tab-id");
+  if (!tabId) {
+    return null;
+  }
+
+  const tabs = Array.from(readProperty(browser, "tabs", []) ?? []);
+  return tabs.find(candidate => getStableTabId(candidate) === tabId) ?? null;
+}
+
+function defaultViewSplitter() {
+  return typeof gZenViewSplitter == "undefined" ? null : gZenViewSplitter;
+}
+
+function normalizeWorkspace(workspace, activeWorkspaceId, index) {
+  const id = readString(
+    readProperty(workspace, "uuid") ?? readProperty(workspace, "id")
+  );
+  const containerTabId = readProperty(workspace, "containerTabId");
+  return {
+    id,
+    name: readString(
+      readProperty(workspace, "name") ?? readProperty(workspace, "label")
+    ),
+    active: !!id && id === activeWorkspaceId,
+    icon: readString(readProperty(workspace, "icon")),
+    containerTabId: typeof containerTabId == "number" ? containerTabId : null,
+    position: index,
+  };
+}
+
+function getWorkspaces(workspaceManager, activeWorkspaceId) {
+  let workspaces = [];
+  try {
+    const getWorkspaceList = readProperty(workspaceManager, "getWorkspaces");
+    workspaces =
+      typeof getWorkspaceList == "function"
+        ? Array.from(getWorkspaceList.call(workspaceManager) ?? [])
+        : [];
+  } catch {
+    workspaces = [];
+  }
+
+  return workspaces
+    .map((workspace, index) =>
+      normalizeWorkspace(workspace, activeWorkspaceId, index)
+    )
+    .filter(workspace => workspace.id);
+}
+
+function getTabId(tab, position) {
+  return getStableTabId(tab) || `tab-${position}`;
+}
+
+function getStableTabId(tab) {
+  return (
+    readAttribute(tab, "linkedpanel") ||
+    readString(readProperty(tab, "linkedPanel")) ||
+    readAttribute(tab, "id")
+  );
+}
+
+function getTabPosition(tab, fallbackPosition) {
+  const tabPosition = readProperty(tab, "_tPos");
+  const elementIndex = readProperty(tab, "elementIndex");
+  return Number.isInteger(tabPosition)
+    ? tabPosition
+    : Number.isInteger(elementIndex)
+      ? elementIndex
+      : fallbackPosition;
+}
+
+function tabBelongsToWorkspace(tab, activeWorkspaceId) {
+  if (!activeWorkspaceId) {
+    return true;
+  }
+
+  const workspaceId = readAttribute(tab, "zen-workspace-id");
+  return (
+    !workspaceId ||
+    workspaceId === activeWorkspaceId ||
+    hasAttribute(tab, "zen-essential")
+  );
+}
+
+function getGroupId(group) {
+  return readString(readProperty(group, "id") || readAttribute(group, "id"));
+}
+
+function normalizeTab(tab, selectedTab, index) {
+  const position = getTabPosition(tab, index);
+  const workspaceId = readAttribute(tab, "zen-workspace-id");
+  const group = readProperty(tab, "group", null);
+  const splitView =
+    readBoolProperty(tab, "splitView") ||
+    hasAttribute(tab, "split-view") ||
+    hasAttribute(group, "split-view-group");
+  const selected =
+    tab === selectedTab ||
+    readBoolProperty(tab, "selected") ||
+    hasAttribute(tab, "selected") ||
+    hasAttribute(tab, "visuallyselected");
+  const favicon =
+    readAttribute(tab, "image") ||
+    readString(readProperty(tab, "image")) ||
+    readAttribute(tab, "pendingicon");
+
+  return {
+    id: getTabId(tab, position),
+    position,
+    workspaceId,
+    title:
+      readString(readProperty(tab, "label")) ||
+      readAttribute(tab, "label") ||
+      readString(readNestedProperty(tab, ["linkedBrowser", "contentTitle"])),
+    favicon,
+    image: favicon,
+    pinned: readBoolProperty(tab, "pinned") || hasAttribute(tab, "pinned"),
+    essential: hasAttribute(tab, "zen-essential"),
+    active: selected,
+    selected,
+    hidden: readBoolProperty(tab, "hidden") || hasAttribute(tab, "hidden"),
+    closing: readBoolProperty(tab, "closing") || hasAttribute(tab, "closing"),
+    busy: readBoolProperty(tab, "busy") || hasAttribute(tab, "busy"),
+    loading: readBoolProperty(tab, "busy") || hasAttribute(tab, "busy"),
+    pending: readBoolProperty(tab, "pending") || hasAttribute(tab, "pending"),
+    muted:
+      readBoolProperty(tab, "muted") ||
+      !!readNestedProperty(tab, ["linkedBrowser", "audioMuted"], false) ||
+      hasAttribute(tab, "muted"),
+    soundPlaying:
+      readBoolProperty(tab, "soundPlaying") ||
+      hasAttribute(tab, "soundplaying"),
+    activeMediaBlocked:
+      readBoolProperty(tab, "activeMediaBlocked") ||
+      hasAttribute(tab, "activemedia-blocked"),
+    splitView,
+    splitViewValue: readString(readProperty(tab, "splitViewValue")),
+    splitViewGroupId: splitView ? getGroupId(group) : "",
+    groupId: getGroupId(group),
+    groupLabel: readString(readProperty(group, "label")),
+  };
+}
+
+export function buildZenSplitCompanionSnapshot({
+  browser = defaultBrowser(),
+  workspaceManager = defaultWorkspaceManager(),
+} = {}) {
+  const activeWorkspaceId = readString(
+    readProperty(workspaceManager, "activeWorkspace")
+  );
+  const workspaces = getWorkspaces(workspaceManager, activeWorkspaceId);
+  const activeWorkspace =
+    workspaces.find(workspace => workspace.active) ?? {
+      id: activeWorkspaceId,
+      name: "",
+      active: !!activeWorkspaceId,
+      icon: "",
+      containerTabId: null,
+      position: -1,
+    };
+  const selectedTab = readProperty(browser, "selectedTab", null);
+  const tabs = Array.from(readProperty(browser, "tabs", []) ?? [])
+    .filter(tab => tabBelongsToWorkspace(tab, activeWorkspaceId))
+    .map((tab, index) => normalizeTab(tab, selectedTab, index))
+    .sort((first, second) => first.position - second.position);
+
+  return {
+    activeWorkspace,
+    activeWorkspaceId,
+    workspaces,
+    tabs,
+  };
+}
+
+export function clearZenSplitCompanionSnapshotRender(host) {
+  if (!host) {
+    return;
+  }
+
+  while (host.firstChild) {
+    host.firstChild.remove();
+  }
+}
+
+function renderWorkspaceHeader(document, snapshot) {
+  const header = createCompanionElement(
+    document,
+    "hbox",
+    "zen-split-companion-header"
+  );
+  const title = createCompanionElement(
+    document,
+    "label",
+    "zen-split-companion-workspace-title"
+  );
+  const count = createCompanionElement(
+    document,
+    "label",
+    "zen-split-companion-tab-count"
+  );
+  const activeWorkspaceName = readString(snapshot.activeWorkspace?.name);
+  const activeWorkspaceId = readString(snapshot.activeWorkspaceId);
+  const workspaceTitle = activeWorkspaceName || activeWorkspaceId;
+
+  setLabelValue(title, workspaceTitle);
+  setLabelValue(count, readString(snapshot.tabs?.length ?? 0));
+
+  header.append(title, count);
+  return header;
+}
+
+function renderWorkspaceRow(document, workspace) {
+  const row = createCompanionElement(
+    document,
+    "hbox",
+    "zen-split-companion-workspace-row"
+  );
+  const icon = createCompanionElement(
+    document,
+    "label",
+    "zen-split-companion-workspace-icon"
+  );
+  const name = createCompanionElement(
+    document,
+    "label",
+    "zen-split-companion-workspace-name"
+  );
+  const workspaceName = readString(workspace.name) || readString(workspace.id);
+
+  row.setAttribute("role", "button");
+  row.setAttribute("aria-current", workspace.active ? "true" : "false");
+  row.setAttribute("aria-disabled", workspace.active ? "true" : "false");
+  row.tabIndex = 0;
+  setDataAttribute(row, "data-zen-workspace-id", workspace.id);
+  setDataAttribute(row, "data-zen-position", workspace.position);
+  setStateAttribute(row, "data-zen-workspace-active", workspace.active);
+
+  setLabelValue(icon, workspace.icon);
+  icon.setAttribute("crop", "end");
+  setLabelValue(name, workspaceName);
+  name.setAttribute("crop", "end");
+
+  row.append(icon, name);
+  return row;
+}
+
+function renderWorkspaceList(document, snapshot) {
+  const list = createCompanionElement(
+    document,
+    "vbox",
+    "zen-split-companion-workspace-list"
+  );
+  list.setAttribute("role", "list");
+
+  for (const workspace of snapshot.workspaces ?? []) {
+    list.append(renderWorkspaceRow(document, workspace));
+  }
+
+  return list;
+}
+
+function renderTabIcon(document, tab) {
+  const stack = createCompanionElement(
+    document,
+    "hbox",
+    "zen-split-companion-tab-icon-stack"
+  );
+  const favicon = readString(tab.image || tab.favicon);
+
+  if (favicon) {
+    const image = createCompanionElement(
+      document,
+      "image",
+      "zen-split-companion-tab-icon"
+    );
+    image.setAttribute("src", favicon);
+    stack.append(image);
+  } else {
+    stack.setAttribute("icon-placeholder", "true");
+  }
+
+  return stack;
+}
+
+function renderTabLabel(document, tab) {
+  const labels = createCompanionElement(
+    document,
+    "vbox",
+    "zen-split-companion-tab-labels"
+  );
+  const title = createCompanionElement(
+    document,
+    "label",
+    "zen-split-companion-tab-title"
+  );
+  setLabelValue(title, tab.title);
+  title.setAttribute("crop", "end");
+  labels.append(title);
+
+  if (tab.groupLabel) {
+    const group = createCompanionElement(
+      document,
+      "label",
+      "zen-split-companion-tab-group-label"
+    );
+    setLabelValue(group, tab.groupLabel);
+    group.setAttribute("crop", "end");
+    labels.append(group);
+  }
+
+  return labels;
+}
+
+function renderTabIndicators(document, tab) {
+  const indicators = createCompanionElement(
+    document,
+    "hbox",
+    "zen-split-companion-tab-indicators"
+  );
+
+  for (const [name, active] of [
+    ["busy", tab.busy || tab.loading],
+    ["pending", tab.pending],
+    ["muted", tab.muted],
+    ["soundplaying", tab.soundPlaying],
+    ["activemedia-blocked", tab.activeMediaBlocked],
+    ["split-view", tab.splitView],
+  ]) {
+    if (!active) {
+      continue;
+    }
+
+    const indicator = createCompanionElement(
+      document,
+      "box",
+      "zen-split-companion-tab-indicator"
+    );
+    indicator.setAttribute("data-zen-indicator", name);
+    indicators.append(indicator);
+  }
+
+  return indicators;
+}
+
+function renderTabRow(document, tab) {
+  const row = createCompanionElement(
+    document,
+    "hbox",
+    "zen-split-companion-tab-row"
+  );
+  row.setAttribute("role", "option");
+  row.setAttribute("aria-selected", tab.selected || tab.active ? "true" : "false");
+  row.tabIndex = -1;
+
+  setDataAttribute(row, "data-zen-tab-id", tab.id);
+  setDataAttribute(row, "data-zen-position", tab.position);
+  setDataAttribute(row, "data-zen-workspace-id", tab.workspaceId);
+  setDataAttribute(row, "data-zen-group-id", tab.groupId);
+  setDataAttribute(row, "data-zen-group-label", tab.groupLabel);
+  setDataAttribute(row, "data-zen-split-view-value", tab.splitViewValue);
+  setDataAttribute(
+    row,
+    "data-zen-split-view-group-id",
+    tab.splitViewGroupId
+  );
+
+  for (const [name, value] of [
+    ["selected", tab.selected],
+    ["active", tab.active],
+    ["pinned", tab.pinned],
+    ["zen-essential", tab.essential],
+    ["data-zen-hidden", tab.hidden],
+    ["closing", tab.closing],
+    ["busy", tab.busy],
+    ["loading", tab.loading],
+    ["pending", tab.pending],
+    ["muted", tab.muted],
+    ["soundplaying", tab.soundPlaying],
+    ["activemedia-blocked", tab.activeMediaBlocked],
+    ["split-view", tab.splitView],
+  ]) {
+    setStateAttribute(row, name, value);
+  }
+
+  row.append(
+    renderTabIcon(document, tab),
+    renderTabLabel(document, tab),
+    renderTabIndicators(document, tab)
+  );
+  return row;
+}
+
+export function renderZenSplitCompanionSnapshot(host, snapshot) {
+  clearZenSplitCompanionSnapshotRender(host);
+  if (!host || !snapshot) {
+    return null;
+  }
+
+  const document = host.ownerDocument;
+  const root = createCompanionElement(
+    document,
+    "vbox",
+    "zen-split-companion-render"
+  );
+  const list = createCompanionElement(
+    document,
+    "vbox",
+    "zen-split-companion-tab-list"
+  );
+  list.setAttribute("role", "listbox");
+  list.setAttribute("aria-readonly", "true");
+
+  for (const tab of snapshot.tabs ?? []) {
+    list.append(renderTabRow(document, tab));
+  }
+
+  root.append(renderWorkspaceHeader(document, snapshot));
+  if (snapshot.workspaces?.length) {
+    root.append(renderWorkspaceList(document, snapshot));
+  }
+  root.append(list);
+  host.append(root);
+  return root;
+}
+
+class nsZenSplitCompanionPane extends nsZenDOMOperatedFeature {
+  #attachedBrowser = null;
+  #attachedWorkspaceManager = null;
+  #clickEventListener = null;
+  #host = null;
+  #keydownEventListener = null;
+  #pendingRefreshFrame = 0;
+  #prefObserver = null;
+  #refreshEventListener = null;
+  #snapshot = null;
+  #tabsProgressListener = null;
+  #workspaceChangeListener = null;
+
+  init() {
+    const host = document.getElementById("zen-split-companion-pane");
+    if (!host) {
+      return;
+    }
+
+    if (this.#prefObserver) {
+      this.#moveClickListenerToHost(host);
+      this.#updateState();
+      return;
+    }
+
+    this.#host = host;
+    this.#prefObserver = this.#updateState.bind(this);
+    for (const pref of Object.values(kPrefs)) {
+      Services.prefs.addObserver(pref, this.#prefObserver);
+    }
+    this.#clickEventListener = this.#handleClick.bind(this);
+    this.#host.addEventListener("click", this.#clickEventListener);
+    this.#keydownEventListener = this.#handleKeyDown.bind(this);
+    this.#host.addEventListener("keydown", this.#keydownEventListener);
+    window.addEventListener("unload", this, { once: true });
+    this.#attachRefreshListeners();
+
+    this.#updateState();
+  }
+
+  #moveClickListenerToHost(host) {
+    if (host === this.#host) {
+      return;
+    }
+
+    if (this.#clickEventListener && this.#host) {
+      this.#host.removeEventListener("click", this.#clickEventListener);
+    }
+    if (this.#keydownEventListener && this.#host) {
+      this.#host.removeEventListener("keydown", this.#keydownEventListener);
+    }
+    this.#host = host;
+    if (this.#clickEventListener) {
+      this.#host.addEventListener("click", this.#clickEventListener);
+    }
+    if (this.#keydownEventListener) {
+      this.#host.addEventListener("keydown", this.#keydownEventListener);
+    }
+  }
+
+  handleEvent(event) {
+    if (event.type === "unload") {
+      this.destroy();
+    }
+  }
+
+  destroy() {
+    if (this.#prefObserver) {
+      for (const pref of Object.values(kPrefs)) {
+        Services.prefs.removeObserver(pref, this.#prefObserver);
+      }
+      this.#prefObserver = null;
+    }
+    window.removeEventListener("unload", this);
+    if (this.#clickEventListener && this.#host) {
+      this.#host.removeEventListener("click", this.#clickEventListener);
+      this.#clickEventListener = null;
+    }
+    if (this.#keydownEventListener && this.#host) {
+      this.#host.removeEventListener("keydown", this.#keydownEventListener);
+      this.#keydownEventListener = null;
+    }
+    this.#detachRefreshListeners();
+    this.#cancelScheduledRefresh();
+    this.#snapshot = null;
+    clearZenSplitCompanionSnapshotRender(this.#host);
+    if (this.#host) {
+      this.#host.hidden = true;
+      this.#host.removeAttribute("zen-split-companion-enabled");
+      this.#host.removeAttribute("zen-split-companion-pane-visible");
+      this.#host.removeAttribute("zen-split-companion-right-web-visible");
+      clearRightWebVisibilityFailure(this.#host);
+    }
+  }
+
+  get snapshot() {
+    return this.#snapshot;
+  }
+
+  buildSnapshot() {
+    this.#snapshot = buildZenSplitCompanionSnapshot();
+    return this.#snapshot;
+  }
+
+  #attachRefreshListeners() {
+    if (this.#refreshEventListener) {
+      return;
+    }
+
+    this.#refreshEventListener = this.#refreshFromSignal.bind(this);
+    for (const eventName of ZEN_SPLIT_COMPANION_REFRESH_EVENTS) {
+      window.addEventListener(eventName, this.#refreshEventListener);
+    }
+
+    this.#workspaceChangeListener = this.#refreshFromSignal.bind(this);
+    const workspaceManager = defaultWorkspaceManager();
+    if (typeof workspaceManager?.addChangeListeners == "function") {
+      workspaceManager.addChangeListeners(this.#workspaceChangeListener);
+      this.#attachedWorkspaceManager = workspaceManager;
+    }
+
+    this.#tabsProgressListener = {
+      onLocationChange: this.#refreshFromSignal.bind(this),
+      onStateChange: this.#refreshFromSignal.bind(this),
+      onLinkIconAvailable: this.#refreshFromSignal.bind(this),
+    };
+    const browser = defaultBrowser();
+    if (typeof browser?.addTabsProgressListener == "function") {
+      browser.addTabsProgressListener(this.#tabsProgressListener);
+      this.#attachedBrowser = browser;
+    }
+  }
+
+  #detachRefreshListeners() {
+    if (this.#refreshEventListener) {
+      for (const eventName of ZEN_SPLIT_COMPANION_REFRESH_EVENTS) {
+        window.removeEventListener(eventName, this.#refreshEventListener);
+      }
+      this.#refreshEventListener = null;
+    }
+
+    if (
+      this.#workspaceChangeListener &&
+      typeof this.#attachedWorkspaceManager?.removeChangeListeners == "function"
+    ) {
+      this.#attachedWorkspaceManager.removeChangeListeners(
+        this.#workspaceChangeListener
+      );
+    }
+    this.#workspaceChangeListener = null;
+    this.#attachedWorkspaceManager = null;
+
+    if (
+      this.#tabsProgressListener &&
+      typeof this.#attachedBrowser?.removeTabsProgressListener == "function"
+    ) {
+      this.#attachedBrowser.removeTabsProgressListener(this.#tabsProgressListener);
+    }
+    this.#tabsProgressListener = null;
+    this.#attachedBrowser = null;
+  }
+
+  #isVisible() {
+    return (
+      !!this.#host &&
+      Services.prefs.getBoolPref(kPrefs.enabled, false) &&
+      Services.prefs.getBoolPref(kPrefs.paneVisible, false)
+    );
+  }
+
+  #refreshFromSignal() {
+    if (!this.#isVisible()) {
+      return;
+    }
+
+    if (this.#pendingRefreshFrame) {
+      return;
+    }
+
+    this.#pendingRefreshFrame = requestAnimationFrame(() => {
+      this.#pendingRefreshFrame = 0;
+      if (!this.#isVisible()) {
+        return;
+      }
+
+      renderZenSplitCompanionSnapshot(this.#host, this.buildSnapshot());
+    });
+  }
+
+  #cancelScheduledRefresh() {
+    if (!this.#pendingRefreshFrame) {
+      return;
+    }
+
+    cancelAnimationFrame(this.#pendingRefreshFrame);
+    this.#pendingRefreshFrame = 0;
+  }
+
+  #handleClick(event) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    const workspaceRow = findCompanionWorkspaceRow(event.target, this.#host);
+    if (workspaceRow) {
+      this.#handleWorkspaceSwitch(workspaceRow);
+      return;
+    }
+
+    const row = findCompanionTabRow(event.target, this.#host);
+    if (!row) {
+      return;
+    }
+
+    const browser = defaultBrowser();
+    const tab = findLiveTabForCompanionRow(row, browser);
+    const viewSplitter = defaultViewSplitter();
+
+    clearSplitActionFailure(row);
+
+    if (!tab) {
+      markSplitActionFailure(row, "tab-not-found");
+      return;
+    }
+
+    if (typeof viewSplitter?.setRightSplitTab != "function") {
+      markSplitActionFailure(row, "split-view-api-unavailable");
+      return;
+    }
+
+    let result;
+    try {
+      result = viewSplitter.setRightSplitTab(tab, {
+        baseTab: readProperty(browser, "selectedTab", null),
+      });
+    } catch (error) {
+      markSplitActionFailure(row, error?.name || "split-action-failed");
+      return;
+    }
+
+    if (result?.ok === false) {
+      markSplitActionFailure(row, result.reason);
+    }
+  }
+
+  #handleKeyDown(event) {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (
+      event.key !== "Enter" &&
+      event.key !== " " &&
+      event.key !== "Spacebar"
+    ) {
+      return;
+    }
+
+    const workspaceRow = findCompanionWorkspaceRow(event.target, this.#host);
+    if (!workspaceRow) {
+      return;
+    }
+
+    event.preventDefault();
+    this.#handleWorkspaceSwitch(workspaceRow);
+  }
+
+  #resolveWorkspaceSwitchFailureRow(row, workspaceId) {
+    const currentRow = findCompanionWorkspaceRowById(workspaceId, this.#host);
+    if (currentRow) {
+      return currentRow;
+    }
+
+    return this.#host?.contains(row) ? row : null;
+  }
+
+  #markWorkspaceSwitchFailure(row, workspaceId, reason) {
+    const failureRow = this.#resolveWorkspaceSwitchFailureRow(row, workspaceId);
+    if (failureRow) {
+      markWorkspaceSwitchFailure(failureRow, reason);
+    }
+  }
+
+  #handleWorkspaceSwitch(row) {
+    clearWorkspaceSwitchFailure(row);
+
+    const workspaceId = readAttribute(row, "data-zen-workspace-id");
+    if (!workspaceId) {
+      markWorkspaceSwitchFailure(row, "workspace-not-found");
+      return;
+    }
+
+    if (row.hasAttribute("data-zen-workspace-active")) {
+      return;
+    }
+
+    const workspaceManager = defaultWorkspaceManager();
+    if (typeof workspaceManager?.changeWorkspaceWithID != "function") {
+      markWorkspaceSwitchFailure(row, "workspace-api-unavailable");
+      return;
+    }
+
+    let result;
+    try {
+      result = workspaceManager.changeWorkspaceWithID(workspaceId, {
+        source: "split-companion-pane",
+      });
+    } catch (error) {
+      this.#markWorkspaceSwitchFailure(
+        row,
+        workspaceId,
+        error?.name || "workspace-switch-failed"
+      );
+      return;
+    }
+
+    Promise.resolve(result)
+      .then(resolved => {
+        if (resolved?.ok === false) {
+          this.#markWorkspaceSwitchFailure(row, workspaceId, resolved.reason);
+        }
+      })
+      .catch(error => {
+        this.#markWorkspaceSwitchFailure(
+          row,
+          workspaceId,
+          error?.name || "workspace-switch-failed"
+        );
+      });
+  }
+
+  #syncRightWebVisibility(rightWebVisible, enabled) {
+    if (!this.#host) {
+      return;
+    }
+
+    if (!enabled) {
+      clearRightWebVisibilityFailure(this.#host);
+      return;
+    }
+
+    const viewSplitter = defaultViewSplitter();
+    if (typeof viewSplitter?.setRightSplitWebVisible != "function") {
+      markRightWebVisibilityFailure(this.#host, "split-view-api-unavailable");
+      return;
+    }
+
+    let result;
+    try {
+      result = viewSplitter.setRightSplitWebVisible(rightWebVisible, {
+        source: "split-companion-pref",
+      });
+    } catch (error) {
+      markRightWebVisibilityFailure(
+        this.#host,
+        error?.name || "right-web-visibility-failed"
+      );
+      return;
+    }
+
+    if (result?.ok === false) {
+      if (result.reason === "missing-active-split") {
+        clearRightWebVisibilityFailure(this.#host);
+        return;
+      }
+      markRightWebVisibilityFailure(this.#host, result.reason);
+      return;
+    }
+
+    clearRightWebVisibilityFailure(this.#host);
+  }
+
+  #updateState() {
+    const enabled = Services.prefs.getBoolPref(kPrefs.enabled, false);
+    const paneVisible = Services.prefs.getBoolPref(kPrefs.paneVisible, false);
+    const rightWebVisible = Services.prefs.getBoolPref(
+      kPrefs.rightWebVisible,
+      false
+    );
+
+    this.#host.toggleAttribute("zen-split-companion-enabled", enabled);
+    this.#host.toggleAttribute(
+      "zen-split-companion-pane-visible",
+      paneVisible
+    );
+    this.#host.toggleAttribute(
+      "zen-split-companion-right-web-visible",
+      rightWebVisible
+    );
+    this.#syncRightWebVisibility(rightWebVisible, enabled);
+
+    const visible = enabled && paneVisible;
+    this.#host.hidden = !visible;
+    if (!visible) {
+      this.#snapshot = null;
+      clearZenSplitCompanionSnapshotRender(this.#host);
+      return;
+    }
+
+    this.#refreshFromSignal();
+  }
+}
+
+window.gZenSplitCompanionPane = new nsZenSplitCompanionPane();

--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -6,6 +6,10 @@
 
 import { nsZenDOMOperatedFeature } from "chrome://browser/content/zen-components/ZenCommonUtils.mjs";
 
+const kZenSplitCompanionEnabledPref = "zen.splitCompanion.enabled";
+const kZenSplitCompanionRightWebVisiblePref =
+  "zen.splitCompanion.rightWeb.visible";
+
 class nsSplitLeafNode {
   /**
    * The percentage of the size of the parent the node takes up, dependent on parent direction this is either
@@ -1375,6 +1379,394 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     }
   }
 
+  #canUseTabForRightSplit(tab) {
+    return (
+      tab &&
+      gBrowser.isTab(tab) &&
+      tab.ownerGlobal === window &&
+      !tab.hidden &&
+      !tab.pinned &&
+      !tab.hasAttribute("zen-empty-tab") &&
+      !tab.hasAttribute("zen-essential") &&
+      !tab.hasAttribute("zen-live-folder-item-id")
+    );
+  }
+
+  #canUseLocalTabForRightSplit(tab) {
+    return (
+      tab &&
+      gBrowser.isTab(tab) &&
+      tab.ownerGlobal === window &&
+      !tab.hidden &&
+      !tab.hasAttribute("zen-empty-tab")
+    );
+  }
+
+  #getSimpleTwoPaneRightLeaf(splitData) {
+    const root = splitData?.layoutTree;
+    if (
+      splitData?.tabs?.length === 2 &&
+      root?.direction === "row" &&
+      root.children?.length === 2 &&
+      root.children.every(child => child?.tab)
+    ) {
+      return root.children[1];
+    }
+    return null;
+  }
+
+  #getRightSplitWebContainerState(tab) {
+    const browser = tab?.linkedBrowser;
+    const container = browser?.closest(".browserSidebarContainer");
+    if (!browser || !container) {
+      return null;
+    }
+    return { browser, container };
+  }
+
+  #setRightSplitWebContainerVisible(tab, visible) {
+    const state = this.#getRightSplitWebContainerState(tab);
+    if (!state) {
+      return false;
+    }
+    const { browser, container } = state;
+
+    browser.zenModeActive = visible;
+    try {
+      browser.docShellIsActive = visible;
+    } catch (error) {
+      console.error(error);
+    }
+
+    if (visible) {
+      container.setAttribute("zen-split", "true");
+      container.addEventListener("dragstart", this.onBrowserDragStart);
+      container.addEventListener("dragend", this.onBrowserDragEnd);
+    } else {
+      container.removeAttribute("zen-split");
+      container.removeEventListener("dragstart", this.onBrowserDragStart);
+      container.removeEventListener("dragend", this.onBrowserDragEnd);
+    }
+
+    return true;
+  }
+
+  #getTargetRightWebVisibility(splitData) {
+    if (Services.prefs.getBoolPref(kZenSplitCompanionEnabledPref, false)) {
+      splitData.rightWebVisible = Services.prefs.getBoolPref(
+        kZenSplitCompanionRightWebVisiblePref,
+        true
+      );
+    }
+    return splitData.rightWebVisible !== false;
+  }
+
+  #applySimpleTwoPaneRightWebVisibility(splitData, visible) {
+    const rightNode = this.#getSimpleTwoPaneRightLeaf(splitData);
+    const leftNode = rightNode?.parent?.children?.[0];
+    if (!rightNode?.tab || !leftNode?.tab) {
+      return false;
+    }
+    if (!this.#getRightSplitWebContainerState(rightNode.tab)) {
+      return false;
+    }
+
+    if (visible) {
+      this.applyGridLayout(splitData.layoutTree);
+      return this.#setRightSplitWebContainerVisible(rightNode.tab, true);
+    }
+
+    leftNode.positionToRoot = { top: 0, bottom: 0, left: 0, right: 0 };
+    this.applyGridLayout(leftNode);
+    this.getSplitters(splitData.layoutTree, 0);
+    this.maybeDisableOpeningTabOnSplitView();
+    return this.#setRightSplitWebContainerVisible(rightNode.tab, false);
+  }
+
+  #replaceSimpleTwoPaneRightTab(splitData, rightNode, tab) {
+    const oldRightTab = rightNode.tab;
+    const leftTab = rightNode.parent?.children?.[0]?.tab;
+    if (!leftTab || !splitData.tabs.includes(leftTab)) {
+      return false;
+    }
+    if (!splitData.tabs.includes(oldRightTab)) {
+      return false;
+    }
+
+    const captureTabVisualState = targetTab => {
+      const container = targetTab.linkedBrowser?.closest(
+        ".browserSidebarContainer"
+      );
+      return {
+        container,
+        isZenSplit: container?.getAttribute("is-zen-split"),
+        zenSplit: container?.getAttribute("zen-split"),
+        style: container?.getAttribute("style"),
+        hasHeader: !!container?.querySelector(
+          ".zen-view-splitter-header-container"
+        ),
+        zenModeActive: targetTab.linkedBrowser.zenModeActive,
+        docShellIsActive: targetTab.linkedBrowser.docShellIsActive,
+      };
+    };
+    const restoreAttribute = (element, name, value) => {
+      if (value === null || value === undefined) {
+        element.removeAttribute(name);
+      } else {
+        element.setAttribute(name, value);
+      }
+    };
+    const restoreTabVisualState = (targetTab, visualState) => {
+      const container =
+        visualState.container ??
+        targetTab.linkedBrowser?.closest(".browserSidebarContainer");
+      if (!container) {
+        return;
+      }
+
+      restoreAttribute(container, "is-zen-split", visualState.isZenSplit);
+      restoreAttribute(container, "zen-split", visualState.zenSplit);
+      restoreAttribute(container, "style", visualState.style);
+      if (!visualState.hasHeader) {
+        this._removeHeader(container);
+      }
+      container.removeEventListener("mousedown", this.handleTabEvent);
+      container.removeEventListener("dragstart", this.onBrowserDragStart);
+      container.removeEventListener("dragend", this.onBrowserDragEnd);
+      targetTab.linkedBrowser.zenModeActive = visualState.zenModeActive;
+      try {
+        targetTab.linkedBrowser.docShellIsActive =
+          visualState.docShellIsActive;
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    const originalState = {
+      tabs: splitData.tabs,
+      rightNodeTab: rightNode.tab,
+      oldRightSplitNode: this._tabToSplitNode.get(oldRightTab),
+      incomingSplitNode: this._tabToSplitNode.get(tab),
+      oldRightGroup: oldRightTab.group,
+      incomingGroup: tab.group,
+      oldRightSplitView: oldRightTab.splitView,
+      oldRightSplitViewValue: oldRightTab.splitViewValue,
+      incomingSplitView: tab.splitView,
+      incomingSplitViewValue: tab.splitViewValue,
+      incomingVisualState: captureTabVisualState(tab),
+      selectedTab: gBrowser.selectedTab,
+    };
+    const restoreSplitValue = (targetTab, splitView, splitViewValue) => {
+      targetTab.splitView = splitView;
+      if (splitViewValue === undefined) {
+        delete targetTab.splitViewValue;
+      } else {
+        targetTab.splitViewValue = splitViewValue;
+      }
+    };
+    const restoreAfterFailure = () => {
+      try {
+        splitData.tabs = originalState.tabs;
+        rightNode.tab = originalState.rightNodeTab;
+
+        if (originalState.oldRightSplitNode) {
+          this._tabToSplitNode.set(
+            oldRightTab,
+            originalState.oldRightSplitNode
+          );
+        } else {
+          this._tabToSplitNode.delete(oldRightTab);
+        }
+        if (originalState.incomingSplitNode) {
+          this._tabToSplitNode.set(tab, originalState.incomingSplitNode);
+        } else {
+          this._tabToSplitNode.delete(tab);
+        }
+
+        if (tab.group !== originalState.incomingGroup) {
+          if (originalState.incomingGroup?.parentNode) {
+            gBrowser.moveTabToExistingGroup(tab, originalState.incomingGroup);
+          } else if (tab.group?.hasAttribute("split-view-group")) {
+            gBrowser.ungroupTab(tab);
+          }
+        }
+        if (
+          oldRightTab.group !== originalState.oldRightGroup &&
+          originalState.oldRightGroup?.parentNode
+        ) {
+          gBrowser.moveTabToExistingGroup(
+            oldRightTab,
+            originalState.oldRightGroup
+          );
+        }
+
+        restoreSplitValue(
+          oldRightTab,
+          originalState.oldRightSplitView,
+          originalState.oldRightSplitViewValue
+        );
+        restoreSplitValue(
+          tab,
+          originalState.incomingSplitView,
+          originalState.incomingSplitViewValue
+        );
+        if (originalState.selectedTab?.parentNode) {
+          gBrowser.selectedTab = originalState.selectedTab;
+        }
+        this.activateSplitView(splitData, true);
+        restoreTabVisualState(tab, originalState.incomingVisualState);
+        if (originalState.selectedTab?.parentNode) {
+          gBrowser.selectedTab = originalState.selectedTab;
+        }
+      } catch (restoreError) {
+        console.error(
+          "Failed to restore right split tab replacement state",
+          restoreError
+        );
+      }
+    };
+
+    try {
+      const splitGroup = oldRightTab.group?.hasAttribute("split-view-group")
+        ? oldRightTab.group
+        : splitData.tabs.find(t => t.group?.hasAttribute("split-view-group"))
+            ?.group;
+      if (!splitGroup) {
+        return false;
+      }
+      if (tab.group !== splitGroup) {
+        gBrowser.moveTabToExistingGroup(tab, splitGroup);
+      }
+
+      splitData.tabs = [leftTab, tab];
+      rightNode.tab = tab;
+      this._tabToSplitNode.delete(oldRightTab);
+      this._tabToSplitNode.set(tab, rightNode);
+
+      gBrowser.selectedTab = tab;
+      this.activateSplitView(splitData, true);
+
+      this.resetTabState(oldRightTab, false);
+      if (oldRightTab.group?.hasAttribute("split-view-group")) {
+        gBrowser.ungroupTab(oldRightTab);
+        this.#dispatchItemEvent("ZenTabRemovedFromSplit", oldRightTab);
+      }
+      this.#dispatchItemEvent("ZenSplitViewTabsSplit", splitGroup);
+      return true;
+    } catch (error) {
+      console.error("Failed to replace right split tab", error);
+      restoreAfterFailure();
+      return false;
+    }
+  }
+
+  /**
+   * Creates or activates a right-side split tab without exposing split internals.
+   *
+   * @param {Tab} tab - The tab to place or focus in the right split slot.
+   * @param {object} options - Additional options.
+   * @param {Tab} options.baseTab - The tab to keep on the left when creating a split.
+   * @returns {object} A result object describing the action taken or why it failed.
+   */
+  setRightSplitTab(tab, options = {}) {
+    const { baseTab = gBrowser.selectedTab } = options ?? {};
+
+    const activeGroup =
+      this.currentView >= 0 ? this._data[this.currentView] : null;
+    if (this.currentView >= 0 && !activeGroup) {
+      return { ok: false, reason: "missing-active-split" };
+    }
+
+    if (activeGroup) {
+      if (!this.#canUseLocalTabForRightSplit(tab)) {
+        return { ok: false, reason: "invalid-tab" };
+      }
+
+      const rightNode = this.#getSimpleTwoPaneRightLeaf(activeGroup);
+      if (!rightNode) {
+        return { ok: false, reason: "complex-layout" };
+      }
+
+      const rightTab = rightNode.tab;
+      if (tab !== rightTab) {
+        if (activeGroup.tabs.includes(tab)) {
+          return { ok: false, reason: "not-right-split-tab" };
+        }
+        if (!this.#canUseTabForRightSplit(rightTab)) {
+          return { ok: false, reason: "invalid-right-split-tab" };
+        }
+        if (!this.#canUseTabForRightSplit(tab) || tab.splitView) {
+          return { ok: false, reason: "invalid-tab" };
+        }
+        const didReplace = this.#replaceSimpleTwoPaneRightTab(
+          activeGroup,
+          rightNode,
+          tab
+        );
+        if (!didReplace) {
+          return { ok: false, reason: "replace-failed" };
+        }
+        return { ok: true, action: "replaced" };
+      }
+
+      gBrowser.selectedTab = rightTab;
+      this.activateSplitView(activeGroup, true);
+      return { ok: true, action: "activated" };
+    }
+
+    if (!this.#canUseTabForRightSplit(tab)) {
+      return { ok: false, reason: "invalid-tab" };
+    }
+
+    if (
+      !this.#canUseTabForRightSplit(baseTab) ||
+      baseTab === tab ||
+      baseTab.splitView ||
+      tab.splitView
+    ) {
+      return { ok: false, reason: "invalid-base-tab" };
+    }
+
+    const splitData = this.splitTabs([baseTab, tab], "vsep", 1);
+    if (!splitData) {
+      return { ok: false, reason: "split-failed" };
+    }
+    return { ok: true, action: "created" };
+  }
+
+  /**
+   * Shows or hides the current simple two-pane split's right web page.
+   *
+   * @param {boolean} visible - Whether the right web page should be visible.
+   * @returns {object} A result object describing the action taken or why it failed.
+   */
+  setRightSplitWebVisible(visible, _options = {}) {
+    const activeGroup =
+      this.currentView >= 0 ? this._data[this.currentView] : null;
+    if (!activeGroup) {
+      return { ok: false, reason: "missing-active-split" };
+    }
+
+    const rightNode = this.#getSimpleTwoPaneRightLeaf(activeGroup);
+    if (!rightNode) {
+      return { ok: false, reason: "complex-layout" };
+    }
+
+    const rightTab = rightNode.tab;
+    if (!rightTab) {
+      return { ok: false, reason: "missing-right-tab" };
+    }
+
+    const shouldShow = !!visible;
+    if (
+      !this.#applySimpleTwoPaneRightWebVisibility(activeGroup, shouldShow)
+    ) {
+      return { ok: false, reason: "missing-right-container" };
+    }
+
+    activeGroup.rightWebVisible = shouldShow;
+    return { ok: true, action: shouldShow ? "shown" : "hidden" };
+  }
+
   /**
    * Splits the given tabs.
    *
@@ -1570,6 +1962,9 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
 
     this.applyGridLayout(splitData.layoutTree);
     this.setTabsDocShellState(splitData.tabs, true);
+    if (!this.#getTargetRightWebVisibility(splitData)) {
+      this.#applySimpleTwoPaneRightWebVisibility(splitData, false);
+    }
     this.toggleWrapperDisplay(true);
     window.dispatchEvent(new CustomEvent("ZenViewSplitter:SplitViewActivated"));
   }
@@ -1749,7 +2144,10 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
    */
   getSplitters(parentNode, splittersNeeded) {
     let currentSplitters = this._splitNodeToSplitters.get(parentNode) || [];
-    if (!splittersNeeded || currentSplitters.length === splittersNeeded) {
+    if (
+      splittersNeeded == null ||
+      currentSplitters.length === splittersNeeded
+    ) {
       return currentSplitters;
     }
     for (let i = currentSplitters?.length || 0; i < splittersNeeded; i++) {

--- a/src/zen/split-view/jar.inc.mn
+++ b/src/zen/split-view/jar.inc.mn
@@ -3,4 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 *       content/browser/zen-styles/zen-split-view.css                           (../../zen/split-view/zen-split-view.css)
+        content/browser/zen-styles/zen-split-companion-pane.css                 (../../zen/split-view/zen-split-companion-pane.css)
         content/browser/zen-components/ZenViewSplitter.mjs                      (../../zen/split-view/ZenViewSplitter.mjs)
+        content/browser/zen-components/ZenSplitCompanionPane.mjs                (../../zen/split-view/ZenSplitCompanionPane.mjs)

--- a/src/zen/split-view/zen-split-companion-pane.css
+++ b/src/zen/split-view/zen-split-companion-pane.css
@@ -1,0 +1,254 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#zen-split-companion-pane {
+  display: flex;
+  flex: 0 0 var(--zen-split-companion-pane-width, 220px);
+  min-width: 0;
+  max-width: min(320px, 35vw);
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+#zen-split-companion-pane[hidden] {
+  display: none;
+}
+
+.zen-split-companion-render {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: var(--tab-block-margin, 2px);
+  gap: var(--tab-block-margin, 2px);
+  color: inherit;
+  background: transparent;
+  overflow: hidden;
+}
+
+.zen-split-companion-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 26px;
+  padding-inline: 8px 6px;
+  color: var(--toolbar-color);
+  opacity: 0.72;
+}
+
+.zen-split-companion-workspace-title,
+.zen-split-companion-tab-count,
+.zen-split-companion-tab-title,
+.zen-split-companion-tab-group-label {
+  min-width: 0;
+  margin: 0;
+}
+
+.zen-split-companion-workspace-title {
+  font-weight: 600;
+}
+
+.zen-split-companion-tab-count {
+  font-variant-numeric: tabular-nums;
+}
+
+.zen-split-companion-workspace-list {
+  display: flex;
+  flex: 0 0 auto;
+  max-height: 96px;
+  min-height: 0;
+  padding: 0 4px 2px;
+  overflow: hidden auto;
+}
+
+.zen-split-companion-workspace-row {
+  --zen-split-companion-workspace-bg: transparent;
+
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 24px;
+  margin: 1px 0;
+  padding-inline: 6px;
+  gap: 6px;
+  border-radius: var(--border-radius-small, 6px);
+  background: var(--zen-split-companion-workspace-bg);
+  color: inherit;
+  cursor: default;
+  user-select: none;
+}
+
+.zen-split-companion-workspace-row:hover {
+  --zen-split-companion-workspace-bg: var(
+    --tab-hover-background-color,
+    var(--zen-toolbar-element-bg)
+  );
+}
+
+.zen-split-companion-workspace-row[data-zen-workspace-active] {
+  --zen-split-companion-workspace-bg: var(
+    --tab-selected-bgcolor,
+    var(--zen-toolbar-element-bg)
+  );
+  font-weight: 600;
+}
+
+.zen-split-companion-workspace-row[data-zen-workspace-switch-failed] {
+  outline: 1px solid var(--warning-color, var(--zen-colors-border-contrast));
+  outline-offset: -1px;
+}
+
+.zen-split-companion-workspace-icon {
+  flex: 0 0 16px;
+  max-width: 16px;
+  text-align: center;
+}
+
+.zen-split-companion-workspace-name {
+  flex: 1;
+  min-width: 0;
+}
+
+.zen-split-companion-tab-list {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden auto;
+}
+
+.zen-split-companion-tab-row {
+  --zen-split-companion-row-bg: transparent;
+
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: var(--tab-min-height, 36px);
+  margin: var(--tab-block-margin, 2px);
+  padding-inline: 8px 6px;
+  gap: 8px;
+  border-radius: var(--border-radius-medium, var(--tab-border-radius, 8px));
+  background: var(--zen-split-companion-row-bg);
+  color: inherit;
+  cursor: default;
+  opacity: 1;
+  user-select: none;
+}
+
+.zen-split-companion-tab-row:hover {
+  --zen-split-companion-row-bg: var(
+    --tab-hover-background-color,
+    var(--zen-toolbar-element-bg)
+  );
+}
+
+.zen-split-companion-tab-row[selected],
+.zen-split-companion-tab-row[active] {
+  --zen-split-companion-row-bg: var(
+    --tab-selected-bgcolor,
+    var(--zen-toolbar-element-bg)
+  );
+  box-shadow: var(--tab-selected-shadow, none);
+}
+
+.zen-split-companion-tab-row[data-zen-hidden],
+.zen-split-companion-tab-row[closing] {
+  opacity: 0.48;
+}
+
+.zen-split-companion-tab-row[split-view] {
+  outline: 1px solid var(--zen-colors-border-contrast);
+  outline-offset: -1px;
+}
+
+.zen-split-companion-tab-row[zen-essential] {
+  min-height: var(--zen-split-companion-essential-height, 32px);
+  background: var(--zen-toolbar-element-bg);
+}
+
+.zen-split-companion-tab-icon-stack {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  position: relative;
+}
+
+.zen-split-companion-tab-icon {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  -moz-context-properties: fill, stroke, fill-opacity;
+  fill-opacity: 0.5;
+}
+
+.zen-split-companion-tab-icon-stack[icon-placeholder="true"]::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  background: color-mix(
+    in srgb,
+    var(--zen-primary-color) 72%,
+    light-dark(rgb(0, 0, 0), rgb(255, 255, 255))
+  );
+  opacity: 0.42;
+}
+
+.zen-split-companion-tab-labels {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.zen-split-companion-tab-title {
+  color: inherit;
+}
+
+.zen-split-companion-tab-group-label {
+  color: color-mix(in srgb, currentColor 68%, transparent);
+  font-size: 0.86em;
+}
+
+.zen-split-companion-tab-indicators {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  gap: 4px;
+}
+
+.zen-split-companion-tab-indicator {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, currentColor 55%, transparent);
+}
+
+.zen-split-companion-tab-indicator[data-zen-indicator="busy"],
+.zen-split-companion-tab-indicator[data-zen-indicator="pending"] {
+  background: var(--zen-primary-color);
+}
+
+.zen-split-companion-tab-indicator[data-zen-indicator="soundplaying"] {
+  background: var(--success-color, var(--zen-primary-color));
+}
+
+.zen-split-companion-tab-indicator[data-zen-indicator="muted"],
+.zen-split-companion-tab-indicator[data-zen-indicator="activemedia-blocked"] {
+  background: var(--warning-color, var(--zen-primary-color));
+}
+
+.zen-split-companion-tab-indicator[data-zen-indicator="split-view"] {
+  width: 10px;
+  border-radius: 999px;
+  background: var(--zen-colors-border-contrast);
+}

--- a/src/zen/split-view/zen-split-view.css
+++ b/src/zen/split-view/zen-split-view.css
@@ -7,6 +7,7 @@
 /** Zen Decks - ONLY USED FOR SPLIT VIEWS, DO NOT USE THIS CLASS FOR ANY OTHER PURPOSE **/
 
 %include zen-split-group.inc.css
+%include zen-split-companion-pane.css
 
 #tabbrowser-tabpanels[zen-split-view="true"] {
   display: flex;

--- a/src/zen/tests/split_view/browser.toml
+++ b/src/zen/tests/split_view/browser.toml
@@ -18,6 +18,10 @@ support-files = [
 
 ["browser_split_view_empty.js"]
 
+["browser_split_view_set_right_tab.js"]
+
+["browser_split_view_right_web_visibility.js"]
+
 ["browser_split_view_with_folders.js"]
 
 ["browser_split_view_with_glance.js"]

--- a/src/zen/tests/split_view/browser_split_view_right_web_visibility.js
+++ b/src/zen/tests/split_view/browser_split_view_right_web_visibility.js
@@ -1,0 +1,480 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+function getRightWebContainer(tab) {
+  return tab.linkedBrowser?.closest(".browserSidebarContainer");
+}
+
+function getActiveSplitters() {
+  return [...document.querySelectorAll(".zen-split-view-splitter")].filter(
+    splitter => splitter.isConnected
+  );
+}
+
+function assertSimpleRightWebHiddenLayout(leftTab, rightTab, message) {
+  const leftContainer = getRightWebContainer(leftTab);
+  const rightContainer = getRightWebContainer(rightTab);
+
+  Assert.deepEqual(
+    {
+      top: leftContainer.style.top,
+      right: leftContainer.style.right,
+      bottom: leftContainer.style.bottom,
+      left: leftContainer.style.left,
+    },
+    { top: "0%", right: "0%", bottom: "0%", left: "0%" },
+    `${message}: the left web pane should fill the split web area`
+  );
+  Assert.ok(
+    !rightContainer.hasAttribute("zen-split"),
+    `${message}: the hidden right container should not be in the visible split layout`
+  );
+  Assert.equal(
+    getActiveSplitters().length,
+    0,
+    `${message}: hidden right slot should not leave active splitters`
+  );
+}
+
+function captureSimpleRightWebLayout(leftTab, rightTab) {
+  const leftContainer = getRightWebContainer(leftTab);
+  const rightContainer = getRightWebContainer(rightTab);
+  return {
+    leftStyle: {
+      top: leftContainer.style.top,
+      right: leftContainer.style.right,
+      bottom: leftContainer.style.bottom,
+      left: leftContainer.style.left,
+    },
+    rightStyle: {
+      top: rightContainer.style.top,
+      right: rightContainer.style.right,
+      bottom: rightContainer.style.bottom,
+      left: rightContainer.style.left,
+    },
+    rightContainerZenSplit: rightContainer.hasAttribute("zen-split"),
+    activeSplitterCount: getActiveSplitters().length,
+  };
+}
+
+function assertSimpleRightWebLayoutPreserved(
+  state,
+  leftTab,
+  rightTab,
+  message
+) {
+  Assert.deepEqual(
+    captureSimpleRightWebLayout(leftTab, rightTab),
+    state,
+    `${message}: split web layout should be preserved`
+  );
+}
+
+function captureRightWebState(baseTab, rightTab, extraTabs = []) {
+  const rightContainer = getRightWebContainer(rightTab);
+  const inspectedTabs = [...new Set([baseTab, rightTab, ...extraTabs])];
+  return {
+    currentView: gZenViewSplitter.currentView,
+    group: rightTab.group,
+    groupTabs: [...(rightTab.group?.tabs ?? [])],
+    selectedTab: gBrowser.selectedTab,
+    splitViewBrowsers: [...gZenViewSplitter.splitViewBrowsers],
+    tabStates: new Map(
+      inspectedTabs.map(tab => [
+        tab,
+        {
+          splitView: tab.splitView,
+          splitViewValue: tab.splitViewValue,
+          group: tab.group,
+        },
+      ])
+    ),
+    rightContainer,
+    rightContainerIsZenSplit: rightContainer?.hasAttribute("is-zen-split"),
+    rightContainerZenSplit: rightContainer?.hasAttribute("zen-split"),
+    rightContainerStyle: rightContainer?.getAttribute("style") ?? "",
+    rightZenModeActive: rightTab.linkedBrowser.zenModeActive,
+    rightDocShellIsActive: rightTab.linkedBrowser.docShellIsActive,
+  };
+}
+
+function assertRightWebMembershipPreserved(state, message) {
+  Assert.equal(
+    gZenViewSplitter.currentView,
+    state.currentView,
+    `${message}: active split view should stay active`
+  );
+  Assert.strictEqual(
+    gBrowser.selectedTab,
+    state.selectedTab,
+    `${message}: selected tab should be preserved`
+  );
+  Assert.deepEqual(
+    gZenViewSplitter.splitViewBrowsers,
+    state.splitViewBrowsers,
+    `${message}: split browser order should be preserved`
+  );
+  Assert.deepEqual(
+    state.group?.tabs ?? [],
+    state.groupTabs,
+    `${message}: split group tabs should be preserved`
+  );
+  for (const [tab, tabState] of state.tabStates) {
+    Assert.strictEqual(
+      tab.group,
+      tabState.group,
+      `${message}: ${tab.label} group should be preserved`
+    );
+    Assert.equal(
+      tab.splitView,
+      tabState.splitView,
+      `${message}: ${tab.label} split-view state should be preserved`
+    );
+    Assert.equal(
+      tab.splitViewValue,
+      tabState.splitViewValue,
+      `${message}: ${tab.label} split-view value should be preserved`
+    );
+  }
+}
+
+add_task(async function test_right_web_visibility_api_fails_closed_when_right_container_missing() {
+  const [baseTab, rightTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(9)),
+    addTabTo(gBrowser, getUrlForNthTab(10)),
+  ]);
+
+  try {
+    await createSplitView([baseTab, rightTab], "vsep");
+    const shownState = captureRightWebState(baseTab, rightTab);
+    const shownLayout = captureSimpleRightWebLayout(baseTab, rightTab);
+    const rightBrowser = rightTab.linkedBrowser;
+    const originalClosest = rightBrowser.closest;
+    let result;
+    try {
+      rightBrowser.closest = function(selector) {
+        if (selector === ".browserSidebarContainer") {
+          return null;
+        }
+        return originalClosest.call(this, selector);
+      };
+      result = gZenViewSplitter.setRightSplitWebVisible(false);
+    } finally {
+      rightBrowser.closest = originalClosest;
+    }
+
+    Assert.deepEqual(
+      result,
+      { ok: false, reason: "missing-right-container" },
+      "Missing right container should fail closed"
+    );
+    assertRightWebMembershipPreserved(
+      shownState,
+      "Failing with a missing right container"
+    );
+    assertSimpleRightWebLayoutPreserved(
+      shownLayout,
+      baseTab,
+      rightTab,
+      "Failing with a missing right container"
+    );
+    Assert.equal(
+      rightTab.linkedBrowser.zenModeActive,
+      shownState.rightZenModeActive,
+      "Failing with a missing right container should not change Zen mode"
+    );
+    Assert.equal(
+      rightTab.linkedBrowser.docShellIsActive,
+      shownState.rightDocShellIsActive,
+      "Failing with a missing right container should not change docshell state"
+    );
+  } finally {
+    for (const tab of [rightTab, baseTab]) {
+      if (tab.parentNode) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});
+
+add_task(async function test_right_web_visibility_api_hides_and_shows_right_page() {
+  const [baseTab, rightTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(1)),
+    addTabTo(gBrowser, getUrlForNthTab(2)),
+  ]);
+
+  try {
+    await createSplitView([baseTab, rightTab], "vsep");
+    gBrowser.selectedTab = rightTab;
+
+    const shownState = captureRightWebState(baseTab, rightTab);
+    Assert.ok(
+      shownState.rightContainerZenSplit,
+      "The right web container should start visible in split view"
+    );
+    Assert.ok(
+      shownState.rightZenModeActive,
+      "The right web docshell should start in Zen active mode"
+    );
+    Assert.ok(
+      shownState.rightDocShellIsActive,
+      "The right web docshell should start active"
+    );
+
+    const hideResult = gZenViewSplitter.setRightSplitWebVisible(false);
+    Assert.deepEqual(
+      hideResult,
+      { ok: true, action: "hidden" },
+      "Hiding should return a structured success"
+    );
+    assertRightWebMembershipPreserved(
+      shownState,
+      "Hiding the right web page"
+    );
+
+    const hiddenContainer = getRightWebContainer(rightTab);
+    assertSimpleRightWebHiddenLayout(
+      baseTab,
+      rightTab,
+      "Hiding the right web page"
+    );
+    Assert.ok(
+      hiddenContainer.hasAttribute("is-zen-split"),
+      "Hiding should keep the right container associated with split view"
+    );
+    Assert.ok(
+      !hiddenContainer.hasAttribute("zen-split"),
+      "Hiding should remove the right container from the visible split layout"
+    );
+    Assert.equal(
+      rightTab.linkedBrowser.zenModeActive,
+      false,
+      "Hiding should deactivate Zen mode for the right docshell"
+    );
+    Assert.equal(
+      rightTab.linkedBrowser.docShellIsActive,
+      false,
+      "Hiding should deactivate the right docshell"
+    );
+
+    const hiddenState = captureRightWebState(baseTab, rightTab);
+    const showResult = gZenViewSplitter.setRightSplitWebVisible(true);
+    Assert.deepEqual(
+      showResult,
+      { ok: true, action: "shown" },
+      "Showing should return a structured success"
+    );
+    assertRightWebMembershipPreserved(
+      hiddenState,
+      "Showing the right web page"
+    );
+
+    const restoredContainer = getRightWebContainer(rightTab);
+    Assert.ok(
+      restoredContainer.hasAttribute("zen-split"),
+      "Showing should restore the right container to the visible split layout"
+    );
+    Assert.equal(
+      restoredContainer.getAttribute("style") ?? "",
+      shownState.rightContainerStyle,
+      "Showing should preserve the right container layout style"
+    );
+    Assert.equal(
+      getActiveSplitters().length,
+      1,
+      "Showing should restore the simple two-pane splitter"
+    );
+    Assert.equal(
+      rightTab.linkedBrowser.zenModeActive,
+      true,
+      "Showing should reactivate Zen mode for the right docshell"
+    );
+    Assert.equal(
+      rightTab.linkedBrowser.docShellIsActive,
+      true,
+      "Showing should reactivate the right docshell"
+    );
+  } finally {
+    for (const tab of [rightTab, baseTab]) {
+      if (tab.parentNode) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});
+
+add_task(async function test_right_web_visibility_api_is_idempotent_for_repeated_visibility() {
+  const [baseTab, rightTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(11)),
+    addTabTo(gBrowser, getUrlForNthTab(12)),
+  ]);
+
+  try {
+    await createSplitView([baseTab, rightTab], "vsep");
+
+    Assert.deepEqual(
+      gZenViewSplitter.setRightSplitWebVisible(false),
+      { ok: true, action: "hidden" },
+      "First hide should return a structured success"
+    );
+    const hiddenState = captureRightWebState(baseTab, rightTab);
+    const hiddenLayout = captureSimpleRightWebLayout(baseTab, rightTab);
+    Assert.deepEqual(
+      gZenViewSplitter.setRightSplitWebVisible(false),
+      { ok: true, action: "hidden" },
+      "Repeated hide should return the same structured success"
+    );
+    assertRightWebMembershipPreserved(hiddenState, "Repeated hide");
+    assertSimpleRightWebLayoutPreserved(
+      hiddenLayout,
+      baseTab,
+      rightTab,
+      "Repeated hide"
+    );
+
+    Assert.deepEqual(
+      gZenViewSplitter.setRightSplitWebVisible(true),
+      { ok: true, action: "shown" },
+      "First show should return a structured success"
+    );
+    const shownState = captureRightWebState(baseTab, rightTab);
+    const shownLayout = captureSimpleRightWebLayout(baseTab, rightTab);
+    Assert.deepEqual(
+      gZenViewSplitter.setRightSplitWebVisible(true),
+      { ok: true, action: "shown" },
+      "Repeated show should return the same structured success"
+    );
+    assertRightWebMembershipPreserved(shownState, "Repeated show");
+    assertSimpleRightWebLayoutPreserved(
+      shownLayout,
+      baseTab,
+      rightTab,
+      "Repeated show"
+    );
+  } finally {
+    for (const tab of [rightTab, baseTab]) {
+      if (tab.parentNode) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});
+
+add_task(async function test_right_web_pref_hidden_before_split_creation_applies_to_new_split() {
+  const [baseTab, rightTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(7)),
+    addTabTo(gBrowser, getUrlForNthTab(8)),
+  ]);
+
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["zen.splitCompanion.enabled", true],
+      ["zen.splitCompanion.rightWeb.visible", false],
+    ],
+  });
+
+  try {
+    gZenViewSplitter.deactivateCurrentSplitView();
+    await createSplitView([baseTab, rightTab], "vsep");
+
+    assertSimpleRightWebHiddenLayout(
+      baseTab,
+      rightTab,
+      "Creating a split after the right web pref was hidden"
+    );
+    Assert.equal(
+      rightTab.linkedBrowser.zenModeActive,
+      false,
+      "Creating a split should apply the pref-hidden Zen mode state"
+    );
+    Assert.equal(
+      rightTab.linkedBrowser.docShellIsActive,
+      false,
+      "Creating a split should apply the pref-hidden docshell state"
+    );
+  } finally {
+    await SpecialPowers.popPrefEnv();
+    for (const tab of [rightTab, baseTab]) {
+      if (tab.parentNode) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});
+
+add_task(async function test_right_web_visibility_api_rejects_missing_and_complex_splits() {
+  const [soloTab, baseTab, rightTab, thirdTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(3)),
+    addTabTo(gBrowser, getUrlForNthTab(4)),
+    addTabTo(gBrowser, getUrlForNthTab(5)),
+    addTabTo(gBrowser, getUrlForNthTab(6)),
+  ]);
+
+  try {
+    gZenViewSplitter.deactivateCurrentSplitView();
+    gBrowser.selectedTab = soloTab;
+    const soloState = {
+      selectedTab: gBrowser.selectedTab,
+      currentView: gZenViewSplitter.currentView,
+      containerZenSplit: getRightWebContainer(soloTab)?.hasAttribute(
+        "zen-split"
+      ),
+      zenModeActive: soloTab.linkedBrowser.zenModeActive,
+      docShellIsActive: soloTab.linkedBrowser.docShellIsActive,
+    };
+
+    Assert.deepEqual(
+      gZenViewSplitter.setRightSplitWebVisible(false),
+      { ok: false, reason: "missing-active-split" },
+      "Hiding without an active split should fail closed"
+    );
+    Assert.deepEqual(
+      {
+        selectedTab: gBrowser.selectedTab,
+        currentView: gZenViewSplitter.currentView,
+        containerZenSplit: getRightWebContainer(soloTab)?.hasAttribute(
+          "zen-split"
+        ),
+        zenModeActive: soloTab.linkedBrowser.zenModeActive,
+        docShellIsActive: soloTab.linkedBrowser.docShellIsActive,
+      },
+      soloState,
+      "Failing without an active split should not mutate tab or container state"
+    );
+
+    await createSplitView([baseTab, rightTab, thirdTab], "grid");
+    const complexState = captureRightWebState(baseTab, rightTab, [thirdTab]);
+    Assert.deepEqual(
+      gZenViewSplitter.setRightSplitWebVisible(false),
+      { ok: false, reason: "complex-layout" },
+      "Complex layouts should fail closed"
+    );
+    assertRightWebMembershipPreserved(
+      complexState,
+      "Rejecting a complex layout"
+    );
+    Assert.equal(
+      getRightWebContainer(rightTab)?.hasAttribute("zen-split"),
+      complexState.rightContainerZenSplit,
+      "Rejecting a complex layout should not change right container visibility"
+    );
+    Assert.equal(
+      rightTab.linkedBrowser.zenModeActive,
+      complexState.rightZenModeActive,
+      "Rejecting a complex layout should not change Zen docshell state"
+    );
+    Assert.equal(
+      rightTab.linkedBrowser.docShellIsActive,
+      complexState.rightDocShellIsActive,
+      "Rejecting a complex layout should not change docshell active state"
+    );
+  } finally {
+    for (const tab of [thirdTab, rightTab, baseTab, soloTab]) {
+      if (tab.parentNode) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});

--- a/src/zen/tests/split_view/browser_split_view_set_right_tab.js
+++ b/src/zen/tests/split_view/browser_split_view_set_right_tab.js
@@ -1,0 +1,1019 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+function getTabContainer(tab) {
+  return tab.linkedBrowser?.closest(".browserSidebarContainer");
+}
+
+function captureTabContainerState(tab) {
+  const container = getTabContainer(tab);
+  return {
+    isZenSplit: container?.hasAttribute("is-zen-split"),
+    zenSplit: container?.hasAttribute("zen-split"),
+    headerCount: container?.querySelectorAll(
+      ".zen-view-splitter-header-container"
+    ).length,
+    style: container?.getAttribute("style") ?? "",
+    zenModeActive: tab.linkedBrowser.zenModeActive,
+    docShellIsActive: tab.linkedBrowser.docShellIsActive,
+  };
+}
+
+function captureSplitState(anchorTab, extraTabs = []) {
+  const group = anchorTab.group;
+  const inspectedTabs = [...new Set([...(group?.tabs ?? []), ...extraTabs])];
+  return {
+    selectedTab: gBrowser.selectedTab,
+    splitViewBrowsers: [...gZenViewSplitter.splitViewBrowsers],
+    group,
+    groupTabs: [...(group?.tabs ?? [])],
+    tabContainerStates: new Map(
+      inspectedTabs.map(tab => [tab, captureTabContainerState(tab)])
+    ),
+    tabBrowserPanelSplitView:
+      gZenViewSplitter.tabBrowserPanel.hasAttribute("zen-split-view"),
+    tabboxSplitView: document
+      .getElementById("tabbrowser-tabbox")
+      ?.hasAttribute("zen-split-view"),
+    splitterCount: document.querySelectorAll(".zen-split-view-splitter")
+      .length,
+  };
+}
+
+function assertSplitStateUnchanged(state, message) {
+  Assert.strictEqual(
+    gBrowser.selectedTab,
+    state.selectedTab,
+    `${message}: selected tab should not change`
+  );
+  Assert.deepEqual(
+    gZenViewSplitter.splitViewBrowsers,
+    state.splitViewBrowsers,
+    `${message}: split browsers should not change`
+  );
+  Assert.strictEqual(
+    state.groupTabs[0]?.group,
+    state.group,
+    `${message}: split group should stay attached`
+  );
+  Assert.deepEqual(
+    state.group?.tabs ?? [],
+    state.groupTabs,
+    `${message}: split group tabs should not change`
+  );
+  for (const [tab, containerState] of state.tabContainerStates) {
+    Assert.deepEqual(
+      captureTabContainerState(tab),
+      containerState,
+      `${message}: ${tab.label} container and docshell state should not change`
+    );
+  }
+  Assert.equal(
+    gZenViewSplitter.tabBrowserPanel.hasAttribute("zen-split-view"),
+    state.tabBrowserPanelSplitView,
+    `${message}: tab browser panel split state should not change`
+  );
+  Assert.equal(
+    document
+      .getElementById("tabbrowser-tabbox")
+      ?.hasAttribute("zen-split-view"),
+    state.tabboxSplitView,
+    `${message}: tabbox split state should not change`
+  );
+  Assert.equal(
+    document.querySelectorAll(".zen-split-view-splitter").length,
+    state.splitterCount,
+    `${message}: splitters should not be added or removed`
+  );
+}
+
+add_task(async function test_set_right_split_tab_creates_vertical_split() {
+  const [baseTab, rightTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(1)),
+    addTabTo(gBrowser, getUrlForNthTab(2)),
+  ]);
+
+  try {
+    gBrowser.selectedTab = baseTab;
+
+    const activationPromise = BrowserTestUtils.waitForEvent(
+      window,
+      "ZenViewSplitter:SplitViewActivated"
+    );
+    const result = gZenViewSplitter.setRightSplitTab(rightTab, { baseTab });
+    await activationPromise;
+
+    Assert.equal(result?.ok, true, "The right tab should be accepted");
+    Assert.equal(result?.action, "created", "A new split should be created");
+    Assert.strictEqual(
+      gBrowser.selectedTab,
+      rightTab,
+      "The requested right tab should be selected"
+    );
+    Assert.deepEqual(
+      gZenViewSplitter.splitViewBrowsers,
+      [baseTab.linkedBrowser, rightTab.linkedBrowser],
+      "The split browsers should keep the base tab on the left and target tab on the right"
+    );
+    Assert.equal(
+      rightTab.group.tabs.length,
+      2,
+      "The split group should contain exactly the two split tabs"
+    );
+  } finally {
+    for (const tab of [rightTab, baseTab]) {
+      await BrowserTestUtils.removeTab(tab);
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_activates_existing_split_tab() {
+  const [baseTab, rightTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(1)),
+    addTabTo(gBrowser, getUrlForNthTab(2)),
+  ]);
+
+  try {
+    await createSplitView([baseTab, rightTab], "vsep");
+    gBrowser.selectedTab = baseTab;
+
+    const activationPromise = BrowserTestUtils.waitForEvent(
+      window,
+      "ZenViewSplitter:SplitViewActivated"
+    );
+    const result = gZenViewSplitter.setRightSplitTab(rightTab);
+    await activationPromise;
+
+    Assert.equal(result?.ok, true, "The existing split tab should be accepted");
+    Assert.equal(
+      result?.action,
+      "activated",
+      "The existing split tab should be activated"
+    );
+    Assert.strictEqual(
+      gBrowser.selectedTab,
+      rightTab,
+      "The requested split tab should be selected"
+    );
+    Assert.equal(
+      rightTab.group.tabs.length,
+      2,
+      "The split group should not gain duplicate tabs"
+    );
+    Assert.deepEqual(
+      gZenViewSplitter.splitViewBrowsers,
+      [baseTab.linkedBrowser, rightTab.linkedBrowser],
+      "The split browsers should stay in their original order"
+    );
+  } finally {
+    for (const tab of [rightTab, baseTab]) {
+      await BrowserTestUtils.removeTab(tab);
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_replaces_existing_right_split_tab() {
+  const [baseTab, oldRightTab, newRightTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(1)),
+    addTabTo(gBrowser, getUrlForNthTab(2)),
+    addTabTo(gBrowser, getUrlForNthTab(3)),
+  ]);
+
+  try {
+    await createSplitView([baseTab, oldRightTab], "vsep");
+    gBrowser.selectedTab = baseTab;
+
+    const activationPromise = BrowserTestUtils.waitForEvent(
+      window,
+      "ZenViewSplitter:SplitViewActivated"
+    );
+    const result = gZenViewSplitter.setRightSplitTab(newRightTab);
+
+    Assert.equal(
+      result?.ok,
+      true,
+      "The outside tab should replace the simple split right tab"
+    );
+    Assert.equal(
+      result?.action,
+      "replaced",
+      "The result should describe a right-slot replacement"
+    );
+    if (result?.ok) {
+      await activationPromise;
+    }
+
+    Assert.strictEqual(
+      gBrowser.selectedTab,
+      newRightTab,
+      "The replacement right tab should be selected"
+    );
+    Assert.deepEqual(
+      gZenViewSplitter.splitViewBrowsers,
+      [baseTab.linkedBrowser, newRightTab.linkedBrowser],
+      "The split browsers should keep the base tab on the left and replacement tab on the right"
+    );
+    Assert.strictEqual(
+      gZenViewSplitter.splitViewBrowsers[1],
+      newRightTab.linkedBrowser,
+      "The replacement tab should occupy the right split browser slot"
+    );
+    Assert.equal(
+      newRightTab.splitView,
+      true,
+      "The replacement right tab should enter split view state"
+    );
+    Assert.equal(
+      newRightTab.splitViewValue,
+      baseTab.splitViewValue,
+      "The replacement right tab should share the active split view value"
+    );
+    Assert.strictEqual(
+      newRightTab.group,
+      baseTab.group,
+      "The replacement right tab should join the base tab split group"
+    );
+    Assert.ok(
+      newRightTab.group?.hasAttribute("split-view-group"),
+      "The replacement right tab should be in a split tab group"
+    );
+    Assert.equal(
+      oldRightTab.splitView,
+      false,
+      "The previous right tab should leave split view state"
+    );
+    Assert.ok(
+      !oldRightTab.group?.hasAttribute("split-view-group"),
+      "The previous right tab should leave the split tab group"
+    );
+    Assert.equal(
+      newRightTab.group.tabs.length,
+      2,
+      "The split group should still contain exactly two tabs"
+    );
+  } finally {
+    for (const tab of [newRightTab, oldRightTab, baseTab]) {
+      if (tab?.parentNode) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_replacement_event_sees_final_state() {
+  const [baseTab, oldRightTab, newRightTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(1)),
+    addTabTo(gBrowser, getUrlForNthTab(2)),
+    addTabTo(gBrowser, getUrlForNthTab(3)),
+  ]);
+
+  try {
+    await createSplitView([baseTab, oldRightTab], "vsep");
+    gBrowser.selectedTab = baseTab;
+    const splitGroup = baseTab.group;
+    let eventState = null;
+
+    splitGroup.addEventListener(
+      "ZenSplitViewTabsSplit",
+      event => {
+        eventState = {
+          item: event.detail?.item,
+          selectedTab: gBrowser.selectedTab,
+          splitViewBrowsers: [...gZenViewSplitter.splitViewBrowsers],
+          newRightSplitView: newRightTab.splitView,
+          newRightSplitViewValue: newRightTab.splitViewValue,
+          oldRightSplitView: oldRightTab.splitView,
+          newRightGroup: newRightTab.group,
+        };
+      },
+      { once: true }
+    );
+
+    const activationPromise = BrowserTestUtils.waitForEvent(
+      window,
+      "ZenViewSplitter:SplitViewActivated"
+    );
+    const result = gZenViewSplitter.setRightSplitTab(newRightTab);
+
+    Assert.equal(result?.ok, true, "The replacement should succeed");
+    if (result?.ok) {
+      await activationPromise;
+    }
+
+    Assert.ok(eventState, "Replacing the right split tab should dispatch");
+    Assert.strictEqual(
+      eventState.item,
+      splitGroup,
+      "The split event should identify the updated split group"
+    );
+    Assert.strictEqual(
+      eventState.selectedTab,
+      newRightTab,
+      "Split event observers should see the replacement tab selected"
+    );
+    Assert.deepEqual(
+      eventState.splitViewBrowsers,
+      [baseTab.linkedBrowser, newRightTab.linkedBrowser],
+      "Split event observers should see the replacement tab in the right slot"
+    );
+    Assert.equal(
+      eventState.newRightSplitView,
+      true,
+      "Split event observers should see the replacement tab in split view"
+    );
+    Assert.equal(
+      eventState.newRightSplitViewValue,
+      baseTab.splitViewValue,
+      "Split event observers should see the final split view value"
+    );
+    Assert.equal(
+      eventState.oldRightSplitView,
+      false,
+      "Split event observers should see the previous right tab reset"
+    );
+    Assert.strictEqual(
+      eventState.newRightGroup,
+      splitGroup,
+      "Split event observers should see the replacement tab in the split group"
+    );
+  } finally {
+    for (const tab of [newRightTab, oldRightTab, baseTab]) {
+      if (tab?.parentNode) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_reports_replace_dependency_failure_without_mutation() {
+  const [baseTab, rightTab, replacementTab, existingGroupTab] =
+    await Promise.all([
+      addTabTo(gBrowser, getUrlForNthTab(1)),
+      addTabTo(gBrowser, getUrlForNthTab(2)),
+      addTabTo(gBrowser, getUrlForNthTab(3)),
+      addTabTo(gBrowser, getUrlForNthTab(4)),
+    ]);
+  const originalMoveTabToExistingGroup = gBrowser.moveTabToExistingGroup;
+
+  try {
+    const replacementOriginalGroup = gBrowser.addTabGroup(
+      [replacementTab, existingGroupTab],
+      { color: "blue", insertBefore: replacementTab }
+    );
+    Assert.ok(
+      replacementOriginalGroup,
+      "The incoming tab should start in a regular tab group"
+    );
+    await createSplitView([baseTab, rightTab], "vsep");
+    gBrowser.selectedTab = baseTab;
+    const replacementOriginalPinned = replacementTab.pinned;
+    const replacementOriginalSplitView = replacementTab.splitView;
+    const state = captureSplitState(baseTab, [replacementTab]);
+
+    gBrowser.moveTabToExistingGroup = function () {
+      throw new Error("Expected replacement dependency failure");
+    };
+
+    const result = gZenViewSplitter.setRightSplitTab(replacementTab);
+
+    Assert.equal(
+      result?.ok,
+      false,
+      "A replacement dependency failure should be reported instead of thrown"
+    );
+    Assert.equal(
+      result?.reason,
+      "replace-failed",
+      "The failure should identify a failed replacement dependency step"
+    );
+    assertSplitStateUnchanged(
+      state,
+      "Failing a replacement dependency before state mutation"
+    );
+    Assert.strictEqual(
+      replacementTab.group,
+      replacementOriginalGroup,
+      "Failing replacement should not move the incoming tab to another group"
+    );
+    Assert.equal(
+      replacementTab.pinned,
+      replacementOriginalPinned,
+      "Failing replacement should not change incoming tab pin state"
+    );
+    Assert.equal(
+      replacementTab.splitView,
+      replacementOriginalSplitView,
+      "Failing replacement should not put the incoming tab in split view"
+    );
+  } finally {
+    gBrowser.moveTabToExistingGroup = originalMoveTabToExistingGroup;
+    const tabsToRemove = new Set([
+      ...(baseTab.group?.tabs ?? []),
+      replacementTab,
+      existingGroupTab,
+      rightTab,
+      baseTab,
+    ]);
+    for (const tab of tabsToRemove) {
+      if (tab?.parentNode) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_reports_replace_post_staging_failure_without_mutation() {
+  const [baseTab, rightTab, replacementTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(1)),
+    addTabTo(gBrowser, getUrlForNthTab(2)),
+    addTabTo(gBrowser, getUrlForNthTab(3)),
+  ]);
+  const originalResetTabState = gZenViewSplitter.resetTabState;
+
+  try {
+    await createSplitView([baseTab, rightTab], "vsep");
+    gBrowser.selectedTab = baseTab;
+    const replacementOriginalSplitView = replacementTab.splitView;
+    const state = captureSplitState(baseTab, [replacementTab]);
+
+    gZenViewSplitter.resetTabState = function (tab, forUnsplit) {
+      if (tab === rightTab) {
+        throw new Error("Expected replacement post-staging failure");
+      }
+      return originalResetTabState.call(this, tab, forUnsplit);
+    };
+
+    const result = gZenViewSplitter.setRightSplitTab(replacementTab);
+
+    Assert.equal(
+      result?.ok,
+      false,
+      "A replacement post-staging failure should be reported instead of thrown"
+    );
+    Assert.equal(
+      result?.reason,
+      "replace-failed",
+      "The failure should identify a failed replacement step"
+    );
+    assertSplitStateUnchanged(
+      state,
+      "Failing replacement after state staging"
+    );
+    Assert.notStrictEqual(
+      replacementTab.group,
+      state.group,
+      "Failing replacement should not leave the incoming tab in the split group"
+    );
+    Assert.equal(
+      replacementTab.splitView,
+      replacementOriginalSplitView,
+      "Failing replacement should not put the incoming tab in split view"
+    );
+  } finally {
+    gZenViewSplitter.resetTabState = originalResetTabState;
+    const tabsToRemove = new Set([
+      ...(baseTab.group?.tabs ?? []),
+      replacementTab,
+      rightTab,
+      baseTab,
+    ]);
+    for (const tab of tabsToRemove) {
+      if (tab?.parentNode) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_rejects_complex_layout_without_mutation() {
+  const [baseTab, rightTab, thirdTab, replacementTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(1)),
+    addTabTo(gBrowser, getUrlForNthTab(2)),
+    addTabTo(gBrowser, getUrlForNthTab(3)),
+    addTabTo(gBrowser, getUrlForNthTab(4)),
+  ]);
+
+  try {
+    await createSplitView([baseTab, rightTab, thirdTab], "grid");
+    gBrowser.selectedTab = baseTab;
+    const replacementOriginalSplitView = replacementTab.splitView;
+    const state = captureSplitState(baseTab);
+
+    const result = gZenViewSplitter.setRightSplitTab(replacementTab);
+
+    Assert.equal(
+      result?.ok,
+      false,
+      "A non-two-pane split should not accept right-slot replacement"
+    );
+    Assert.equal(
+      result?.reason,
+      "complex-layout",
+      "The failure should identify complex split layouts"
+    );
+    assertSplitStateUnchanged(state, "Rejecting a complex layout replacement");
+    Assert.equal(
+      replacementTab.splitView,
+      replacementOriginalSplitView,
+      "Rejecting replacement should not put the outside tab in split view"
+    );
+    Assert.notStrictEqual(
+      replacementTab.group,
+      state.group,
+      "Rejecting replacement should not move the outside tab into the split group"
+    );
+    Assert.equal(
+      replacementTab.pinned,
+      false,
+      "Rejecting replacement should not change the outside tab pin state"
+    );
+  } finally {
+    const tabsToRemove = new Set([
+      ...(baseTab.group?.tabs ?? []),
+      replacementTab,
+      thirdTab,
+      rightTab,
+      baseTab,
+    ]);
+    for (const tab of tabsToRemove) {
+      if (tab?.parentNode) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_activates_existing_pinned_right_tab() {
+  const [baseTab, rightTab, replacementTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(1)),
+    addTabTo(gBrowser, getUrlForNthTab(2)),
+    addTabTo(gBrowser, getUrlForNthTab(3)),
+  ]);
+
+  try {
+    const pinBaseEvent = BrowserTestUtils.waitForEvent(baseTab, "TabPinned");
+    const pinRightEvent = BrowserTestUtils.waitForEvent(rightTab, "TabPinned");
+    gBrowser.pinTab(baseTab);
+    gBrowser.pinTab(rightTab);
+    await Promise.all([pinBaseEvent, pinRightEvent]);
+
+    await createSplitView([baseTab, rightTab], "vsep");
+    gBrowser.selectedTab = baseTab;
+
+    const activationPromise = BrowserTestUtils.waitForEvent(
+      window,
+      "ZenViewSplitter:SplitViewActivated"
+    );
+    const result = gZenViewSplitter.setRightSplitTab(rightTab);
+    await activationPromise;
+
+    Assert.equal(
+      result?.ok,
+      true,
+      "The pinned right split tab should be accepted once it is already in the active split"
+    );
+    Assert.equal(
+      result?.action,
+      "activated",
+      "The pinned right split tab should be activated"
+    );
+    Assert.strictEqual(
+      gBrowser.selectedTab,
+      rightTab,
+      "The requested pinned right tab should be selected"
+    );
+
+    const replacementResult =
+      gZenViewSplitter.setRightSplitTab(replacementTab);
+
+    Assert.equal(
+      replacementResult?.ok,
+      false,
+      "An outside tab should not replace an existing pinned right split tab"
+    );
+    Assert.equal(
+      replacementResult?.reason,
+      "invalid-right-split-tab",
+      "The failure should identify that the current right slot is not replaceable"
+    );
+    Assert.strictEqual(
+      gBrowser.selectedTab,
+      rightTab,
+      "Rejecting replacement should not change the selected tab"
+    );
+    Assert.deepEqual(
+      gZenViewSplitter.splitViewBrowsers,
+      [baseTab.linkedBrowser, rightTab.linkedBrowser],
+      "The pinned right split tab should remain in the right slot"
+    );
+    Assert.equal(
+      replacementTab.pinned,
+      false,
+      "Rejecting replacement should not transfer pinned policy to the outside tab"
+    );
+  } finally {
+    const tabsToRemove = new Set([
+      ...(baseTab.group?.tabs ?? []),
+      replacementTab,
+      rightTab,
+      baseTab,
+    ]);
+    for (const tab of tabsToRemove) {
+      if (tab?.parentNode) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_rejects_protected_incoming_tabs_without_mutation() {
+  const protectedCases = [
+    {
+      name: "pinned",
+      async apply(tab) {
+        const pinEvent = BrowserTestUtils.waitForEvent(tab, "TabPinned");
+        gBrowser.pinTab(tab);
+        await pinEvent;
+      },
+      async cleanup(tab) {
+        if (!tab.pinned) {
+          return;
+        }
+        const unpinEvent = BrowserTestUtils.waitForEvent(tab, "TabUnpinned");
+        gBrowser.unpinTab(tab);
+        await unpinEvent;
+      },
+    },
+    {
+      name: "zen-empty-tab",
+      apply(tab) {
+        tab.setAttribute("zen-empty-tab", "true");
+      },
+      cleanup(tab) {
+        tab.removeAttribute("zen-empty-tab");
+      },
+    },
+    {
+      name: "hidden",
+      apply(tab) {
+        gBrowser.hideTab(tab);
+      },
+      cleanup(tab) {
+        gBrowser.showTab(tab);
+      },
+    },
+    {
+      name: "essential",
+      apply(tab) {
+        tab.setAttribute("zen-essential", "true");
+      },
+      cleanup(tab) {
+        tab.removeAttribute("zen-essential");
+      },
+    },
+    {
+      name: "live-folder",
+      apply(tab) {
+        tab.setAttribute("zen-live-folder-item-id", "test-live-folder-item");
+      },
+      cleanup(tab) {
+        tab.removeAttribute("zen-live-folder-item-id");
+      },
+    },
+    {
+      name: "already-split-view",
+      apply(tab) {
+        tab.splitView = true;
+        tab.splitViewValue = "test-split-view";
+      },
+      cleanup(tab) {
+        tab.splitView = false;
+        delete tab.splitViewValue;
+      },
+    },
+  ];
+
+  for (const protectedCase of protectedCases) {
+    const [baseTab, rightTab, incomingTab] = await Promise.all([
+      addTabTo(gBrowser, getUrlForNthTab(1)),
+      addTabTo(gBrowser, getUrlForNthTab(2)),
+      addTabTo(gBrowser, getUrlForNthTab(3)),
+    ]);
+
+    try {
+      await createSplitView([baseTab, rightTab], "vsep");
+      gBrowser.selectedTab = baseTab;
+      await protectedCase.apply(incomingTab);
+      const incomingOriginalPinned = incomingTab.pinned;
+      const incomingOriginalSplitView = incomingTab.splitView;
+      const state = captureSplitState(baseTab);
+
+      const result = gZenViewSplitter.setRightSplitTab(incomingTab);
+
+      Assert.equal(
+        result?.ok,
+        false,
+        `A ${protectedCase.name} incoming tab should not replace the right slot`
+      );
+      Assert.equal(
+        result?.reason,
+        "invalid-tab",
+        `The ${protectedCase.name} incoming tab failure should identify an invalid tab`
+      );
+      assertSplitStateUnchanged(
+        state,
+        `Rejecting ${protectedCase.name} incoming tab replacement`
+      );
+      Assert.equal(
+        incomingTab.splitView,
+        incomingOriginalSplitView,
+        `Rejecting a ${protectedCase.name} incoming tab should not put it in split view`
+      );
+      Assert.notStrictEqual(
+        incomingTab.group,
+        state.group,
+        `Rejecting a ${protectedCase.name} incoming tab should not move it into the split group`
+      );
+      Assert.equal(
+        incomingTab.pinned,
+        incomingOriginalPinned,
+        `Rejecting a ${protectedCase.name} incoming tab should preserve its pin state`
+      );
+    } finally {
+      await protectedCase.cleanup(incomingTab);
+      const tabsToRemove = new Set([
+        ...(baseTab.group?.tabs ?? []),
+        incomingTab,
+        rightTab,
+        baseTab,
+      ]);
+      for (const tab of tabsToRemove) {
+        if (tab?.parentNode) {
+          await BrowserTestUtils.removeTab(tab);
+        }
+      }
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_rejects_invalid_base_tab_creation_inputs() {
+  const invalidBaseCases = [
+    {
+      name: "null",
+      baseTab(_baseTab, _rightTab) {
+        return null;
+      },
+    },
+    {
+      name: "same-as-right",
+      baseTab(_baseTab, rightTab) {
+        return rightTab;
+      },
+    },
+    {
+      name: "pinned",
+      async apply(baseTab) {
+        const pinEvent = BrowserTestUtils.waitForEvent(baseTab, "TabPinned");
+        gBrowser.pinTab(baseTab);
+        await pinEvent;
+      },
+      async cleanup(baseTab) {
+        if (!baseTab.pinned) {
+          return;
+        }
+        const unpinEvent = BrowserTestUtils.waitForEvent(
+          baseTab,
+          "TabUnpinned"
+        );
+        gBrowser.unpinTab(baseTab);
+        await unpinEvent;
+      },
+    },
+    {
+      name: "zen-empty-tab",
+      apply(baseTab) {
+        baseTab.setAttribute("zen-empty-tab", "true");
+      },
+      cleanup(baseTab) {
+        baseTab.removeAttribute("zen-empty-tab");
+      },
+    },
+    {
+      name: "already-split-view",
+      apply(baseTab) {
+        baseTab.splitView = true;
+        baseTab.splitViewValue = "test-base-split-view";
+      },
+      cleanup(baseTab) {
+        baseTab.splitView = false;
+        delete baseTab.splitViewValue;
+      },
+    },
+  ];
+
+  for (const invalidBaseCase of invalidBaseCases) {
+    const [baseTab, rightTab] = await Promise.all([
+      addTabTo(gBrowser, getUrlForNthTab(1)),
+      addTabTo(gBrowser, getUrlForNthTab(2)),
+    ]);
+
+    try {
+      gBrowser.selectedTab = baseTab;
+      await invalidBaseCase.apply?.(baseTab, rightTab);
+      const requestedBaseTab = invalidBaseCase.baseTab
+        ? invalidBaseCase.baseTab(baseTab, rightTab)
+        : baseTab;
+      const selectedTab = gBrowser.selectedTab;
+
+      const result = gZenViewSplitter.setRightSplitTab(rightTab, {
+        baseTab: requestedBaseTab,
+      });
+
+      Assert.equal(
+        result?.ok,
+        false,
+        `A ${invalidBaseCase.name} base tab should not create a split`
+      );
+      Assert.equal(
+        result?.reason,
+        "invalid-base-tab",
+        `The ${invalidBaseCase.name} base tab failure should be reported`
+      );
+      Assert.strictEqual(
+        gBrowser.selectedTab,
+        selectedTab,
+        `Rejecting a ${invalidBaseCase.name} base tab should not change selection`
+      );
+      Assert.ok(
+        !rightTab.splitView,
+        `Rejecting a ${invalidBaseCase.name} base tab should not split the right tab`
+      );
+      Assert.deepEqual(
+        gZenViewSplitter.splitViewBrowsers,
+        [],
+        `Rejecting a ${invalidBaseCase.name} base tab should not create split browsers`
+      );
+    } finally {
+      await invalidBaseCase.cleanup?.(baseTab, rightTab);
+      for (const tab of [rightTab, baseTab]) {
+        if (tab?.parentNode) {
+          await BrowserTestUtils.removeTab(tab);
+        }
+      }
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_rejects_protected_current_right_slot_without_mutation() {
+  const protectedCases = [
+    {
+      name: "hidden",
+      apply(tab) {
+        gBrowser.hideTab(tab);
+      },
+      cleanup(tab) {
+        gBrowser.showTab(tab);
+      },
+    },
+    {
+      name: "essential",
+      apply(tab) {
+        tab.setAttribute("zen-essential", "true");
+      },
+      cleanup(tab) {
+        tab.removeAttribute("zen-essential");
+      },
+    },
+    {
+      name: "live-folder",
+      apply(tab) {
+        tab.setAttribute("zen-live-folder-item-id", "test-live-folder-item");
+      },
+      cleanup(tab) {
+        tab.removeAttribute("zen-live-folder-item-id");
+      },
+    },
+  ];
+
+  for (const protectedCase of protectedCases) {
+    const [baseTab, rightTab, replacementTab] = await Promise.all([
+      addTabTo(gBrowser, getUrlForNthTab(1)),
+      addTabTo(gBrowser, getUrlForNthTab(2)),
+      addTabTo(gBrowser, getUrlForNthTab(3)),
+    ]);
+
+    try {
+      await createSplitView([baseTab, rightTab], "vsep");
+      gBrowser.selectedTab = baseTab;
+      protectedCase.apply(rightTab);
+      const replacementOriginalSplitView = replacementTab.splitView;
+      const state = captureSplitState(baseTab);
+
+      const result = gZenViewSplitter.setRightSplitTab(replacementTab);
+
+      Assert.equal(
+        result?.ok,
+        false,
+        `A ${protectedCase.name} current right slot should not be replaced`
+      );
+      Assert.equal(
+        result?.reason,
+        "invalid-right-split-tab",
+        `The ${protectedCase.name} current right slot failure should identify an invalid right slot`
+      );
+      assertSplitStateUnchanged(
+        state,
+        `Rejecting replacement of a ${protectedCase.name} current right slot`
+      );
+      Assert.equal(
+        replacementTab.splitView,
+        replacementOriginalSplitView,
+        `Rejecting replacement of a ${protectedCase.name} current right slot should not put the outside tab in split view`
+      );
+      Assert.notStrictEqual(
+        replacementTab.group,
+        state.group,
+        `Rejecting replacement of a ${protectedCase.name} current right slot should not move the outside tab into the split group`
+      );
+      Assert.equal(
+        replacementTab.pinned,
+        false,
+        `Rejecting replacement of a ${protectedCase.name} current right slot should not change the outside tab pin state`
+      );
+    } finally {
+      protectedCase.cleanup(rightTab);
+      const tabsToRemove = new Set([
+        ...(baseTab.group?.tabs ?? []),
+        replacementTab,
+        rightTab,
+        baseTab,
+      ]);
+      for (const tab of tabsToRemove) {
+        if (tab?.parentNode) {
+          await BrowserTestUtils.removeTab(tab);
+        }
+      }
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_rejects_left_split_tab() {
+  const [baseTab, rightTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(1)),
+    addTabTo(gBrowser, getUrlForNthTab(2)),
+  ]);
+
+  try {
+    await createSplitView([baseTab, rightTab], "vsep");
+    gBrowser.selectedTab = rightTab;
+
+    const result = gZenViewSplitter.setRightSplitTab(baseTab);
+
+    Assert.equal(result?.ok, false, "The left tab should not be accepted");
+    Assert.equal(
+      result?.reason,
+      "not-right-split-tab",
+      "The failure should identify that the target is not the right split tab"
+    );
+    Assert.strictEqual(
+      gBrowser.selectedTab,
+      rightTab,
+      "Rejecting the left tab should not change the selected tab"
+    );
+  } finally {
+    for (const tab of [rightTab, baseTab]) {
+      await BrowserTestUtils.removeTab(tab);
+    }
+  }
+});
+
+add_task(async function test_set_right_split_tab_accepts_null_options() {
+  const [baseTab, rightTab] = await Promise.all([
+    addTabTo(gBrowser, getUrlForNthTab(1)),
+    addTabTo(gBrowser, getUrlForNthTab(2)),
+  ]);
+
+  try {
+    gBrowser.selectedTab = baseTab;
+
+    const activationPromise = BrowserTestUtils.waitForEvent(
+      window,
+      "ZenViewSplitter:SplitViewActivated"
+    );
+    const result = gZenViewSplitter.setRightSplitTab(rightTab, null);
+    await activationPromise;
+
+    Assert.equal(result?.ok, true, "Null options should be treated as empty");
+    Assert.equal(result?.action, "created", "A new split should be created");
+    Assert.strictEqual(
+      gBrowser.selectedTab,
+      rightTab,
+      "The requested right tab should be selected"
+    );
+  } finally {
+    for (const tab of [rightTab, baseTab]) {
+      await BrowserTestUtils.removeTab(tab);
+    }
+  }
+});

--- a/src/zen/tests/tabs/browser.toml
+++ b/src/zen/tests/tabs/browser.toml
@@ -17,6 +17,16 @@ tags = [
 
 ["browser_tabs_cycle_by_attribute.js"]
 
+["browser_tabs_split_companion_inert.js"]
+
+["browser_tabs_split_companion_model.js"]
+
+["browser_tabs_split_companion_click.js"]
+
+["browser_tabs_split_companion_workspace.js"]
+
+["browser_tabs_split_companion_sync.js"]
+
 ["browser_tabs_empty_checks.js"]
 
 ["browser_tabs_fetch_checks.js"]

--- a/src/zen/tests/tabs/browser_tabs_split_companion_click.js
+++ b/src/zen/tests/tabs/browser_tabs_split_companion_click.js
@@ -1,0 +1,329 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+async function pushCompanionClickPrefs() {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["zen.splitCompanion.enabled", true],
+      ["zen.splitCompanion.pane.visible", true],
+      ["zen.splitCompanion.rightWeb.visible", true],
+    ],
+  });
+}
+
+function nextCompanionClickRefreshFrame() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+function fakeCompanionClickTab(attributes = {}, properties = {}) {
+  const attrs = new Map(Object.entries(attributes));
+  return {
+    ...properties,
+    hasAttribute(name) {
+      return attrs.has(name);
+    },
+    getAttribute(name) {
+      return attrs.get(name) ?? null;
+    },
+  };
+}
+
+async function withRenderedCompanionRows(splitterResult, task) {
+  const companionPane = window.gZenSplitCompanionPane;
+  const originalBrowser = window.gBrowser;
+  const originalWorkspaceManager = window.gZenWorkspaces;
+  const originalSplitter = window.gZenViewSplitter;
+  let pushedPrefEnv = false;
+  const baseTab = fakeCompanionClickTab(
+    {
+      linkedpanel: "base-panel",
+    },
+    {
+      label: "Base tab",
+      _tPos: 0,
+    }
+  );
+  const rightTab = fakeCompanionClickTab(
+    {
+      linkedpanel: "right-panel",
+    },
+    {
+      label: "Right candidate",
+      _tPos: 1,
+    }
+  );
+  const calls = [];
+  let selectedTabValue = baseTab;
+  let selectedTabSetCount = 0;
+  const browser = {
+    tabs: [baseTab, rightTab],
+    get selectedTab() {
+      return selectedTabValue;
+    },
+    set selectedTab(tab) {
+      selectedTabSetCount++;
+      selectedTabValue = tab;
+    },
+  };
+  const splitter = {
+    setRightSplitTab(tab, options) {
+      calls.push({ tab, options });
+      return splitterResult;
+    },
+  };
+
+  try {
+    companionPane.destroy();
+    window.gBrowser = browser;
+    window.gZenWorkspaces = null;
+    window.gZenViewSplitter = splitter;
+
+    await pushCompanionClickPrefs();
+    pushedPrefEnv = true;
+    companionPane.init();
+    await nextCompanionClickRefreshFrame();
+
+    const host = document.getElementById("zen-split-companion-pane");
+    await task({
+      baseTab,
+      calls,
+      host,
+      rightTab,
+      selectedTabSetCount: () => selectedTabSetCount,
+      selectedTabValue: () => selectedTabValue,
+    });
+  } finally {
+    companionPane.destroy();
+    if (pushedPrefEnv) {
+      await SpecialPowers.popPrefEnv();
+    }
+    window.gBrowser = originalBrowser;
+    window.gZenWorkspaces = originalWorkspaceManager;
+    window.gZenViewSplitter = originalSplitter;
+    companionPane.init();
+  }
+}
+
+add_task(async function test_Split_Companion_Click_Delegates_To_Right_Split_API() {
+  await withRenderedCompanionRows({ ok: true, action: "set-right-tab" }, async ({
+    baseTab,
+    calls,
+    host,
+    rightTab,
+    selectedTabSetCount,
+    selectedTabValue,
+  }) => {
+    const row = host.querySelector('[data-zen-tab-id="right-panel"]');
+    ok(row, "Companion pane should render the right candidate row");
+
+    EventUtils.synthesizeMouseAtCenter(row, {});
+
+    is(
+      calls.length,
+      1,
+      "Clicking a companion row should call the Split View right-tab API once"
+    );
+    is(
+      calls[0].tab,
+      rightTab,
+      "Companion row identity should resolve back to the live tab"
+    );
+    is(
+      calls[0].options?.baseTab,
+      baseTab,
+      "Companion row clicks should pass the currently selected tab as API context"
+    );
+    is(
+      selectedTabSetCount(),
+      0,
+      "Companion click handling should not assign gBrowser.selectedTab directly"
+    );
+    is(
+      selectedTabValue(),
+      baseTab,
+      "Companion click handling should leave browser selection unchanged"
+    );
+    ok(
+      !row.hasAttribute("data-zen-split-action-failed"),
+      "Successful companion actions should not mark the row as failed"
+    );
+    ok(
+      !row.hasAttribute("data-zen-split-action-error"),
+      "Successful companion actions should not leave an error reason"
+    );
+  });
+});
+
+add_task(async function test_Split_Companion_Click_Failure_Stays_Companion_Owned() {
+  await withRenderedCompanionRows(
+    { ok: false, reason: "right-split-unavailable" },
+    async ({
+      baseTab,
+      calls,
+      host,
+      rightTab,
+      selectedTabSetCount,
+      selectedTabValue,
+    }) => {
+      const row = host.querySelector('[data-zen-tab-id="right-panel"]');
+      ok(row, "Companion pane should render the right candidate row");
+
+      EventUtils.synthesizeMouseAtCenter(row, {});
+
+      is(
+        calls.length,
+        1,
+        "Failing companion row clicks should still delegate to the Split View API"
+      );
+      is(
+        calls[0].tab,
+        rightTab,
+        "Failure handling should use the live tab resolved from row identity"
+      );
+      is(
+        selectedTabSetCount(),
+        0,
+        "Failure handling should not assign gBrowser.selectedTab directly"
+      );
+      is(
+        selectedTabValue(),
+        baseTab,
+        "Failure handling should leave browser selection unchanged"
+      );
+      ok(
+        row.hasAttribute("data-zen-split-action-failed"),
+        "Failure handling should mark companion-owned row state only"
+      );
+      is(
+        row.getAttribute("data-zen-split-action-error"),
+        "right-split-unavailable",
+        "Failure handling should expose the API reason on companion-owned DOM"
+      );
+      ok(
+        !row.hasAttribute("selected"),
+        "Failure handling should not make the candidate row selected"
+      );
+      is(
+        row.getAttribute("aria-selected"),
+        "false",
+        "Failure handling should not change the rendered selection state"
+      );
+    }
+  );
+});
+
+add_task(async function test_Split_Companion_Click_Requires_Stable_Row_Identity() {
+  await withRenderedCompanionRows({ ok: true, action: "set-right-tab" }, async ({
+    baseTab,
+    calls,
+    host,
+    selectedTabSetCount,
+    selectedTabValue,
+  }) => {
+    const row = host.querySelector('[data-zen-tab-id="right-panel"]');
+    ok(row, "Companion pane should render the right candidate row");
+
+    row.setAttribute("data-zen-tab-id", "stale-panel");
+    EventUtils.synthesizeMouseAtCenter(row, {});
+
+    is(
+      calls.length,
+      0,
+      "A stale stable row identity should not fall back to row position"
+    );
+    is(
+      row.getAttribute("data-zen-split-action-error"),
+      "tab-not-found",
+      "A stale stable row identity should mark a companion-owned not-found failure"
+    );
+    is(
+      selectedTabSetCount(),
+      0,
+      "A stale stable row identity should not assign gBrowser.selectedTab"
+    );
+    is(
+      selectedTabValue(),
+      baseTab,
+      "A stale stable row identity should leave browser selection unchanged"
+    );
+    ok(
+      !row.hasAttribute("selected"),
+      "A stale stable row identity should not select the companion row"
+    );
+    is(
+      row.getAttribute("aria-selected"),
+      "false",
+      "A stale stable row identity should leave rendered selection state unchanged"
+    );
+
+    row.removeAttribute("data-zen-tab-id");
+    EventUtils.synthesizeMouseAtCenter(row, {});
+
+    is(
+      calls.length,
+      0,
+      "A missing stable row identity should not fall back to row position"
+    );
+    is(
+      row.getAttribute("data-zen-split-action-error"),
+      "tab-not-found",
+      "A missing stable row identity should mark a companion-owned not-found failure"
+    );
+    is(
+      selectedTabSetCount(),
+      0,
+      "A missing stable row identity should not assign gBrowser.selectedTab"
+    );
+    is(
+      selectedTabValue(),
+      baseTab,
+      "A missing stable row identity should leave browser selection unchanged"
+    );
+  });
+});
+
+add_task(async function test_Split_Companion_Click_Listener_Moves_To_Replaced_Host() {
+  await withRenderedCompanionRows({ ok: true, action: "set-right-tab" }, async ({
+    calls,
+    host,
+    rightTab,
+  }) => {
+    const originalHost = host;
+    const staleRow = originalHost.querySelector('[data-zen-tab-id="right-panel"]');
+    const replacementHost = originalHost.cloneNode(true);
+
+    ok(staleRow, "Original companion host should have a rendered row");
+    originalHost.replaceWith(replacementHost);
+    window.gZenSplitCompanionPane.init();
+    await nextCompanionClickRefreshFrame();
+
+    staleRow.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 })
+    );
+    is(
+      calls.length,
+      0,
+      "Reinitializing with a replaced host should detach the old click listener"
+    );
+
+    const replacementRow = replacementHost.querySelector(
+      '[data-zen-tab-id="right-panel"]'
+    );
+    ok(replacementRow, "Replacement companion host should have a rendered row");
+
+    EventUtils.synthesizeMouseAtCenter(replacementRow, {});
+
+    is(
+      calls.length,
+      1,
+      "Reinitializing with a replaced host should attach the current click listener"
+    );
+    is(
+      calls[0].tab,
+      rightTab,
+      "Replacement host clicks should delegate using the live tab identity"
+    );
+  });
+});

--- a/src/zen/tests/tabs/browser_tabs_split_companion_inert.js
+++ b/src/zen/tests/tabs/browser_tabs_split_companion_inert.js
@@ -1,0 +1,266 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const COMPANION_PREFS = [
+  "zen.splitCompanion.enabled",
+  "zen.splitCompanion.pane.visible",
+  "zen.splitCompanion.rightWeb.visible",
+];
+
+async function setCompanionPrefs(enabled, paneVisible, rightWebVisible) {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["zen.splitCompanion.enabled", enabled],
+      ["zen.splitCompanion.pane.visible", paneVisible],
+      ["zen.splitCompanion.rightWeb.visible", rightWebVisible],
+    ],
+  });
+}
+
+function nextCompanionRefreshFrame() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+add_task(async function test_Split_Companion_Default_Startup_Inert() {
+  for (const id of [
+    "tabbrowser-tabs",
+    "tabbrowser-arrowscrollbox",
+    "zen-tabs-wrapper",
+    "tabbrowser-tabbox",
+    "zen-split-companion-pane",
+  ]) {
+    is(
+      document.querySelectorAll(`#${id}`).length,
+      1,
+      `${id} should be unique at startup`
+    );
+  }
+
+  for (const pref of COMPANION_PREFS) {
+    is(Services.prefs.getBoolPref(pref), false, `${pref} should default false`);
+  }
+
+  const companionPane = document.getElementById("zen-split-companion-pane");
+  ok(window.gZenSplitCompanionPane, "Companion pane module should initialize");
+  ok(companionPane.hidden, "Companion pane should be hidden by default");
+  is(
+    getComputedStyle(companionPane).display,
+    "none",
+    "Companion pane should not be visible by default"
+  );
+
+  let pushedPrefEnvs = 0;
+  async function pushCompanionPrefs(enabled, paneVisible, rightWebVisible) {
+    await setCompanionPrefs(enabled, paneVisible, rightWebVisible);
+    pushedPrefEnvs++;
+  }
+
+  async function restoreCompanionDefaults() {
+    while (pushedPrefEnvs > 0) {
+      await SpecialPowers.popPrefEnv();
+      pushedPrefEnvs--;
+    }
+
+    window.gZenSplitCompanionPane.destroy();
+    window.gZenSplitCompanionPane.init();
+  }
+
+  registerCleanupFunction(restoreCompanionDefaults);
+
+  try {
+    await pushCompanionPrefs(true, true, true);
+    ok(
+      !companionPane.hidden,
+      "Production-initialized companion pane should show after startup pref changes"
+    );
+    await nextCompanionRefreshFrame();
+    ok(
+      companionPane.querySelector(".zen-split-companion-render"),
+      "Production-initialized companion pane should render after startup pref changes"
+    );
+
+    await pushCompanionPrefs(false, false, false);
+    ok(
+      companionPane.hidden,
+      "Production-initialized companion pane should hide after startup prefs reset"
+    );
+
+    window.gZenSplitCompanionPane.init();
+    window.gZenSplitCompanionPane.init();
+    window.gZenSplitCompanionPane.destroy();
+    await pushCompanionPrefs(true, true, true);
+    ok(
+      companionPane.hidden,
+      "Destroyed companion pane should not react after repeated init"
+    );
+    ok(
+      !companionPane.hasAttribute("zen-split-companion-enabled"),
+      "Destroyed companion pane should not leak enabled observers"
+    );
+    ok(
+      !companionPane.hasAttribute("zen-split-companion-pane-visible"),
+      "Destroyed companion pane should not leak pane visibility observers"
+    );
+    ok(
+      !companionPane.hasAttribute("zen-split-companion-right-web-visible"),
+      "Destroyed companion pane should not leak right web visibility observers"
+    );
+
+    window.gZenSplitCompanionPane.init();
+    ok(
+      !companionPane.hidden,
+      "Companion pane should show when enabled and visible"
+    );
+    ok(
+      companionPane.hasAttribute("zen-split-companion-enabled"),
+      "Companion pane should mirror the enabled pref"
+    );
+    ok(
+      companionPane.hasAttribute("zen-split-companion-pane-visible"),
+      "Companion pane should mirror the pane visibility pref"
+    );
+    ok(
+      companionPane.hasAttribute("zen-split-companion-right-web-visible"),
+      "Companion pane should mirror the right web visibility pref"
+    );
+
+    await nextCompanionRefreshFrame();
+    ok(
+      companionPane.querySelector(".zen-split-companion-render"),
+      "Visible companion pane should have rendered content before destroy"
+    );
+    ok(
+      window.gZenSplitCompanionPane.snapshot,
+      "Visible companion pane should expose a snapshot before destroy"
+    );
+
+    window.gZenSplitCompanionPane.destroy();
+    ok(
+      companionPane.hidden,
+      "Destroying a visible companion pane should leave the host hidden"
+    );
+    ok(
+      !companionPane.hasAttribute("zen-split-companion-enabled"),
+      "Destroying a visible companion pane should clear the enabled attribute"
+    );
+    ok(
+      !companionPane.hasAttribute("zen-split-companion-pane-visible"),
+      "Destroying a visible companion pane should clear the pane visibility attribute"
+    );
+    ok(
+      !companionPane.hasAttribute("zen-split-companion-right-web-visible"),
+      "Destroying a visible companion pane should clear the right web visibility attribute"
+    );
+    ok(
+      !companionPane.querySelector(".zen-split-companion-render"),
+      "Destroying a visible companion pane should clear rendered content"
+    );
+    is(
+      window.gZenSplitCompanionPane.snapshot,
+      null,
+      "Destroying a visible companion pane should clear the public snapshot getter"
+    );
+
+    window.gZenSplitCompanionPane.init();
+    ok(
+      !companionPane.hidden,
+      "Companion pane should show again after reinitializing with visible prefs"
+    );
+
+    await pushCompanionPrefs(false, false, false);
+    ok(companionPane.hidden, "Companion pane should hide when disabled");
+    ok(
+      !companionPane.hasAttribute("zen-split-companion-enabled"),
+      "Companion pane should clear the enabled attribute when disabled"
+    );
+    ok(
+      !companionPane.hasAttribute("zen-split-companion-pane-visible"),
+      "Companion pane should clear the pane visibility attribute"
+    );
+    ok(
+      !companionPane.hasAttribute("zen-split-companion-right-web-visible"),
+      "Companion pane should clear the right web visibility attribute"
+    );
+  } finally {
+    await restoreCompanionDefaults();
+  }
+
+  ok(companionPane.hidden, "Companion pane should restore hidden default state");
+});
+
+add_task(async function test_Split_Companion_Right_Web_Pref_Delegates_To_Split_View_API() {
+  const companionPane = window.gZenSplitCompanionPane;
+  const companionHost = document.getElementById("zen-split-companion-pane");
+  const originalSplitter = window.gZenViewSplitter;
+  const calls = [];
+  let pushedPrefEnvs = 0;
+
+  try {
+    companionPane.destroy();
+    window.gZenViewSplitter = {
+      setRightSplitWebVisible(visible, options) {
+        calls.push({ visible, options });
+        if (visible) {
+          return { ok: false, reason: "missing-active-split" };
+        }
+        return { ok: true, action: "hidden" };
+      },
+    };
+
+    await setCompanionPrefs(true, true, false);
+    pushedPrefEnvs++;
+    companionPane.init();
+
+    is(calls.length, 1, "Initializing should sync the right web pref once");
+    is(
+      calls[0].visible,
+      false,
+      "The companion pane should request hidden right web state"
+    );
+    ok(
+      calls[0].options?.source === "split-companion-pref",
+      "The companion pane should identify the pref bridge as the request source"
+    );
+    ok(
+      !companionHost.hasAttribute("zen-split-companion-right-web-visible"),
+      "The host should continue to mirror the right web visibility pref"
+    );
+    ok(
+      !companionHost.hasAttribute("data-zen-right-web-visibility-failed"),
+      "Successful bridge calls should not leave a failure marker"
+    );
+
+    await SpecialPowers.pushPrefEnv({
+      set: [["zen.splitCompanion.rightWeb.visible", true]],
+    });
+    pushedPrefEnvs++;
+    is(calls.length, 2, "Changing the right web pref should call the API");
+    is(
+      calls[1].visible,
+      true,
+      "The companion pane should request visible right web state"
+    );
+    ok(
+      companionHost.hasAttribute("zen-split-companion-right-web-visible"),
+      "The host should mirror the updated right web visibility pref"
+    );
+    ok(
+      !companionHost.hasAttribute("data-zen-right-web-visibility-failed"),
+      "Missing active split should not be recorded as a host failure"
+    );
+    ok(
+      !companionHost.hasAttribute("data-zen-right-web-visibility-error"),
+      "Missing active split should not leave a structured failure reason"
+    );
+  } finally {
+    companionPane.destroy();
+    while (pushedPrefEnvs > 0) {
+      await SpecialPowers.popPrefEnv();
+      pushedPrefEnvs--;
+    }
+    window.gZenViewSplitter = originalSplitter;
+    companionPane.init();
+  }
+});

--- a/src/zen/tests/tabs/browser_tabs_split_companion_model.js
+++ b/src/zen/tests/tabs/browser_tabs_split_companion_model.js
@@ -1,0 +1,415 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const {
+  buildZenSplitCompanionSnapshot,
+  renderZenSplitCompanionSnapshot,
+} = ChromeUtils.importESModule(
+  "chrome://browser/content/zen-components/ZenSplitCompanionPane.mjs",
+  { global: "current" }
+);
+
+function fakeTab(attributes = {}, properties = {}) {
+  const attrs = new Map(Object.entries(attributes));
+  return {
+    ...properties,
+    hasAttribute(name) {
+      return attrs.has(name);
+    },
+    getAttribute(name) {
+      return attrs.get(name) ?? null;
+    },
+  };
+}
+
+add_task(async function test_Split_Companion_Disabled_Does_Not_Build_Snapshot() {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["zen.splitCompanion.enabled", false],
+      ["zen.splitCompanion.pane.visible", true],
+      ["zen.splitCompanion.rightWeb.visible", true],
+    ],
+  });
+
+  try {
+    window.gZenSplitCompanionPane.destroy();
+    window.gZenSplitCompanionPane.init();
+    Assert.equal(
+      window.gZenSplitCompanionPane.snapshot,
+      null,
+      "Disabled companion pane should not build tab snapshots"
+    );
+  } finally {
+    window.gZenSplitCompanionPane.destroy();
+    await SpecialPowers.popPrefEnv();
+    window.gZenSplitCompanionPane.init();
+  }
+});
+
+add_task(async function test_Split_Companion_Model_Maps_ReadOnly_Tab_State() {
+  const activeWorkspaceId = "workspace-active";
+  const inactiveTab = fakeTab(
+    {
+      "zen-workspace-id": "workspace-inactive",
+      linkedpanel: "inactive-panel",
+    },
+    { label: "Inactive tab" }
+  );
+  const selectedPinnedTab = fakeTab(
+    {
+      "zen-workspace-id": activeWorkspaceId,
+      image: "chrome://test/selected.svg",
+      linkedpanel: "selected-panel",
+      busy: "true",
+      soundplaying: "true",
+    },
+    {
+      label: "Selected pinned tab",
+      pinned: true,
+      _tPos: 3,
+    }
+  );
+  const hiddenEssentialSplitTab = fakeTab(
+    {
+      "zen-workspace-id": activeWorkspaceId,
+      "zen-essential": "true",
+      hidden: "true",
+      muted: "true",
+      linkedpanel: "essential-panel",
+      "split-view": "true",
+    },
+    {
+      label: "Hidden essential split tab",
+      closing: true,
+      group: {
+        id: "split-group",
+        hasAttribute(name) {
+          return name === "split-view-group";
+        },
+      },
+      splitView: true,
+      _tPos: 4,
+    }
+  );
+
+  const snapshot = buildZenSplitCompanionSnapshot({
+    browser: {
+      selectedTab: selectedPinnedTab,
+      tabs: [inactiveTab, selectedPinnedTab, hiddenEssentialSplitTab],
+    },
+    workspaceManager: {
+      activeWorkspace: activeWorkspaceId,
+      getWorkspaces() {
+        return [
+          { uuid: activeWorkspaceId, name: "Active Workspace" },
+          { uuid: "workspace-inactive", name: "Inactive Workspace" },
+        ];
+      },
+    },
+  });
+
+  Assert.equal(
+    snapshot.activeWorkspace.id,
+    activeWorkspaceId,
+    "Snapshot records the active workspace"
+  );
+  Assert.deepEqual(
+    snapshot.workspaces.map(workspace => ({
+      id: workspace.id,
+      name: workspace.name,
+      active: workspace.active,
+    })),
+    [
+      { id: activeWorkspaceId, name: "Active Workspace", active: true },
+      { id: "workspace-inactive", name: "Inactive Workspace", active: false },
+    ],
+    "Snapshot maps the workspace list without exposing workspace objects"
+  );
+  Assert.deepEqual(
+    snapshot.tabs.map(tab => tab.id),
+    ["selected-panel", "essential-panel"],
+    "Snapshot keeps ordered active-workspace tabs only"
+  );
+
+  const pinned = snapshot.tabs[0];
+  Assert.equal(pinned.title, "Selected pinned tab", "Snapshot maps tab title");
+  Assert.equal(
+    pinned.favicon,
+    "chrome://test/selected.svg",
+    "Snapshot maps tab favicon/image"
+  );
+  Assert.ok(pinned.pinned, "Snapshot maps pinned state");
+  Assert.ok(pinned.active, "Snapshot maps the selected tab as active");
+  Assert.ok(pinned.busy, "Snapshot maps busy/loading state");
+  Assert.ok(pinned.soundPlaying, "Snapshot maps sound-playing state");
+  Assert.ok(!pinned.essential, "Pinned tab is not marked essential");
+  Assert.ok(!pinned.hidden, "Pinned tab is not marked hidden");
+  Assert.ok(!pinned.splitView, "Pinned tab is not marked split-view");
+
+  const essential = snapshot.tabs[1];
+  Assert.ok(essential.essential, "Snapshot maps essential state");
+  Assert.ok(essential.hidden, "Snapshot maps hidden state");
+  Assert.ok(essential.closing, "Snapshot maps closing state");
+  Assert.ok(essential.splitView, "Snapshot maps split-view membership");
+  Assert.equal(
+    essential.splitViewGroupId,
+    "split-group",
+    "Snapshot maps split-view group identity"
+  );
+  Assert.ok(essential.muted, "Snapshot maps muted state");
+  Assert.ok(
+    !("tab" in essential),
+    "Snapshot does not expose a source tab reference"
+  );
+  Assert.notEqual(
+    essential,
+    hiddenEssentialSplitTab,
+    "Snapshot does not expose the source tab DOM node"
+  );
+});
+
+add_task(
+  async function test_Split_Companion_Model_Tolerates_Transient_Tab_Getter_Failures() {
+    const activeWorkspaceId = "workspace-active";
+    const throwingTab = fakeTab(
+      {
+        "zen-workspace-id": activeWorkspaceId,
+        linkedpanel: "getter-panel",
+        hidden: "true",
+        closing: "true",
+      },
+      {}
+    );
+
+    for (const property of [
+      "_tPos",
+      "elementIndex",
+      "group",
+      "label",
+      "linkedBrowser",
+      "image",
+      "pinned",
+      "selected",
+      "hidden",
+      "closing",
+      "busy",
+      "pending",
+      "muted",
+      "soundPlaying",
+      "activeMediaBlocked",
+      "splitView",
+      "splitViewValue",
+    ]) {
+      Object.defineProperty(throwingTab, property, {
+        get() {
+          throw new Error(`${property} unavailable`);
+        },
+      });
+    }
+
+    const snapshot = buildZenSplitCompanionSnapshot({
+      browser: {
+        selectedTab: null,
+        tabs: [throwingTab],
+      },
+      workspaceManager: {
+        activeWorkspace: activeWorkspaceId,
+        getWorkspaces() {
+          return [{ uuid: activeWorkspaceId, name: "Active Workspace" }];
+        },
+      },
+    });
+
+    Assert.equal(snapshot.tabs.length, 1, "Snapshot keeps the readable tab");
+    Assert.equal(
+      snapshot.tabs[0].id,
+      "getter-panel",
+      "Snapshot keeps readable tab identity"
+    );
+    Assert.equal(
+      snapshot.tabs[0].position,
+      0,
+      "Snapshot falls back when tab position getters fail"
+    );
+    Assert.equal(
+      snapshot.tabs[0].title,
+      "",
+      "Snapshot falls back when title getters fail"
+    );
+    Assert.ok(
+      snapshot.tabs[0].hidden,
+      "Snapshot still reads hidden state from attributes"
+    );
+    Assert.ok(
+      snapshot.tabs[0].closing,
+      "Snapshot still reads closing state from attributes"
+    );
+  }
+);
+
+add_task(async function test_Split_Companion_Rendering_Is_ReadOnly_Companion_DOM() {
+  const host = document.createXULElement("vbox");
+  const sourceTab = document.createXULElement("tab");
+  sourceTab.id = "source-tab-node";
+  sourceTab.className = "tabbrowser-tab";
+
+  renderZenSplitCompanionSnapshot(host, {
+    activeWorkspaceId: "workspace-active",
+    activeWorkspace: {
+      id: "workspace-active",
+      name: "Active Workspace",
+    },
+    workspaces: [],
+    tabs: [
+      {
+        id: "selected-panel",
+        position: 2,
+        workspaceId: "workspace-active",
+        title: "Selected Busy Audio Tab",
+        favicon: "chrome://test/selected.svg",
+        image: "chrome://test/selected.svg",
+        pinned: true,
+        essential: false,
+        active: true,
+        selected: true,
+        hidden: false,
+        closing: false,
+        busy: true,
+        loading: true,
+        pending: false,
+        muted: false,
+        soundPlaying: true,
+        activeMediaBlocked: false,
+        splitView: false,
+        splitViewValue: "",
+        splitViewGroupId: "",
+        groupId: "group-a",
+        groupLabel: "Research",
+        sourceTab,
+      },
+      {
+        id: "split-panel",
+        position: 3,
+        workspaceId: "workspace-active",
+        title: "Hidden Essential Split Tab",
+        favicon: "",
+        image: "",
+        pinned: false,
+        essential: true,
+        active: false,
+        selected: false,
+        hidden: true,
+        closing: true,
+        busy: false,
+        loading: false,
+        pending: true,
+        muted: true,
+        soundPlaying: false,
+        activeMediaBlocked: true,
+        splitView: true,
+        splitViewValue: "right",
+        splitViewGroupId: "split-group",
+        groupId: "split-group",
+        groupLabel: "Compare",
+      },
+    ],
+  });
+
+  const rows = host.querySelectorAll(".zen-split-companion-tab-row");
+  Assert.equal(rows.length, 2, "Renderer creates one companion row per tab");
+  Assert.equal(
+    host.querySelectorAll(".tabbrowser-tab").length,
+    0,
+    "Renderer does not move or clone tabbrowser tab DOM"
+  );
+  Assert.equal(
+    host.querySelectorAll("[id]").length,
+    0,
+    "Renderer avoids repeated/global ids inside generated content"
+  );
+  Assert.equal(
+    sourceTab.parentNode,
+    null,
+    "Renderer leaves source tab nodes untouched"
+  );
+
+  const selectedRow = rows[0];
+  Assert.equal(
+    selectedRow.getAttribute("data-zen-tab-id"),
+    "selected-panel",
+    "Renderer records safe tab identity as data"
+  );
+  Assert.equal(
+    selectedRow.getAttribute("aria-selected"),
+    "true",
+    "Renderer exposes selection state"
+  );
+  Assert.ok(selectedRow.hasAttribute("active"), "Renderer reflects active");
+  Assert.ok(selectedRow.hasAttribute("selected"), "Renderer reflects selected");
+  Assert.ok(selectedRow.hasAttribute("pinned"), "Renderer reflects pinned");
+  Assert.ok(selectedRow.hasAttribute("busy"), "Renderer reflects busy");
+  Assert.ok(selectedRow.hasAttribute("loading"), "Renderer reflects loading");
+  Assert.ok(
+    selectedRow.hasAttribute("soundplaying"),
+    "Renderer reflects audio playback"
+  );
+  Assert.equal(
+    selectedRow.querySelector(".zen-split-companion-tab-title").value,
+    "Selected Busy Audio Tab",
+    "Renderer writes the tab title into companion label DOM"
+  );
+  Assert.equal(
+    selectedRow.querySelector(".zen-split-companion-tab-icon").getAttribute("src"),
+    "chrome://test/selected.svg",
+    "Renderer writes favicon/image state"
+  );
+  Assert.equal(
+    selectedRow.querySelector(".zen-split-companion-tab-group-label").value,
+    "Research",
+    "Renderer shows the group label when available"
+  );
+  Assert.equal(selectedRow.tabIndex, -1, "Rows are not keyboard focus targets");
+
+  const splitRow = rows[1];
+  Assert.ok(splitRow.hasAttribute("zen-essential"), "Renderer reflects essential");
+  Assert.ok(
+    !splitRow.hasAttribute("hidden"),
+    "Renderer does not hide companion rows with the native hidden attribute"
+  );
+  Assert.ok(
+    splitRow.hasAttribute("data-zen-hidden"),
+    "Renderer reflects hidden as companion-only state"
+  );
+  Assert.ok(splitRow.hasAttribute("closing"), "Renderer reflects closing");
+  Assert.ok(splitRow.hasAttribute("pending"), "Renderer reflects pending");
+  Assert.ok(splitRow.hasAttribute("muted"), "Renderer reflects muted");
+  Assert.ok(
+    splitRow.hasAttribute("activemedia-blocked"),
+    "Renderer reflects blocked media"
+  );
+  Assert.ok(splitRow.hasAttribute("split-view"), "Renderer reflects split view");
+  Assert.equal(
+    splitRow.getAttribute("data-zen-split-view-group-id"),
+    "split-group",
+    "Renderer records split-view group identity"
+  );
+  Assert.equal(
+    splitRow.getAttribute("data-zen-split-view-value"),
+    "right",
+    "Renderer records split-view value"
+  );
+  const splitIconStack = splitRow.querySelector(
+    ".zen-split-companion-tab-icon-stack"
+  );
+  Assert.ok(
+    splitIconStack.hasAttribute("icon-placeholder"),
+    "Renderer marks missing favicons with the placeholder state"
+  );
+  Assert.equal(
+    splitIconStack.querySelector(".zen-split-companion-tab-icon"),
+    null,
+    "Renderer should not append an empty favicon image over the placeholder"
+  );
+});

--- a/src/zen/tests/tabs/browser_tabs_split_companion_sync.js
+++ b/src/zen/tests/tabs/browser_tabs_split_companion_sync.js
@@ -1,0 +1,297 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { ZEN_SPLIT_COMPANION_REFRESH_EVENTS } = ChromeUtils.importESModule(
+  "chrome://browser/content/zen-components/ZenSplitCompanionPane.mjs",
+  { global: "current" }
+);
+
+async function pushCompanionPrefs(enabled, paneVisible, rightWebVisible) {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["zen.splitCompanion.enabled", enabled],
+      ["zen.splitCompanion.pane.visible", paneVisible],
+      ["zen.splitCompanion.rightWeb.visible", rightWebVisible],
+    ],
+  });
+}
+
+function nextCompanionRefreshFrame() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+function makeCompanionListenerOwner({
+  addName,
+  removeName,
+  addCalls,
+  removeCalls,
+}) {
+  return {
+    [addName](listener) {
+      addCalls.push(listener);
+    },
+    [removeName](listener) {
+      removeCalls.push(listener);
+    },
+  };
+}
+
+add_task(async function test_Split_Companion_Refresh_Listeners_Are_Lifecycle_Gated() {
+  const companionPane = window.gZenSplitCompanionPane;
+  const host = document.getElementById("zen-split-companion-pane");
+  const originalBuildSnapshot = companionPane.buildSnapshot;
+  const originalBrowser = window.gBrowser;
+  const originalWorkspaceManager = window.gZenWorkspaces;
+  const originalAddEventListener = window.addEventListener;
+  const originalRemoveEventListener = window.removeEventListener;
+  const originalAddEventListenerDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    "addEventListener"
+  );
+  const originalRemoveEventListenerDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    "removeEventListener"
+  );
+  const capturedWindowRefreshListeners = new Map(
+    ZEN_SPLIT_COMPANION_REFRESH_EVENTS.map(eventName => [eventName, new Set()])
+  );
+  const workspaceAddCalls = [];
+  const workspaceRemoveCalls = [];
+  const tabsProgressAddCalls = [];
+  const tabsProgressRemoveCalls = [];
+  const workspaceManager = makeCompanionListenerOwner({
+    addName: "addChangeListeners",
+    removeName: "removeChangeListeners",
+    addCalls: workspaceAddCalls,
+    removeCalls: workspaceRemoveCalls,
+  });
+  const browser = makeCompanionListenerOwner({
+    addName: "addTabsProgressListener",
+    removeName: "removeTabsProgressListener",
+    addCalls: tabsProgressAddCalls,
+    removeCalls: tabsProgressRemoveCalls,
+  });
+  let pushedPrefEnvs = 0;
+  let refreshes = 0;
+
+  async function pushTrackedCompanionPrefs(enabled, paneVisible, rightWebVisible) {
+    await pushCompanionPrefs(enabled, paneVisible, rightWebVisible);
+    pushedPrefEnvs++;
+  }
+
+  function dispatchCapturedWindowRefreshEvents(...eventNames) {
+    for (const eventName of eventNames) {
+      for (const listener of capturedWindowRefreshListeners.get(eventName)) {
+        listener.call(window, new CustomEvent(eventName));
+      }
+    }
+  }
+
+  companionPane.buildSnapshot = function () {
+    refreshes++;
+    return {
+      activeWorkspaceId: "workspace-sync",
+      activeWorkspace: {
+        id: "workspace-sync",
+        name: `Workspace Sync ${refreshes}`,
+      },
+      workspaces: [],
+      tabs: [
+        {
+          id: `sync-tab-${refreshes}`,
+          position: refreshes,
+          workspaceId: "workspace-sync",
+          title: `Synchronized Tab ${refreshes}`,
+          favicon: "",
+          image: "",
+          pinned: false,
+          essential: false,
+          active: true,
+          selected: true,
+          hidden: false,
+          closing: false,
+          busy: false,
+          loading: false,
+          pending: false,
+          muted: false,
+          soundPlaying: false,
+          activeMediaBlocked: false,
+          splitView: false,
+          splitViewValue: "",
+          splitViewGroupId: "",
+          groupId: "",
+          groupLabel: "",
+        },
+      ],
+    };
+  };
+
+  try {
+    companionPane.destroy();
+    window.gZenWorkspaces = workspaceManager;
+    window.gBrowser = browser;
+    window.addEventListener = function (type, listener, options) {
+      const capturedListeners = capturedWindowRefreshListeners.get(type);
+      if (capturedListeners) {
+        capturedListeners.add(listener);
+        return;
+      }
+      return originalAddEventListener.call(this, type, listener, options);
+    };
+    window.removeEventListener = function (type, listener, options) {
+      const capturedListeners = capturedWindowRefreshListeners.get(type);
+      if (capturedListeners) {
+        capturedListeners.delete(listener);
+        return;
+      }
+      return originalRemoveEventListener.call(this, type, listener, options);
+    };
+
+    await pushTrackedCompanionPrefs(true, true, true);
+    companionPane.init();
+    companionPane.init();
+    await nextCompanionRefreshFrame();
+
+    is(refreshes, 1, "Visible companion pane should build its initial snapshot");
+    is(
+      workspaceAddCalls.length,
+      1,
+      "Repeated init should attach one workspace change listener"
+    );
+    is(
+      tabsProgressAddCalls.length,
+      1,
+      "Repeated init should attach one tabs progress listener"
+    );
+
+    dispatchCapturedWindowRefreshEvents(...ZEN_SPLIT_COMPANION_REFRESH_EVENTS);
+    workspaceAddCalls[0]();
+    tabsProgressAddCalls[0].onLocationChange();
+    tabsProgressAddCalls[0].onStateChange();
+    tabsProgressAddCalls[0].onLinkIconAvailable();
+
+    is(
+      refreshes,
+      1,
+      "Refresh signals should not rebuild synchronously"
+    );
+    await nextCompanionRefreshFrame();
+    is(
+      refreshes,
+      2,
+      "Window, workspace, and tab progress signals in one frame should coalesce"
+    );
+    is(
+      host.querySelector(".zen-split-companion-tab-title").value,
+      `Synchronized Tab ${refreshes}`,
+      "Refresh events should render the latest read-only snapshot"
+    );
+
+    await pushTrackedCompanionPrefs(true, false, true);
+    await nextCompanionRefreshFrame();
+    const hiddenRefreshes = refreshes;
+    dispatchCapturedWindowRefreshEvents(...ZEN_SPLIT_COMPANION_REFRESH_EVENTS);
+    workspaceAddCalls[0]();
+    tabsProgressAddCalls[0].onLocationChange();
+    await nextCompanionRefreshFrame();
+    is(
+      refreshes,
+      hiddenRefreshes,
+      "Hidden companion pane should ignore all refresh listener signals"
+    );
+    is(
+      host.querySelector(".zen-split-companion-render"),
+      null,
+      "Hidden companion pane should clear rendered snapshot DOM"
+    );
+
+    await pushTrackedCompanionPrefs(false, true, true);
+    await nextCompanionRefreshFrame();
+    const disabledRefreshes = refreshes;
+    dispatchCapturedWindowRefreshEvents(...ZEN_SPLIT_COMPANION_REFRESH_EVENTS);
+    workspaceAddCalls[0]();
+    tabsProgressAddCalls[0].onLocationChange();
+    await nextCompanionRefreshFrame();
+    is(
+      refreshes,
+      disabledRefreshes,
+      "Disabled companion pane should ignore all refresh listener signals"
+    );
+
+    await pushTrackedCompanionPrefs(true, true, true);
+    await nextCompanionRefreshFrame();
+    const beforeCanceledRefresh = refreshes;
+    dispatchCapturedWindowRefreshEvents("TabOpen");
+    window.gZenWorkspaces = null;
+    window.gBrowser = null;
+    companionPane.destroy();
+    await nextCompanionRefreshFrame();
+    is(
+      refreshes,
+      beforeCanceledRefresh,
+      "Destroy should cancel a pending scheduled refresh"
+    );
+    is(
+      workspaceRemoveCalls.length,
+      1,
+      "Destroy should remove workspace listeners from the attached owner"
+    );
+    is(
+      workspaceRemoveCalls[0],
+      workspaceAddCalls[0],
+      "Destroy should remove the exact workspace listener that was attached"
+    );
+    is(
+      tabsProgressRemoveCalls.length,
+      1,
+      "Destroy should remove tabs progress listeners from the attached owner"
+    );
+    is(
+      tabsProgressRemoveCalls[0],
+      tabsProgressAddCalls[0],
+      "Destroy should remove the exact tabs progress listener that was attached"
+    );
+
+    companionPane.destroy();
+    is(
+      workspaceRemoveCalls.length,
+      1,
+      "Repeated destroy should not remove workspace listeners twice"
+    );
+    is(
+      tabsProgressRemoveCalls.length,
+      1,
+      "Repeated destroy should not remove tabs progress listeners twice"
+    );
+  } finally {
+    window.gZenWorkspaces = originalWorkspaceManager;
+    window.gBrowser = originalBrowser;
+    companionPane.buildSnapshot = originalBuildSnapshot;
+    companionPane.destroy();
+    if (originalAddEventListenerDescriptor) {
+      Object.defineProperty(
+        window,
+        "addEventListener",
+        originalAddEventListenerDescriptor
+      );
+    } else {
+      delete window.addEventListener;
+    }
+    if (originalRemoveEventListenerDescriptor) {
+      Object.defineProperty(
+        window,
+        "removeEventListener",
+        originalRemoveEventListenerDescriptor
+      );
+    } else {
+      delete window.removeEventListener;
+    }
+    while (pushedPrefEnvs > 0) {
+      await SpecialPowers.popPrefEnv();
+      pushedPrefEnvs--;
+    }
+    companionPane.init();
+  }
+});

--- a/src/zen/tests/tabs/browser_tabs_split_companion_workspace.js
+++ b/src/zen/tests/tabs/browser_tabs_split_companion_workspace.js
@@ -1,0 +1,555 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { renderZenSplitCompanionSnapshot } = ChromeUtils.importESModule(
+  "chrome://browser/content/zen-components/ZenSplitCompanionPane.mjs",
+  { global: "current" }
+);
+
+async function pushCompanionWorkspacePrefs() {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["zen.splitCompanion.enabled", true],
+      ["zen.splitCompanion.pane.visible", true],
+      ["zen.splitCompanion.rightWeb.visible", true],
+    ],
+  });
+}
+
+function nextCompanionWorkspaceRefreshFrame() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+async function flushWorkspaceSwitchPromiseHandlers() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function dispatchCompanionKey(target, key, options = {}) {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key,
+  });
+  if (options.defaultPrevented) {
+    event.preventDefault();
+  }
+  target.dispatchEvent(event);
+  return event;
+}
+
+function createDeferred() {
+  let reject;
+  const promise = new Promise((_, rejectPromise) => {
+    reject = rejectPromise;
+  });
+  return { promise, reject };
+}
+
+function fakeWorkspaceClickTab(attributes = {}, properties = {}) {
+  const attrs = new Map(Object.entries(attributes));
+  const setAttributeCalls = [];
+  return {
+    ...properties,
+    setAttribute(name, value) {
+      setAttributeCalls.push({ name, value });
+      attrs.set(name, String(value));
+    },
+    hasAttribute(name) {
+      return attrs.has(name);
+    },
+    getAttribute(name) {
+      return attrs.get(name) ?? null;
+    },
+    getSetAttributeCalls() {
+      return setAttributeCalls;
+    },
+  };
+}
+
+async function withRenderedWorkspaceControls(changeWorkspaceWithID, task) {
+  const companionPane = window.gZenSplitCompanionPane;
+  const originalBrowser = window.gBrowser;
+  const originalWorkspaceManager = window.gZenWorkspaces;
+  const originalSplitter = window.gZenViewSplitter;
+  let activeWorkspaceSetCount = 0;
+  let activeWorkspaceValue = "workspace-active";
+  let pushedPrefEnv = false;
+  const activeTab = fakeWorkspaceClickTab(
+    {
+      "zen-workspace-id": "workspace-active",
+      linkedpanel: "active-panel",
+    },
+    {
+      label: "Active tab",
+      _tPos: 0,
+    }
+  );
+  const targetTab = fakeWorkspaceClickTab(
+    {
+      "zen-workspace-id": "workspace-target",
+      linkedpanel: "target-panel",
+    },
+    {
+      label: "Target tab",
+      _tPos: 1,
+    }
+  );
+  const workspaceManager = {
+    get activeWorkspace() {
+      return activeWorkspaceValue;
+    },
+    set activeWorkspace(value) {
+      activeWorkspaceSetCount++;
+      activeWorkspaceValue = value;
+    },
+    getWorkspaces() {
+      return [
+        { uuid: "workspace-active", name: "Active Space", icon: "A" },
+        { uuid: "workspace-target", name: "Target Space", icon: "T" },
+      ];
+    },
+    changeWorkspaceWithID,
+  };
+
+  try {
+    companionPane.destroy();
+    window.gBrowser = {
+      selectedTab: activeTab,
+      tabs: [activeTab, targetTab],
+    };
+    window.gZenWorkspaces = workspaceManager;
+    window.gZenViewSplitter = {
+      setRightSplitTab() {
+        throw new Error("workspace click should not use split tab routing");
+      },
+    };
+
+    await pushCompanionWorkspacePrefs();
+    pushedPrefEnv = true;
+    companionPane.init();
+    await nextCompanionWorkspaceRefreshFrame();
+
+    const host = document.getElementById("zen-split-companion-pane");
+    await task({
+      activeTab,
+      host,
+      targetTab,
+      activeWorkspaceSetCount: () => activeWorkspaceSetCount,
+      activeWorkspaceValue: () => activeWorkspaceValue,
+    });
+  } finally {
+    companionPane.destroy();
+    if (pushedPrefEnv) {
+      await SpecialPowers.popPrefEnv();
+    }
+    window.gBrowser = originalBrowser;
+    window.gZenWorkspaces = originalWorkspaceManager;
+    window.gZenViewSplitter = originalSplitter;
+    companionPane.init();
+  }
+}
+
+add_task(async function test_Split_Companion_Renders_Workspace_Controls_From_Snapshot() {
+  const host = document.createXULElement("vbox");
+  const nativeWorkspaceNode = document.createXULElement("toolbarbutton");
+  nativeWorkspaceNode.id = "native-workspace-node";
+  nativeWorkspaceNode.className = "zen-workspace-button";
+
+  renderZenSplitCompanionSnapshot(host, {
+    activeWorkspaceId: "workspace-active",
+    activeWorkspace: {
+      id: "workspace-active",
+      name: "Active Space",
+      active: true,
+    },
+    workspaces: [
+      {
+        id: "workspace-active",
+        name: "Active Space",
+        active: true,
+        icon: "A",
+        position: 0,
+        sourceNode: nativeWorkspaceNode,
+      },
+      {
+        id: "workspace-target",
+        name: "Target Space",
+        active: false,
+        icon: "T",
+        position: 1,
+      },
+    ],
+    tabs: [],
+  });
+
+  const rows = host.querySelectorAll(".zen-split-companion-workspace-row");
+  is(rows.length, 2, "Renderer creates one companion-owned row per workspace");
+  is(
+    host.querySelectorAll(".zen-workspace-button").length,
+    0,
+    "Renderer does not move or clone native workspace DOM"
+  );
+  is(
+    host.querySelectorAll("[id]").length,
+    0,
+    "Renderer avoids repeated/global ids in workspace controls"
+  );
+  is(
+    nativeWorkspaceNode.parentNode,
+    null,
+    "Renderer leaves source workspace nodes untouched"
+  );
+
+  const activeRow = rows[0];
+  is(
+    activeRow.getAttribute("data-zen-workspace-id"),
+    "workspace-active",
+    "Workspace controls keep identity as companion-owned data"
+  );
+  ok(
+    activeRow.hasAttribute("data-zen-workspace-active"),
+    "Active workspace is marked with companion-owned state"
+  );
+  is(
+    activeRow.getAttribute("aria-current"),
+    "true",
+    "Active workspace exposes current state"
+  );
+  is(
+    activeRow.querySelector(".zen-split-companion-workspace-name").value,
+    "Active Space",
+    "Workspace controls render the workspace name"
+  );
+  is(
+    activeRow.querySelector(".zen-split-companion-workspace-icon").value,
+    "A",
+    "Workspace controls render the workspace icon text"
+  );
+  is(
+    host.querySelector("[zen-workspace-id]"),
+    null,
+    "Workspace controls do not write native workspace attributes"
+  );
+});
+
+add_task(async function test_Split_Companion_Workspace_Click_Delegates_To_Manager() {
+  const calls = [];
+  await withRenderedWorkspaceControls((workspaceId, options) => {
+    calls.push({ workspaceId, options });
+  }, async ({ activeTab, host, targetTab, activeWorkspaceSetCount }) => {
+    const row = host.querySelector('[data-zen-workspace-id="workspace-target"]');
+    ok(row, "Companion pane should render the target workspace row");
+
+    EventUtils.synthesizeMouseAtCenter(row, {});
+
+    is(calls.length, 1, "Workspace click should call changeWorkspaceWithID once");
+    is(
+      calls[0].workspaceId,
+      "workspace-target",
+      "Workspace click should delegate the target workspace id"
+    );
+    is(
+      calls[0].options?.source,
+      "split-companion-pane",
+      "Workspace click should include companion source context"
+    );
+    is(
+      activeWorkspaceSetCount(),
+      0,
+      "Workspace click should not assign gZenWorkspaces.activeWorkspace directly"
+    );
+    is(
+      activeTab
+        .getSetAttributeCalls()
+        .filter(call => call.name === "zen-workspace-id").length,
+      0,
+      "Workspace click should not write native workspace attributes on active tabs"
+    );
+    is(
+      targetTab
+        .getSetAttributeCalls()
+        .filter(call => call.name === "zen-workspace-id").length,
+      0,
+      "Workspace click should not write native workspace attributes on target tabs"
+    );
+    ok(
+      !row.hasAttribute("data-zen-workspace-switch-failed"),
+      "Successful workspace switch should not mark failure"
+    );
+  });
+});
+
+add_task(async function test_Split_Companion_Workspace_Keyboard_Delegates_To_Manager() {
+  for (const key of ["VK_RETURN", "VK_SPACE"]) {
+    const calls = [];
+    await withRenderedWorkspaceControls((workspaceId, options) => {
+      calls.push({ workspaceId, options });
+    }, async ({ host, activeWorkspaceSetCount }) => {
+      const row = host.querySelector(
+        '[data-zen-workspace-id="workspace-target"]'
+      );
+      ok(row, "Companion pane should render the target workspace row");
+
+      row.focus();
+      EventUtils.synthesizeKey(key);
+
+      is(
+        calls.length,
+        1,
+        `${key} should call changeWorkspaceWithID exactly once`
+      );
+      is(
+        calls[0].workspaceId,
+        "workspace-target",
+        `${key} should delegate the target workspace id`
+      );
+      is(
+        calls[0].options?.source,
+        "split-companion-pane",
+        `${key} should include companion source context`
+      );
+      is(
+        activeWorkspaceSetCount(),
+        0,
+        `${key} should not assign gZenWorkspaces.activeWorkspace directly`
+      );
+    });
+  }
+});
+
+add_task(async function test_Split_Companion_Workspace_Keyboard_Ignores_Non_Activation_Keys() {
+  const calls = [];
+  await withRenderedWorkspaceControls((workspaceId, options) => {
+    calls.push({ workspaceId, options });
+  }, async ({ host }) => {
+    const row = host.querySelector('[data-zen-workspace-id="workspace-target"]');
+    ok(row, "Companion pane should render the target workspace row");
+
+    row.focus();
+    for (const key of ["Escape", "ArrowDown", "a"]) {
+      const event = dispatchCompanionKey(row, key);
+
+      is(
+        calls.length,
+        0,
+        `${key} should not call changeWorkspaceWithID`
+      );
+      ok(!event.defaultPrevented, `${key} should not prevent default`);
+    }
+  });
+});
+
+add_task(async function test_Split_Companion_Workspace_Keyboard_Ignores_Default_Prevented_Activation_Keys() {
+  for (const key of ["Enter", " ", "Spacebar"]) {
+    const calls = [];
+    await withRenderedWorkspaceControls((workspaceId, options) => {
+      calls.push({ workspaceId, options });
+    }, async ({ host }) => {
+      const row = host.querySelector(
+        '[data-zen-workspace-id="workspace-target"]'
+      );
+      ok(row, "Companion pane should render the target workspace row");
+
+      row.focus();
+      const event = dispatchCompanionKey(row, key, {
+        defaultPrevented: true,
+      });
+
+      ok(event.defaultPrevented, `${key} should remain default-prevented`);
+      is(
+        calls.length,
+        0,
+        `${key} should not call changeWorkspaceWithID when defaultPrevented`
+      );
+    });
+  }
+});
+
+add_task(async function test_Split_Companion_Workspace_Keyboard_Ignores_Companion_Tab_Rows() {
+  for (const key of ["Enter", " ", "Spacebar"]) {
+    const calls = [];
+    await withRenderedWorkspaceControls((workspaceId, options) => {
+      calls.push({ workspaceId, options });
+    }, async ({ host }) => {
+      const row = host.querySelector('[data-zen-tab-id="active-panel"]');
+      ok(row, "Companion pane should render a companion tab row");
+      ok(
+        !row.classList.contains("zen-split-companion-workspace-row"),
+        "Companion tab row should not be a workspace row"
+      );
+
+      row.focus();
+      dispatchCompanionKey(row, key);
+
+      is(
+        calls.length,
+        0,
+        `${key} on a companion tab row should not call changeWorkspaceWithID`
+      );
+    });
+  }
+});
+
+add_task(async function test_Split_Companion_Active_Workspace_Click_Is_NoOp() {
+  const calls = [];
+  await withRenderedWorkspaceControls((workspaceId, options) => {
+    calls.push({ workspaceId, options });
+  }, async ({ host, activeWorkspaceSetCount, activeWorkspaceValue }) => {
+    const row = host.querySelector('[data-zen-workspace-id="workspace-active"]');
+    ok(row, "Companion pane should render the active workspace row");
+
+    EventUtils.synthesizeMouseAtCenter(row, {});
+
+    is(calls.length, 0, "Clicking the active workspace should not switch");
+    is(
+      activeWorkspaceSetCount(),
+      0,
+      "Active workspace no-op should not assign activeWorkspace directly"
+    );
+    is(
+      activeWorkspaceValue(),
+      "workspace-active",
+      "Active workspace no-op should leave manager state unchanged"
+    );
+  });
+});
+
+add_task(async function test_Split_Companion_Workspace_Failure_Stays_Companion_Owned() {
+  await withRenderedWorkspaceControls(() => {
+    throw new Error("workspace switch rejected");
+  }, async ({ host, activeWorkspaceSetCount, activeWorkspaceValue }) => {
+    const row = host.querySelector('[data-zen-workspace-id="workspace-target"]');
+    ok(row, "Companion pane should render the target workspace row");
+
+    EventUtils.synthesizeMouseAtCenter(row, {});
+
+    ok(
+      row.hasAttribute("data-zen-workspace-switch-failed"),
+      "Thrown workspace switches should mark companion-owned failure state"
+    );
+    is(
+      row.getAttribute("data-zen-workspace-switch-error"),
+      "Error",
+      "Thrown workspace switches should expose a safe error name"
+    );
+    ok(
+      !row.hasAttribute("data-zen-workspace-active"),
+      "Failure handling should not mark the target row active"
+    );
+    is(
+      row.getAttribute("aria-current"),
+      "false",
+      "Failure handling should not change rendered active state"
+    );
+    is(
+      activeWorkspaceSetCount(),
+      0,
+      "Failure handling should not assign activeWorkspace directly"
+    );
+    is(
+      activeWorkspaceValue(),
+      "workspace-active",
+      "Failure handling should leave manager state unchanged"
+    );
+  });
+});
+
+add_task(async function test_Split_Companion_Workspace_Rejection_Stays_Companion_Owned() {
+  await withRenderedWorkspaceControls(
+    () => Promise.reject(new DOMException("denied", "InvalidStateError")),
+    async ({ host }) => {
+      const row = host.querySelector('[data-zen-workspace-id="workspace-target"]');
+      ok(row, "Companion pane should render the target workspace row");
+
+      EventUtils.synthesizeMouseAtCenter(row, {});
+      await flushWorkspaceSwitchPromiseHandlers();
+
+      ok(
+        row.hasAttribute("data-zen-workspace-switch-failed"),
+        "Rejected workspace switches should mark companion-owned failure state"
+      );
+      is(
+        row.getAttribute("data-zen-workspace-switch-error"),
+        "InvalidStateError",
+        "Rejected workspace switches should expose a safe error name"
+      );
+    }
+  );
+});
+
+add_task(async function test_Split_Companion_Workspace_Rejection_Marks_Current_Rendered_Row() {
+  const deferred = createDeferred();
+  await withRenderedWorkspaceControls(
+    () => deferred.promise,
+    async ({ host }) => {
+      const originalRow = host.querySelector(
+        '[data-zen-workspace-id="workspace-target"]'
+      );
+      ok(originalRow, "Companion pane should render the target workspace row");
+
+      EventUtils.synthesizeMouseAtCenter(originalRow, {});
+      renderZenSplitCompanionSnapshot(host, {
+        activeWorkspaceId: "workspace-active",
+        activeWorkspace: {
+          id: "workspace-active",
+          name: "Active Space",
+          active: true,
+        },
+        workspaces: [
+          {
+            id: "workspace-active",
+            name: "Active Space",
+            active: true,
+            icon: "A",
+            position: 0,
+          },
+          {
+            id: "workspace-target",
+            name: "Target Space",
+            active: false,
+            icon: "T",
+            position: 1,
+          },
+        ],
+        tabs: [],
+      });
+      const currentRow = host.querySelector(
+        '[data-zen-workspace-id="workspace-target"]'
+      );
+      ok(currentRow, "Companion pane should render a replacement target row");
+      ok(
+        currentRow !== originalRow,
+        "Companion pane replacement row should be a different element"
+      );
+
+      deferred.reject(new DOMException("denied", "InvalidStateError"));
+      await flushWorkspaceSwitchPromiseHandlers();
+
+      ok(
+        !originalRow.hasAttribute("data-zen-workspace-switch-failed"),
+        "Rejected stale row should not receive companion failure state"
+      );
+      ok(
+        currentRow.hasAttribute("data-zen-workspace-switch-failed"),
+        "Rejected workspace switches should mark the current companion row"
+      );
+      is(
+        currentRow.getAttribute("data-zen-workspace-switch-error"),
+        "InvalidStateError",
+        "Rejected workspace switches should expose a safe error name"
+      );
+      ok(
+        !currentRow.hasAttribute("data-zen-workspace-active"),
+        "Failure handling should not mark the replacement target row active"
+      );
+      is(
+        host.querySelector("[zen-workspace-id]"),
+        null,
+        "Failure handling should not write native workspace attributes"
+      );
+    }
+  );
+});

--- a/src/zen/zen.globals.mjs
+++ b/src/zen/zen.globals.mjs
@@ -39,6 +39,7 @@ export default [
   "gZenThemePicker",
 
   "gZenViewSplitter",
+  "gZenSplitCompanionPane",
 
   "gZenSpaceRoutingManager",
 


### PR DESCRIPTION
## Summary
- Add disabled-by-default Zen Split Companion prefs, preloaded module wiring, pane markup/styles, and companion globals.
- Add a companion-owned read-only pane renderer over split/tab snapshot state, with right-side split/tab activation APIs in `ZenViewSplitter`.
- Add focused browser tests for the companion model, inert default behavior, click/workspace delegation, sync lifecycle, right-tab replacement, and right-web visibility.

## Validation
- `git diff --check`
- `node --check` for changed/new JS/MJS files:
  - `src/zen/common/ZenPreloadedScripts.js`
  - `src/zen/split-view/ZenViewSplitter.mjs`
  - `src/zen/split-view/ZenSplitCompanionPane.mjs`
  - `src/zen/tests/split_view/browser_split_view_right_web_visibility.js`
  - `src/zen/tests/split_view/browser_split_view_set_right_tab.js`
  - `src/zen/tests/tabs/browser_tabs_split_companion_click.js`
  - `src/zen/tests/tabs/browser_tabs_split_companion_inert.js`
  - `src/zen/tests/tabs/browser_tabs_split_companion_model.js`
  - `src/zen/tests/tabs/browser_tabs_split_companion_sync.js`
  - `src/zen/tests/tabs/browser_tabs_split_companion_workspace.js`
- Clean runtime import in `C:\zsc-runtime-clean-20260617-000111`:
  - `npm ci`
  - `npm run download`
  - synced only the 18 feature files from the source checkout
  - `npm run import`
  - `npm run bootstrap`
  - `py -3.11 mach configure`

## Known Unverified
- Focused runtime browser tests did not complete in this local Windows environment.
- Initial `mach test zen/tests/split_view/browser_split_view_set_right_tab.js` returned `UNKNOWN TEST` before configure; after `mach configure`, the command timed out after 15 minutes without useful output.
- `npm run build` then failed because Windows application control policy blocked a generated Rust build script executable: `icu_normalizer_data ... build-script-build`, `os error 4551`.
- This is recorded as an environmental runtime blocker, not a source patch blocker.

## Staging Scope
Only the 18 feature files are included. Local `.codex-tools/...` files were intentionally excluded.
