### PR TITLE
no-bug: Fix glance tab positioning and prevent split-view (gh-14343)

### DIFF
--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabbrowser.js b/browser/components/tabbrowser/content/tabbrowser.js
-index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f3682852f8a52bd 100644
+index 08b5b56e069d038d72c87355920c4ce8a55ed805..87f41c8583c26f364530def5bd5d83330c265dfc 100644
 --- a/browser/components/tabbrowser/content/tabbrowser.js
 +++ b/browser/components/tabbrowser/content/tabbrowser.js
 @@ -511,6 +511,7 @@
@@ -523,12 +523,15 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
  
        if (tabs.length > 1 || !tabs[0].selected) {
          this._updateTabsAfterInsert();
-@@ -4866,11 +5030,14 @@
+@@ -4866,11 +5030,17 @@
        if (ownerTab) {
          tab.owner = ownerTab;
        }
 +      if ((!tab.pinned && tabGroup?.isZenFolder && !Services.prefs.getBoolPref('zen.folders.owned-tabs-in-folder')) || (tabGroup && tabGroup.hasAttribute("split-view-group"))) {
 +        tabGroup = null;
++      }
++      if (openerTab?.hasAttribute("zen-glance-tab")) {
++        openerTab = gZenGlanceManager.getTabOrGlanceParent(openerTab);
 +      }
  
        // Ensure we have an index if one was not provided.
@@ -539,7 +542,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
          if (
            !bulkOrderedOpen &&
            ((openerTab &&
-@@ -4882,7 +5049,7 @@
+@@ -4882,7 +5052,7 @@
            let lastRelatedTab =
              openerTab && this._lastRelatedTabMap.get(openerTab);
            let previousTab = lastRelatedTab || openerTab || this.selectedTab;
@@ -548,7 +551,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
              tabGroup = previousTab.group;
            }
            if (
-@@ -4898,7 +5065,7 @@
+@@ -4898,7 +5068,7 @@
                  previousTab.splitview
                ) + 1;
            } else if (previousTab.visible) {
@@ -557,7 +560,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
            } else if (previousTab == FirefoxViewHandler.tab) {
              elementIndex = 0;
            }
-@@ -4926,14 +5093,14 @@
+@@ -4926,14 +5096,14 @@
        }
        // Ensure index is within bounds.
        if (tab.pinned) {
@@ -576,7 +579,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
  
        if (pinned && !itemAfter?.pinned) {
          itemAfter = null;
-@@ -4950,7 +5117,7 @@
+@@ -4950,7 +5120,7 @@
  
        this.tabContainer._invalidateCachedTabs();
  
@@ -585,7 +588,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
          if (
            (this.isTab(itemAfter) && itemAfter.group == tabGroup) ||
            this.isSplitViewWrapper(itemAfter)
-@@ -4981,7 +5148,11 @@
+@@ -4981,7 +5151,11 @@
          const tabContainer = pinned
            ? this.tabContainer.pinnedTabsContainer
            : this.tabContainer;
@@ -597,7 +600,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        }
  
        if (tab.group?.collapsed) {
-@@ -4996,6 +5167,7 @@
+@@ -4996,6 +5170,7 @@
        if (pinned) {
          this._updateTabBarForPinnedTabs();
        }
@@ -605,7 +608,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
  
        TabBarVisibility.update();
      }
-@@ -5544,6 +5716,7 @@
+@@ -5544,6 +5719,7 @@
          telemetrySource,
        } = {}
      ) {
@@ -613,7 +616,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        // When 'closeWindowWithLastTab' pref is enabled, closing all tabs
        // can be considered equivalent to closing the window.
        if (
-@@ -5633,6 +5806,7 @@
+@@ -5633,6 +5809,7 @@
          if (lastToClose) {
            this.removeTab(lastToClose, aParams);
          }
@@ -621,7 +624,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        } catch (e) {
          console.error(e);
        }
-@@ -5678,6 +5852,14 @@
+@@ -5678,6 +5855,14 @@
          return;
        }
  
@@ -636,7 +639,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        let isVisibleTab = aTab.visible;
        // We have to sample the tab width now, since _beginRemoveTab might
        // end up modifying the DOM in such a way that aTab gets a new
-@@ -5685,6 +5867,9 @@
+@@ -5685,6 +5870,9 @@
        // state).
        let tabWidth = window.windowUtils.getBoundsWithoutFlushing(aTab).width;
        let isLastTab = this.#isLastTabInWindow(aTab);
@@ -646,7 +649,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        if (
          !this._beginRemoveTab(aTab, {
            closeWindowFastpath: true,
-@@ -5696,13 +5881,14 @@
+@@ -5696,13 +5884,14 @@
            telemetrySource,
          })
        ) {
@@ -662,7 +665,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        let lockTabSizing =
          !this.tabContainer.verticalMode &&
          !aTab.pinned &&
-@@ -5733,7 +5919,13 @@
+@@ -5733,7 +5922,13 @@
          // We're not animating, so we can cancel the animation stopwatch.
          Glean.browserTabclose.timeAnim.cancel(aTab._closeTimeAnimTimerId);
          aTab._closeTimeAnimTimerId = null;
@@ -677,7 +680,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
          return;
        }
  
-@@ -5867,7 +6059,7 @@
+@@ -5867,7 +6062,7 @@
            closeWindowWithLastTab != null
              ? closeWindowWithLastTab
              : !window.toolbar.visible ||
@@ -686,7 +689,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
  
          if (closeWindow) {
            // We've already called beforeunload on all the relevant tabs if we get here,
-@@ -5891,6 +6083,7 @@
+@@ -5891,6 +6086,7 @@
  
          newTab = true;
        }
@@ -694,7 +697,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        aTab._endRemoveArgs = [closeWindow, newTab];
  
        // swapBrowsersAndCloseOther will take care of closing the window without animation.
-@@ -5931,13 +6124,7 @@
+@@ -5931,13 +6127,7 @@
        aTab._mouseleave();
  
        if (newTab) {
@@ -709,7 +712,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        } else {
          TabBarVisibility.update();
        }
-@@ -6070,6 +6257,7 @@
+@@ -6070,6 +6260,7 @@
          this.tabs[i]._tPos = i;
        }
  
