### PR TITLE
gh-14448: fix glance tabs not getting pinned with `zen.folders.owned-tabs-in-folder` on

### DIFF
--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -1794,7 +1794,6 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
     const currentTab = this.#currentTab;
     const currentParentTab = this.#currentParentTab;
 
-    this.#handleZenFolderPinning();
     await this.fullyOpenGlance({ forSplit: true });
 
     const isRightSidebar = gZenVerticalTabsManager._prefsRightSide;

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -1650,6 +1650,9 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
 
   /**
    * Handle Zen folder pinning if applicable
+   *
+   * @param {Tab} currentTab - The current tab
+   * @param {Tab} currentParentTab - The current parent tab
    */
   #handleZenFolderPinning(currentTab, currentParentTab) {
     const isZenFolder = currentParentTab?.group?.isZenFolder;

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -1659,6 +1659,7 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
       Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder") &&
       isZenFolder
     ) {
+      this.#currentTab.removeAttribute("glance-id");
       gBrowser.pinTab(this.#currentTab);
     }
   }
@@ -1824,6 +1825,7 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
       Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder") &&
       isZenFolder
     ) {
+      this.#currentTab.removeAttribute("glance-id");
       gBrowser.pinTab(this.#currentTab);
     }
   }

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -1603,7 +1603,6 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
     gZenWorkspaces.updateTabsContainers();
     this.overlay.classList.remove("zen-glance-overlay");
     this.#clearContainerStyles(this.browserWrapper);
-    this.animatingFullOpen = false;
     const glanceID = this.#currentGlanceID;
     this.closeGlance({ noAnimation: true, skipPermitUnload: true });
     this.#deleteGlance(glanceID);
@@ -1616,16 +1615,15 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
    * @param {boolean} options.forSplit - Whether this is for split view
    */
   async fullyOpenGlance({ forSplit = false } = {}) {
-    if (!this.#currentGlanceID || !this.#currentTab) {
+    const currentTab = this.#currentTab;
+    const currentParentTab = this.#currentParentTab;
+
+    if (!this.#currentGlanceID || !currentTab) {
       return;
     }
 
     this.animatingFullOpen = true;
-    this.#currentTab.setAttribute("zen-dont-split-glance", true);
-
-    this.#handleZenFolderPinning();
-    gBrowser.moveTabAfter(this.#currentTab, this.#currentParentTab);
-
+    currentTab.setAttribute("zen-dont-split-glance", true);
     this.#prepareTabForFullOpen();
 
     const sidebarButtons = this.browserWrapper.querySelector(
@@ -1635,32 +1633,31 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
       sidebarButtons.remove();
     }
 
-    if (forSplit) {
-      this.finishOpeningGlance();
-      return;
-    }
-
-    if (gReduceMotion) {
+    if (!forSplit && gReduceMotion) {
       gZenViewSplitter.deactivateCurrentSplitView();
-      this.finishOpeningGlance();
-      return;
     }
 
-    await this.#animateFullOpen();
     this.finishOpeningGlance();
+    this.#handleZenFolderPinning(currentTab, currentParentTab);
+    gBrowser.moveTabAfter(currentTab, currentParentTab);
+
+    if (!forSplit && !gReduceMotion) {
+      await this.#animateFullOpen();
+    }
+
+    this.animatingFullOpen = false;
   }
 
   /**
    * Handle Zen folder pinning if applicable
    */
-  #handleZenFolderPinning() {
-    const isZenFolder = this.#currentParentTab?.group?.isZenFolder;
+  #handleZenFolderPinning(currentTab, currentParentTab) {
+    const isZenFolder = currentParentTab?.group?.isZenFolder;
     if (
       Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder") &&
       isZenFolder
     ) {
-      this.#currentTab.removeAttribute("glance-id");
-      gBrowser.pinTab(this.#currentTab);
+      gBrowser.pinTab(currentTab);
     }
   }
 

--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -1794,7 +1794,7 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
     const currentTab = this.#currentTab;
     const currentParentTab = this.#currentParentTab;
 
-    this.#handleZenFolderPinningForSplit(currentParentTab);
+    this.#handleZenFolderPinning();
     await this.fullyOpenGlance({ forSplit: true });
 
     const isRightSidebar = gZenVerticalTabsManager._prefsRightSide;
@@ -1811,22 +1811,6 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
     );
     if (!gReduceMotion && browserContainer) {
       gZenViewSplitter.animateBrowserDrop(browserContainer);
-    }
-  }
-
-  /**
-   * Handle Zen folder pinning for split view
-   *
-   * @param {Tab} parentTab - The parent tab
-   */
-  #handleZenFolderPinningForSplit(parentTab) {
-    const isZenFolder = parentTab?.group?.isZenFolder;
-    if (
-      Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder") &&
-      isZenFolder
-    ) {
-      this.#currentTab.removeAttribute("glance-id");
-      gBrowser.pinTab(this.#currentTab);
     }
   }
 


### PR DESCRIPTION
fixes: #14448 
regression from [#14431](https://github.com/zen-browser/desktop/pull/14432)