### PR TITLE
gh-14317: Show pinned-tab scroll-shadow dividers based on scroll position

### DIFF
--- a/src/toolkit/content/widgets/arrowscrollbox-js.patch
+++ b/src/toolkit/content/widgets/arrowscrollbox-js.patch
@@ -1,5 +1,5 @@
 diff --git a/toolkit/content/widgets/arrowscrollbox.js b/toolkit/content/widgets/arrowscrollbox.js
-index b80d1049bb6ae305f2ac9c4c35fe975fd508031c..574149bffa49329e927c8db9db0c080eb6b87f5f 100644
+index b80d1049bb6ae305f2ac9c4c35fe975fd508031c..bb06b68b9e023b14d1b0655289ad11dab3d35313 100644
 --- a/toolkit/content/widgets/arrowscrollbox.js
 +++ b/toolkit/content/widgets/arrowscrollbox.js
 @@ -98,6 +98,7 @@
@@ -22,7 +22,32 @@ index b80d1049bb6ae305f2ac9c4c35fe975fd508031c..574149bffa49329e927c8db9db0c080e
      connectedCallback() {
        this.removeAttribute("overflowing");
  
-@@ -642,7 +648,7 @@
+@@ -594,17 +600,21 @@
+       let scrolledToStart = false;
+       let scrolledToEnd = false;
+ 
++      // This is enough slop (>2/3) so that no subpixel value should
++      // get us confused about whether we reached the end.
++      const EPSILON = 0.7;
+       if (!this.overflowing) {
+         scrolledToStart = true;
+         scrolledToEnd = true;
++      } else if (this.classList.contains("workspace-arrowscrollbox")) {
++        const maxScrollPosition = this.scrollSize - this.scrollClientSize;
++        scrolledToStart = this.scrollPosition <= EPSILON;
++        scrolledToEnd = this.scrollPosition >= maxScrollPosition - EPSILON;
+       } else {
+         let isAtEdge = (element, start) => {
+           let edge = start ? this.startEndProps[0] : this.startEndProps[1];
+           let scrollEdge = this._boundsWithoutFlushing(this.scrollbox)[edge];
+           let elementEdge = this._boundsWithoutFlushing(element)[edge];
+-          // This is enough slop (>2/3) so that no subpixel value should
+-          // get us confused about whether we reached the end.
+-          const EPSILON = 0.7;
+           if (start) {
+             return scrollEdge <= elementEdge + EPSILON;
+           }
+@@ -642,7 +652,7 @@
  
      on_wheel(event) {
        // Don't consume the event if we can't scroll.

--- a/src/toolkit/content/widgets/arrowscrollbox-js.patch
+++ b/src/toolkit/content/widgets/arrowscrollbox-js.patch
@@ -1,5 +1,5 @@
 diff --git a/toolkit/content/widgets/arrowscrollbox.js b/toolkit/content/widgets/arrowscrollbox.js
-index b80d1049bb6ae305f2ac9c4c35fe975fd508031c..bb06b68b9e023b14d1b0655289ad11dab3d35313 100644
+index b80d1049bb6ae305f2ac9c4c35fe975fd508031c..17722e20abdffe943dcf64518e9426faa564b527 100644
 --- a/toolkit/content/widgets/arrowscrollbox.js
 +++ b/toolkit/content/widgets/arrowscrollbox.js
 @@ -98,6 +98,7 @@
@@ -22,32 +22,19 @@ index b80d1049bb6ae305f2ac9c4c35fe975fd508031c..bb06b68b9e023b14d1b0655289ad11da
      connectedCallback() {
        this.removeAttribute("overflowing");
  
-@@ -594,17 +600,21 @@
-       let scrolledToStart = false;
-       let scrolledToEnd = false;
- 
-+      // This is enough slop (>2/3) so that no subpixel value should
-+      // get us confused about whether we reached the end.
-+      const EPSILON = 0.7;
+@@ -597,6 +603,11 @@
        if (!this.overflowing) {
          scrolledToStart = true;
          scrolledToEnd = true;
 +      } else if (this.classList.contains("workspace-arrowscrollbox")) {
++        const EPSILON = 0.7;
 +        const maxScrollPosition = this.scrollSize - this.scrollClientSize;
 +        scrolledToStart = this.scrollPosition <= EPSILON;
 +        scrolledToEnd = this.scrollPosition >= maxScrollPosition - EPSILON;
        } else {
          let isAtEdge = (element, start) => {
            let edge = start ? this.startEndProps[0] : this.startEndProps[1];
-           let scrollEdge = this._boundsWithoutFlushing(this.scrollbox)[edge];
-           let elementEdge = this._boundsWithoutFlushing(element)[edge];
--          // This is enough slop (>2/3) so that no subpixel value should
--          // get us confused about whether we reached the end.
--          const EPSILON = 0.7;
-           if (start) {
-             return scrollEdge <= elementEdge + EPSILON;
-           }
-@@ -642,7 +652,7 @@
+@@ -642,7 +653,7 @@
  
      on_wheel(event) {
        // Don't consume the event if we can't scroll.

--- a/src/zen/tests/spaces/browser.toml
+++ b/src/zen/tests/spaces/browser.toml
@@ -10,6 +10,8 @@ support-files = [
 
 ["browser_basic_workspaces.js"]
 
+["browser_collapsed_pinned_scroll_shadow.js"]
+
 ["browser_double_click_newtab.js"]
 
 ["browser_issue_10455.js"]

--- a/src/zen/tests/spaces/browser_collapsed_pinned_scroll_shadow.js
+++ b/src/zen/tests/spaces/browser_collapsed_pinned_scroll_shadow.js
@@ -1,0 +1,119 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// gh-14317: the scroll-shadow dividers are gated on the arrowscrollbox's
+// scrolledtostart / scrolledtoend attributes. With pinned tabs collapsed, the
+// pinned section's start marker is pulled out of the scroll flow, so the native
+// element-edge computation reported the wrong state and a false top divider
+// showed at scrollTop 0. The fix derives both attributes from the real scroll
+// position for the workspace scrollbox. This test pins+collapses, overflows the
+// list, and asserts the attributes track scroll position.
+
+async function settle() {
+  // Wait for the scroll event + the arrowscrollbox's rAF-batched
+  // #updateScrollButtonsDisabledState (aRafCount = 2) to run.
+  /* eslint-disable-next-line mozilla/no-arbitrary-setTimeout */
+  await new Promise(resolve => setTimeout(resolve, 200));
+}
+
+add_task(async function test_scroll_shadow_with_collapsed_pinned_tabs() {
+  const arrowscrollbox = gZenWorkspaces.activeScrollbox;
+  arrowscrollbox.smoothScroll = false;
+  const scrollbox = arrowscrollbox.scrollbox;
+  const originalTab = gBrowser.selectedTab;
+  const createdTabs = [];
+
+  // Pin a couple of tabs so there is a pinned section to collapse.
+  for (let i = 0; i < 2; i++) {
+    const tab = await BrowserTestUtils.openNewForegroundTab(
+      window.gBrowser,
+      "https://example.com/",
+      true
+    );
+    createdTabs.push(tab);
+    gBrowser.pinTab(tab);
+  }
+
+  // Open enough normal tabs to overflow, plus generous margin so the list
+  // still overflows after collapsing removes the pinned tabs' height.
+  while (!arrowscrollbox.overflowing) {
+    const tab = await BrowserTestUtils.openNewForegroundTab(
+      window.gBrowser,
+      "https://example.com/",
+      true
+    );
+    createdTabs.push(tab);
+  }
+  let lastNormalTab;
+  for (let i = 0; i < 6; i++) {
+    lastNormalTab = await BrowserTestUtils.openNewForegroundTab(
+      window.gBrowser,
+      "https://example.com/",
+      true
+    );
+    createdTabs.push(lastNormalTab);
+  }
+
+  // A NORMAL tab must be selected when collapsing: the collapse only applies
+  // the negative-margin shift to the start marker when no pinned tab is
+  // active (#calculateHeightShift returns 0 otherwise), and that shift is the
+  // condition that triggers gh-14317.
+  gBrowser.selectedTab = lastNormalTab;
+
+  const workspace = gZenWorkspaces.activeWorkspaceElement;
+  workspace.collapsiblePins.collapsed = true;
+  ok(workspace.hasCollapsedPinnedTabs, "Pinned tabs should be collapsed");
+  await settle();
+
+  ok(
+    arrowscrollbox.overflowing,
+    "The scrollbox should still overflow with pinned tabs collapsed"
+  );
+
+  // Scroll to the very top.
+  scrollbox.scrollTop = 0;
+  scrollbox.dispatchEvent(new Event("scroll"));
+  await settle();
+
+  // The gh-14317 regression: at the top, scrolledtostart must be set even
+  // though the collapsed pinned marker is shifted above the viewport.
+  ok(
+    arrowscrollbox.hasAttribute("scrolledtostart"),
+    "scrolledtostart set at scrollTop 0 with collapsed pinned tabs (no false top divider)"
+  );
+  ok(
+    !arrowscrollbox.hasAttribute("scrolledtoend"),
+    "scrolledtoend not set at the top while overflowing"
+  );
+
+  // Scroll down a bit -> no longer at the start.
+  scrollbox.scrollTop = 100;
+  scrollbox.dispatchEvent(new Event("scroll"));
+  await settle();
+  ok(
+    !arrowscrollbox.hasAttribute("scrolledtostart"),
+    "scrolledtostart cleared after scrolling down"
+  );
+
+  // Scroll to the bottom -> scrolledtoend.
+  scrollbox.scrollTop = scrollbox.scrollHeight;
+  scrollbox.dispatchEvent(new Event("scroll"));
+  await settle();
+  ok(
+    arrowscrollbox.hasAttribute("scrolledtoend"),
+    "scrolledtoend set at the bottom"
+  );
+  ok(
+    !arrowscrollbox.hasAttribute("scrolledtostart"),
+    "scrolledtostart not set at the bottom"
+  );
+
+  // Cleanup.
+  workspace.collapsiblePins.collapsed = false;
+  gBrowser.selectedTab = originalTab;
+  for (const tab of createdTabs.reverse()) {
+    await BrowserTestUtils.removeTab(tab);
+  }
+});


### PR DESCRIPTION
The top/bottom scroll-shadow dividers were derived from the arrowscrollbox's scrolledtostart/scrolledtoend, which it computes from the first/last scrollable element's edge. With collapsed pinned tabs those edges are unreliable, so the divider either flashed at the top (when pinned tabs were counted) or only appeared once scrolled past the pinned/normal separator (when excluded).