### PR TITLE
feat: Mark the workspace's current container in the Set Profile menu

### DIFF
--- a/src/browser/base/content/utilityOverlay-js.patch
+++ b/src/browser/base/content/utilityOverlay-js.patch
@@ -1,0 +1,32 @@
+diff --git a/browser/base/content/utilityOverlay.js b/browser/base/content/utilityOverlay.js
+index e692f340a0fb20c785507e5728c8ee9d5a7e011d..33b4820f4593fa07228ea0ef5ae2cfad21bfb34e 100644
+--- a/browser/base/content/utilityOverlay.js
++++ b/browser/base/content/utilityOverlay.js
+@@ -182,6 +182,7 @@ function createUserContextMenu(
+     excludeUserContextId = 0,
+     showDefaultTab = false,
+     useAccessKeys = true,
++    checkedUserContextId = null,
+   } = {}
+ ) {
+   while (event.target.hasChildNodes()) {
+@@ -202,6 +203,9 @@ function createUserContextMenu(
+       menuitem.setAttribute("label", label);
+     }
+     menuitem.setAttribute("data-usercontextid", "0");
++    if (checkedUserContextId === 0) {
++      menuitem.setAttribute("checked", "true");
++    }
+     if (!isContextMenu) {
+       menuitem.setAttribute("command", "Browser:NewUserContextTab");
+     }
+@@ -219,6 +223,9 @@ function createUserContextMenu(
+ 
+     let menuitem = document.createXULElement("menuitem");
+     menuitem.setAttribute("data-usercontextid", identity.userContextId);
++    if (identity.userContextId == checkedUserContextId) {
++      menuitem.setAttribute("checked", "true");
++    }
+     if (identity.name) {
+       menuitem.setAttribute("label", identity.name);
+     } else if (useAccessKeys) {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -1193,11 +1193,11 @@ class nsZenWorkspaces {
     } else {
       workspace = this.getActiveWorkspaceFromCache();
     }
-    let containerTabId = workspace.containerTabId;
+    // Check the workspace's currently assigned container.
     return window.createUserContextMenu(event, {
       isContextMenu: true,
-      excludeUserContextId: containerTabId,
       showDefaultTab: true,
+      checkedUserContextId: workspace.containerTabId || 0,
     });
   }
 


### PR DESCRIPTION
The container assigned to a space used to be excluded from its Set Profile menu, so nothing indicated the current selection. Include it and mark it with the menuitem `checked` state, which maps to the native macOS menu checkmark while keeping the container's colored icon. "No Container" (id 0) is checked when the space has no container.