### PR TITLE
gh-14495: Fix misaligned symbolic space icons in Space options menu on Linux

### DIFF
--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -1161,6 +1161,9 @@ class nsZenWorkspaces {
     const item = document.createXULElement("menuitem");
     item.className = "zen-workspace-context-menu-item";
     item.setAttribute("zen-workspace-id", workspace.uuid);
+    if (AppConstants.platform === "linux") {
+      disableCurrent = true;
+    }
     if (!disableCurrent) {
       item.setAttribute("type", "radio");
     }


### PR DESCRIPTION
Fixes #14495

Symbolic space icons were set via the native `image` attribute, which Firefox binds to the same `.menu-icon` element GTK uses to draw the `type="radio"` indicator on Linux, so the icon was overwriting the radio bubble instead of sitting next to it. Emoji icons never hit this since they're just plain text in the label.

Fix: stop setting `image` for SVG icons, and instead insert the icon as a separate `<span>` next to the label, styled via `mask-image` (same pattern already used in zen-omnibox.css). Tried a `::before` on the label first, but `.menu-text` is a native XUL element and that broke its text rendering, hence the separate span.

Tested on Arch Linux + Hyprland (Wayland): radio bubble + icon + name now render together for symbolic icons, matching emoji rows. Checked active/checked state,
no-icon spaces, long names, and repeated menu open/close. No regressions or duplicate icons.

(Side note: `icons.css` isn't covered by the `zen` lint scope, so there are some pre-existing unrelated stylelint errors in that file, not introduced by this change. I left those alone.)

I'm open to feedback! If there's a cleaner way to avoid touching `.menu-icon`, I'd love to hear it. This was the least invasive fix I could find that didn't break the native XUL label rendering.

**Before**
<img width="502" height="650" alt="image" src="https://github.com/user-attachments/assets/fa358d12-afdc-41a3-9b08-5d1f9750f6b7" />

**After**
<img width="441" height="583" alt="image" src="https://github.com/user-attachments/assets/9036a327-a243-4e37-a844-03b92c8b87cf" />