### PR TITLE
gh-14330: Fixes wrong workspace context in the right-click actions menu

### DIFF
--- a/src/zen/common/emojis/ZenEmojiPicker.mjs
+++ b/src/zen/common/emojis/ZenEmojiPicker.mjs
@@ -242,7 +242,7 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     this.#lastSelectedEmoji = null;
 
     this.#anchor.removeAttribute("zen-emoji-open");
-    this.#anchor.parentElement.removeAttribute("zen-emoji-open");
+    this.#anchor.parentElement?.removeAttribute("zen-emoji-open");
     this.#anchor = null;
   }
 

--- a/src/zen/spaces/ZenSpace.mjs
+++ b/src/zen/spaces/ZenSpace.mjs
@@ -382,7 +382,7 @@ export class nsZenWorkspace extends MozXULElement {
       popup.removeEventListener("popuphidden", handlePopupHidden);
     };
     popup.addEventListener("popuphidden", handlePopupHidden);
-    popup.openPopup(event.target, "after_start");
+    popup.openPopup(event.target, "after_start", 0, 0, false, false, event);
   }
 
   get newTabButton() {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -937,14 +937,20 @@ class nsZenWorkspaces {
   }
 
   changeWorkspaceIcon() {
-    let anchor = this.activeWorkspaceIndicator?.querySelector(
-      ".zen-current-workspace-indicator-icon"
-    );
-    if (this.#contextMenuData?.workspaceId) {
-      anchor = this.#contextMenuData.originalTarget;
+    let workspaceId;
+    let anchor;
+    if (this.#contextMenuData) {
+      workspaceId = this.#contextMenuData.workspaceId;
+      anchor =
+        this.#contextMenuData.originalTarget?.querySelector(
+          ".zen-current-workspace-indicator-icon"
+        ) || this.#contextMenuData.originalTarget;
+    } else {
+      workspaceId = this.activeWorkspace;
+      anchor = this.activeWorkspaceIndicator?.querySelector(
+        ".zen-current-workspace-indicator-icon"
+      );
     }
-    const workspaceId =
-      this.#contextMenuData?.workspaceId || this.activeWorkspace;
     if (!anchor) {
       return;
     }
@@ -1073,12 +1079,10 @@ class nsZenWorkspaces {
       "popupshowing",
       this.updateWorkspaceActionsMenu.bind(this)
     );
-    workspaceActions.addEventListener("popuphidden", () => {
-      setTimeout(() => {
-        setTimeout(() => {
-          this.#contextMenuData = null;
-        }, 0);
-      }, 0); // Delay to ensure the context menu data is cleared after the popup is hidden
+    workspaceActions.addEventListener("popuphidden", event => {
+      if (event.target === workspaceActions) {
+        this.#contextMenuData = null;
+      }
     });
 
     const contextChangeContainerTabMenu = document.getElementById(
@@ -1130,15 +1134,10 @@ class nsZenWorkspaces {
     } else {
       openInContainerMenuItem.setAttribute("hidden", "true");
     }
-    // Call parent node as on windows, the text can be double clicked
-    let target;
-    try {
-      target = event.explicitOriginalTarget?.closest("toolbarbutton");
-    } catch (e) {
-      console.error("Error getting explicitOriginalTarget in context menu:", e);
-    }
-    this.#contextMenuData = {
-      workspaceId: target?.getAttribute("zen-workspace-id"),
+    const target = event.target.triggerNode?.closest?.("[zen-workspace-id]");
+    const contextWorkspaceId = target?.getAttribute("zen-workspace-id");
+    this.#contextMenuData = target && {
+      workspaceId: contextWorkspaceId,
       originalTarget: target,
     };
     const workspaceName = document.getElementById("context_zenEditWorkspace");
@@ -1151,19 +1150,15 @@ class nsZenWorkspaces {
       "zen.view.sidebar-expanded"
     );
     workspaceName.hidden =
-      isCollapsed ||
-      (this.#contextMenuData.workspaceId &&
-        this.#contextMenuData.workspaceId !== this.activeWorkspace);
-    themePicker.hidden =
-      this.#contextMenuData.workspaceId &&
-      this.#contextMenuData.workspaceId !== this.activeWorkspace;
+      isCollapsed || contextWorkspaceId !== this.activeWorkspace;
+    themePicker.hidden = contextWorkspaceId !== this.activeWorkspace;
     const separator = document.getElementById("context_zenWorkspacesSeparator");
     for (const item of event.target.querySelectorAll(
       ".zen-workspace-context-menu-item"
     )) {
       item.remove();
     }
-    if (!this.#contextMenuData.workspaceId) {
+    if (!contextWorkspaceId) {
       separator.hidden = false;
       for (const workspace of this.getWorkspaces().reverse()) {
         const item = this.generateMenuItemForWorkspace(workspace);
@@ -1177,13 +1172,6 @@ class nsZenWorkspaces {
     } else {
       separator.hidden = true;
     }
-    event.target.addEventListener(
-      "popuphidden",
-      () => {
-        this.#contextMenuData = null;
-      },
-      { once: true }
-    );
   }
 
   updateWorkspaceActionsMenuContainer(event) {


### PR DESCRIPTION
Populate #contextMenuData from the popup's triggerNode instead of explicitOriginalTarget.closest("toolbarbutton"), which carries no zen-workspace-id, and pass the triggering event to the programmatic openPopup in onActionsCommand so that path sets triggerNode too. Clear #contextMenuData with a single synchronous, popup-scoped popuphidden handler, replacing the deferred double-setTimeout and the duplicate {once:true} clearer.