### PR TITLE
gh-14713: Fix workspace creation crash

### DIFF
--- a/locales/en-US/browser/browser/zen-workspaces.ftl
+++ b/locales/en-US/browser/browser/zen-workspaces.ftl
@@ -82,7 +82,7 @@ zen-workspace-creation-profile = Profile
     .tooltiptext = Profiles are used to separate cookies and site data between spaces.
 zen-workspace-creation-header = Create a Space
 zen-workspace-creation-label = Spaces are used to organize your tabs and sessions.
-zen-workspace-creation-default-profile = Default
+zen-workspace-default-profile = Default
 
 zen-workspaces-delete-workspace-title = Delete Space?
 zen-workspaces-delete-workspace-body = Are you sure you want to delete { $name }? This action cannot be undone.

--- a/locales/en-US/browser/browser/zen-workspaces.ftl
+++ b/locales/en-US/browser/browser/zen-workspaces.ftl
@@ -82,6 +82,7 @@ zen-workspace-creation-profile = Profile
     .tooltiptext = Profiles are used to separate cookies and site data between spaces.
 zen-workspace-creation-header = Create a Space
 zen-workspace-creation-label = Spaces are used to organize your tabs and sessions.
+zen-workspace-creation-default-profile = Default
 
 zen-workspaces-delete-workspace-title = Delete Space?
 zen-workspaces-delete-workspace-body = Are you sure you want to delete { $name }? This action cannot be undone.

--- a/src/zen/common/styles/zen-theme.css
+++ b/src/zen/common/styles/zen-theme.css
@@ -190,7 +190,7 @@
   --urlbar-box-active-bgcolor: var(--toolbarbutton-hover-background) !important;
   --zen-input-border-color: light-dark(rgb(204, 204, 204), rgb(66, 65, 77));
   --urlbar-box-hover-bgcolor: var(--toolbarbutton-hover-background) !important;
