### PR TITLE
gh-14724: Fix non-tab drags switching workspaces

### DIFF
--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -726,10 +726,11 @@
 
     #handle_sidebarDragOver(event) {
       const dt = event.dataTransfer;
+      const isTabDrag = dt.mozTypesAt(0)[0] === TAB_DROP_TYPE;
 
       const { isNearLeftEdge, isNearRightEdge } =
         this.#shouldSwitchSpace(event);
-      if (isNearLeftEdge || isNearRightEdge) {
+      if (isTabDrag && (isNearLeftEdge || isNearRightEdge)) {
         if (!this.#changeSpaceTimer && !this.#isOutOfWindow) {
           this.#changeSpaceTimer = setTimeout(() => {
             this.clearDragOverVisuals();
@@ -753,6 +754,10 @@
 
     handle_spaceIconDragOver(event) {
       const dt = event.dataTransfer;
+      if (dt.mozTypesAt(0)[0] !== TAB_DROP_TYPE) {
+        return;
+      }
+
       const draggedTab = dt.mozGetDataAt(TAB_DROP_TYPE, 0);
       if (draggedTab.hasAttribute("zen-essential")) {
         return;

--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -198,9 +198,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
 
       this.currentProfile = {
         id: 0,
-        name: lazy.l10n.formatValueSync(
-          "zen-workspace-default-profile"
-        ),
+        name: lazy.l10n.formatValueSync("zen-workspace-default-profile"),
       };
     } else {
       this.inputProfile.parentNode.hidden = true;
@@ -311,9 +309,7 @@ class nsZenWorkspaceCreation extends MozXULElement {
       showManageContainers: false,
     });
 
-    const defaultItem = event.target.querySelector(
-      '[data-usercontextid="0"]'
-    );
+    const defaultItem = event.target.querySelector('[data-usercontextid="0"]');
     if (defaultItem) {
       defaultItem.removeAttribute("data-l10n-id");
       defaultItem.label = lazy.l10n.formatValueSync(

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -1273,9 +1273,7 @@ class nsZenWorkspaces {
       showDefaultTab: true,
     });
 
-    const defaultItem = event.target.querySelector(
-      '[data-usercontextid="0"]'
-    );
+    const defaultItem = event.target.querySelector('[data-usercontextid="0"]');
     if (defaultItem) {
       defaultItem.removeAttribute("data-l10n-id");
       defaultItem.label = lazy.l10n.formatValueSync(


### PR DESCRIPTION
non-tab drags could trigger workspace switching because the sidebar drag-over handlers were running workspace-switch logic without checking whether the dragged item was actually a tab. the two added checks now prevents non-tab drags from triggering workspace switching, 

## testing

- reproduced on macOS 1.21.9b
- confirmed non-tab drags no longer switch workspaces
- confirmed tab drags can still switch workspaces
- confirmed dragging tabs over workspace icons still works

the original Windows reproduction is shown in #14724, and my macOS reproduction is in the issue comments.

demo showing that the same external file drag motions and workspace icon hover no longer trigger workspace changes.

https://github.com/user-attachments/assets/5db66dfc-27c4-4bc4-8af0-cfc11d0e0bea

closes #14724 