### PR TITLE
Add visual guidance to the theme color picker

### DIFF
--- a/src/zen/spaces/ZenGradientGenerator.mjs
+++ b/src/zen/spaces/ZenGradientGenerator.mjs
@@ -580,6 +580,24 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
     return JSON.stringify({ x: Math.round(x), y: Math.round(y) });
   }
 
+  updateThemePickerVisualization() {
+    const gradient = this.panel.querySelector(".zen-theme-picker-gradient");
+    const primaryDot = this.dots.find(dot => dot.ID === 0);
+    let mode = "lightness";
+
+    if (primaryDot?.type === EXPLICIT_LIGHTNESS_TYPE) {
+      mode = "saturation";
+    } else if (primaryDot?.type === EXPLICIT_BLACKWHITE_TYPE) {
+      mode = "grayscale";
+    }
+
+    gradient.setAttribute("data-color-mode", mode);
+    gradient.style.setProperty(
+      "--zen-theme-picker-lightness",
+      `${primaryDot?.lightness ?? this.#currentLightness}%`
+    );
+  }
+
   createDot(color, fromWorkspace = false) {
     const [r, g, b] = color.c;
     const dot = document.createElement("div");
@@ -624,6 +642,9 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
         type: color.type,
         lightness: color.lightness,
       });
+      if (id === 0) {
+        this.updateThemePickerVisualization();
+      }
     }
     if (!fromWorkspace) {
       this.updateCurrentWorkspace(true);
@@ -762,6 +783,9 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
       lightness: this.#currentLightness,
       type: dotData.type,
     });
+    if (id === 0) {
+      this.updateThemePickerVisualization();
+    }
   }
 
   calculateCompliments(dots, action = "update", useHarmony = "") {
@@ -952,6 +976,7 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
         });
       }
     });
+    this.updateThemePickerVisualization();
   }
 
   onThemePickerClick(event) {
@@ -1777,6 +1802,7 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
       if (!skipUpdate) {
         browser.gZenThemePicker.dots = [];
         browser.gZenThemePicker.recalculateDots(workspaceTheme.gradientColors);
+        browser.gZenThemePicker.updateThemePickerVisualization();
       }
     });
 
@@ -1925,6 +1951,7 @@ export class nsZenThemePicker extends nsZenMultiWindowFeature {
 
   handlePanelOpen() {
     this.initThemePicker();
+    this.updateThemePickerVisualization();
     setTimeout(() => {
       this.updateCurrentWorkspace();
     }, 200);

--- a/src/zen/spaces/zen-gradient-generator.css
+++ b/src/zen/spaces/zen-gradient-generator.css
@@ -244,15 +244,71 @@
 }
 
 .zen-theme-picker-gradient {
+  --zen-theme-picker-lightness: 50%;
+  --zen-theme-picker-hues: conic-gradient(
+    from 90deg,
+    hsl(0 100% 50%),
+    hsl(60 100% 50%),
+    hsl(120 100% 50%),
+    hsl(180 100% 50%),
+    hsl(240 100% 50%),
+    hsl(300 100% 50%),
+    hsl(360 100% 50%)
+  );
+  --zen-theme-picker-pattern: radial-gradient(
+    light-dark(rgba(0, 0, 0, 0.18), rgba(255, 255, 255, 0.14)) 1px,
+    transparent 0
+  );
   position: relative;
   overflow: hidden;
   border-radius: calc(var(--panel-border-radius) - 4px);
 
   min-height: calc(var(--panel-width) - var(--panel-padding) * 2 - 2px);
   background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.03));
