### PR TITLE
gh-14390: fix profile picker menu when creating new workspace (gh-14421)

### DIFF
--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -182,8 +182,8 @@ class nsZenWorkspaceCreation extends MozXULElement {
         this.onProfileCommand.bind(this)
       );
       this.profilesPopup.addEventListener(
-        "popupshown",
-        this.onProfilePopupShown.bind(this)
+        "popupshowing",
+        this.onProfilePopupShowing.bind(this)
       );
       this.profilesPopup.addEventListener(
         "command",
@@ -296,7 +296,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
     this.profilesPopup.openPopup(event.target, "after_start");
   }
 
-  onProfilePopupShown(event) {
+  onProfilePopupShowing(event) {
     return window.createUserContextMenu(event, {
       isContextMenu: true,
       showDefaultTab: true,


### PR DESCRIPTION
fixes #14390

items are now getting determined correctly timed and not duplicated anymore