### PR TITLE
fix: Select renamed tab label from the start instead of caret-at-end

### DIFF
--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -1708,7 +1708,11 @@ window.gZenVerticalTabsManager = {
       this._tabEdited.after(input);
     }
     input.focus();
-    input.select();
+    // Select all, but keep the viewport anchored at the start (show the
+    // beginning of long labels, like the non-editing display) instead of the
+    // caret-at-end that input.select() leaves.
+    input.setSelectionRange(0, input.value.length, "backward");
+    input.scrollLeft = 0;
 
     input.addEventListener("blur", this._renameTabHalt);
   },


### PR DESCRIPTION
Instead of starting of with the caret at the very end when editing a tab label, now the full text gets selected directly and the label isn't scrolled to the end automatically, effectively showing it the same way as in non-edit mode