### PR TITLE
feat: allow editing pinned tab URLs directly and grouping pinned URL options

### DIFF
--- a/locales/en-US/browser/browser/zen-general.ftl
+++ b/locales/en-US/browser/browser/zen-general.ftl
@@ -19,6 +19,13 @@ tab-context-zen-add-essential-badge = { $num } / { $max }
 tab-context-zen-remove-essential =
     .label = Remove from Essentials
     .accesskey = R
+tab-context-zen-edit-pinned-page =
+    .label =
+        { $isEssential ->
+            [true] Edit Essential Page
+           *[false] Edit Pinned Page
+        }
+    .accesskey = P
 tab-context-zen-replace-pinned-url-with-current =
     .label =
         { $isEssential ->
@@ -26,6 +33,9 @@ tab-context-zen-replace-pinned-url-with-current =
            *[false] Replace Pinned URL with Current
         }
     .accesskey = C
+tab-context-zen-edit-pinned-url =
+    .label = Edit...
+    .accesskey = E
 tab-context-zen-edit-title =
     .label = Change Label...
 tab-context-zen-edit-icon =
@@ -55,6 +65,10 @@ zen-general-confirm =
     .label = Confirm
 
 zen-pinned-tab-replaced = Pinned tab URL has been replaced with the current URL!
+zen-pinned-tab-url-edited = Pinned tab URL has been updated!
+zen-pinned-tab-url-invalid = That doesn't look like a valid URL.
+zen-pinned-tab-edit-url-title = Edit Pinned URL
+zen-pinned-tab-edit-url-label = Enter the URL this pinned tab should point to:
 zen-tabs-renamed = Tab has been successfully renamed!
 zen-background-tab-opened-toast = New background tab opened!
 zen-workspace-renamed-toast = Workspace has been successfully renamed!

--- a/src/browser/base/content/zen-commands.inc.xhtml
+++ b/src/browser/base/content/zen-commands.inc.xhtml
@@ -35,6 +35,7 @@
   <command id="cmd_zenToggleTabsOnRight" />
 
   <command id="cmd_zenReplacePinnedUrlWithCurrent" />
+  <command id="cmd_zenEditPinnedUrl" />
   <command id="cmd_contextZenAddToEssentials" />
   <command id="cmd_contextZenRemoveFromEssentials" />
 

