### PR TITLE
gh-10394: Fix microphone capture on macOS

### DIFF
--- a/prefs/zen/media.yaml
+++ b/prefs/zen/media.yaml
@@ -14,3 +14,20 @@
 
 - name: media.eme.enabled
   value: true
+
+# Avoid macOS VoiceProcessingIO for microphone capture. When engaged (even in
+# bypass mode, as Google Meet's raw-audio request causes), it attenuates the
+# built-in microphone by 20-35 dB for the capturing page and for every other
+# app system-wide on affected Macs. See gh-10394.
+- name: media.getusermedia.microphone.prefer_voice_stream_with_processing.enabled
+  value: false
+  condition: "defined(XP_MACOSX)"
+
+- name: media.getusermedia.microphone.voice_stream_priming.enabled
+  value: false
+  condition: "defined(XP_MACOSX)"
+
+# Use Firefox's software audio processing after opting out of VPIO.
+- name: media.getusermedia.audio.processing.platform.enabled
+  value: false
+  condition: "defined(XP_MACOSX)"

--- a/src/dom/media/MediaTrackGraph-cpp.patch
+++ b/src/dom/media/MediaTrackGraph-cpp.patch
@@ -1,0 +1,16 @@
+diff --git a/dom/media/MediaTrackGraph.cpp b/dom/media/MediaTrackGraph.cpp
+index 7b27d9db19487d353a75dbf9da301006792b4aca..1bea2369a14f5d077e18f883347885534cfafe90 100644
+--- a/dom/media/MediaTrackGraph.cpp
++++ b/dom/media/MediaTrackGraph.cpp
+@@ -4230,6 +4230,9 @@ AudioInputType MediaTrackGraphImpl::AudioInputDevicePreference(
+   MOZ_ASSERT(OnGraphThreadOrNotRunning());
+   DeviceInputTrack* t =
+       mDeviceInputTrackManagerGraphThread.GetDeviceInputTrack(aID);
+-  return t && t->HasVoiceInput() ? AudioInputType::Voice
+-                                 : AudioInputType::Unknown;
++  return t && t->HasVoiceInput() &&
++                 StaticPrefs::
++                     media_getusermedia_microphone_prefer_voice_stream_with_processing_enabled()
++             ? AudioInputType::Voice
++             : AudioInputType::Unknown;
+ }

