### PR TITLE
gh-14371: Added workspace indicator to urlbar switch-to-tab suggestions

### DIFF
--- a/src/browser/components/urlbar/UrlbarView-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarView-sys-mjs.patch
@@ -40,3 +40,35 @@ index b665adb1a1ce8bbae8df4cbea6c3248c3e4fb431..1de7f9461b8ccbd4680b917e6dd5ba3c
      this.#rows.toggleAttribute("wrap", wrap);
      this.oneOffSearchButtons?.container.toggleAttribute("wrap", wrap);
    }
+@@ -2914,6 +2914,30 @@
+       return;
+     }
+     actionNode.innerHTML = "";
++
++    let tabWorkspace = null;
++    if (this.#window.gZenWorkspaces) {
++      let browsers = this.#window.gZenWorkspaces.allUsedBrowsers;
++      for (let browser of browsers) {
++        let tab = this.#window.gBrowser.getTabForBrowser(browser);
++        if (tab && tab.getAttribute("usercontextid") == result.payload.userContextId) {
++           if (result.payload.url === browser.currentURI?.spec || result.payload.url === browser.userTypedValue) {
++             let wsId = tab.getAttribute("zen-workspace-id");
++             if (wsId) {
++               tabWorkspace = this.#window.gZenWorkspaces.getWorkspaceFromId(wsId);
++               break;
++             }
++           }
++        }
++      }
++    }
++    if (tabWorkspace) {
++      actionNode.textContent = (tabWorkspace.icon ? tabWorkspace.icon + " " : "") + tabWorkspace.name;
++      actionNode.classList.add("urlbarView-userContext");
++      actionNode.classList.remove("urlbarView-switchToTab");
++      actionNode.style.display = "flex";
++      return;
++    }
++
+     let identity = lazy.ContextualIdentityService.getPublicIdentityFromId(
+       result.payload.userContextId
+     );

--- a/src/zen/common/styles/zen-omnibox.css
+++ b/src/zen/common/styles/zen-omnibox.css
@@ -696,6 +696,18 @@
   }
 }
 
+.urlbarView-row[has-action]:is([type="switchtab"]) .action-contextualidentity {
+  display: flex !important;
+  align-items: center;
+  gap: 4px;
+  background-color: var(--zen-colors-tertiary, color-mix(in srgb, currentColor 10%, transparent));
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.9em;
+  opacity: 0.8;
+  margin-right: 8px;
+}
+
 :root:not([zen-single-toolbar="true"]) #urlbar[breakout-extend]:not([zen-floating-urlbar="true"]) {
   & .urlbar-background {
     border-radius: 10px !important;


### PR DESCRIPTION
Fixes #14371

**Description**
When multiple tabs are open on the same site across different workspaces (and containers), the 'Switch to Tab' suggestions in the URL bar previously looked identical. This PR leverages Firefox's native `.action-contextualidentity` element (which was hidden in Zen) and populates it with the target tab's workspace name and icon.

- Removed `display: none` for `.action-contextualidentity` in `zen-omnibox.css` and styled it to look like a workspace pill.
- Patched `UrlbarView.sys.mjs` to resolve the target tab via `gZenWorkspaces.allUsedBrowsers`, extract the workspace info, and render it in the suggestion row.

@mr-cheffy PTAL.