@@ -717,7 +720,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        if (!this._windowIsClosing) {
          // update tab close buttons state
          this.tabContainer._updateCloseButtons();
-@@ -6255,6 +6443,7 @@
+@@ -6255,6 +6446,7 @@
          memory_after: await getTotalMemoryUsage(),
          time_to_unload_in_ms: timeElapsed,
        });
@@ -725,7 +728,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
      }
  
      /**
-@@ -6300,6 +6489,7 @@
+@@ -6300,6 +6492,7 @@
        }
  
        let excludeTabs = new Set(aExcludeTabs);
@@ -733,7 +736,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
  
        // If this tab has a successor, it should be selectable, since
        // hiding or closing a tab removes that tab as a successor.
-@@ -6312,15 +6502,22 @@
+@@ -6312,15 +6505,22 @@
          !excludeTabs.has(aTab.owner) &&
          Services.prefs.getBoolPref("browser.tabs.selectOwnerOnClose")
        ) {
@@ -758,7 +761,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        let tab = this.tabContainer.findNextTab(aTab, {
          direction: 1,
          filter: _tab => remainingTabs.includes(_tab),
-@@ -6334,7 +6531,7 @@
+@@ -6334,7 +6534,7 @@
        }
  
        if (tab) {
@@ -767,7 +770,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        }
  
        // If no qualifying visible tab was found, see if there is a tab in
-@@ -6355,7 +6552,7 @@
+@@ -6355,7 +6555,7 @@
          });
        }
  
@@ -776,7 +779,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
      }
  
      _blurTab(aTab) {
-@@ -6366,7 +6563,7 @@
+@@ -6366,7 +6566,7 @@
       * @returns {boolean}
       *   False if swapping isn't permitted, true otherwise.
       */
