### PR TITLE
gh-14595: add url bar renamed tab provider

### DIFF
--- a/src/browser/components/urlbar/UrlbarUtils-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarUtils-sys-mjs.patch
@@ -48,3 +48,13 @@ index aa7c67f2bfaa3f15d592a14b527a8721dfc9bc6f..d2fe012796ea3a5be05090a732011b3c
          case "UrlbarProviderOmnibox":
            return this.RESULT_GROUP.HEURISTIC_OMNIBOX;
          case "UrlbarProviderRestrictKeywordsAutofill":
+@@ -2678,6 +2696,9 @@ UrlbarUtils.RESULT_PAYLOAD_SCHEMA = {
+       userContextId: {
+         type: "number",
+       },
++      zenTargetBrowsingContextId: {
++        type: "number",
++      },
+     },
+   },
+   [UrlbarUtils.RESULT_TYPE.SEARCH]: {

--- a/src/browser/components/urlbar/content/UrlbarInput-mjs.patch
+++ b/src/browser/components/urlbar/content/UrlbarInput-mjs.patch
@@ -74,6 +74,13 @@ index 0fba59d62af9d3cd05bfee2cf84cd8b7cf9bfd6e..3997a5109267f378b59aa6510cbacd07
      }
  
      if (isCanonized) {
+@@ -1708,5 +1741,6 @@ ${
+         let loadOpts = {
+           adoptIntoActiveWindow: lazy.UrlbarPrefs.get(
+             "switchTabs.adoptIntoActiveWindow"
+           ),
++          zenTargetBrowsingContextId: result.payload.zenTargetBrowsingContextId,
+         };
 @@ -2936,6 +2969,42 @@ ${
      await this.#updateLayoutBreakoutDimensions();
    }

--- a/src/browser/modules/URILoadingHelper-sys-mjs.patch
+++ b/src/browser/modules/URILoadingHelper-sys-mjs.patch
@@ -19,7 +19,17 @@ index b60820ef0cc62c27a8bab127218d625012153791..04cdd58ed4426af802f2868310140a8a
          where = "tab";
          targetBrowser = null;
        } else if (
-@@ -981,7 +982,7 @@ export const URILoadingHelper = {
+@@ -930,3 +931,4 @@ export const URILoadingHelper = {
+     let ignoreQueryString = aOpenParams.ignoreQueryString;
+     let replaceQueryString = aOpenParams.replaceQueryString;
++    let zenTargetBrowsingContextId = aOpenParams.zenTargetBrowsingContextId;
+     let adoptIntoActiveWindow = aOpenParams.adoptIntoActiveWindow;
+@@ -937,3 +939,4 @@ export const URILoadingHelper = {
+     delete aOpenParams.ignoreQueryString;
+     delete aOpenParams.replaceQueryString;
++    delete aOpenParams.zenTargetBrowsingContextId;
+     delete aOpenParams.adoptIntoActiveWindow;
+@@ -981,9 +984,15 @@ export const URILoadingHelper = {
          ignoreQueryString || replaceQueryString,
          ignoreFragmentWhenComparing
        );
@@ -27,7 +37,15 @@ index b60820ef0cc62c27a8bab127218d625012153791..04cdd58ed4426af802f2868310140a8a
 +      let browsers = aWindow.gZenWorkspaces.allUsedBrowsers;
        for (let i = 0; i < browsers.length; i++) {
          let browser = browsers[i];
++        if (
++          zenTargetBrowsingContextId != null &&
++          browser.browsingContext.id != zenTargetBrowsingContextId
++        ) {
++          continue;
++        }
          let browserCompare = cleanURL(
+           browser.currentURI.displaySpec,
+           ignoreQueryString || replaceQueryString,
 @@ -1037,7 +1038,7 @@ export const URILoadingHelper = {
                }
                aSplitView.documentGlobal.focus();

--- a/src/zen/tests/urlbar/browser.toml
+++ b/src/zen/tests/urlbar/browser.toml
@@ -12,3 +12,5 @@ support-files = [
 ["browser_floating_urlbar.js"]
 
 ["browser_issue_7385.js"]
+
+["browser_renamed_tabs.js"]

--- a/src/zen/tests/urlbar/browser_renamed_tabs.js
+++ b/src/zen/tests/urlbar/browser_renamed_tabs.js
@@ -1,0 +1,97 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+ChromeUtils.defineESModuleGetters(this, {
+  UrlbarTestUtils: "resource://testing-common/UrlbarTestUtils.sys.mjs",
+});
+
+UrlbarTestUtils.init(this);
+
+const CUSTOM_LABEL = "Zen Project Dashboard 14595";
+const PROVIDER_NAME = "ZenUrlbarProviderRenamedTabs";
+
+async function findRenamedTabResult(searchString) {
+  await UrlbarTestUtils.promiseAutocompleteResultPopup({
+    window,
+    value: searchString,
+  });
+
+  const resultCount = UrlbarTestUtils.getResultCount(window);
+  for (let index = 0; index < resultCount; index++) {
+    const details = await UrlbarTestUtils.getDetailsOfResultAt(window, index);
+    if (details.result.providerName == PROVIDER_NAME) {
+      return { details, index };
+    }
+  }
+  return null;
+}
+
+add_task(async function test_urlbar_matches_renamed_tab_label() {
+  const targetTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.com/?zen-renamed-tab"
+  );
+  const searchTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.org/?zen-urlbar-search"
+  );
+
+  registerCleanupFunction(async () => {
+    for (const tab of [targetTab, searchTab]) {
+      if (tab.isConnected) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+  });
+
+  targetTab.zenStaticLabel = CUSTOM_LABEL;
+  gBrowser._setTabLabel(targetTab, CUSTOM_LABEL, {
+    _zenChangeLabelFlag: true,
+  });
+
+  for (const searchString of [CUSTOM_LABEL, `% ${CUSTOM_LABEL}`]) {
+    const match = await findRenamedTabResult(searchString);
+    Assert.ok(match, `The renamed tab should match "${searchString}"`);
+    Assert.equal(
+      match.details.result.payload.title,
+      CUSTOM_LABEL,
+      "The result should display the renamed label"
+    );
+    Assert.equal(
+      match.details.result.payload.url,
+      targetTab.linkedBrowser.currentURI.spec,
+      "The result should point to the renamed tab"
+    );
+    gURLBar.view.close();
+  }
+
+  delete targetTab.zenStaticLabel;
+  gBrowser.setTabTitle(targetTab);
+  Assert.ok(
+    !(await findRenamedTabResult(CUSTOM_LABEL)),
+    "Resetting the label should remove the custom title match"
+  );
+  gURLBar.view.close();
+
+  targetTab.zenStaticLabel = CUSTOM_LABEL;
+  gBrowser._setTabLabel(targetTab, CUSTOM_LABEL, {
+    _zenChangeLabelFlag: true,
+  });
+  const match = await findRenamedTabResult(CUSTOM_LABEL);
+  Assert.ok(match, "The renamed tab should be available for switching");
+
+  UrlbarTestUtils.setSelectedRowIndex(window, match.index);
+  const switched = BrowserTestUtils.waitForEvent(
+    gBrowser.tabContainer,
+    "TabSelect"
+  );
+  EventUtils.synthesizeKey("KEY_Enter");
+  await switched;
+  Assert.equal(
+    gBrowser.selectedTab,
+    targetTab,
+    "Selecting the result should switch to the renamed tab"
+  );
+});

--- a/src/zen/tests/urlbar/browser_renamed_tabs.js
+++ b/src/zen/tests/urlbar/browser_renamed_tabs.js
@@ -10,7 +10,7 @@ ChromeUtils.defineESModuleGetters(this, {
 UrlbarTestUtils.init(this);
 
 const CUSTOM_LABEL = "Zen Project Dashboard 14595";
-const PROVIDER_NAME = "ZenUrlbarProviderRenamedTabs";
+const PROVIDER_NAME = "ZenUrlbarProviderTabs";
 
 async function findRenamedTabResult(searchString) {
   await UrlbarTestUtils.promiseAutocompleteResultPopup({
@@ -29,6 +29,10 @@ async function findRenamedTabResult(searchString) {
 }
 
 add_task(async function test_urlbar_matches_renamed_tab_label() {
+  const duplicateTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.com/?zen-renamed-tab"
+  );
   const targetTab = await BrowserTestUtils.openNewForegroundTab(
     gBrowser,
     "https://example.com/?zen-renamed-tab"
@@ -39,7 +43,7 @@ add_task(async function test_urlbar_matches_renamed_tab_label() {
   );
 
   registerCleanupFunction(async () => {
-    for (const tab of [targetTab, searchTab]) {
+    for (const tab of [duplicateTab, targetTab, searchTab]) {
       if (tab.isConnected) {
         await BrowserTestUtils.removeTab(tab);
       }
@@ -92,6 +96,6 @@ add_task(async function test_urlbar_matches_renamed_tab_label() {
   Assert.equal(
     gBrowser.selectedTab,
     targetTab,
-    "Selecting the result should switch to the renamed tab"
+    "Selecting the result should switch to the matched renamed tab when URLs are duplicated"
   );
 });

--- a/src/zen/urlbar/ZenUBProvider.sys.mjs
+++ b/src/zen/urlbar/ZenUBProvider.sys.mjs
@@ -9,8 +9,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
   /* eslint-disable mozilla/valid-lazy */
   ZenUrlbarProviderGlobalActions:
     "resource:///modules/ZenUBActionsProvider.sys.mjs",
-  ZenUrlbarProviderRenamedTabs:
-    "resource:///modules/ZenUBRenamedTabsProvider.sys.mjs",
+  ZenUrlbarProviderTabs: "resource:///modules/ZenUBTabsProvider.sys.mjs",
 });
 
 export function registerZenUrlbarProviders() {

--- a/src/zen/urlbar/ZenUBProvider.sys.mjs
+++ b/src/zen/urlbar/ZenUBProvider.sys.mjs
@@ -9,6 +9,8 @@ ChromeUtils.defineESModuleGetters(lazy, {
   /* eslint-disable mozilla/valid-lazy */
   ZenUrlbarProviderGlobalActions:
     "resource:///modules/ZenUBActionsProvider.sys.mjs",
+  ZenUrlbarProviderRenamedTabs:
+    "resource:///modules/ZenUBRenamedTabsProvider.sys.mjs",
 });
 
 export function registerZenUrlbarProviders() {

--- a/src/zen/urlbar/ZenUBRenamedTabsProvider.sys.mjs
+++ b/src/zen/urlbar/ZenUBRenamedTabsProvider.sys.mjs
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  UrlbarProvider,
+  UrlbarUtils,
+} from "moz-src:///browser/components/urlbar/UrlbarUtils.sys.mjs";
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  BrowserWindowTracker: "resource:///modules/BrowserWindowTracker.sys.mjs",
+  PrivateBrowsingUtils: "resource://gre/modules/PrivateBrowsingUtils.sys.mjs",
+  UrlbarPrefs: "moz-src:///browser/components/urlbar/UrlbarPrefs.sys.mjs",
+  UrlbarProviderOpenTabs:
+    "moz-src:///browser/components/urlbar/UrlbarProviderOpenTabs.sys.mjs",
+  UrlbarResult: "moz-src:///browser/components/urlbar/UrlbarResult.sys.mjs",
+  UrlbarTokenizer:
+    "moz-src:///browser/components/urlbar/UrlbarTokenizer.sys.mjs",
+});
+
+/**
+ * Provides switch-to-tab results that match a tab's Zen-specific static label.
+ */
+export class ZenUrlbarProviderRenamedTabs extends UrlbarProvider {
+  /**
+   * @returns {Values<typeof UrlbarUtils.PROVIDER_TYPE>}
+   */
+  get type() {
+    return UrlbarUtils.PROVIDER_TYPE.PROFILE;
+  }
+
+  /**
+   * @param {UrlbarQueryContext} queryContext The query context object.
+   * @returns {Promise<boolean>}
+   */
+  async isActive(queryContext) {
+    return (
+      queryContext.sources.includes(UrlbarUtils.RESULT_SOURCE.TABS) &&
+      queryContext.tokens.some(
+        token => token.value && !lazy.UrlbarTokenizer.isRestrictionToken(token)
+      )
+    );
+  }
+
+  /**
+   * @param {UrlbarQueryContext} queryContext The query context object.
+   * @param {(provider: UrlbarProvider, result: UrlbarResult) => void} addCallback
+   *   Callback invoked by the provider to add a result.
+   */
+  async startQuery(queryContext, addCallback) {
+    const tokens = queryContext.tokens.filter(
+      token => token.value && !lazy.UrlbarTokenizer.isRestrictionToken(token)
+    );
+    const activeWindow = lazy.BrowserWindowTracker.getTopWindow({
+      private: queryContext.isPrivate,
+    });
+
+    for (const browserWindow of lazy.BrowserWindowTracker.orderedWindows) {
+      if (
+        browserWindow.closed ||
+        !browserWindow.gBrowser ||
+        lazy.PrivateBrowsingUtils.isWindowPrivate(browserWindow) !=
+          queryContext.isPrivate
+      ) {
+        continue;
+      }
+
+      for (const tab of browserWindow.gBrowser.tabs) {
+        const title = tab.zenStaticLabel;
+        if (
+          tab.closing ||
+          typeof title != "string" ||
+          !title.trim() ||
+          (browserWindow == activeWindow && tab.selected)
+        ) {
+          continue;
+        }
+
+        const lowerCaseTitle = title.toLocaleLowerCase();
+        if (
+          !tokens.every(token => lowerCaseTitle.includes(token.lowerCaseValue))
+        ) {
+          continue;
+        }
+
+        const url = tab.linkedBrowser?.currentURI?.spec;
+        if (!url || browserWindow.isBlankPageURL(url)) {
+          continue;
+        }
+
+        const userContextId =
+          lazy.UrlbarProviderOpenTabs.getUserContextIdForOpenPagesTable(
+            tab.userContextId,
+            queryContext.isPrivate
+          );
+        const payload = {
+          url,
+          title,
+          icon:
+            browserWindow.gBrowser.getIcon(tab) ||
+            UrlbarUtils.getIconForUrl(url),
+          userContextId,
+          action: lazy.UrlbarPrefs.get("secondaryActions.switchToTab")
+            ? UrlbarUtils.createTabSwitchSecondaryAction(userContextId)
+            : undefined,
+        };
+        if (tab.group?.id) {
+          payload.tabGroup = tab.group.id;
+        }
+
+        addCallback(
+          this,
+          new lazy.UrlbarResult({
+            type: UrlbarUtils.RESULT_TYPE.TAB_SWITCH,
+            source: UrlbarUtils.RESULT_SOURCE.TABS,
+            payload,
+            highlights: {
+              url: UrlbarUtils.HIGHLIGHT.TYPED,
+              title: UrlbarUtils.HIGHLIGHT.TYPED,
+            },
+          })
+        );
+      }
+    }
+  }
+
+  /**
+   * @returns {number} The provider priority.
+   */
+  getPriority() {
+    return 0;
+  }
+}

--- a/src/zen/urlbar/ZenUBTabsProvider.sys.mjs
+++ b/src/zen/urlbar/ZenUBTabsProvider.sys.mjs
@@ -21,9 +21,9 @@ ChromeUtils.defineESModuleGetters(lazy, {
 });
 
 /**
- * Provides switch-to-tab results that match a tab's Zen-specific static label.
+ * Provides Zen-specific switch-to-tab results.
  */
-export class ZenUrlbarProviderRenamedTabs extends UrlbarProvider {
+export class ZenUrlbarProviderTabs extends UrlbarProvider {
   /**
    * @returns {Values<typeof UrlbarUtils.PROVIDER_TYPE>}
    */
@@ -98,6 +98,7 @@ export class ZenUrlbarProviderRenamedTabs extends UrlbarProvider {
         const payload = {
           url,
           title,
+          zenTargetBrowsingContextId: tab.linkedBrowser.browsingContext.id,
           icon:
             browserWindow.gBrowser.getIcon(tab) ||
             UrlbarUtils.getIconForUrl(url),

--- a/src/zen/urlbar/moz.build
+++ b/src/zen/urlbar/moz.build
@@ -7,5 +7,6 @@ EXTRA_JS_MODULES += [
   "ZenUBActionsProvider.sys.mjs",
   "ZenUBGlobalActions.sys.mjs",
   "ZenUBProvider.sys.mjs",
+  "ZenUBRenamedTabsProvider.sys.mjs",
   "ZenUBResultsLearner.sys.mjs",
 ]

--- a/src/zen/urlbar/moz.build
+++ b/src/zen/urlbar/moz.build
@@ -7,6 +7,6 @@ EXTRA_JS_MODULES += [
   "ZenUBActionsProvider.sys.mjs",
   "ZenUBGlobalActions.sys.mjs",
   "ZenUBProvider.sys.mjs",
-  "ZenUBRenamedTabsProvider.sys.mjs",
+  "ZenUBTabsProvider.sys.mjs",
   "ZenUBResultsLearner.sys.mjs",
 ]


### PR DESCRIPTION
## Description

Adds a Zen-specific URL bar provider so renamed tab labels are searchable alongside standard URL bar results. It supports normal searches and the `%` open-tabs restriction.

Switch-to-tab results also retain the matched tab’s identity, ensuring the correct tab is selected when multiple tabs share the same URL.

## Testing

```
cd engine
./mach test zen/tests/urlbar/browser_renamed_tabs.js
```

https://github.com/user-attachments/assets/d27a561f-23eb-465b-af0c-f39c7c489468

