### PR TITLE
fix(workspaces): prevent !bang searches from bypassing space routing rules

### DIFF
--- a/src/zen/common/sys/ui/ZenSpaceRoutingNavigation.sys.mjs
+++ b/src/zen/common/sys/ui/ZenSpaceRoutingNavigation.sys.mjs
@@ -35,12 +35,13 @@ export class ZenSpaceRoutingNavigation extends ZenUIComponent {
       return;
     }
 
-    let uri;
+    let channel;
     try {
-      uri = aRequest.QueryInterface(Ci.nsIChannel).URI;
+      channel = aRequest.QueryInterface(Ci.nsIChannel);
     } catch (e) {
       return;
     }
+    const uri = channel.URI;
     if (!uri || !(uri.schemeIs("http") || uri.schemeIs("https"))) {
       return;
     }
@@ -56,7 +57,8 @@ export class ZenSpaceRoutingNavigation extends ZenUIComponent {
     } catch (e) {
       currentURI = null;
     }
-    if (currentURI?.equals(uri)) {
+    const isRedirect = channel.originalURI && !channel.originalURI.equals(uri);
+    if (!isRedirect && currentURI?.equals(uri)) {
       return;
     }
 
@@ -77,7 +79,7 @@ export class ZenSpaceRoutingNavigation extends ZenUIComponent {
       win.gZenSpaceRoutingManager.getRedirectTargetWorkspaceId(
         uri.spec,
         currentWorkspaceId,
-        win
+        win,
       );
     if (!targetWorkspaceId) {
       return;


### PR DESCRIPTION
Closes #14487.

### Root Cause
When a search is performed using a \!bang\ (e.g., \!yt\), the search engine redirects the request (HTTP 302/303 redirect) to the target site. During this redirect transition, Gecko/Firefox's \onLocationChange\ fires and updates the browser's \currentURI\ before the new redirected channel's \STATE_START\ event is processed by \onStateChange\ in \ZenSpaceRoutingNavigation.sys.mjs\. Because \currentURI\ has already been updated to the redirected URL, the check \currentURI.equals(uri)\ returns true, causing the space routing logic to return early.

### Fix
Modify the listener to check if the channel has been redirected by comparing \channel.originalURI\ and \channel.URI\. If it is a redirect, we bypass the \currentURI.equals(uri)\ early return to ensure the routing rules are correctly applied.