### PR TITLE
gh-14507: Fix essentials being added to folder without being removed

### DIFF
--- a/src/browser/components/tabbrowser/content/tabgroup-js.patch
+++ b/src/browser/components/tabbrowser/content/tabgroup-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabgroup.js b/browser/components/tabbrowser/content/tabgroup.js
-index e78fa0dec83424c0059c081f83fda0d23bdb5a94..f900ad1bfb6d9d13b6a77a05d727b4306c39282a 100644
+index e78fa0dec83424c0059c081f83fda0d23bdb5a94..a7de584d9029ff9e55d809d50377593e398ee999 100644
 --- a/browser/components/tabbrowser/content/tabgroup.js
 +++ b/browser/components/tabbrowser/content/tabgroup.js
 @@ -14,11 +14,11 @@
@@ -221,16 +221,7 @@ index e78fa0dec83424c0059c081f83fda0d23bdb5a94..f900ad1bfb6d9d13b6a77a05d727b430
      }
  
      /**
-@@ -596,6 +684,8 @@
-      */
-     addTabs(tabsOrSplitViews, metricsContext = null) {
-       for (let tabOrSplitView of tabsOrSplitViews) {
-+        if (tabOrSplitView.hasAttribute("zen-essential"))
-+          gZenPinnedTabManager.removeEssentials(tabOrSplitView, false);
-         if (gBrowser.isSplitViewWrapper(tabOrSplitView)) {
-           let splitViewToMove =
-             this.documentGlobal === tabOrSplitView.documentGlobal
-@@ -610,7 +700,6 @@
+@@ -610,7 +698,6 @@
            );
          } else {
            if (tabOrSplitView.pinned) {
@@ -238,7 +229,7 @@ index e78fa0dec83424c0059c081f83fda0d23bdb5a94..f900ad1bfb6d9d13b6a77a05d727b430
            }
            let tabToMove =
              this.documentGlobal === tabOrSplitView.documentGlobal
-@@ -679,7 +768,7 @@
+@@ -679,7 +766,7 @@
       */
      on_click(event) {
        let isToggleElement =
@@ -247,7 +238,7 @@ index e78fa0dec83424c0059c081f83fda0d23bdb5a94..f900ad1bfb6d9d13b6a77a05d727b430
          event.target === this.#overflowCountLabel;
        if (isToggleElement && event.button === 0) {
          event.preventDefault();
-@@ -758,5 +847,6 @@
+@@ -758,5 +845,6 @@
      }
    }
  

--- a/src/browser/components/tabbrowser/content/tabgroup-js.patch
+++ b/src/browser/components/tabbrowser/content/tabgroup-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabgroup.js b/browser/components/tabbrowser/content/tabgroup.js
-index e78fa0dec83424c0059c081f83fda0d23bdb5a94..a7de584d9029ff9e55d809d50377593e398ee999 100644
+index e78fa0dec83424c0059c081f83fda0d23bdb5a94..f900ad1bfb6d9d13b6a77a05d727b4306c39282a 100644
 --- a/browser/components/tabbrowser/content/tabgroup.js
 +++ b/browser/components/tabbrowser/content/tabgroup.js
 @@ -14,11 +14,11 @@
@@ -221,7 +221,16 @@ index e78fa0dec83424c0059c081f83fda0d23bdb5a94..a7de584d9029ff9e55d809d50377593e
      }
  
      /**
-@@ -610,7 +698,6 @@
+@@ -596,6 +684,8 @@
+      */
+     addTabs(tabsOrSplitViews, metricsContext = null) {
+       for (let tabOrSplitView of tabsOrSplitViews) {
++        if (tabOrSplitView.hasAttribute("zen-essential"))
++          gZenPinnedTabManager.removeEssentials(tabOrSplitView, false);
+         if (gBrowser.isSplitViewWrapper(tabOrSplitView)) {
+           let splitViewToMove =
+             this.documentGlobal === tabOrSplitView.documentGlobal
+@@ -610,7 +700,6 @@
            );
          } else {
            if (tabOrSplitView.pinned) {
@@ -229,7 +238,7 @@ index e78fa0dec83424c0059c081f83fda0d23bdb5a94..a7de584d9029ff9e55d809d50377593e
            }
            let tabToMove =
              this.documentGlobal === tabOrSplitView.documentGlobal
-@@ -679,7 +766,7 @@
+@@ -679,7 +768,7 @@
       */
      on_click(event) {
        let isToggleElement =
@@ -238,7 +247,7 @@ index e78fa0dec83424c0059c081f83fda0d23bdb5a94..a7de584d9029ff9e55d809d50377593e
          event.target === this.#overflowCountLabel;
        if (isToggleElement && event.button === 0) {
          event.preventDefault();
-@@ -758,5 +845,6 @@
+@@ -758,5 +847,6 @@
      }
    }
  

--- a/src/zen/folders/ZenFolder.mjs
+++ b/src/zen/folders/ZenFolder.mjs
@@ -289,6 +289,9 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
   addTabs(tabs) {
     let tabsFromOutside = [];
     for (let tab of tabs) {
+      if (tab.hasAttribute("zen-essential")) {
+        gZenPinnedTabManager.removeEssentials(tab, false);
+      }
       if (tab.group !== this) {
         tabsFromOutside.push(tab);
       }

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -623,7 +623,6 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
 
   createFolder(tabs = [], options = {}) {
     const filteredTabs = tabs
-      .filter(tab => !tab.hasAttribute("zen-essential"))
       .map(tab => {
         gBrowser.pinTab(tab);
         if (tab?.group?.hasAttribute("split-view-group")) {

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -622,14 +622,13 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
   }
 
   createFolder(tabs = [], options = {}) {
-    const filteredTabs = tabs
-      .map(tab => {
-        gBrowser.pinTab(tab);
-        if (tab?.group?.hasAttribute("split-view-group")) {
-          tab = tab.group;
-        }
-        return tab;
-      });
+    const filteredTabs = tabs.map(tab => {
+      gBrowser.pinTab(tab);
+      if (tab?.group?.hasAttribute("split-view-group")) {
+        tab = tab.group;
+      }
+      return tab;
+    });
 
     const workspacePinned = gZenWorkspaces.workspaceElement(
       options.workspaceId


### PR DESCRIPTION
fixes: #14507 
Do tell me if we should rather do it in `#initMoveTabToFolder()` and `#onNewFolder()`