### PR TITLE
gh-14545: Correctly handle dnd moving a tab to an empty space

### DIFF
--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -1336,7 +1336,8 @@
       // Essentials should be properly handled by ::animateVerticalPinnedGridDragOver
       if (!dropElement || dropElement.hasAttribute("zen-essential")) {
         this.clearDragOverVisuals();
-        return null;
+        // If dropElement is null or essential, dropElement should be the empty tab
+        return [dropBefore, gZenWorkspaces._emptyTab];
       }
       if (dropElement.hasAttribute("zen-empty-tab") && dropElement.group) {
         let secondTab = dropElement.group.tabs[1];


### PR DESCRIPTION
fixed:  https://github.com/zen-browser/desktop/issues/14545