### PR TITLE
gh-14461: Fix boost applying wrong size override

### DIFF
--- a/src/zen/boosts/ZenBoostsEditor.mjs
+++ b/src/zen/boosts/ZenBoostsEditor.mjs
@@ -64,11 +64,11 @@ export class nsZenBoostEditor {
   }
 
   /**
-   * Returns the ZenBoosts JSWindowActor child for the currently selected tab.
+   * Returns the parent Boost JSActor for the currently selected tab.
    *
-   * @returns {ZenBoostsChild} zenBoostsChild Boost JSActor child
+   * @returns {ZenBoostsParent} Boost JSActor parent
    */
-  get zenBoostsChild() {
+  get zenBoostsParent() {
     const linkedBrowser = this.openerWindow.gBrowser.selectedTab.linkedBrowser;
     const actor =
       linkedBrowser.browsingContext.currentWindowGlobal.getActor("ZenBoosts");
@@ -466,13 +466,13 @@ export class nsZenBoostEditor {
   }
 
   async onZapButtonPressed() {
-    this.zenBoostsChild.sendQuery("ZenBoost:ToggleZapMode");
+    this.zenBoostsParent.sendQuery("ZenBoost:ToggleZapMode");
     // Focus the parent browser window
     this.openerWindow.focus();
   }
 
   async onPickerButtonPressed() {
-    this.zenBoostsChild.sendQuery("ZenBoost:TogglePickerMode");
+    this.zenBoostsParent.sendQuery("ZenBoost:TogglePickerMode");
     this.openerWindow.focus();
   }
 
@@ -497,11 +497,11 @@ ${cssSelector} {
   }
 
   onInspectorButtonPressed() {
-    this.zenBoostsChild.sendQuery("ZenBoost:OpenInspector");
+    this.zenBoostsParent.sendQuery("ZenBoost:OpenInspector");
   }
 
   async onUpdateZapButtonVisual() {
-    const actor = this.zenBoostsChild;
+    const actor = this.zenBoostsParent;
     const zapButton = this.doc.getElementById("zen-boost-zap");
 
     const zapEnabled = await actor.sendQuery("ZenBoost:ZapModeEnabled");
@@ -513,7 +513,7 @@ ${cssSelector} {
 
   async onUpdatePickerButtonVisual() {
     const pickerButton = this.doc.getElementById("zen-boost-css-picker");
-    const selectEnabled = await this.zenBoostsChild.sendQuery(
+    const selectEnabled = await this.zenBoostsParent.sendQuery(
       "ZenBoost:SelectorPickerModeEnabled"
     );
 
@@ -660,7 +660,7 @@ ${cssSelector} {
   /**
    * Handles the size toggle button press, cycling through size override options
    */
-  async onBoostSizePressed() {
+  onBoostSizePressed() {
     if (this.currentBoostData.sizeOverride == 1) {
       this.currentBoostData.sizeOverride = 1.1;
     } else if (this.currentBoostData.sizeOverride == 1.1) {
@@ -671,7 +671,7 @@ ${cssSelector} {
       this.currentBoostData.sizeOverride = 0.9;
     } else if (this.currentBoostData.sizeOverride == 0.9) {
       this.currentBoostData.sizeOverride = 1;
-      await this.zenBoostsChild.updateBoostSizeOverride(
+      this.zenBoostsParent.updateBoostSizeOverride(
         this.currentBoostData.sizeOverride,
         /* disable: */ true
       );

--- a/src/zen/boosts/actors/ZenBoostsParent.sys.mjs
+++ b/src/zen/boosts/actors/ZenBoostsParent.sys.mjs
@@ -85,7 +85,7 @@ export class ZenBoostsParent extends JSWindowActorParent {
       (sizeOverride !== 1 || disable)
     ) {
       const fullZoom = this.browsingContext.topChromeWindow.FullZoom;
-      fullZoom.setZoom(sizeOverride);
+      fullZoom.setZoom(sizeOverride, this.browsingContext.top.embedderElement);
     }
   }
 


### PR DESCRIPTION
regression from https://github.com/zen-browser/desktop/pull/14664
Boosts were applying a different tab's size override to the current tab sometimes

Don't mind the changes in ZenBoostEditor, just changed the name and removed a useless async call