### PR TITLE
gh-14550: Use opaque container IDs in Spaces Sync

### DIFF
--- a/src/zen/sync/ZenSyncManager.sys.mjs
+++ b/src/zen/sync/ZenSyncManager.sys.mjs
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const lazy = {};
+const CONTAINER_SYNC_MAPPINGS_PREF = "zen.sync.container-id-mappings";
+const MAX_CONTAINER_SEMANTIC_ORDINAL = 128;
 
 ChromeUtils.defineESModuleGetters(lazy, {
   ZenSessionStore: "resource:///modules/zen/ZenSessionManager.sys.mjs",
@@ -14,6 +16,17 @@ ChromeUtils.defineESModuleGetters(lazy, {
 function normalizeUserContextId(value) {
   const normalized = typeof value === "string" ? Number(value) : value;
   if (!Number.isSafeInteger(normalized) || normalized <= 0) {
+    return null;
+  }
+  return normalized;
+}
+
+function normalizeContainerSyncId(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 64 || normalized.includes("~")) {
     return null;
   }
   return normalized;
@@ -34,6 +47,184 @@ class ZenSyncManager {
 
   #changedItems = new Map();
 
+  // Firefox container IDs are profile-local. Sync records use opaque IDs and
+  // this local mapping translates them to each profile's numeric IDs.
+  #containerMappings = null;
+
+  #getContainerMappings() {
+    if (this.#containerMappings) {
+      return this.#containerMappings;
+    }
+
+    let stored = {};
+    try {
+      stored = JSON.parse(
+        Services.prefs.getStringPref(CONTAINER_SYNC_MAPPINGS_PREF, "{}")
+      );
+    } catch {
+      // A malformed local mapping is rebuilt as containers are encountered.
+    }
+    if (!stored || typeof stored !== "object" || Array.isArray(stored)) {
+      stored = {};
+    }
+
+    const primaryByLocalId = {};
+    const localIdBySyncId = {};
+    for (const [localIdValue, syncIdValue] of Object.entries(
+      stored.primaryByLocalId || {}
+    )) {
+      const localId = normalizeUserContextId(localIdValue);
+      const syncId = normalizeContainerSyncId(syncIdValue);
+      if (localId && syncId) {
+        localIdBySyncId[syncId] = localId;
+      }
+    }
+    for (const [syncIdValue, localIdValue] of Object.entries(
+      stored.localIdBySyncId || {}
+    )) {
+      const localId = normalizeUserContextId(localIdValue);
+      const syncId = normalizeContainerSyncId(syncIdValue);
+      if (localId && syncId) {
+        localIdBySyncId[syncId] = localId;
+      }
+    }
+    for (const [syncId, localId] of Object.entries(localIdBySyncId).sort()) {
+      primaryByLocalId[localId] ??= syncId;
+    }
+
+    this.#containerMappings = { primaryByLocalId, localIdBySyncId };
+    return this.#containerMappings;
+  }
+
+  #saveContainerMappings() {
+    Services.prefs.setStringPref(
+      CONTAINER_SYNC_MAPPINGS_PREF,
+      JSON.stringify({ version: 1, ...this.#getContainerMappings() })
+    );
+  }
+
+  #recomputePrimaryContainerSyncId(localId) {
+    const mappings = this.#getContainerMappings();
+    const aliases = Object.entries(mappings.localIdBySyncId)
+      .filter(([, mappedLocalId]) => mappedLocalId === localId)
+      .map(([syncId]) => syncId)
+      .sort();
+    if (aliases.length) {
+      mappings.primaryByLocalId[localId] = aliases[0];
+    } else {
+      delete mappings.primaryByLocalId[localId];
+    }
+  }
+
+  getContainerSyncId(userContextId) {
+    const localId = normalizeUserContextId(userContextId);
+    if (!localId) {
+      return null;
+    }
+
+    const mappings = this.#getContainerMappings();
+    if (mappings.primaryByLocalId[localId]) {
+      return mappings.primaryByLocalId[localId];
+    }
+
+    let syncId;
+    do {
+      syncId = Services.uuid.generateUUID().toString().slice(1, -1);
+    } while (mappings.localIdBySyncId[syncId]);
+    mappings.primaryByLocalId[localId] = syncId;
+    mappings.localIdBySyncId[syncId] = localId;
+    this.#saveContainerMappings();
+    return syncId;
+  }
+
+  getContainerSyncIds(userContextId) {
+    const localId = normalizeUserContextId(userContextId);
+    if (!localId) {
+      return [];
+    }
+
+    const mappings = this.#getContainerMappings();
+    let aliases = Object.entries(mappings.localIdBySyncId)
+      .filter(([, mappedLocalId]) => mappedLocalId === localId)
+      .map(([syncId]) => syncId)
+      .sort();
+    if (!aliases.length) {
+      const syncId = this.getContainerSyncId(localId);
+      aliases = syncId ? [syncId] : [];
+    }
+    return aliases;
+  }
+
+  resolveLocalContainerId(syncIdValue) {
+    const syncId = normalizeContainerSyncId(syncIdValue);
+    if (!syncId) {
+      return null;
+    }
+    return (
+      normalizeUserContextId(
+        this.#getContainerMappings().localIdBySyncId[syncId]
+      ) || null
+    );
+  }
+
+  #associateContainerSyncId(userContextId, syncIdValue) {
+    const localId = normalizeUserContextId(userContextId);
+    const syncId = normalizeContainerSyncId(syncIdValue);
+    if (!localId || !syncId) {
+      return null;
+    }
+
+    const mappings = this.#getContainerMappings();
+    const previousLocalId = mappings.localIdBySyncId[syncId];
+    if (previousLocalId && previousLocalId !== localId) {
+      delete mappings.localIdBySyncId[syncId];
+      this.#recomputePrimaryContainerSyncId(previousLocalId);
+    }
+    mappings.localIdBySyncId[syncId] = localId;
+    this.#recomputePrimaryContainerSyncId(localId);
+    this.#saveContainerMappings();
+    return localId;
+  }
+
+  #getContainerSemanticSignature(container) {
+    if (!container) {
+      return null;
+    }
+    const name = container.l10nId
+      ? null
+      : lazy.ContextualIdentityService.getUserContextLabel(
+          container.userContextId
+        )
+          .trim()
+          .toLocaleLowerCase();
+    return JSON.stringify({
+      l10nId: container.l10nId || null,
+      name,
+      icon: container.icon || null,
+      color: container.color || null,
+    });
+  }
+
+  getContainerSemanticOrdinal(userContextId) {
+    const localId = normalizeUserContextId(userContextId);
+    const containers = lazy.ContextualIdentityService.getPublicIdentities();
+    const container = containers.find(
+      candidate => candidate.userContextId === localId
+    );
+    const signature = this.#getContainerSemanticSignature(container);
+    if (!signature) {
+      return 0;
+    }
+    const ordinal = containers
+      .filter(
+        candidate =>
+          this.#getContainerSemanticSignature(candidate) === signature
+      )
+      .sort((a, b) => a.userContextId - b.userContextId)
+      .findIndex(candidate => candidate.userContextId === localId);
+    return Math.max(0, ordinal);
+  }
+
   markItemChanged(item) {
     if (item.type && item.id && !this.#ignoreChanges) {
       const key = `${item.type}~${item.id}`;
@@ -51,7 +242,6 @@ class ZenSyncManager {
 
   notifyAboutChanges() {
     const changedItems = this.#getChangedItems();
-
     for (const item of changedItems) {
       Services.obs.notifyObservers(
         { wrappedJSObject: item },
@@ -64,10 +254,8 @@ class ZenSyncManager {
   async applyIncomingBatch(pulled, removals) {
     try {
       this.#ignoreChanges = true;
-      this.#applyIncomingContainers(
-        pulled.containers || [],
-        removals.containers || []
-      );
+      this.#applyIncomingContainers(pulled.containers || []);
+      this.#mapIncomingSpaceReferences(pulled.spaces || []);
 
       const win = lazy.ZenWindowSync.firstSyncedWindow;
       if (win?.gZenWorkspaces) {
@@ -81,78 +269,129 @@ class ZenSyncManager {
     }
   }
 
-  #applyIncomingContainers(pulledContainers, removedContainers) {
+  #getIncomingContainerSyncId(container) {
+    const syncId = normalizeContainerSyncId(container?.syncId);
+    if (syncId) {
+      return syncId;
+    }
+    const legacyId = normalizeUserContextId(container?.userContextId);
+    return legacyId ? String(legacyId) : null;
+  }
+
+  #containerMetadataMatches(localContainer, incomingContainer) {
+    const identityMatches = incomingContainer.l10nId
+      ? localContainer.l10nId === incomingContainer.l10nId
+      : lazy.ContextualIdentityService.getUserContextLabel(
+          localContainer.userContextId
+        ) === incomingContainer.name;
+    return (
+      identityMatches &&
+      localContainer.icon === incomingContainer.icon &&
+      localContainer.color === incomingContainer.color
+    );
+  }
+
+  #getIncomingContainerOrdinal(container) {
+    return Number.isSafeInteger(container?.semanticOrdinal) &&
+      container.semanticOrdinal >= 0 &&
+      container.semanticOrdinal <= MAX_CONTAINER_SEMANTIC_ORDINAL
+      ? container.semanticOrdinal
+      : 0;
+  }
+
+  #getMatchingLocalContainers(localContainers, incomingContainer) {
+    return Array.from(localContainers.values())
+      .filter(candidate =>
+        this.#containerMetadataMatches(candidate, incomingContainer)
+      )
+      .sort((a, b) => a.userContextId - b.userContextId);
+  }
+
+  #createIncomingContainer(incomingContainer, localContainers) {
+    const localContainer = lazy.ContextualIdentityService.create(
+      incomingContainer.name,
+      incomingContainer.icon,
+      incomingContainer.color
+    );
+    if (localContainer) {
+      localContainers.set(localContainer.userContextId, localContainer);
+    }
+    return localContainer;
+  }
+
+  #findOrCreateEquivalentContainer(incomingContainer, localContainers) {
+    const ordinal = this.#getIncomingContainerOrdinal(incomingContainer);
+    let matches = this.#getMatchingLocalContainers(
+      localContainers,
+      incomingContainer
+    );
+    while (matches.length <= ordinal) {
+      if (!this.#createIncomingContainer(incomingContainer, localContainers)) {
+        return null;
+      }
+      matches = this.#getMatchingLocalContainers(
+        localContainers,
+        incomingContainer
+      );
+    }
+    return matches[ordinal];
+  }
+
+  #applyIncomingContainers(pulledContainers) {
     const localContainersById = new Map(
       lazy.ContextualIdentityService.getPublicIdentities().map(container => [
         container.userContextId,
         container,
       ])
     );
+    const orderedContainers = [...pulledContainers].sort(
+      (a, b) =>
+        this.#getIncomingContainerOrdinal(a) -
+        this.#getIncomingContainerOrdinal(b)
+    );
 
-    for (const container of pulledContainers) {
-      if (!container.name) {
+    for (const container of orderedContainers) {
+      const syncId = this.#getIncomingContainerSyncId(container);
+      if (!container.name || !syncId) {
         continue;
       }
 
-      const userContextId = normalizeUserContextId(container.userContextId);
-      if (userContextId === null) {
-        console.warn(
-          "ZenSyncManager: Ignoring incoming container with invalid userContextId",
-          { container }
+      let userContextId = this.resolveLocalContainerId(syncId);
+      let localContainer = localContainersById.get(userContextId);
+      if (!localContainer) {
+        localContainer = this.#findOrCreateEquivalentContainer(
+          container,
+          localContainersById
         );
-        continue;
+        userContextId = localContainer?.userContextId || null;
       }
 
-      const existsLocally = localContainersById.has(userContextId);
-
-      if (existsLocally) {
+      if (
+        localContainer &&
+        !container.l10nId &&
+        !this.#containerMetadataMatches(localContainer, container)
+      ) {
         lazy.ContextualIdentityService.update(
           userContextId,
           container.name,
           container.icon,
           container.color
         );
-        continue;
       }
-
-      const createdIdentity = lazy.ContextualIdentityService.create(
-        container.name,
-        container.icon,
-        container.color,
-        userContextId
-      );
-      if (createdIdentity) {
-        localContainersById.set(createdIdentity.userContextId, createdIdentity);
-      }
-      if (createdIdentity && createdIdentity.userContextId !== userContextId) {
-        console.warn("ZenSyncManager: Container sync created unexpected ID", {
-          requestedId: userContextId,
-          createdId: createdIdentity.userContextId,
-          name: container.name,
-        });
-      }
+      this.#associateContainerSyncId(userContextId, syncId);
     }
+  }
 
-    for (const container of removedContainers) {
-      const userContextId = normalizeUserContextId(container.userContextId);
-      if (userContextId === null) {
-        console.warn(
-          "ZenSyncManager: Ignoring container removal with invalid userContextId",
-          { container }
-        );
-        continue;
-      }
-
-      if (!localContainersById.has(userContextId)) {
-        continue;
-      }
-
-      try {
-        lazy.ContextualIdentityService.remove(userContextId);
-        localContainersById.delete(userContextId);
-      } catch {
-        // Container may already be gone locally.
-      }
+  #mapIncomingSpaceReferences(spaces) {
+    for (const space of spaces) {
+      const syncId =
+        normalizeContainerSyncId(space.containerSyncId) ||
+        (normalizeUserContextId(space.containerTabId)
+          ? String(space.containerTabId)
+          : null);
+      const localId = syncId ? this.resolveLocalContainerId(syncId) : null;
+      space.containerTabId = localId || 0;
+      delete space.containerSyncId;
     }
   }
 }

--- a/src/zen/sync/ZenSyncManager.sys.mjs
+++ b/src/zen/sync/ZenSyncManager.sys.mjs
@@ -254,6 +254,8 @@ class ZenSyncManager {
   async applyIncomingBatch(pulled, removals) {
     try {
       this.#ignoreChanges = true;
+      // ContextualIdentityService.remove() clears local site data. Container
+      // deletion therefore remains an explicit, device-local operation.
       this.#applyIncomingContainers(pulled.containers || []);
       this.#mapIncomingSpaceReferences(pulled.spaces || []);
 

--- a/src/zen/sync/ZenWorkspacesSync.sys.mjs
+++ b/src/zen/sync/ZenWorkspacesSync.sys.mjs
@@ -56,14 +56,6 @@ function createRecordId(type, id) {
   return `${prefix}~${id}`;
 }
 
-function normalizeUserContextId(value) {
-  const normalized = typeof value === "string" ? Number(value) : value;
-  if (!Number.isSafeInteger(normalized) || normalized <= 0) {
-    return null;
-  }
-  return normalized;
-}
-
 /**
  * Strips the sync-envelope fields (`id` and `type`) from incoming record data
  * and restores the item's real identity key where needed
@@ -96,8 +88,12 @@ class ZenWorkspacesStore extends Store {
       }
     }
 
-    for (const c of lazy.ContextualIdentityService.getPublicIdentities()) {
-      ids[createRecordId("container", c.userContextId)] = true;
+    for (const container of lazy.ContextualIdentityService.getPublicIdentities()) {
+      for (const syncId of lazy.ZenSyncStore.getContainerSyncIds(
+        container.userContextId
+      )) {
+        ids[createRecordId("container", syncId)] = true;
+      }
     }
 
     return ids;
@@ -115,7 +111,9 @@ class ZenWorkspacesStore extends Store {
         return (sidebar.spaces || []).some(s => s.uuid === parsed.key);
       case "container":
         return lazy.ContextualIdentityService.getPublicIdentities().some(
-          c => String(c.userContextId) === parsed.key
+          container =>
+            container.userContextId ===
+            lazy.ZenSyncStore.resolveLocalContainerId(parsed.key)
         );
       default:
         return false;
@@ -142,14 +140,22 @@ class ZenWorkspacesStore extends Store {
         }
         const rest = { ...spaces[idx] };
         delete rest.syncStatus;
+        const containerSyncId = lazy.ZenSyncStore.getContainerSyncId(
+          rest.containerTabId
+        );
+        delete rest.containerTabId;
         record.cleartext = { id, type: "space", ...rest, position: idx };
+        if (containerSyncId) {
+          record.cleartext.containerSyncId = containerSyncId;
+        }
         break;
       }
 
       case "container": {
+        const localId = lazy.ZenSyncStore.resolveLocalContainerId(parsed.key);
         const container =
           lazy.ContextualIdentityService.getPublicIdentities().find(
-            c => String(c.userContextId) === parsed.key
+            candidate => candidate.userContextId === localId
           );
         if (!container) {
           record.deleted = true;
@@ -158,10 +164,16 @@ class ZenWorkspacesStore extends Store {
         record.cleartext = {
           id,
           type: "container",
-          userContextId: container.userContextId,
-          name: container.name,
+          syncId: parsed.key,
+          name: lazy.ContextualIdentityService.getUserContextLabel(
+            container.userContextId
+          ),
+          l10nId: container.l10nId || null,
           icon: container.icon,
           color: container.color,
+          semanticOrdinal: lazy.ZenSyncStore.getContainerSemanticOrdinal(
+            container.userContextId
+          ),
         };
         break;
       }
@@ -187,11 +199,19 @@ class ZenWorkspacesStore extends Store {
         continue;
       }
       const clean = stripSyncFields(data);
+      const parsedRecordId = parseRecordId(record.id);
       switch (data.type) {
         case "space":
           pulled.spaces.push(clean);
           break;
         case "container":
+          clean.syncId =
+            parsedRecordId?.type === "container"
+              ? parsedRecordId.key
+              : clean.syncId;
+          if (!clean.syncId) {
+            break;
+          }
           pulled.containers.push(clean);
           break;
       }
@@ -218,15 +238,7 @@ class ZenWorkspacesStore extends Store {
         removals.spaces.push({ uuid: parsed.key });
         break;
       case "container": {
-        const userContextId = normalizeUserContextId(parsed.key);
-        if (userContextId === null) {
-          console.warn(
-            "ZenWorkspacesStore: Ignoring container removal with invalid userContextId",
-            { id }
-          );
-          break;
-        }
-        removals.containers.push({ userContextId });
+        removals.containers.push({ syncId: parsed.key });
         break;
       }
     }
@@ -257,12 +269,20 @@ class ZenWorkspacesStore extends Store {
         return;
       }
       const clean = stripSyncFields(data);
+      const parsedRecordId = parseRecordId(record.id);
       const pulled = { spaces: [], containers: [] };
       switch (data.type) {
         case "space":
           pulled.spaces.push(clean);
           break;
         case "container":
+          clean.syncId =
+            parsedRecordId?.type === "container"
+              ? parsedRecordId.key
+              : clean.syncId;
+          if (!clean.syncId) {
+            break;
+          }
           pulled.containers.push(clean);
           break;
       }
@@ -330,8 +350,8 @@ class ZenWorkspacesTracker extends Tracker {
       }
     } else if (topic.startsWith("contextual-identity-")) {
       const id = subject?.wrappedJSObject?.userContextId;
-      if (id && normalizeUserContextId(id) !== null) {
-        this._trackChange({ type: "container", id });
+      for (const syncId of lazy.ZenSyncStore.getContainerSyncIds(id)) {
+        this._trackChange({ type: "container", id: syncId });
       }
     }
   }
@@ -391,7 +411,7 @@ export class ZenWorkspacesEngine extends SyncEngine {
   }
 
   get version() {
-    return 2;
+    return 3;
   }
 
   get syncPriority() {

--- a/src/zen/tests/moz.build
+++ b/src/zen/tests/moz.build
@@ -16,6 +16,7 @@ BROWSER_CHROME_MANIFESTS += [
     "space_routing/browser.toml",
     "spaces/browser.toml",
     "split_view/browser.toml",
+    "sync/browser.toml",
     "tabs/browser.toml",
     "ub-actions/browser.toml",
     "urlbar/browser.toml",

--- a/src/zen/tests/sync/browser.toml
+++ b/src/zen/tests/sync/browser.toml
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+["browser_sync_container_identity.js"]

--- a/src/zen/tests/sync/browser_sync_container_identity.js
+++ b/src/zen/tests/sync/browser_sync_container_identity.js
@@ -1,0 +1,92 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { ZenSyncStore } = ChromeUtils.importESModule(
+  "resource:///modules/zen/ZenSyncManager.sys.mjs"
+);
+const { ContextualIdentityService } = ChromeUtils.importESModule(
+  "resource://gre/modules/ContextualIdentityService.sys.mjs"
+);
+
+function emptySyncItems() {
+  return { spaces: [], containers: [] };
+}
+
+add_task(async function test_opaque_container_aliases_are_non_destructive() {
+  const name = `Zen Sync test ${Services.uuid.generateUUID()}`;
+  const first = ContextualIdentityService.create(name, "circle", "blue");
+  const second = ContextualIdentityService.create(name, "circle", "blue");
+
+  registerCleanupFunction(() => {
+    ContextualIdentityService.remove(first.userContextId);
+    ContextualIdentityService.remove(second.userContextId);
+  });
+
+  const localSyncId = ZenSyncStore.getContainerSyncId(first.userContextId);
+  Assert.ok(
+    /^[0-9a-f-]{36}$/i.test(localSyncId),
+    "The wire identity is opaque"
+  );
+  Assert.notEqual(
+    localSyncId,
+    String(first.userContextId),
+    "The profile-local numeric ID is not used on the wire"
+  );
+  Assert.equal(
+    ZenSyncStore.getContainerSemanticOrdinal(first.userContextId),
+    0,
+    "The first otherwise-identical container has ordinal zero"
+  );
+  Assert.equal(
+    ZenSyncStore.getContainerSemanticOrdinal(second.userContextId),
+    1,
+    "Intentional duplicate containers remain distinct"
+  );
+
+  const firstRemoteId = Services.uuid.generateUUID().toString().slice(1, -1);
+  const secondRemoteId = Services.uuid.generateUUID().toString().slice(1, -1);
+  const pulled = emptySyncItems();
+  pulled.containers = [
+    {
+      syncId: firstRemoteId,
+      name,
+      icon: "circle",
+      color: "blue",
+      semanticOrdinal: 0,
+    },
+    {
+      syncId: secondRemoteId,
+      name,
+      icon: "circle",
+      color: "blue",
+      semanticOrdinal: 1,
+    },
+  ];
+  await ZenSyncStore.applyIncomingBatch(pulled, emptySyncItems());
+
+  Assert.equal(
+    ZenSyncStore.resolveLocalContainerId(firstRemoteId),
+    first.userContextId,
+    "The first remote identity aliases the first local container"
+  );
+  Assert.equal(
+    ZenSyncStore.resolveLocalContainerId(secondRemoteId),
+    second.userContextId,
+    "The second remote identity aliases the second local container"
+  );
+
+  const removals = emptySyncItems();
+  removals.containers = [{ syncId: firstRemoteId }, { syncId: secondRemoteId }];
+  await ZenSyncStore.applyIncomingBatch(emptySyncItems(), removals);
+
+  Assert.ok(
+    ContextualIdentityService.getPublicIdentityFromId(first.userContextId),
+    "A remote tombstone does not delete local container data"
+  );
+  Assert.ok(
+    ContextualIdentityService.getPublicIdentityFromId(second.userContextId),
+    "Every intentional local container remains available"
+  );
+});


### PR DESCRIPTION
Fixes #14550

## Summary

- replace profile-local numeric container record IDs with random opaque Sync IDs
- persist a profile-local map from opaque IDs to `userContextId`
- serialize Space references as `containerSyncId` and resolve them locally on apply
- reconcile independently-created matching containers by semantic ordinal without collapsing intentional same-name duplicates
- preserve local containers for remote tombstones so Sync never clears cookies or site data on another device
- bump the Spaces engine from version 2 to 3 to reset incompatible preview records
- add browser coverage for opaque IDs, aliases, duplicate ordinals, and non-destructive tombstones

## Why

Firefox allocates `userContextId` independently per profile. Using `c~2` account-wide can rename an unrelated ID 2, attach a Space to the wrong local cookie jar, or call `ContextualIdentityService.remove(2)` and clear unrelated local site data.

## Verification

- `node --check` passes for both modified modules and the browser test
- Firefox ESLint rules pass for the production modules and test
- `git diff --check` passes
- the same code path passes full imported-tree ESLint in the integration fork

A local browser-chrome run could not launch because this Windows checkout has no compiled browser and Visual Studio Build Tools installation was blocked by UAC. The PR is draft so CI can validate the imported build and browser test before it is marked ready.