-  --input-bgcolor: light-dark(rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0.2)) !important;
+  --input-text-background-color: light-dark(rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0.2)) !important;
   --toolbar-field-focus-background-color: light-dark(
     rgba(255, 255, 255, 0.25),
     rgba(0, 0, 0, 0.3)

--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -308,6 +308,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
     window.createUserContextMenu(event, {
       isContextMenu: true,
       showDefaultTab: true,
+      showManageContainers: false,
     });
 
     const defaultItem = event.target.querySelector(

--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -199,7 +199,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
       this.currentProfile = {
         id: 0,
         name: lazy.l10n.formatValueSync(
-          "zen-workspace-creation-default-profile"
+          "zen-workspace-default-profile"
         ),
       };
     } else {
@@ -317,7 +317,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
     if (defaultItem) {
       defaultItem.removeAttribute("data-l10n-id");
       defaultItem.label = lazy.l10n.formatValueSync(
-        "zen-workspace-creation-default-profile"
+        "zen-workspace-default-profile"
       );
     }
   }

--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -2,6 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const lazy = {};
+
+ChromeUtils.defineLazyGetter(lazy, "l10n", () => {
+  return new Localization(["browser/zen-workspaces.ftl"], true);
+});
+
 class nsZenWorkspaceCreation extends MozXULElement {
   #wasInCollapsedMode = false;
 
@@ -192,7 +198,9 @@ class nsZenWorkspaceCreation extends MozXULElement {
 
       this.currentProfile = {
         id: 0,
-        name: ContextualIdentityService.formatContextLabel("user-context-none"),
+        name: lazy.l10n.formatValueSync(
+          "zen-workspace-creation-default-profile"
+        ),
       };
     } else {
       this.inputProfile.parentNode.hidden = true;
@@ -297,10 +305,21 @@ class nsZenWorkspaceCreation extends MozXULElement {
   }
 
   onProfilePopupShowing(event) {
-    return window.createUserContextMenu(event, {
+    window.createUserContextMenu(event, {
       isContextMenu: true,
       showDefaultTab: true,
     });
+
+    const defaultItem = event.target.querySelector(
+      '[data-usercontextid="0"]'
+    );
+
+    if (defaultItem) {
+      defaultItem.removeAttribute("data-l10n-id");
+      defaultItem.label = lazy.l10n.formatValueSync(
+        "zen-workspace-creation-default-profile"
+      );
+    }
   }
 
   onProfilePopupCommand(event) {

--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -313,7 +313,6 @@ class nsZenWorkspaceCreation extends MozXULElement {
     const defaultItem = event.target.querySelector(
       '[data-usercontextid="0"]'
     );
-
     if (defaultItem) {
       defaultItem.removeAttribute("data-l10n-id");
       defaultItem.label = lazy.l10n.formatValueSync(

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -1279,7 +1279,7 @@ class nsZenWorkspaces {
     if (defaultItem) {
       defaultItem.removeAttribute("data-l10n-id");
       defaultItem.label = lazy.l10n.formatValueSync(
-        "zen-workspace-creation-default-profile"
+        "zen-workspace-default-profile"
       );
     }
   }

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -22,6 +22,10 @@ ChromeUtils.defineLazyGetter(lazy, "toolbarBackgroundElement", () => {
   return document.getElementById("zen-toolbar-background");
 });
 
+ChromeUtils.defineLazyGetter(lazy, "l10n", () => {
+  return new Localization(["browser/zen-workspaces.ftl"], true);
+});
+
 /**
  * Zen Spaces manager. This class is mainly responsible for the UI
  * and user interactions but it also contains some logic to manage
@@ -1263,11 +1267,21 @@ class nsZenWorkspaces {
       workspace = this.getActiveWorkspaceFromCache();
     }
     let containerTabId = workspace.containerTabId;
-    return window.createUserContextMenu(event, {
+    window.createUserContextMenu(event, {
       isContextMenu: true,
       excludeUserContextId: containerTabId,
       showDefaultTab: true,
     });
+
+    const defaultItem = event.target.querySelector(
+      '[data-usercontextid="0"]'
+    );
+    if (defaultItem) {
+      defaultItem.removeAttribute("data-l10n-id");
+      defaultItem.label = lazy.l10n.formatValueSync(
+        "zen-workspace-creation-default-profile"
+      );
+    }
   }
 
   saveWorkspace(workspaceData) {

--- a/src/zen/spaces/create-workspace-form.css
+++ b/src/zen/spaces/create-workspace-form.css
@@ -26,7 +26,7 @@ zen-workspace-creation {
     }
 
     & form {
-      --input-bgcolor: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
+      --input-text-background-color: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
 
       display: flex;
       flex-direction: column;
@@ -53,7 +53,7 @@ zen-workspace-creation {
         padding: 9px 6px;
         border-radius: 8px !important;
         margin: 0;
-        background-color: var(--input-bgcolor);
+        background-color: var(--input-text-background-color);
         gap: 8px;
         align-items: center;
         padding-left: 8px;
@@ -108,7 +108,7 @@ zen-workspace-creation {
 
         & .zen-workspace-creation-name {
           --input-border-color: transparent;
-          --input-bgcolor: transparent;
+          --input-text-background-color: transparent;
           padding: 0 !important;
           width: 100%;
           outline: none;
@@ -120,7 +120,7 @@ zen-workspace-creation {
         padding: 4px;
         border-radius: 8px !important;
         margin: 0;
-        background-color: var(--input-bgcolor);
+        background-color: var(--input-text-background-color);
         gap: 4px;
         align-items: center;
         flex-wrap: wrap;
@@ -149,7 +149,7 @@ zen-workspace-creation {
       & .zen-workspace-creation-edit-theme-button {
         border-radius: 8px !important;
         margin: 0;
-        background-color: var(--input-bgcolor);
+        background-color: var(--input-text-background-color);
         justify-content: center;
         align-items: center;
         appearance: none;


### PR DESCRIPTION
when creating a new space, workspace creation referenced a Firefox localization key that no longer exists upstream. this caused `ContextualIdentityService.formatContextLabel` to receive `null ` and throw while looping through it.

original error message: 
```text
Uncaught TypeError: can't access property "attributes", msg is null
```

these changes replace Firefox’s old default profile label, **“New Tab,”** with a Zen-owned localized label. since this menu is choosing which profile/context a workspace uses, **“Default”** is a clearer label than “New Tab” in terms of workspace creations.

this also fixes cases where `ContextualIdentityService.formatContextLabel` returned an empty string, which caused the profile dropdown to render extremely narrow.

Demo showcasing workspace creation no longer crashing and use of the "*“Default”** label.

https://github.com/user-attachments/assets/859ea8be-76fd-434e-baba-e5682ef1fcad


Closes #14713

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zen-browser/codesmith/desktop/pr/14715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787640189&installation_model_id=4703&pr_number=14715&repository=zen-browser%2Fdesktop&return_to=https%3A%2F%2Fgithub.com%2Fzen-browser%2Fdesktop%2Fpull%2F14715&signature=00c875bd97a1de059834349ee15d652207f94cf71b11563ed28a0954b11b530e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->