--- a/src/zen/common/zen-sets.js
+++ b/src/zen/common/zen-sets.js
@@ -78,6 +78,9 @@ document.addEventListener(
           case "cmd_zenReplacePinnedUrlWithCurrent":
             gZenPinnedTabManager.replacePinnedUrlWithCurrent();
             break;
+          case "cmd_zenEditPinnedUrl":
+            gZenPinnedTabManager.editPinnedUrl();
+            break;
           case "cmd_contextZenAddToEssentials":
             gZenPinnedTabManager.addToEssentials();
             break;

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -1249,6 +1249,32 @@ class nsZenWindowSync {
   }
 
   /**
+   * Sets the canonical pinned URL for a tab across all windows, keeping the
+   * existing title/icon. Used to let the user edit a pinned tab's URL directly.
+   *
+   * @param {object} aTab - The tab to set the pinned URL for.
+   * @param {string} aUrl - The URL to store as the canonical pinned URL.
+   */
+  setPinnedUrl(aTab, aUrl) {
+    this.log(`Setting pinned url for tab ${aTab.id}`);
+    const image =
+      aTab.getAttribute("image") || aTab.ownerGlobal.gBrowser.getIcon(aTab);
+    const initialState = {
+      entry: {
+        url: aUrl,
+        title: aTab._zenPinnedInitialState?.entry?.title ?? aTab.label,
+      },
+      image,
+    };
+    this.#runOnAllWindows(null, win => {
+      const targetTab = this.getItemFromWindow(win, aTab.id);
+      if (targetTab) {
+        targetTab._zenPinnedInitialState = initialState;
+      }
+    });
+  }
+
+  /**
    * Propagates the workspaces to all windows.
    *
    * @param {Array} aWorkspaces - The workspaces to propagate.

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -274,7 +274,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     }
 
     let url = result.value.trim();
-    if (!url || url === currentUrl) {
+    if (!url) {
       return;
     }
 
@@ -287,6 +287,12 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
         gZenUIManager.showToast("zen-pinned-tab-url-invalid");
         return;
       }
+    }
+
+    // Compare after normalization so re-entering the same URL without a scheme
+    // is correctly treated as a no-op.
+    if (url === currentUrl) {
+      return;
     }
 
     window.gZenWindowSync.setPinnedUrl(tab, url);

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -246,6 +246,54 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     gZenUIManager.showToast("zen-pinned-tab-replaced");
   }
 
+  async editPinnedUrl(tab = undefined) {
+    tab ??= TabContextMenu.contextTab;
+    if (!tab || !tab.pinned) {
+      return;
+    }
+
+    const currentUrl =
+      tab._zenPinnedInitialState?.entry?.url ||
+      tab.linkedBrowser?.currentURI?.spec ||
+      "";
+    const [title, label] = await document.l10n.formatValues([
+      { id: "zen-pinned-tab-edit-url-title" },
+      { id: "zen-pinned-tab-edit-url-label" },
+    ]);
+    const result = { value: currentUrl };
+    const confirmed = Services.prompt.prompt(
+      window,
+      title,
+      label,
+      result,
+      null,
+      { value: false }
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    let url = result.value.trim();
+    if (!url || url === currentUrl) {
+      return;
+    }
+
+    try {
+      url = Services.io.newURI(url).spec;
+    } catch (e) {
+      try {
+        url = Services.io.newURI(`https://${url}`).spec;
+      } catch (e2) {
+        gZenUIManager.showToast("zen-pinned-tab-url-invalid");
+        return;
+      }
+    }
+
+    window.gZenWindowSync.setPinnedUrl(tab, url);
+    this.resetPinnedTab(tab);
+    gZenUIManager.showToast("zen-pinned-tab-url-edited");
+  }
+
   _initClosePinnedTabShortcut() {
     let cmdClose = document.getElementById("cmd_close");
 
@@ -545,11 +593,20 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     }
     const elements = window.MozXULElement.parseXULToFragment(`
             <menuseparator id="context_zen-pinned-tab-separator" hidden="true"/>
-            <menuitem id="context_zen-replace-pinned-url-with-current"
-                      data-lazy-l10n-id="tab-context-zen-replace-pinned-url-with-current"
-                      data-l10n-args="{&quot;isEssential&quot;:&quot;&quot;}"
-                      hidden="true"
-                      command="cmd_zenReplacePinnedUrlWithCurrent"/>
+            <menu id="context_zen-edit-pinned-page"
+                  data-lazy-l10n-id="tab-context-zen-edit-pinned-page"
+                  data-l10n-args="{&quot;isEssential&quot;:&quot;&quot;}"
+                  hidden="true">
+              <menupopup>
+                <menuitem id="context_zen-replace-pinned-url-with-current"
+                          data-lazy-l10n-id="tab-context-zen-replace-pinned-url-with-current"
+                          data-l10n-args="{&quot;isEssential&quot;:&quot;&quot;}"
+                          command="cmd_zenReplacePinnedUrlWithCurrent"/>
+                <menuitem id="context_zen-edit-pinned-url"
+                          data-lazy-l10n-id="tab-context-zen-edit-pinned-url"
+                          command="cmd_zenEditPinnedUrl"/>
+              </menupopup>
+            </menu>
             <menuitem id="context_zen-reset-pinned-tab"
                       data-lazy-l10n-id="tab-context-zen-reset-pinned-tab"
                       data-l10n-args="{&quot;isEssential&quot;:&quot;&quot;}"
@@ -619,12 +676,19 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     const zenResetPinnedTab = document.getElementById(
       "context_zen-reset-pinned-tab"
     );
+    const zenEditPinnedPage = document.getElementById(
+      "context_zen-edit-pinned-page"
+    );
     const zenReplacePinnedUrl = document.getElementById(
       "context_zen-replace-pinned-url-with-current"
     );
-    [zenResetPinnedTab, zenReplacePinnedUrl].forEach(element => {
+    [zenResetPinnedTab, zenEditPinnedPage].forEach(element => {
       if (element) {
         element.hidden = !isVisible;
+      }
+    });
+    [zenResetPinnedTab, zenEditPinnedPage, zenReplacePinnedUrl].forEach(element => {
+      if (element) {
         document.l10n.setArgs(element, { isEssential });
       }
     });


### PR DESCRIPTION
Currently its not possible to edit a pinned tab's URL directly. Zen only offers to apply the current URL ("Replace <...> URL with current). This makes it impossible to configure it a URL which is usually e.g. redirecting - but maybe thats intended.

For this reason I implemented a dedicated "Edit URL" option, which allows the editing directly.
As there would be 3 options for those URLs now, I decided to group them together in a sub menu