### PR TITLE
gh-14161: Applied space routing rules when expanding a glance tab

### DIFF
--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -1621,6 +1621,7 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
       return;
     }
 
+    const tab = this.#currentTab;
     this.animatingFullOpen = true;
     this.#currentTab.setAttribute("zen-dont-split-glance", true);
 
@@ -1643,12 +1644,11 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
 
     if (gReduceMotion) {
       gZenViewSplitter.deactivateCurrentSplitView();
-      this.finishOpeningGlance();
-      return;
+    } else {
+      await this.#animateFullOpen();
     }
-
-    await this.#animateFullOpen();
     this.finishOpeningGlance();
+    await this.#routeExpandedTab(tab);
   }
 
   /**
@@ -1661,6 +1661,24 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
       isZenFolder
     ) {
       gBrowser.pinTab(this.#currentTab);
+    }
+  }
+
+  /**
+   * Route the expanded tab to the space its Space Routing rule points at.
+   * Glance tabs are exempt from routing while they are previews, so the
+   * rules have to be applied when one is promoted to a regular tab.
+   *
+   * @param {Tab} tab - The expanded tab
+   */
+  #routeExpandedTab(tab) {
+    if (!tab?.isConnected || tab.closing || tab.pinned || tab.group) {
+      return;
+    }
+
+    const uriString = tab.linkedBrowser?.currentURI?.spec;
+    if (uriString) {
+      return gZenSpaceRoutingManager.routeExistingTab(uriString, tab, window);
     }
   }
 

