### PR TITLE
gh-14496: Split GitHub live-folder "Review Requested" into "My" and "Team"

### DIFF
--- a/locales/en-US/browser/browser/zen-live-folders.ftl
+++ b/locales/en-US/browser/browser/zen-live-folders.ftl
@@ -17,8 +17,11 @@ zen-live-folder-github-option-author-self =
 zen-live-folder-github-option-assigned-self =
     .label = Assigned to Me
 
-zen-live-folder-github-option-review-requested =
-    .label = Review Requests
+zen-live-folder-github-option-my-review-requested =
+    .label = My Review Requests
+
+zen-live-folder-github-option-team-review-requested =
+    .label = Team Review Requests
 
 zen-live-folder-type-rss =
     .label = RSS Feed

--- a/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
@@ -19,14 +19,25 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
     this.state.options = state.options ?? {};
     this.state.repos = new Set(state.repos ?? []);
     this.state.options.repoExcludes = new Set(state.options.repoExcludes ?? []);
+
+    // Migrate the legacy combined "Review Requests" filter into "My"/"Team".
+    if ("reviewRequested" in this.state.options) {
+      if (this.state.options.reviewRequested) {
+        this.state.options.reviewMe ??= true;
+        this.state.options.reviewTeam ??= true;
+      }
+      delete this.state.options.reviewRequested;
+    }
   }
 
   async fetchItems() {
     try {
+      const isPr = this.state.type === "pull-requests";
       const hasAnyFilterEnabled =
         (this.state.options.authorMe ?? false) ||
         (this.state.options.assignedMe ?? true) ||
-        (this.state.options.reviewRequested ?? false);
+        (isPr && (this.state.options.reviewMe ?? false)) ||
+        (isPr && (this.state.options.reviewTeam ?? false));
 
       if (!hasAnyFilterEnabled) {
         return "zen-live-folder-github-no-filter";
@@ -253,6 +264,8 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
       "sort:updated-desc",
     ];
 
+    const isPr = this.state.type === "pull-requests";
+
     const options = [
       {
         value: "author:@me",
@@ -263,8 +276,12 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
         enabled: this.state.options.assignedMe ?? true,
       },
       {
-        value: "review-requested:@me",
-        enabled: this.state.options.reviewRequested ?? false,
+        value: "user-review-requested:@me",
+        enabled: isPr && (this.state.options.reviewMe ?? false),
+      },
+      {
+        value: "team-review-requested-user:@me",
+        enabled: isPr && (this.state.options.reviewTeam ?? false),
       },
     ];
 
@@ -331,9 +348,15 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
         checked: this.state.options.assignedMe ?? true,
       },
       {
-        l10nId: "zen-live-folder-github-option-review-requested",
-        key: "reviewRequested",
-        checked: this.state.options.reviewRequested ?? false,
+        l10nId: "zen-live-folder-github-option-my-review-requested",
+        key: "reviewMe",
+        checked: this.state.options.reviewMe ?? false,
+        hidden: this.state.type === "issues",
+      },
+      {
+        l10nId: "zen-live-folder-github-option-team-review-requested",
+        key: "reviewTeam",
+        checked: this.state.options.reviewTeam ?? false,
         hidden: this.state.type === "issues",
       },
       { type: "separator" },

--- a/src/zen/tests/live-folders/browser_github_live_folder.js
+++ b/src/zen/tests/live-folders/browser_github_live_folder.js
@@ -13,7 +13,8 @@ function getGithubProviderForTest(sandbox, customOptions = {}) {
   const defaultOptions = {
     authorMe: true,
     assignedMe: false,
-    reviewRequested: false,
+    reviewMe: false,
+    reviewTeam: false,
     ...customOptions,
   };
 
@@ -49,7 +50,8 @@ add_task(async function test_fetch_items_url_construction() {
   let instance = getGithubProviderForTest(sandbox, {
     authorMe: true,
     assignedMe: false,
-    reviewRequested: false,
+    reviewMe: false,
+    reviewTeam: false,
     type: "pull-requests",
   });
 
@@ -73,8 +75,8 @@ add_task(async function test_fetch_items_url_construction() {
   Assert.ok(query.includes("author:@me"), "Should include author:@me");
   Assert.ok(!query.includes("assignee:@me"), "Should NOT include assignee:@me");
   Assert.ok(
-    !query.includes("review-requested:@me"),
-    "Should NOT include review-requested"
+    !query.includes("user-review-requested:@me"),
+    "Should NOT include user-review-requested"
   );
 
   sandbox.restore();
@@ -88,8 +90,12 @@ add_task(async function test_fetch_items_url_complex_options() {
   let instance = getGithubProviderForTest(sandbox, {
     authorMe: true,
     assignedMe: true,
-    reviewRequested: true,
+    reviewMe: true,
+    type: "pull-requests",
   });
+
+  // The JSON API path combines every enabled filter into a single OR query.
+  instance.state.isJsonApi = true;
 
   instance.fetch.resolves({
     status: 200,
@@ -104,11 +110,67 @@ add_task(async function test_fetch_items_url_complex_options() {
   Assert.ok(query.includes("author:@me"), "Should include author");
   Assert.ok(query.includes("assignee:@me"), "Should include assignee");
   Assert.ok(
-    query.includes("review-requested:@me"),
-    "Should include review-requested"
+    query.includes("user-review-requested:@me"),
+    "Should include user-review-requested"
   );
 
   Assert.ok(query.includes(" OR "), "Should contain OR operators");
+  sandbox.restore();
+});
+
+add_task(async function test_team_review_requested_uses_team_qualifier() {
+  info(
+    "team review requests should query team-review-requested-user:@me directly"
+  );
+
+  let sandbox = sinon.createSandbox();
+  let instance = getGithubProviderForTest(sandbox, {
+    type: "pull-requests",
+    authorMe: false,
+    assignedMe: false,
+    reviewMe: false,
+    reviewTeam: true,
+  });
+
+  // Use the JSON API path so we can return a structured payload.
+  instance.state.isJsonApi = true;
+
+  instance.fetch.resolves({
+    status: 200,
+    text: JSON.stringify({
+      payload: {
+        pullsDashboardSurfaceContentRoute: {
+          results: [
+            {
+              repoNameWithOwner: "zen-browser/desktop",
+              number: 1,
+              title: "PR 1",
+              author: { displayLogin: "alice" },
+              permalink: "https://github.com/zen-browser/desktop/pull/1",
+            },
+          ],
+        },
+      },
+    }),
+  });
+
+  const items = await instance.fetchItems();
+
+  Assert.ok(instance.fetch.calledOnce, "Should fetch a single query");
+
+  const query = new URL(instance.fetch.firstCall.args[0]).searchParams.get("q");
+  Assert.ok(
+    query.includes("team-review-requested-user:@me"),
+    "Should query team-review-requested-user:@me"
+  );
+  Assert.ok(
+    !query.includes("user-review-requested:@me"),
+    "Should NOT query user-review-requested for team-only"
+  );
+
+  Assert.equal(items.length, 1, "Should return the team-routed PR");
+  Assert.equal(items[0].id, "zen-browser/desktop#1");
+
   sandbox.restore();
 });
 
@@ -187,7 +249,8 @@ add_task(async function test_no_filter_enabled_returns_error() {
     type: "pull-requests",
     authorMe: false,
     assignedMe: false,
-    reviewRequested: false,
+    reviewMe: false,
+    reviewTeam: false,
   });
 
   const result = await instance.fetchItems();
@@ -235,7 +298,8 @@ add_task(async function test_repo_excludes_emit_negative_repo_filters() {
     type: "pull-requests",
     authorMe: true,
     assignedMe: false,
-    reviewRequested: false,
+    reviewMe: false,
+    reviewTeam: false,
     repoExcludes: ["zen-browser/desktop", "foo/bar"],
   });
 


### PR DESCRIPTION
## Split GitHub live-folder "Review Requested" into "My" and "Team"

Implements zen-browser/desktop#14496.

**Full-disclosure**: I used Claude for the code changes and description below this statement. I did however thoroughly review it, ensure the solution made sense, removed all the awful comments, and tested it.

### Problem

Teams that use `CODEOWNERS` with team auto-assignment see the same PR show up **twice** in a live folder: once when the team is requested for review, and again when a specific engineer from that team is added. The single `review-requested:@me` filter matches both, so there's no way to separate "assigned to me directly" from "routed to a team I'm on."

### Solution

Replace the single **Review Requests** filter with two independent options:

| Option | GitHub qualifier | Shows |
| --- | --- | --- |
| **My Review Requests** | `user-review-requested:@me` | PRs requested from you directly |
| **Team Review Requests** | `team-review-requested-user:@me` | PRs requested from a team you're on (excluding direct requests) |

Both are plain additive filters, so they slot into the existing query pipeline with no special-casing — enabling both is equivalent to the old `review-requested:@me` behavior.

### Backward compatibility

Existing folders with the legacy `reviewRequested` option are migrated on load: if it was enabled, **both** new options are toggled on so behavior is preserved. The legacy key is then removed.

### Notes

- Both options are pull-request only and hidden for issue folders.
- `team-review-requested-user` is a [documented GitHub search qualifier](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-pull-request-review-status-and-reviewer).

### Testing

- Updated `browser_github_live_folder.js`: the review-filter tests now cover the split options, and a new test asserts "Team Review Requests" issues a single `team-review-requested-user:@me` query.