### PR TITLE
no-bug: add ellipsis to create space and folder menu items

### DIFF
--- a/locales/en-US/browser/browser/zen-workspaces.ftl
+++ b/locales/en-US/browser/browser/zen-workspaces.ftl
@@ -8,10 +8,10 @@ zen-panel-ui-spaces-label =
     .label = Spaces
 
 zen-panel-ui-workspaces-create =
-    .label = Create Space
+    .label = Create Space…
 
 zen-panel-ui-folder-create =
-    .label = Create Folder
+    .label = Create Folder…
 
 zen-panel-ui-live-folder-create =
     .label = Live Folder


### PR DESCRIPTION
Create Space and Create Folder open the creation panel but were missing the
trailing … that the other menu items already use (New Subfolder…, Rename Folder…,
Change Name…). Just added it so they match — small follow-up to #14388.

Screenshot after the change:

<img width="495" height="512" alt="tes" src="https://github.com/user-attachments/assets/654e4213-0db0-4ead-82f2-5a875c726be2" />
