### PR TITLE
gh-14390: fix profile picker menu when creating new workspace

### DIFF
--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -182,8 +182,8 @@ class nsZenWorkspaceCreation extends MozXULElement {
         this.onProfileCommand.bind(this)
       );
       this.profilesPopup.addEventListener(
-        "popupshown",
-        this.onProfilePopupShown.bind(this)
+        "popupshowing",
+        this.onProfilePopupShowing.bind(this)
       );
       this.profilesPopup.addEventListener(
         "command",
@@ -192,7 +192,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
 
       this.currentProfile = {
         id: 0,
-        name: "Default",
+        name: ContextualIdentityService.formatContextLabel("user-context-none"),
       };
     } else {
       this.inputProfile.parentNode.hidden = true;
@@ -296,10 +296,11 @@ class nsZenWorkspaceCreation extends MozXULElement {
     this.profilesPopup.openPopup(event.target, "after_start");
   }
 
-  onProfilePopupShown(event) {
+  onProfilePopupShowing(event) {
     return window.createUserContextMenu(event, {
       isContextMenu: true,
       showDefaultTab: true,
+      excludeUserContextId: this.currentProfile || 0,
     });
   }
 


### PR DESCRIPTION
Profile menu now opens directly and lists profiles only once