-  background-image: radial-gradient(light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.05)) 1px, transparent 0);
-  background-position: -23px -23px;
-  background-size: 6px 6px;
+  background-image:
+    var(--zen-theme-picker-pattern),
+    radial-gradient(
+      circle,
+      black 0%,
+      transparent 50%,
+      hsl(0 0% 92.5% / 92.5%) 100%
+    ),
+    var(--zen-theme-picker-hues);
+  background-position:
+    -23px -23px,
+    center,
+    center;
+  background-size:
+    6px 6px,
+    100% 100%,
+    100% 100%;
+
+  &[data-color-mode="saturation"] {
+    --zen-theme-picker-hues: conic-gradient(
+      from 90deg,
+      hsl(0 100% var(--zen-theme-picker-lightness)),
+      hsl(60 100% var(--zen-theme-picker-lightness)),
+      hsl(120 100% var(--zen-theme-picker-lightness)),
+      hsl(180 100% var(--zen-theme-picker-lightness)),
+      hsl(240 100% var(--zen-theme-picker-lightness)),
+      hsl(300 100% var(--zen-theme-picker-lightness)),
+      hsl(360 100% var(--zen-theme-picker-lightness))
+    );
+    background-image:
+      var(--zen-theme-picker-pattern),
+      radial-gradient(
+        circle,
+        transparent 0%,
+        hsl(0 0% var(--zen-theme-picker-lightness) / 92.5%) 100%
+      ),
+      var(--zen-theme-picker-hues);
+  }
+
+  &[data-color-mode="grayscale"] {
+    background-image:
+      var(--zen-theme-picker-pattern),
+      radial-gradient(circle, black 0%, hsl(0 0% 92.5%) 100%);
+  }
 
   & .zen-theme-picker-dot {
     position: fixed;

--- a/src/zen/tests/spaces/browser.toml
+++ b/src/zen/tests/spaces/browser.toml
@@ -28,6 +28,8 @@ support-files = [
 
 ["browser_select_tab_switches_space.js"]
 
+["browser_theme_picker_visualization.js"]
+
 ["browser_unload_all_other_spaces.js"]
 
 ["browser_workspace_bookmarks.js"]

--- a/src/zen/tests/spaces/browser_theme_picker_visualization.js
+++ b/src/zen/tests/spaces/browser_theme_picker_visualization.js
@@ -1,0 +1,52 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_Theme_Picker_Visualization_Mode() {
+  const originalDots = gZenThemePicker.dots;
+  const gradient = document.querySelector(".zen-theme-picker-gradient");
+
+  registerCleanupFunction(() => {
+    gZenThemePicker.dots = originalDots;
+    gZenThemePicker.updateThemePickerVisualization();
+  });
+
+  gZenThemePicker.dots = [];
+  gZenThemePicker.updateThemePickerVisualization();
+  Assert.equal(
+    gradient.getAttribute("data-color-mode"),
+    "lightness",
+    "A picker without generated colors resets to the default visualization"
+  );
+
+  const testCases = [
+    { type: undefined, lightness: 50, expectedMode: "lightness" },
+    {
+      type: "explicit-lightness",
+      lightness: 70,
+      expectedMode: "saturation",
+    },
+    {
+      type: "explicit-black-white",
+      lightness: 30,
+      expectedMode: "grayscale",
+    },
+  ];
+
+  for (const { type, lightness, expectedMode } of testCases) {
+    gZenThemePicker.dots = [{ ID: 0, type, lightness }];
+    gZenThemePicker.updateThemePickerVisualization();
+
+    Assert.equal(
+      gradient.getAttribute("data-color-mode"),
+      expectedMode,
+      `The ${type ?? "default"} picker uses the expected visualization`
+    );
+    Assert.equal(
+      gradient.style.getPropertyValue("--zen-theme-picker-lightness"),
+      `${lightness}%`,
+      "The visualization reflects the primary color lightness"
+    );
+  }
+});


### PR DESCRIPTION
## A personal note

Hey! While setting up Zen, I encountered two issues. One was closed quite quickly because it is tracked internally and should be fixed in the future, cool! :D

The other had already been raised by someone else in an [earlier issue](https://github.com/zen-browser/desktop/issues/9666), but it was closed as a `feature request` rather than a bug. I therefore opened [a discussion](https://github.com/zen-browser/desktop/discussions/14485), and I have now implemented the missing color wheel.

There is a working build available on my fork if you would like to try it. I have also recorded myself testing the finished build, and it works great! You can, of course, close the PR if you do not feel it is the right direction, and I am open to criticism. ;)

Thanks for creating an awesome browser!
CT4nk3r

## Summary

The theme picker currently presents its main color-selection area as a neutral dotted surface, even though pointer position already controls hue, saturation, and lightness. This makes the available color range difficult to discover.

This change gives the picker a visual representation of the colors that its existing position calculations produce:

- the default mode shows hue around the circle and lightness from black at the center to white at the edge;
- fixed-lightness presets show hue around the circle and saturation fading toward the edge;
- grayscale presets show the available black-to-white range.

The visualization follows the primary color's mode and lightness without changing the existing color-selection behavior.

## Context

This follows the proposal and user-facing discussion in https://github.com/zen-browser/desktop/discussions/14485.

It is also related to the earlier report in https://github.com/zen-browser/desktop/issues/9666.

## Demo

https://github.com/user-attachments/assets/b31e05ed-eb1b-4105-8555-d23ae795bd46

## Validation

- Added a browser test covering default, fixed-lightness, and grayscale visualization state.
- Mozilla lint passes for the changed files.
- Built the ARM64 macOS application from this branch and manually verified the picker behavior in the installed build.

