### PR TITLE
gh-9186: Support dropping tabs onto a space switcher icon

### DIFF
--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -126,6 +126,10 @@
           "dragover",
           this.handle_spaceIconDragOver.bind(this)
         );
+        gZenWorkspaces.workspaceIcons.addEventListener(
+          "drop",
+          this.#handle_spaceIconDrop.bind(this)
+        );
       }
       window.addEventListener(
         "dragleave",
@@ -755,10 +759,15 @@
       if (draggedTab.hasAttribute("zen-essential")) {
         return;
       }
-      const target = event.target;
-      const spaceId = target.getAttribute("zen-workspace-id");
+      const spaceId = event.target
+        .closest("[zen-workspace-id]")
+        ?.getAttribute("zen-workspace-id");
       if (!spaceId) {
         return;
+      }
+      if (this.#supportsDirectSpaceIconDrop(draggedTab)) {
+        event.preventDefault();
+        dt.dropEffect = "move";
       }
       this.clearDragOverVisuals();
       const currentSpaceId = gZenWorkspaces.activeWorkspace;
@@ -768,6 +777,45 @@
       gZenWorkspaces.changeWorkspaceWithID(spaceId).then(spaceChanged => {
         this.#onSpaceChanged(spaceChanged, dt);
       });
+    }
+
+    #handle_spaceIconDrop(event) {
+      const draggedTab = event.dataTransfer.mozGetDataAt(TAB_DROP_TYPE, 0);
+      if (!this.#supportsDirectSpaceIconDrop(draggedTab)) {
+        return;
+      }
+      const spaceId = event.target
+        .closest("[zen-workspace-id]")
+        ?.getAttribute("zen-workspace-id");
+      if (!spaceId) {
+        return;
+      }
+      event.preventDefault();
+      this.clearSpaceSwitchTimer();
+      this.clearDragOverVisuals();
+      requestAnimationFrame(() =>
+        gZenCompactModeManager?._clearAllHoverStates()
+      );
+
+      const movingTabs = draggedTab._dragData?.movingTabs || [draggedTab];
+      const moveTabs = () => {
+        gZenWorkspaces.moveTabsToWorkspace(movingTabs, spaceId);
+        gBrowser.selectedTab = draggedTab;
+        gZenWorkspaces.updateTabsContainers();
+      };
+      if (spaceId === gZenWorkspaces.activeWorkspace) {
+        moveTabs();
+      } else {
+        gZenWorkspaces.changeWorkspaceWithID(spaceId).then(moveTabs);
+      }
+    }
+
+    #supportsDirectSpaceIconDrop(draggedTab) {
+      return (
+        isTab(draggedTab) &&
+        !draggedTab.hasAttribute("zen-essential") &&
+        draggedTab.documentGlobal === window
+      );
     }
 
     #handle_tabDragOverToSplit(event) {


### PR DESCRIPTION
Disclaimer: there was already a PR of an earlier version of this feature.

This now should really be a minimal and non-intrusive implementation for supporting drag and drop of tabs onto the space switcher icons (without having to wait for activation of that space and manually finding a drop-position for insertions).
It is using the default settings of the "add tab-position" for locating the target position of the dragged tabs (this was already implemented before, the same is used for the "move to space" functionality).

This PR is currently only supporting tabs (no folders) dragged inside of the same window and skipping essentials as usual. For unsupported tabs, the releasing of mouse button is a simple noop - not causing any harm - and it is falling back to the previous "hover => activate workspace"-behaviour.

When additional types should be supported, this can easily be implemented later into the existing architecture by extending `#supportsDirectSpaceIconDrop`.