### PR TITLE
fix: prevent black tabs on workspace switch (Windows)

### DIFF
--- a/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
+++ b/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
@@ -254,6 +254,13 @@ class nsZenSpaceRoutingManager {
               ] = newTab;
 
               if (!inBackground) {
+                // Yield to the event loop so the compositor can settle
+                // after DOM reparenting before switching workspace.
+                // On Windows, DirectComposition needs time to re-establish
+                // the browser surface after the element is reparented.
+                await new Promise(resolve =>
+                  Services.tm.dispatchToMainThread(resolve)
+                );
                 await win.gZenWorkspaces.changeWorkspace(targetWorkspace);
               }
             }
@@ -567,3 +574,4 @@ class nsZenSpaceRoutingManager {
 }
 
 export const gZenSpaceRoutingManager = new nsZenSpaceRoutingManager();
+

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -2348,16 +2348,21 @@ class nsZenWorkspaces {
 
     // If we found a tab to select, select it
     if (!onInit && !tabToSelect) {
-      // Create new tab if needed and no suitable tab was found
       const newTab = this.selectEmptyTab();
       tabToSelect = newTab;
     }
-    if (tabToSelect && !onInit) {
+
+    if (!tabToSelect) {
+      const newTab = this.selectEmptyTab();
+      tabToSelect = newTab;
+    }
+
+    if (tabToSelect) {
       tabToSelect._visuallySelected = true;
     }
 
-    // Always make sure we always unselect the tab from the old workspace
-    if (currentSelectedTab && currentSelectedTab !== tabToSelect) {
+    // Only unselect the old tab when we have a confirmed replacement
+    if (tabToSelect && currentSelectedTab && currentSelectedTab !== tabToSelect) {
       currentSelectedTab._selected = false;
     }
     return tabToSelect;
@@ -3356,3 +3361,4 @@ class nsZenWorkspaces {
 }
 
 window.gZenWorkspaces = new nsZenWorkspaces();
+


### PR DESCRIPTION
## Description

Fixes #14510

This PR addresses the issue where tab contents turn black/blank on Windows when switching tabs or workspaces.

## Root Causes

1. **Tab deselection race condition** (ZenSpaceManager.mjs:2310): _handleTabSelection was deselecting the current tab (currentSelectedTab._selected = false) *before* confirming that a replacement tab exists. This leaves a window with no selected tab, causing the rendering surface to go blank.

2. **DirectComposition timing issue** (ZenSpaceRoutingManager.sys.mjs:255): #routeToWorkspace calls moveTabToWorkspace (which reparents the browser element in the DOM) and then immediately calls changeWorkspace. On Windows, DirectComposition needs time to re-establish the browser surface after the element is reparented.

## Changes

### src/zen/spaces/ZenSpaceManager.mjs
- Add a second fallback in _handleTabSelection to always ensure a replacement tab exists before deselecting the current one
- Gate the currentSelectedTab._selected = false with a check that 	abToSelect is truthy

### src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
- Add an explicit wait yielding to the main thread (via Services.tm.dispatchToMainThread) after moveTabToWorkspace and before changeWorkspace, giving the compositor time to settle

## Testing
- Switch between workspaces repeatedly on Windows
- Open/close tabs in different workspaces
- Verify no black/blank tab contents appear