### PR TITLE
Fix keyboard shortcut conflicts

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -104,7 +104,9 @@ zen-settings-workspaces-hide-default-container-indicator =
     .label = Hide the default container indicator in the tab bar
 
 zen-key-unsaved = Unsaved shortcut! Please save it by clicking the "Escape" key after retyping it.
-zen-key-conflict = Conflicts with { $group } -> { $shortcut }
+zen-key-conflict-dialog-title = Shortcut conflict
+zen-key-conflict-dialog-description = This shortcut is already assigned to { $existingAction }. Do you want to move it to { $targetAction }?
+zen-key-conflict-dialog-action = Move shortcut
 
 pane-zen-theme-title = Theme Settings
 

--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -104,9 +104,9 @@ zen-settings-workspaces-hide-default-container-indicator =
     .label = Hide the default container indicator in the tab bar
 
 zen-key-unsaved = Unsaved shortcut! Please save it by clicking the "Escape" key after retyping it.
-zen-key-conflict-dialog-title = Shortcut conflict
+zen-key-conflict-dialog-title = Shortcut Conflict
 zen-key-conflict-dialog-description = This shortcut is already assigned to { $existingAction }. Do you want to move it to { $targetAction }?
-zen-key-conflict-dialog-action = Move shortcut
+zen-key-conflict-dialog-action = Move Shortcut
 
 pane-zen-theme-title = Theme Settings
 

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1072,23 +1072,81 @@ var gZenCKSSettings = {
             zenMissingKeyboardShortcutL10n[conflictShortcut.getID()] ??
             conflictShortcut.getL10NID();
 
-          const [group, conflictName] = await document.l10n.formatValues([
-            { id: `${ZEN_CKS_GROUP_PREFIX}-${conflictShortcut.getGroup()}` },
-            { id: shortcutL10nKey },
-          ]);
+          const conflictName =
+            await document.l10n.formatValue(shortcutL10nKey);
 
-          if (!input.nextElementSibling) {
-            input.after(
-              window.MozXULElement.parseXULToFragment(`
-                <label class="${ZEN_CKS_CLASS_BASE}-conflict" data-l10n-id="zen-key-conflict"></label>
-              `)
+          const shortcuts =
+            await gZenKeyboardShortcutsManager.getModifiableShortcuts();
+
+          const targetShortcut = shortcuts.find(
+            shortcut => shortcut.getID() === this._currentActionID
+          );
+
+          const targetL10nKey =
+            zenMissingKeyboardShortcutL10n[targetShortcut.getID()] ??
+            targetShortcut.getL10NID();
+
+          const targetActionName =
+            await document.l10n.formatValue(targetL10nKey);
+
+          const [promptTitle, promptDescription, moveButtonLabel] =
+            await document.l10n.formatValues([
+              { id: "zen-key-conflict-dialog-title" },
+              {
+                id: "zen-key-conflict-dialog-description",
+                args: {
+                  existingAction: conflictName,
+                  targetAction: targetActionName,
+                },
+              },
+              { id: "zen-key-conflict-dialog-action" },
+            ]);
+
+          const buttonPressed = Services.prompt.confirmEx(
+            window,
+            promptTitle,
+            promptDescription,
+            Services.prompt.BUTTON_POS_0 *
+              Services.prompt.BUTTON_TITLE_IS_STRING +
+              Services.prompt.BUTTON_POS_1 *
+                Services.prompt.BUTTON_TITLE_CANCEL +
+              Services.prompt.BUTTON_POS_1_DEFAULT,
+            moveButtonLabel,
+            null,
+            null,
+            null,
+            {}
+          );
+
+          if (buttonPressed === 0) {
+            await gZenKeyboardShortcutsManager.moveShortcut(
+              conflictShortcut.getID(),
+              this._currentActionID,
+              this._latestValidKey,
+              this._latestModifier
             );
+
+            const conflictInput = document.getElementById(
+              `${ZEN_CKS_INPUT_FIELD_CLASS}-${conflictShortcut.getID()}`
+            );
+
+            if (conflictInput) {
+              conflictInput.value = "Not set";
+              conflictInput.classList.add(`${ZEN_CKS_INPUT_FIELD_CLASS}-not-set`);
+            }
+          } else {
+            if (targetShortcut.isEmpty()) {
+              input.value = "Not set";
+              input.classList.add(`${ZEN_CKS_INPUT_FIELD_CLASS}-not-set`);
+            } else {
+              input.value = targetShortcut.toDisplayString();
+            }
           }
 
-          document.l10n.setAttributes(input.nextElementSibling, "zen-key-conflict", {
-            group: group ?? "",
-            shortcut: conflictName ?? shortcut ?? "",
-          });
+          this._latestValidKey = null;
+          this._latestModifier = null;
+          input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-invalid`);
+          input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-editing`);
         }
       } else {
         input.classList.remove(`${ZEN_CKS_INPUT_FIELD_CLASS}-editing`);

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1110,7 +1110,7 @@ var gZenCKSSettings = {
               Services.prompt.BUTTON_TITLE_IS_STRING +
               Services.prompt.BUTTON_POS_1 *
                 Services.prompt.BUTTON_TITLE_CANCEL +
-              Services.prompt.BUTTON_POS_1_DEFAULT,
+              Services.prompt.BUTTON_POS_0_DEFAULT,
             moveButtonLabel,
             null,
             null,

--- a/src/browser/themes/shared/preferences/zen-preferences.css
+++ b/src/browser/themes/shared/preferences/zen-preferences.css
@@ -199,12 +199,6 @@ groupbox h2 {
   box-shadow: 0 0 0 2px var(--zen-primary-color);
 }
 
-.zenCKSOption-conflict {
-  color: red;
-  margin-left: 10px;
-  margin-top: 5px;
-}
-
 .zenCKSOption-unsafed {
   color: light-dark(orange, yellow);
   margin-left: 10px;

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -1546,6 +1546,33 @@ window.gZenKeyboardShortcutsManager = {
     };
   },
 
+  async moveShortcut(existingShortcutId, targetShortcutId, key, modifiers) {
+    const existingShortcut = this._currentShortcutList.find(
+      shortcut => shortcut.getID() === existingShortcutId
+    );
+
+    const targetShortcut = this._currentShortcutList.find(
+      shortcut => shortcut.getID() === targetShortcutId
+    );
+
+    if (!existingShortcut || !targetShortcut) {
+      throw new Error(
+        `Unable to move shortcut: existing=${existingShortcutId}, target=${targetShortcutId}`
+      );
+    }
+
+    if (existingShortcutId === targetShortcutId) {
+      throw new Error("Cannot move a shortcut to the same action");
+    }
+
+    existingShortcut.clearKeybind();
+    targetShortcut.setNewBinding(key);
+    targetShortcut.setModifiers(modifiers);
+
+    await this._saveShortcuts();
+    this.triggerShortcutRebuild();
+  },
+
   getShortcutFromCommand(command) {
     for (let targetShortcut of this._currentShortcutList) {
       if (targetShortcut.getAction() == command) {


### PR DESCRIPTION
when setting a shortcut that is already being used, it now asks if you want to move it to the new action.

if you choose **Move shortcut**, the shortcut is cleared from the old action and assigned to the new one. choosing **Cancel** leaves both actions unchanged.

inspired by @exotara's approach in the original issue's thread.

(Since filming demo i updated the capitalization of the dialog title and action)

https://github.com/user-attachments/assets/7687bc63-84e1-4e8d-b2b1-3bbcf664f344

## testing

- tested moving a conflicting shortcut
- tested cancelling the prompt and confirmed both shortcuts stayed unchanged
- checked that the shortcut changes were saved after restarting Zen and opening a new Settings tab
- tested on macOS

## note

there seems to be an existing issue where restored Settings tabs show stale shortcut values after restarting Zen. closing the restored Settings tab and opening a new one shows the correct saved values. I was also able to reproduce this with normal non-conflicting shortcut changes on the dev branch, so it doesn’t appear to be related to this change.

Closes #14492

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zen-browser/codesmith/desktop/pr/14704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787531515&installation_model_id=4703&pr_number=14704&repository=zen-browser%2Fdesktop&return_to=https%3A%2F%2Fgithub.com%2Fzen-browser%2Fdesktop%2Fpull%2F14704&signature=fefc075cd633899c7a8d80d16d429b63283d4780d71cd03bf98a73dd16ff5d8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->