### PR TITLE
Fix sidebar scroll position reset on fullscreen exit

### DIFF
--- a/src/browser/components/tabbrowser/content/tabs-js.patch
+++ b/src/browser/components/tabbrowser/content/tabs-js.patch
@@ -240,11 +240,14 @@ index 568f3a7cc7051ff8cb569f6bcb8018a5212f7072..b9a1cfe3a4a5035d9b06b0b3826a97c5
        selectedTab._notselectedsinceload = false;
      }
  
-@@ -1386,7 +1423,7 @@
+@@ -1386,7 +1423,10 @@
       * @param {boolean} [shouldScrollInstantly=false]
       */
      #ensureTabIsVisible(tab, shouldScrollInstantly = false) {
 -      let arrowScrollbox = tab.closest("arrowscrollbox");
++      if (document.documentElement.hasAttribute("inDOMFullscreen")) {
++        return;
++      }
 +      let arrowScrollbox = this.arrowScrollbox;
        if (arrowScrollbox?.overflowing) {
          arrowScrollbox.ensureElementIsVisible(tab, shouldScrollInstantly);


### PR DESCRIPTION
Fixes #14389

## Problem
Sidebar tab scroll position resets to top after exiting fullscreen video, specifically when the new-tab-button is positioned at the bottom of the sidebar. Caused by `_handleTabSelect` re-triggering during the fullscreen exit transition, when `arrowScrollbox`'s layout geometry is still transiently distorted.

## Fix
Adds an `inDOMFullscreen` guard to `#ensureTabIsVisible()`, matching the existing guard pattern already used in `ZenSpaceManager`'s `onPinnedTabsResize()` for the same class of fullscreen-transition layout bug.

## Testing
Submitted from source review — I wasn't able to build and manually test this locally yet due to environment constraints. The fix follows an existing, precedented guard pattern in the codebase for this exact transition. Happy to verify against a running build once my environment is set up, or sooner if a maintainer can confirm the approach.