--- a/src/dom/media/gtest/TestAudioTrackGraph-cpp.patch
+++ b/src/dom/media/gtest/TestAudioTrackGraph-cpp.patch
@@ -1,0 +1,143 @@
+diff --git a/dom/media/gtest/TestAudioTrackGraph.cpp b/dom/media/gtest/TestAudioTrackGraph.cpp
+index 17c15c454087389259a15629d535e6bf215b94cd..06a048ec673a7a26afee6d4c4f461fe1440d11cf 100644
+--- a/dom/media/gtest/TestAudioTrackGraph.cpp
++++ b/dom/media/gtest/TestAudioTrackGraph.cpp
+@@ -51,5 +51,35 @@ using testing::StrictMock;
+ namespace {
+ #ifdef MOZ_WEBRTC
++class MOZ_RAII ScopedBoolPref {
++ public:
++  ScopedBoolPref(const char* aPrefName, bool aValue)
++      : mPrefName(aPrefName),
++        mHadUserValue(Preferences::HasUserValue(aPrefName)),
++        mOriginalValue(Preferences::GetBool(aPrefName, false)) {
++    MOZ_ASSERT(NS_IsMainThread());
++    MOZ_ALWAYS_SUCCEEDS(Preferences::SetBool(mPrefName, aValue));
++  }
++
++  ~ScopedBoolPref() {
++    MOZ_ASSERT(NS_IsMainThread());
++    if (mHadUserValue) {
++      MOZ_ALWAYS_SUCCEEDS(Preferences::SetBool(mPrefName, mOriginalValue));
++    } else {
++      MOZ_ALWAYS_SUCCEEDS(Preferences::ClearUser(mPrefName));
++    }
++  }
++
++  ScopedBoolPref(const ScopedBoolPref&) = delete;
++  ScopedBoolPref& operator=(const ScopedBoolPref&) = delete;
++  ScopedBoolPref(ScopedBoolPref&&) = delete;
++  ScopedBoolPref& operator=(ScopedBoolPref&&) = delete;
++
++ private:
++  const char* mPrefName;
++  const bool mHadUserValue;
++  const bool mOriginalValue;
++};
++
+ /*
+  * Common ControlMessages
+  */
+@@ -1333,5 +1363,101 @@ TEST(TestAudioTrackGraph, AudioProcessingTrack)
+   EXPECT_LE(nrDiscontinuities, 1U);
+ }
+-
++
++TEST(TestAudioTrackGraph, ProcessedInputWithoutVoicePreference)
++{
++  ScopedBoolPref preferVoice(
++      "media.getusermedia.microphone."
++      "prefer_voice_stream_with_processing.enabled",
++      false);
++
++  MockCubeb* cubeb = new MockCubeb();
++  CubebUtils::ForceSetCubebContext(cubeb->AsCubebContext());
++  auto unforcer = WaitFor(cubeb->ForceAudioThread()).unwrap();
++  (void)unforcer;
++
++  MediaTrackGraph* graph = MediaTrackGraphImpl::GetInstance(
++      MediaTrackGraph::SYSTEM_THREAD_DRIVER, /*Window ID*/ 1,
++      CubebUtils::PreferredSampleRate(/* aShouldResistFingerprinting */ false),
++      nullptr, GetMainThreadSerialEventTarget());
++
++  const CubebUtils::AudioDeviceID deviceId = (CubebUtils::AudioDeviceID)1;
++
++  RefPtr<AudioProcessingTrack> processingTrack;
++  RefPtr<ProcessedMediaTrack> outputTrack;
++  RefPtr<MediaInputPort> port;
++  RefPtr<AudioInputProcessing> listener;
++  DispatchFunction([&] {
++    processingTrack = AudioProcessingTrack::Create(graph);
++    outputTrack = graph->CreateForwardedInputTrack(MediaSegment::AUDIO);
++    outputTrack->QueueSetAutoend(false);
++    outputTrack->AddAudioOutput(reinterpret_cast<void*>(1), nullptr);
++    port = outputTrack->AllocateInputPort(processingTrack);
++
++    listener = new AudioInputProcessing(2);
++    processingTrack->SetInputProcessing(listener);
++    processingTrack->GraphImpl()->AppendMessage(
++        MakeUnique<StartInputProcessing>(processingTrack, listener));
++    processingTrack->ConnectDeviceInput(deviceId, listener,
++                                        PRINCIPAL_HANDLE_NONE);
++
++    MediaEnginePrefs settings;
++    settings.mChannels = 2;
++    settings.mAgcOn = true;
++    settings.mUsePlatformProcessing = false;
++    QueueApplySettings(processingTrack, listener, settings);
++  });
++
++  RefPtr<SmartMockCubebStream> stream = WaitFor(cubeb->StreamInitEvent());
++  if (!stream->mHasInput) {
++    stream = WaitFor(cubeb->StreamInitEvent());
++  }
++  ASSERT_TRUE(stream->mHasInput);
++
++  using PreferencePromise =
++      MozPromise<AudioInputType, nsresult, /* IsExclusive = */ true>;
++  struct PreferenceMessage : public ControlMessage {
++    const CubebUtils::AudioDeviceID mDeviceId;
++    MozPromiseHolder<PreferencePromise> mHolder;
++
++    PreferenceMessage(AudioProcessingTrack* aTrack,
++                      CubebUtils::AudioDeviceID aDeviceId,
++                      MozPromiseHolder<PreferencePromise>&& aHolder)
++        : ControlMessage(aTrack),
++          mDeviceId(aDeviceId),
++          mHolder(std::move(aHolder)) {}
++
++    void Run() override {
++      const AudioInputType preference =
++          mTrack->GraphImpl()->AudioInputDevicePreference(mDeviceId);
++      mTrack->GraphImpl()->Dispatch(NS_NewRunnableFunction(
++          "TestAudioTrackGraph::PreferenceMessage",
++          [holder = std::move(mHolder), preference]() mutable {
++            holder.Resolve(preference, __func__);
++          }));
++    }
++  };
++
++  MozPromiseHolder<PreferencePromise> holder;
++  RefPtr<PreferencePromise> preference = holder.Ensure(__func__);
++  DispatchFunction([&] {
++    processingTrack->GraphImpl()->AppendMessage(MakeUnique<PreferenceMessage>(
++        processingTrack, deviceId, std::move(holder)));
++  });
++  Result<AudioInputType, nsresult> result = WaitFor(preference);
++  ASSERT_TRUE(result.isOk());
++  EXPECT_EQ(result.unwrap(), AudioInputType::Unknown);
++
++  DispatchFunction([&] {
++    outputTrack->RemoveAudioOutput((void*)1);
++    outputTrack->Destroy();
++    port->Destroy();
++    processingTrack->GraphImpl()->AppendMessage(
++        MakeUnique<StopInputProcessing>(processingTrack, listener));
++    processingTrack->DisconnectDeviceInput();
++    processingTrack->Destroy();
++  });
++  WaitFor(cubeb->StreamDestroyEvent());
++}
++
+ TEST(TestAudioTrackGraph, ReConnectDeviceInput)
+ {

--- a/src/toolkit/library/rust/shared/Cargo-toml.patch
+++ b/src/toolkit/library/rust/shared/Cargo-toml.patch
@@ -1,0 +1,13 @@
+diff --git a/toolkit/library/rust/shared/Cargo.toml b/toolkit/library/rust/shared/Cargo.toml
+index dbcd527798..d87d9cb898 100644
+--- a/toolkit/library/rust/shared/Cargo.toml
++++ b/toolkit/library/rust/shared/Cargo.toml
+@@ -23,7 +23,7 @@ profiler_helper = { path = "../../../../tools/profiler/rust-helper" }
+ mozurl = { path = "../../../../netwerk/base/mozurl" }
+ harfbuzz_glue = { path = "../../../../gfx/harfbuzz_glue" }
+ webrender_bindings = { path = "../../../../gfx/webrender_bindings" }
+-cubeb-coreaudio = { git = "https://github.com/mozilla/cubeb-coreaudio-rs", rev = "0bb8a45a040e85d313eb18deb36570e87df3a6af", optional = true, features=["vpio-forcelist"] }
++cubeb-coreaudio = { git = "https://github.com/mozilla/cubeb-coreaudio-rs", rev = "0bb8a45a040e85d313eb18deb36570e87df3a6af", optional = true, features=[] }
+ cubeb-pulse = { git = "https://github.com/mozilla/cubeb-pulse-rs", rev="5eb4d5bdb725d3d53e42cc88f82269fac2aa42b7", optional = true, features=["pulse-dlopen"] }
+ cubeb-sys = { version = "0.32.0", optional = true, features=["gecko-in-tree"] }
+ audioipc2-client = { git = "https://github.com/mozilla/audioipc", rev = "c9dcbaee1624daad2fa6b1445fd047efde4f1ec0", optional = true }


### PR DESCRIPTION
### Summary

Fixes severely attenuated microphone capture in Google Meet on macOS and
prevents Zen from attenuating other microphone clients system-wide.

Closes #10394.

The corresponding primary Firefox issue is
[bug 1896938](https://bugzilla.mozilla.org/show_bug.cgi?id=1896938).

### Root cause

Firefox enables cubeb-coreaudio's `vpio-forcelist`, which sends built-in
microphones through Apple's VoiceProcessingIO even when a page requests raw
audio. On affected Macs, VoiceProcessingIO in bypass mode attenuates the
captured signal by roughly 34 dB and attenuates other microphone clients by
19–28 dB.

Google Meet creates a processed stream followed by a raw stream and repeatedly
changes its capture streams. The shared VoiceProcessingIO unit is cached for
ten seconds, so Meet keeps the affected audio path active throughout a call.

Disabling Voice streams also exposed a Firefox MediaTrackGraph bug:
`AudioCallbackDriver` opened a regular input, while the graph continued to
request Voice and replaced the driver on every iteration. Processed microphone
tracks then produced digital silence.

### Changes

- On macOS, prefer regular CoreAudio microphone streams.
- Disable pre-permission Voice stream priming.
- Use Firefox's software AEC, noise suppression, and automatic gain control.
- Stop enabling cubeb-coreaudio's compile-time `vpio-forcelist`.
- Backport the MediaTrackGraph preference-consistency fix.
- Add a deterministic regression gtest for processed input with Voice routing
  disabled.

VPIO support remains compiled into cubeb-coreaudio; this only stops forcing
built-in microphones through it and changes Zen's macOS defaults.

### Compatibility

This intentionally applies to all macOS builds, including Intel Macs. It does
not affect Windows or Linux.

The resulting architecture—regular platform capture followed by WebRTC
software audio processing—is also used by Chromium-based browsers. Audio
processing may sound different from Apple's VPIO implementation, particularly
for acoustic echo cancellation, but it avoids VPIO's system-wide capture side
effects and respects raw capture requests.

The cubeb forcelist originally protected a regular built-in-microphone stream
from attenuation when another application had already engaged VPIO. That
CoreAudio interaction remains a possible tradeoff when Zen is used
simultaneously with another VPIO application.

### Validation

MacBook Pro M5, macOS Tahoe 26.5.1:

- raw capture: -23.9 dBFS
- echo cancellation: -25.5 dBFS
- noise suppression: -25.9 dBFS
- automatic gain control: -19.2 dBFS
- all processing enabled: -17.8 dBFS
- simultaneous native capture stayed between -22 and -29 dBFS
- Meet-style processed-first/raw-second transition: -24.0 dBFS
- real Google Meet input indicator responded normally
- macOS System Settings input meter remained responsive
- a simultaneous Voice Memo recording was clear
- no continuous MediaTrackGraph driver-replacement loop
- no VoiceProcessingIO creation in the final Meet log

Clean-profile packaging verification:

- regenerated Zen's preference outputs with the `ffprefs` generator
- confirmed all three macOS defaults in the rebuilt app's packaged
  `browser/defaults/preferences/firefox.js`
- launched the rebuilt app under WebDriver with a newly generated profile
- verified that none of the three workaround preferences were present in the
  profile's `user.js` or `prefs.js`
- Meet-style processed-first/raw-second recordings: -27.2 and -28.8 dBFS
- processed AEC + NS + AGC recording: -48.8 dBFS (not digital silence)
- simultaneous native capture: approximately -20 to -28 dBFS during speech
- full Zen build: successful; only existing tree/third-party warnings

Automated tests:

```text
./mach gtest TestAudioTrackGraph.ProcessedInputWithoutVoicePreference
  1 passed, 0 failed

./mach gtest 'TestAudioTrackGraph.*'
  30 passed, 0 failed
```

The targeted gtest rebuild completed with zero compiler warnings.
`./mach format` reported 0 problems. All four downstream patches apply cleanly
to the Firefox 153 source used by Zen.

A second call participant has not yet independently confirmed perceived voice
quality, but in-browser level monitoring, system-wide capture, recorded audio,
automated measurements, and graph logs are all healthy.

### Upstream

- Primary Firefox VPIO issue:
  https://bugzilla.mozilla.org/show_bug.cgi?id=1896938#c60
- MediaTrackGraph implementation dependency:
  https://bugzilla.mozilla.org/show_bug.cgi?id=2057748
- Firefox patch review: https://phabricator.services.mozilla.com/D314226

The upstream submission contains only the MediaTrackGraph fix and its
regression test. The macOS preference and cubeb feature changes are Zen's
downstream workaround for the VPIO behavior.

## Exact intended repository scope

Only:

- `prefs/zen/media.yaml`
- `src/toolkit/library/rust/shared/Cargo-toml.patch`
- `src/dom/media/MediaTrackGraph-cpp.patch`
- `src/dom/media/gtest/TestAudioTrackGraph-cpp.patch`

Explicitly excluded:

- `.contribution-drafts/`
- `engine/`
- `engine-plain/`
- `tests/`
- generated reports and recordings
- compiled `micprobe`
- `src/browser/actors/WebRTCParent-sys-mjs.patch`
- `src/zen/media/ZenMediaController.mjs`
- any unrelated working-tree changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zen-browser/codesmith/desktop/pr/14707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787586956&installation_model_id=4703&pr_number=14707&repository=zen-browser%2Fdesktop&return_to=https%3A%2F%2Fgithub.com%2Fzen-browser%2Fdesktop%2Fpull%2F14707&signature=a94c33d2e3aabf92205b27daa0264617a1a8696c6fe02f07a1c801471877fe10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
