### PR TITLE
gh-14717: Fixed extra divider when urlbar has no results

### DIFF
--- a/src/zen/common/styles/zen-omnibox.css
+++ b/src/zen/common/styles/zen-omnibox.css
@@ -712,7 +712,7 @@
 }
 
 /* Hide the results body when there are no results, to avoid showing an empty box */
-.urlbarView[noresults] > .urlbarView-body-outer > .urlbarView-body-inner,
+.urlbar[noresults] > .urlbarView-body-outer > .urlbarView-body-inner,
 #urlbar-search-mode-indicator-close {
   display: none;
 }

--- a/surfer.json
+++ b/surfer.json
@@ -20,7 +20,7 @@
       "brandShortName": "Zen",
       "brandFullName": "Zen Browser",
       "release": {
-        "displayVersion": "1.21.9b",
+        "displayVersion": "1.21.10b",
         "github": {
           "repo": "zen-browser/desktop"
         },


### PR DESCRIPTION
https://phabricator.services.mozilla.com/D302682#change-6NgIHjjuvNZK

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zen-browser/codesmith/desktop/pr/14718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787645941&installation_model_id=4703&pr_number=14718&repository=zen-browser%2Fdesktop&return_to=https%3A%2F%2Fgithub.com%2Fzen-browser%2Fdesktop%2Fpull%2F14718&signature=c0f42ee359834bb7528bbdc507731a73d1c1a0e0a9d04a35bf070feca74202b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->