### PR TITLE
no-bug: show local and LAN dev URLs as a tab sublabel

### DIFF
--- a/prefs/zen/zen.yaml
+++ b/prefs/zen/zen.yaml
@@ -11,6 +11,9 @@
 - name: zen.tabs.rename-tabs
   value: true
 
+- name: zen.tabs.show-localhost-url
+  value: true # Show the host:port of local/LAN dev servers as a tab sublabel
+
 - name: zen.tabs.essentials.max
   value: 12
 

--- a/src/zen/common/ZenPreloadedScripts.js
+++ b/src/zen/common/ZenPreloadedScripts.js
@@ -23,6 +23,7 @@
     "chrome://browser/content/zen-components/ZenMediaController.mjs",
     "chrome://browser/content/zen-components/ZenGlanceManager.mjs",
     "chrome://browser/content/zen-components/ZenPinnedTabManager.mjs",
+    "chrome://browser/content/zen-components/ZenLocalhostSublabel.mjs",
     "chrome://browser/content/zen-components/ZenViewSplitter.mjs",
     "chrome://browser/content/zen-components/ZenFolders.mjs",
     "chrome://browser/content/zen-components/ZenEmojiPicker.mjs",

--- a/src/zen/tabs/ZenLocalhostSublabel.mjs
+++ b/src/zen/tabs/ZenLocalhostSublabel.mjs
@@ -1,0 +1,181 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { nsZenDOMOperatedFeature } from "chrome://browser/content/zen-components/ZenCommonUtils.mjs";
+
+const lazy = {};
+
+const PREF_SHOW_LOCALHOST_URL = "zen.tabs.show-localhost-url";
+
+// eslint-disable-next-line mozilla/valid-lazy
+XPCOMUtils.defineLazyPreferenceGetter(
+  lazy,
+  "showLocalhostUrl",
+  PREF_SHOW_LOCALHOST_URL,
+  true
+);
+
+// Property stamped on tabs whose sublabel we own. We only ever clear a sublabel
+// that we set, so we never stomp on the ones managed by pinned tabs or live
+// folders.
+const OWNED_SUBLABEL = "_zenLocalhostUrl";
+
+/**
+ * Shows the host (and port) of local development servers as a small sublabel
+ * underneath the tab title, in the style of Arc/Dia. This reuses Zen's existing
+ * `.zen-tab-sublabel` element and the `zen-show-sublabel` attribute, so it needs
+ * no extra markup or styles of its own.
+ */
+class nsZenLocalhostSublabel extends nsZenDOMOperatedFeature {
+  init() {
+    Services.prefs.addObserver(PREF_SHOW_LOCALHOST_URL, this);
+
+    gBrowser.addTabsProgressListener(this);
+    gBrowser.tabContainer.addEventListener("TabOpen", event =>
+      this._update(event.target)
+    );
+    // Session restore can attach the URL after the tab has already opened.
+    window.addEventListener(
+      "SSTabRestored",
+      event => this._update(event.target),
+      true
+    );
+
+    window.addEventListener(
+      "unload",
+      () => Services.prefs.removeObserver(PREF_SHOW_LOCALHOST_URL, this),
+      { once: true }
+    );
+
+    this._updateAll();
+  }
+
+  // nsIObserver: react live when the preference is toggled.
+  observe() {
+    this._updateAll();
+  }
+
+  // nsIWebProgressListener, registered via addTabsProgressListener.
+  onLocationChange(aBrowser) {
+    const tab = gBrowser.getTabForBrowser(aBrowser);
+    if (tab) {
+      this._update(tab);
+    }
+  }
+
+  _updateAll() {
+    for (const tab of gBrowser.tabs) {
+      this._update(tab);
+    }
+  }
+
+  _update(tab) {
+    if (!tab || !tab.linkedBrowser) {
+      return;
+    }
+    // Leave tabs whose sublabel is driven by another feature untouched.
+    if (tab.pinned || tab.hasAttribute("zen-live-folder-item-id")) {
+      this._clearSublabel(tab);
+      return;
+    }
+    const label = lazy.showLocalhostUrl ? this._labelForTab(tab) : "";
+    if (label) {
+      this._setSublabel(tab, label);
+    } else {
+      this._clearSublabel(tab);
+    }
+  }
+
+  _setSublabel(tab, text) {
+    const sublabel = tab.querySelector(".zen-tab-sublabel");
+    if (!sublabel) {
+      return;
+    }
+    tab[OWNED_SUBLABEL] = text;
+    tab.setAttribute("zen-show-sublabel", text);
+    // The `zen-tab-sublabel` Fluent message renders any value that is not a
+    // known key (e.g. "zen-default-pinned") verbatim, so the host is shown
+    // as-is without needing a dedicated string.
+    document.l10n.setArgs(sublabel, { tabSubtitle: text });
+  }
+
+  _clearSublabel(tab) {
+    if (!tab[OWNED_SUBLABEL]) {
+      return;
+    }
+    delete tab[OWNED_SUBLABEL];
+    tab.removeAttribute("zen-show-sublabel");
+    const sublabel = tab.querySelector(".zen-tab-sublabel");
+    if (sublabel) {
+      document.l10n.setArgs(sublabel, { tabSubtitle: "zen-default-pinned" });
+    }
+  }
+
+  /**
+   * Returns the `host:port` to display for a tab pointing at a local or LAN
+   * address, or an empty string for anything else.
+   */
+  _labelForTab(tab) {
+    const uri = tab.linkedBrowser.currentURI;
+    if (!uri || !/^https?$/.test(uri.scheme)) {
+      return "";
+    }
+    let host;
+    try {
+      host = uri.host;
+    } catch (e) {
+      return "";
+    }
+    // `hostPort` omits the port for the default 80/443 and brackets IPv6.
+    return this._isLocalHost(host) ? uri.hostPort : "";
+  }
+
+  _isLocalHost(host) {
+    if (!host) {
+      return false;
+    }
+    // Strip brackets from IPv6 literals (e.g. "[::1]" -> "::1").
+    const bare = host.replace(/^\[|\]$/g, "").toLowerCase();
+
+    // Hostnames reserved for local use.
+    if (
+      bare === "localhost" ||
+      bare.endsWith(".localhost") ||
+      bare.endsWith(".local")
+    ) {
+      return true;
+    }
+
+    // IPv4 loopback, private (RFC 1918) and link-local ranges.
+    const ipv4 = bare.match(/^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
+    if (ipv4) {
+      const a = Number(ipv4[1]);
+      const b = Number(ipv4[2]);
+      return (
+        a === 127 || // 127.0.0.0/8 loopback
+        a === 10 || // 10.0.0.0/8
+        (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
+        (a === 192 && b === 168) || // 192.168.0.0/16
+        (a === 169 && b === 254) // 169.254.0.0/16 link-local
+      );
+    }
+
+    // IPv6 loopback, unique-local (fc00::/7) and link-local (fe80::/10).
+    if (bare.includes(":")) {
+      return (
+        bare === "::1" ||
+        bare.startsWith("fc") ||
+        bare.startsWith("fd") ||
+        bare.startsWith("fe8") ||
+        bare.startsWith("fe9") ||
+        bare.startsWith("fea") ||
+        bare.startsWith("feb")
+      );
+    }
+
+    return false;
+  }
+}
+
+window.gZenLocalhostSublabel = new nsZenLocalhostSublabel();

--- a/src/zen/tabs/jar.inc.mn
+++ b/src/zen/tabs/jar.inc.mn
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
         content/browser/zen-components/ZenPinnedTabManager.mjs                  (../../zen/tabs/ZenPinnedTabManager.mjs)
+        content/browser/zen-components/ZenLocalhostSublabel.mjs                 (../../zen/tabs/ZenLocalhostSublabel.mjs)
         content/browser/zen-components/ZenEssentialsPromo.mjs                   (../../zen/tabs/ZenEssentialsPromo.mjs)
 *       content/browser/zen-styles/zen-tabs.css                                 (../../zen/tabs/zen-tabs.css)
         content/browser/zen-styles/zen-tabs/vertical-tabs.css                   (../../zen/tabs/zen-tabs/vertical-tabs.css)


### PR DESCRIPTION
- [x] Show the `host:port` of local/LAN dev servers as a sublabel under the tab title (Arc/Dia style)
- [x] Reuse the existing `.zen-tab-sublabel` element + `zen-show-sublabel` attribute — no new markup, CSS, or l10n strings
- [x] Gate behind a new `zen.tabs.show-localhost-url` preference (default **on**, live-toggleable from about:config)
- [x] Leave pinned tabs and live-folder items to their existing sublabel owners to avoid conflicts

### Motivation

As a web developer I usually have several `localhost` tabs open at once (`localhost:3000`, `localhost:8080`, a Storybook, an API, …). Their titles are often identical or generic ("React App", "Vite + React"), so the only way to tell them apart is to click in and read the address bar. Arc and Dia solve this by showing the local URL as a small subtitle under the tab title, and it's a genuinely nice quality-of-life touch for anyone doing local development.

This brings that behavior to Zen. When a tab points at a local or LAN address, its `host:port` is shown as a sublabel beneath the title; for everything else, nothing changes.

### How it works

The implementation is intentionally tiny because Zen already has all the pieces:

- Every tab already ships a `<label class="zen-tab-sublabel">`, and the `[zen-show-sublabel]` attribute already reveals it (`src/zen/tabs/zen-tabs/vertical-tabs.css`).
- The `zen-tab-sublabel` Fluent message already has an `*[other] { $tabSubtitle }` branch that renders any literal string, so no new localization entry is needed.
- `ZenLiveFoldersUI` already uses exactly this pattern to put custom text in a sublabel.

So the new `ZenLocalhostSublabel` module just listens for tab location changes (via `addTabsProgressListener`) and, for matching tabs, sets `zen-show-sublabel` + the sublabel arg — the same way live folders do.

**Matched hosts:** `localhost`, `*.localhost`, `*.local`, IPv4 loopback `127.0.0.0/8`, RFC 1918 ranges (`10/8`, `172.16/12`, `192.168/16`), link-local `169.254/16`, and IPv6 loopback/ULA/link-local (`::1`, `fc00::/7`, `fe80::/10`). Only `http`/`https` tabs are considered.

### Preference

`zen.tabs.show-localhost-url` (bool, default `true`). Flipping it in about:config updates all open tabs immediately.

### Notes / open questions

- **Default on vs off:** I've defaulted it on since it's unobtrusive (it only ever appears on local/LAN tabs) and that's the behavior I was after, but I'm very happy to default it off and/or surface a Settings-UI checkbox if maintainers prefer — just say the word.
- **Scope:** I included LAN/private ranges in addition to `localhost`, which is handy for hitting a dev server on another machine. Easy to narrow to `localhost`-only if that's preferred.
- **Pinned tabs / live folders:** these manage their own sublabel, so they're deliberately skipped.
- **Testing:** I haven't been able to do a full local Firefox build for this change; I'd appreciate a maintainer sanity-check on the build, and I'm glad to iterate. Manual behavior to verify: open `http://localhost:3000` → sublabel shows `localhost:3000`; open `https://example.com` → no sublabel; toggle the pref → sublabels appear/disappear live.

Happy to open a tracking issue or move this to a discussion first if that's the preferred process for new defaults.