@@ -785,7 +788,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        // Do not allow transfering a private tab to a non-private window
        // and vice versa.
        if (
-@@ -6420,6 +6617,7 @@
+@@ -6420,6 +6620,7 @@
        // fire the beforeunload event in the process.  Close the other
        // window if this was its last tab.
        if (
@@ -793,7 +796,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
          !remoteBrowser._beginRemoveTab(aOtherTab, {
            adoptedByTab: aOurTab,
            closeWindowWithLastTab: true,
-@@ -6431,7 +6629,7 @@
+@@ -6431,7 +6632,7 @@
        // If this is the last tab of the window, hide the window
        // immediately without animation before the docshell swap, to avoid
        // about:blank being painted.
@@ -802,7 +805,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        if (closeWindow) {
          let win = aOtherTab.documentGlobal;
          win.windowUtils.suppressAnimation(true);
-@@ -6565,11 +6763,13 @@
+@@ -6565,11 +6766,13 @@
        }
  
        // Finish tearing down the tab that's going away.
@@ -816,7 +819,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
  
        this.setTabTitle(aOurTab);
  
-@@ -6771,10 +6971,10 @@
+@@ -6771,10 +6974,10 @@
        SessionStore.deleteCustomTabValue(aTab, "hiddenBy");
      }
  
@@ -829,7 +832,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
          aTab.selected ||
          aTab.closing ||
          // Tabs that are sharing the screen, microphone or camera cannot be hidden.
-@@ -6834,7 +7034,8 @@
+@@ -6834,7 +7037,8 @@
       * @param {object} [aOptions={}]
       *   Key-value pairs that will be serialized into the features string.
       */
@@ -839,7 +842,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        if (this.tabs.length == 1) {
          return null;
        }
-@@ -6851,7 +7052,7 @@
+@@ -6851,7 +7055,7 @@
        // tell a new window to take the "dropped" tab
        let args = Cc["@mozilla.org/array;1"].createInstance(Ci.nsIMutableArray);
        args.appendElement(aTab.splitview ?? aTab);
@@ -848,7 +851,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
          private: PrivateBrowsingUtils.isWindowPrivate(window),
          features: Object.entries(aOptions)
            .map(([key, value]) => `${key}=${value}`)
-@@ -6859,6 +7060,8 @@
+@@ -6859,6 +7063,8 @@
          openerWindow: window,
          args,
        });
@@ -857,7 +860,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
      }
  
      /**
-@@ -6971,7 +7174,7 @@
+@@ -6971,7 +7177,7 @@
       *   `true` if element is a `<tab-group>`
       */
      isTabGroup(element) {
@@ -866,7 +869,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
      }
  
      /**
-@@ -7056,8 +7259,8 @@
+@@ -7056,8 +7262,8 @@
        }
  
        // Don't allow mixing pinned and unpinned tabs.
@@ -877,7 +880,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        } else {
          tabIndex = Math.max(tabIndex, this.pinnedTabCount);
        }
-@@ -7103,8 +7306,8 @@
+@@ -7103,8 +7309,8 @@
        this.#handleTabMove(
          element,
          () => {
@@ -888,7 +891,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
              neighbor = neighbor.group;
            }
            if (neighbor?.splitview) {
-@@ -7115,6 +7318,12 @@
+@@ -7115,6 +7321,12 @@
                return;
              }
            }
@@ -901,7 +904,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
  
            if (movingForwards && neighbor) {
              neighbor.after(element);
-@@ -7173,23 +7382,31 @@
+@@ -7173,23 +7385,31 @@
      #moveTabNextTo(element, targetElement, moveBefore = false, metricsContext) {
        if (this.isTabGroupLabel(targetElement)) {
          targetElement = targetElement.group;
@@ -939,7 +942,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        } else if (!element.pinned && targetElement && targetElement.pinned) {
          // If the caller asks to move an unpinned element next to a pinned
          // tab, move the unpinned element to be the first unpinned element
-@@ -7202,12 +7419,35 @@
+@@ -7202,12 +7422,35 @@
          //    move the tab group right before the first unpinned tab.
          // 4. Moving a tab group and the first unpinned tab is grouped:
          //    move the tab group right before the first unpinned tab's tab group.
@@ -976,7 +979,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
  
        // We want to include the splitview wrapper if it's the targetElement, but
        // not in the case where we want to reverse tabs within the same splitview.
-@@ -7216,6 +7456,7 @@
+@@ -7216,6 +7459,7 @@
        }
  
        let getContainer = () =>
@@ -984,7 +987,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
          element.pinned
            ? this.tabContainer.pinnedTabsContainer
            : this.tabContainer;
-@@ -7224,11 +7465,15 @@
+@@ -7224,11 +7468,15 @@
          element,
          () => {
            if (moveBefore) {
@@ -1001,7 +1004,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
            }
          },
          metricsContext
-@@ -7302,11 +7547,15 @@
+@@ -7302,11 +7550,15 @@
       * @param {TabMetricsContext} [metricsContext]
       */
      moveTabToExistingGroup(aTab, aGroup, metricsContext) {
@@ -1020,7 +1023,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        }
        if (aTab.group && aTab.group.id === aGroup.id) {
          return;
-@@ -7378,6 +7627,7 @@
+@@ -7378,6 +7630,7 @@
  
        let state = {
          tabIndex: tab._tPos,
@@ -1028,7 +1031,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        };
        if (tab.visible) {
          state.elementIndex = tab.elementIndex;
-@@ -7409,7 +7659,7 @@
+@@ -7409,7 +7662,7 @@
        let changedSplitView =
          previousTabState.splitViewId != currentTabState.splitViewId;
  
@@ -1037,7 +1040,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
          tab.dispatchEvent(
            new CustomEvent("TabMove", {
              bubbles: true,
-@@ -7456,6 +7706,10 @@
+@@ -7456,6 +7709,10 @@
  
        moveActionCallback();
  
@@ -1048,7 +1051,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        // Clear tabs cache after moving nodes because the order of tabs may have
        // changed.
        this.tabContainer._invalidateCachedTabs();
-@@ -7506,7 +7760,22 @@
+@@ -7506,7 +7763,22 @@
       * @returns {object}
       *    The new tab in the current window, null if the tab couldn't be adopted.
       */
@@ -1072,7 +1075,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        // Swap the dropped tab with a new one we create and then close
        // it in the other window (making it seem to have moved between
        // windows). We also ensure that the tab we create to swap into has
-@@ -7549,6 +7818,8 @@
+@@ -7549,6 +7821,8 @@
        }
        params.skipLoad = true;
        let newTab = this.addWebTab("about:blank", params);
@@ -1081,7 +1084,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
  
        aTab.container.tabDragAndDrop.finishAnimateTabMove();
  
-@@ -8259,7 +8530,7 @@
+@@ -8259,7 +8533,7 @@
          // preventDefault(). It will still raise the window if appropriate.
          return;
        }
@@ -1090,7 +1093,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        window.focus();
        aEvent.preventDefault();
      }
-@@ -8276,7 +8547,6 @@
+@@ -8276,7 +8550,6 @@
  
      on_TabGroupCollapse(aEvent) {
        aEvent.target.tabs.forEach(tab => {
@@ -1098,7 +1101,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
        });
      }
  
-@@ -8630,7 +8900,9 @@
+@@ -8630,7 +8903,9 @@
  
          let filter = this._tabFilters.get(tab);
          if (filter) {
@@ -1108,7 +1111,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
  
            let listener = this._tabListeners.get(tab);
            if (listener) {
-@@ -9435,6 +9707,7 @@
+@@ -9435,6 +9710,7 @@
              aWebProgress.isTopLevel
            ) {
              this.mTab.setAttribute("busy", "true");
@@ -1116,7 +1119,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
              gBrowser._tabAttrModified(this.mTab, ["busy"]);
              this.mTab._notselectedsinceload = !this.mTab.selected;
            }
-@@ -9515,6 +9788,7 @@
+@@ -9515,6 +9791,7 @@
          // known defaults. Note we use the original URL since about:newtab
          // redirects to a prerendered page.
          const shouldRemoveFavicon =
@@ -1124,7 +1127,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
            !this.mBrowser.mIconURL &&
            !ignoreBlank &&
            !(originalLocation.spec in FAVICON_DEFAULTS);
-@@ -9689,13 +9963,6 @@
+@@ -9689,13 +9966,6 @@
              this.mBrowser.originalURI = aRequest.originalURI;
            }
  
@@ -1138,7 +1141,7 @@ index 08b5b56e069d038d72c87355920c4ce8a55ed805..555ffd4772d9d4903491fdff9f368285
          }
  
          let userContextId = this.mBrowser.getAttribute("usercontextid") || 0;
-@@ -10587,7 +10854,8 @@ var TabContextMenu = {
+@@ -10587,7 +10857,8 @@ var TabContextMenu = {
      );
      contextUnpinSelectedTabs.hidden =
        !this.contextTab.pinned || !this.multiselected;

--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -1240,13 +1240,16 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
    */
   contextSplitTabs(otherTabHint = null) {
     let tabs;
-    let currentTab = TabContextMenu.contextTab || gBrowser.selectedTab;
+    let currentTab = gZenGlanceManager.getTabOrGlanceParent(
+      TabContextMenu.contextTab || gBrowser.selectedTab
+    );
+    console.log(currentTab, currentTab.hasAttribute("zen-glance-tab"));
     if (currentTab.multiselected) {
       tabs = gBrowser.selectedTabs;
     } else if (!currentTab.selected && !currentTab.splitView) {
       tabs = [
         currentTab,
-        ...gBrowser.selectedTabs.filter(t => t !== currentTab),
+        ...gBrowser.selectedTabs.filter(t => t !== currentTab && !t.hasAttribute("zen-glance-tab")),
       ];
     } else {
       tabs = [currentTab];

--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -1248,7 +1248,9 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     } else if (!currentTab.selected && !currentTab.splitView) {
       tabs = [
         currentTab,
-        ...gBrowser.selectedTabs.filter(t => t !== currentTab && !t.hasAttribute("zen-glance-tab")),
+        ...gBrowser.selectedTabs.filter(
+          t => t !== currentTab && !t.hasAttribute("zen-glance-tab")
+        ),
       ];
     } else {
       tabs = [currentTab];

--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -1243,7 +1243,6 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     let currentTab = gZenGlanceManager.getTabOrGlanceParent(
       TabContextMenu.contextTab || gBrowser.selectedTab
     );
-    console.log(currentTab, currentTab.hasAttribute("zen-glance-tab"));
     if (currentTab.multiselected) {
       tabs = gBrowser.selectedTabs;
     } else if (!currentTab.selected && !currentTab.splitView) {


### PR DESCRIPTION
- Fixed: If you try to open a link in a new tab from Glance, it opens in the wrong place
- Fixed: Exclude glance tabs from split-view targets