### PR TITLE
gh-14726: Fix essential tab reordering at maximum capacity

### DIFF
--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -198,9 +198,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
 
       this.currentProfile = {
         id: 0,
-        name: lazy.l10n.formatValueSync(
-          "zen-workspace-default-profile"
-        ),
+        name: lazy.l10n.formatValueSync("zen-workspace-default-profile"),
       };
     } else {
       this.inputProfile.parentNode.hidden = true;
@@ -311,9 +309,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
       showManageContainers: false,
     });
 
-    const defaultItem = event.target.querySelector(
-      '[data-usercontextid="0"]'
-    );
+    const defaultItem = event.target.querySelector('[data-usercontextid="0"]');
     if (defaultItem) {
       defaultItem.removeAttribute("data-l10n-id");
       defaultItem.label = lazy.l10n.formatValueSync(

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -1273,9 +1273,7 @@ class nsZenWorkspaces {
       showDefaultTab: true,
     });
 
-    const defaultItem = event.target.querySelector(
-      '[data-usercontextid="0"]'
-    );
+    const defaultItem = event.target.querySelector('[data-usercontextid="0"]');
     if (defaultItem) {
       defaultItem.removeAttribute("data-l10n-id");
       defaultItem.label = lazy.l10n.formatValueSync(

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -1026,7 +1026,8 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
           (gZenWorkspaces.getActiveWorkspaceFromCache().containerTabId || 0) &&
         gZenWorkspaces.containerSpecificEssentials
       ) &&
-      (isExistingEssentialTab || gBrowser._numZenEssentials < this.maxEssentialTabs)
+      (isExistingEssentialTab ||
+        gBrowser._numZenEssentials < this.maxEssentialTabs)
     );
   }
 

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -1019,12 +1019,14 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
   }
 
   canEssentialBeAdded(tab) {
+    const isExistingEssentialTab = tab.hasAttribute("zen-essential");
     return (
       !(
         (tab.getAttribute("usercontextid") || 0) !=
           (gZenWorkspaces.getActiveWorkspaceFromCache().containerTabId || 0) &&
         gZenWorkspaces.containerSpecificEssentials
-      ) && gBrowser._numZenEssentials < this.maxEssentialTabs
+      ) &&
+      (isExistingEssentialTab || gBrowser._numZenEssentials < this.maxEssentialTabs)
     );
   }
 


### PR DESCRIPTION
the `canEssentialBeAdded` check used in the drag and drop flow prevented existing essential tabs from being reordered at 12/12, so i added a check to allow existing essentials through while still enforcing the limit for new tabs.

demo showing that essentials can be reordered at 12/12 while new essentials still cannot be added.

https://github.com/user-attachments/assets/943e4457-1962-4b71-b99c-c21c661412a1

closes #14726 