### PR TITLE
gh-14544: Fix essentials promo ui leaving gap on pressing esc

### DIFF
--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -460,16 +460,19 @@ class nsZenWorkspaces {
       document
         .getElementById("zen-essentials")
         .appendChild(essentialsContainer);
-
-      // Set an initial hidden state if the essentials section is not supposed
-      // to be shown on the current workspace
-      if (
-        this.containerSpecificEssentials &&
-        this.getActiveWorkspaceFromCache()?.containerTabId != container
-      ) {
-        essentialsContainer.setAttribute("hidden", "true");
-      }
     }
+
+    // Set a hidden state if the essentials section is not supposed
+    // to be shown on the current workspace, else remove the hidden state
+    if (
+      this.containerSpecificEssentials &&
+      this.getActiveWorkspaceFromCache()?.containerTabId != container
+    ) {
+      essentialsContainer.setAttribute("hidden", "true");
+    } else {
+      essentialsContainer.removeAttribute("hidden");
+    }
+
     return essentialsContainer;
   }
 


### PR DESCRIPTION
Fixes https://github.com/zen-browser/desktop/issues/14544

Also fixes essentials promo having weird ui with container specific essentials

https://github.com/user-attachments/assets/f6df3e48-5fa2-471e-afbb-2472efa0620b