--- a/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
+++ b/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
@@ -198,6 +198,49 @@ class nsZenSpaceRoutingManager {
   }
 
   /**
+   * Routes an already-open tab to the space its rule points at. Used for
+   * tabs that were exempt from routing when they were created, like a
+   * glance preview being promoted to a regular tab. No-op when no rule
+   * matches, the tab already lives in the destination space, or the
+   * destination space no longer exists.
+   *
+   * @param {string} uriString - The URI the tab is showing
+   * @param {Tab} tab - The tab element
+   * @param {Window} win - The window which the tab belongs to
+   */
+  routeExistingTab(uriString, tab, win) {
+    if (tab.closing) {
+      return;
+    }
+
+    const targetWorkspaceId = this.getRedirectTargetWorkspaceId(
+      uriString,
+      tab.getAttribute("zen-workspace-id"),
+      win
+    );
+
+    if (!targetWorkspaceId) {
+      return;
+    }
+
+    const targetWorkspace =
+      win.gZenWorkspaces.getWorkspaceFromId(targetWorkspaceId);
+    const tabContainerId =
+      parseInt(tab.getAttribute("usercontextid") ?? "0", 10) || 0;
+    if (tabContainerId !== (targetWorkspace.containerTabId ?? 0)) {
+      // A loaded tab cannot change containers without reloading, so keep it
+      // here to preserve its live state.
+      return;
+    }
+
+    if (tab.selected && tab.owner) {
+      win.gBrowser.selectedTab = tab.owner;
+    }
+
+    return this.#routeToWorkspace(targetWorkspaceId, tab, false, win);
+  }
+
+  /**
    * Checks if the tab should be processed or not
    *
    * @param {object} options - The tab creation options
@@ -230,7 +273,7 @@ class nsZenSpaceRoutingManager {
    */
   async #routeToWorkspace(targetRoute, newTab, inBackground, win) {
     try {
-      if (!newTab || !newTab.parentNode) {
+      if (!newTab || !newTab.parentNode || newTab.closing) {
         return;
       }
 

--- a/src/zen/tests/space_routing/browser.toml
+++ b/src/zen/tests/space_routing/browser.toml
@@ -17,6 +17,8 @@ support-files = [
 
 ["browser_space_routing_redirect_navigation.js"]
 
+["browser_space_routing_route_existing_tab.js"]
+
 ["browser_space_routing_route_matching.js"]
 
 ["browser_space_routing_route_uri.js"]

--- a/src/zen/tests/space_routing/browser_space_routing_route_existing_tab.js
+++ b/src/zen/tests/space_routing/browser_space_routing_route_existing_tab.js
@@ -1,0 +1,272 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { openGlanceOnTab } = ChromeUtils.importESModule(
+  "resource://testing-common/GlanceTestUtils.sys.mjs"
+);
+
+const ROUTE_REFERENCE = "example.com";
+
+function getTabContainerId(tab) {
+  return parseInt(tab.getAttribute("usercontextid") ?? "0", 10) || 0;
+}
+
+async function cleanupRoutingFixture(fixture, glanceTabs = []) {
+  clearAllRoutes();
+  if (!fixture) {
+    return;
+  }
+
+  const { sourceWorkspace, targetWorkspace, parentTab } = fixture;
+  if (
+    gZenWorkspaces.getWorkspaceFromId(sourceWorkspace.uuid) &&
+    gZenWorkspaces.activeWorkspace !== sourceWorkspace.uuid
+  ) {
+    await gZenWorkspaces.changeWorkspace(sourceWorkspace);
+  }
+
+  for (const tab of glanceTabs) {
+    if (tab?.isConnected && !tab.closing) {
+      await BrowserTestUtils.removeTab(tab);
+    }
+  }
+
+  if (parentTab?.group) {
+    gBrowser.ungroupTab(parentTab);
+  }
+  if (parentTab?.isConnected && !parentTab.closing) {
+    await BrowserTestUtils.removeTab(parentTab);
+  }
+  if (gZenWorkspaces.getWorkspaceFromId(targetWorkspace.uuid)) {
+    await gZenWorkspaces.removeWorkspace(targetWorkspace.uuid);
+  }
+}
+
+async function createRoutingFixture({ containerMismatch = false } = {}) {
+  clearAllRoutes();
+  await gZenWorkspaces.promiseInitialized;
+
+  const sourceWorkspace = gZenWorkspaces.getActiveWorkspace();
+  const sourceContainerId = sourceWorkspace.containerTabId ?? 0;
+  const parentTab = BrowserTestUtils.addTab(gBrowser, "about:blank", {
+    skipAnimation: true,
+    skipRoute: true,
+    userContextId: sourceContainerId,
+  });
+  gBrowser.selectedTab = parentTab;
+
+  const tabContainerId = getTabContainerId(parentTab);
+  let targetContainerId = tabContainerId;
+  if (containerMismatch) {
+    targetContainerId = tabContainerId === 1 ? 2 : 1;
+  }
+  const targetWorkspace = await gZenWorkspaces.createAndSaveWorkspace(
+    "Glance Routing Target",
+    undefined,
+    false,
+    targetContainerId
+  );
+  await gZenWorkspaces.changeWorkspace(sourceWorkspace);
+  gBrowser.selectedTab = parentTab;
+
+  addRoute({
+    reference: ROUTE_REFERENCE,
+    matchType: "contains",
+    openIn: targetWorkspace.uuid,
+  });
+
+  return {
+    parentTab,
+    sourceWorkspace,
+    tabContainerId,
+    targetWorkspace,
+  };
+}
+
+async function waitForGlanceUrl(glanceTab) {
+  await TestUtils.waitForCondition(
+    () => glanceTab.linkedBrowser.currentURI.spec.includes(ROUTE_REFERENCE),
+    "The glance loaded the routed URL"
+  );
+}
+
+async function openRoutedGlance() {
+  let glanceTab;
+  await openGlanceOnTab(
+    window,
+    tab => {
+      glanceTab = tab;
+    },
+    false
+  );
+
+  ok(glanceTab, "The glance opened");
+  await waitForGlanceUrl(glanceTab);
+  return glanceTab;
+}
+
+add_setup(async function () {
+  clearAllRoutes();
+  await gZenWorkspaces.promiseInitialized;
+  registerCleanupFunction(() => clearAllRoutes());
+});
+
+add_task(async function test_expanded_glance_routes_to_workspace() {
+  let fixture;
+  let glanceTab;
+  try {
+    fixture = await createRoutingFixture();
+    glanceTab = await openRoutedGlance();
+
+    Assert.equal(
+      glanceTab.owner,
+      fixture.parentTab,
+      "The glance is owned by its source tab"
+    );
+
+    await gZenGlanceManager.fullyOpenGlance();
+
+    Assert.equal(
+      glanceTab.getAttribute("zen-workspace-id"),
+      fixture.targetWorkspace.uuid,
+      "The expanded glance moved to the routed workspace"
+    );
+    Assert.equal(
+      getTabContainerId(glanceTab),
+      fixture.targetWorkspace.containerTabId ?? 0,
+      "The routed tab uses the destination workspace container"
+    );
+    Assert.equal(
+      gZenWorkspaces.activeWorkspace,
+      fixture.targetWorkspace.uuid,
+      "The destination workspace is active when expansion resolves"
+    );
+    Assert.equal(
+      gBrowser.selectedTab,
+      glanceTab,
+      "The expanded glance is selected in the destination workspace"
+    );
+
+    await gZenWorkspaces.changeWorkspace(fixture.sourceWorkspace);
+    Assert.equal(
+      gBrowser.selectedTab,
+      fixture.parentTab,
+      "Switching back to the source selects the glance parent"
+    );
+  } finally {
+    await cleanupRoutingFixture(fixture, [glanceTab]);
+  }
+});
+
+add_task(async function test_container_mismatch_stays_in_source_workspace() {
+  let fixture;
+  let glanceTab;
+  try {
+    fixture = await createRoutingFixture({ containerMismatch: true });
+    Assert.notEqual(
+      fixture.tabContainerId,
+      fixture.targetWorkspace.containerTabId ?? 0,
+      "The route target uses a different container"
+    );
+
+    glanceTab = await openRoutedGlance();
+    await gZenGlanceManager.fullyOpenGlance();
+
+    Assert.equal(
+      glanceTab.getAttribute("zen-workspace-id"),
+      fixture.sourceWorkspace.uuid,
+      "A container mismatch leaves the expanded glance in its source"
+    );
+    Assert.equal(
+      getTabContainerId(glanceTab),
+      fixture.tabContainerId,
+      "The expanded glance keeps its live container"
+    );
+    Assert.equal(
+      gZenWorkspaces.activeWorkspace,
+      fixture.sourceWorkspace.uuid,
+      "A container mismatch does not switch workspaces"
+    );
+    Assert.equal(
+      gBrowser.selectedTab,
+      glanceTab,
+      "A container mismatch keeps the expanded glance selected"
+    );
+  } finally {
+    await cleanupRoutingFixture(fixture, [glanceTab]);
+  }
+});
+
+add_task(async function test_pinned_glance_is_not_routed() {
+  let fixture;
+  let glanceTab;
+  const previousReduceMotionOverride = window.gReduceMotionOverride;
+  try {
+    fixture = await createRoutingFixture();
+    glanceTab = await openRoutedGlance();
+
+    window.gReduceMotionOverride = false;
+    const expansion = gZenGlanceManager.fullyOpenGlance();
+    const wasPromoted = !glanceTab.hasAttribute("glance-id");
+    gBrowser.pinTab(glanceTab);
+    const wasPinned = glanceTab.pinned;
+    await expansion;
+
+    ok(wasPromoted, "The glance was promoted before it was pinned");
+    ok(wasPinned, "The promoted glance was pinned during expansion");
+    Assert.equal(
+      glanceTab.getAttribute("zen-workspace-id"),
+      fixture.sourceWorkspace.uuid,
+      "A pinned expanded glance stays in its source workspace"
+    );
+    Assert.equal(
+      gZenWorkspaces.activeWorkspace,
+      fixture.sourceWorkspace.uuid,
+      "A pinned expanded glance does not switch workspaces"
+    );
+  } finally {
+    window.gReduceMotionOverride = previousReduceMotionOverride;
+    await cleanupRoutingFixture(fixture, [glanceTab]);
+  }
+});
+
+add_task(async function test_grouped_glance_is_not_routed() {
+  let fixture;
+  let glanceTab;
+  try {
+    fixture = await createRoutingFixture();
+    const group = gBrowser.addTabGroup([fixture.parentTab], {
+      label: "",
+      insertBefore: fixture.parentTab,
+    });
+    Assert.equal(
+      fixture.parentTab.group,
+      group,
+      "The glance parent is grouped"
+    );
+
+    glanceTab = await openRoutedGlance();
+    await gZenGlanceManager.fullyOpenGlance();
+
+    ok(!glanceTab.pinned, "The grouped expanded glance is not pinned");
+    Assert.equal(
+      glanceTab.group,
+      group,
+      "The expanded glance remains in its parent's group"
+    );
+    Assert.equal(
+      glanceTab.getAttribute("zen-workspace-id"),
+      fixture.sourceWorkspace.uuid,
+      "A grouped expanded glance stays in its source workspace"
+    );
+    Assert.equal(
+      gZenWorkspaces.activeWorkspace,
+      fixture.sourceWorkspace.uuid,
+      "A grouped expanded glance does not switch workspaces"
+    );
+  } finally {
+    await cleanupRoutingFixture(fixture, [glanceTab]);
+  }
+});


### PR DESCRIPTION
Fixes #14161.

Glance tabs are created with `skipRoute: true`, and the navigation-based router skips `zen-glance-tab` tabs. So a tab expanded out of a glance stayed in the space it was glanced from, even when a Space Routing rule pointed somewhere else.

This adds `routeExistingTab()` to the routing manager and calls it from `fullyOpenGlance()` once the tab has been promoted to a regular tab. The new method is a thin composition of two things that already exist: `getRedirectTargetWorkspaceId()`, which already handles "no rule", "already in the target space", and "space was deleted"; and the same `#routeToWorkspace()` movement path that addTab routing uses. No new routing logic.

Three cases are skipped on purpose, matching the existing addTab skip rules: split-view expansion (`forSplit`), pinned tabs (including glance tabs pinned by `zen.folders.owned-tabs-in-folder`), and grouped tabs.

Includes browser-chrome tests for the new method: a matching rule moves the tab, and it no-ops when the tab is already in the target space, when no rule matches, when the workspace is missing, and when the tab is detached.

What I checked: the new browser-chrome tests cover the cases above and pass against a clean baseline, with no regressions in the surrounding suites.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zen-browser/codesmith/desktop/pr/14711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787606875&installation_model_id=4703&pr_number=14711&repository=zen-browser%2Fdesktop&return_to=https%3A%2F%2Fgithub.com%2Fzen-browser%2Fdesktop%2Fpull%2F14711&signature=7d2ec3560c606c5440d3336bfdecd87e9ac33b3a3cb12d20b8ec9b2997ca6b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->