### PR TITLE
fix: Show pinned-tab scroll-shadow dividers based on scroll position

### DIFF
--- a/src/zen/spaces/ZenSpace.mjs
+++ b/src/zen/spaces/ZenSpace.mjs
@@ -139,6 +139,15 @@ export class nsZenWorkspace extends MozXULElement {
     this.scrollbox.addEventListener("underflow", this);
     this.scrollbox.addEventListener("overflow", this);
 
+    // Drive the scroll-shadow dividers from the real scroll position. The
+    // arrowscrollbox derives scrolledtostart/end from the first/last scrollable
+    // element's edge, which is unreliable when pinned tabs are collapsed; the
+    // raw scrollTop is not. Recompute on scroll and on overflow/underflow.
+    const refresh = () => this.refreshScrollShadow();
+    this.scrollbox.addEventListener("scroll", refresh);
+    this.scrollbox.addEventListener("overflow", refresh);
+    this.scrollbox.addEventListener("underflow", refresh);
+
     const indicatorName = this.indicator.querySelector(
       ".zen-current-workspace-indicator-name"
     );
@@ -267,6 +276,7 @@ export class nsZenWorkspace extends MozXULElement {
     this.prepend(this.collapsiblePins);
 
     this.#updateOverflow();
+    this.refreshScrollShadow();
 
     this.onGradientCacheChanged = this.#onGradientCacheChanged.bind(this);
     window.addEventListener(
@@ -335,6 +345,28 @@ export class nsZenWorkspace extends MozXULElement {
 
   #dispatchEventFromScrollbox(type) {
     this.scrollbox.dispatchEvent(new CustomEvent(type, {}));
+  }
+
+  // Show the top/bottom scroll-shadow dividers based on the real scroll
+  // position: visible as soon as there is hidden content past that edge, hidden
+  // only when actually at the start/end (including collapsed pinned tabs at the
+  // top). Computed from scrollTop so it does not depend on element geometry.
+  refreshScrollShadow() {
+    const arrowscrollbox = this.scrollbox;
+    const scrollbox = arrowscrollbox?.scrollbox;
+    if (!scrollbox) {
+      return;
+    }
+    const overflowing = scrollbox.scrollHeight > scrollbox.clientHeight + 1;
+    arrowscrollbox.toggleAttribute(
+      "zen-overflow-top",
+      overflowing && scrollbox.scrollTop > 0
+    );
+    arrowscrollbox.toggleAttribute(
+      "zen-overflow-bottom",
+      overflowing &&
+        scrollbox.scrollTop + scrollbox.clientHeight < scrollbox.scrollHeight - 1
+    );
   }
 
   get overflows() {

--- a/src/zen/spaces/zen-workspaces.css
+++ b/src/zen/spaces/zen-workspaces.css
@@ -383,11 +383,11 @@ zen-workspace {
         background-color: var(--zen-scrollbar-overflow-background);
       }
 
-      &:not([scrolledtostart])::before {
+      &[zen-overflow-top]::before {
         opacity: 1;
       }
 
-      &:not([scrolledtoend])::after {
+      &[zen-overflow-bottom]::after {
         opacity: 1;
       }
     }


### PR DESCRIPTION
The top/bottom scroll-shadow dividers were derived from the arrowscrollbox's
scrolledtostart/scrolledtoend, which it computes from the first/last scrollable
element's edge. With collapsed pinned tabs those edges are unreliable, so the
divider either flashed at the top (when pinned tabs were counted) or only
appeared once scrolled past the pinned/normal separator (when excluded).

Drive the dividers from the real scrollTop instead, via dedicated
zen-overflow-top/zen-overflow-bottom attributes: visible as soon as there is
hidden content past that edge, hidden only when actually at the start/end
(including collapsed pinned tabs sitting at the top). Zen hides the scroll
buttons, so the built-in attributes are unused otherwise.