### PR TITLE
fix: detect external Firefox profiles during first-run migration

### DIFF
--- a/src/external-patches/firefox/README.md
+++ b/src/external-patches/firefox/README.md
@@ -1,3 +1,7 @@
 # Temporal patches done to Firefox
 
 **IMPORTANT**: Once they start failing (on new Firefox releases), they should be removed as these patches are imported from future versions of Firefox as temporary solutions while we wait.
+
+## firefox_profile_migrator_scan_external.patch
+
+adds _getExternalFirefoxProfiles to FirefoxProfileMigrator so it scans the standard firefox profiles.ini instead of only checking the toolkit profile service which doesnt know about firefox profiles on forks. backup for the runtime fix in ZenExternalFirefoxProfileScanner.sys.mjs

--- a/src/external-patches/firefox/firefox_profile_migrator_scan_external.patch
+++ b/src/external-patches/firefox/firefox_profile_migrator_scan_external.patch
@@ -1,0 +1,150 @@
+diff --git a/browser/components/migration/FirefoxProfileMigrator.sys.mjs b/browser/components/migration/FirefoxProfileMigrator.sys.mjs
+--- a/browser/components/migration/FirefoxProfileMigrator.sys.mjs
++++ b/browser/components/migration/FirefoxProfileMigrator.sys.mjs
+@@ -25,10 +25,12 @@
+ ChromeUtils.defineESModuleGetters(lazy, {
+   FileUtils: "resource://gre/modules/FileUtils.sys.mjs",
++  IOUtils: "resource://gre/modules/IOUtils.sys.mjs",
++  PathUtils: "resource://gre/modules/PathUtils.sys.mjs",
+   PlacesBackups: "resource://gre/modules/PlacesBackups.sys.mjs",
+   ProfileAge: "resource://gre/modules/ProfileAge.sys.mjs",
+   SessionMigration: "resource:///modules/sessionstore/SessionMigration.sys.mjs",
+ });
+ 
+ /**
+  * Firefox profile migrator. Currently, this class only does "pave over"
+@@ -82,10 +84,11 @@
+     let allProfiles = new Map();
+     let profileService = Cc[
+       "@mozilla.org/toolkit-profile-service;1"
+     ].getService(Ci.nsIToolkitProfileService);
++
+     for (let profile of profileService.profiles) {
+       let rootDir = profile.rootDir;
+       let path = rootDir.path;
+       if (
+@@ -92,10 +95,16 @@
+         rootDir.exists() &&
+         rootDir.isReadable() &&
+         !rootDir.equals(MigrationUtils.profileStartup.directory)
+       ) {
+         allProfiles.set(path, {
+           id: path,
+           name: profile.name,
+           rootDir,
+         });
+       }
+     }
++
++    let externalProfiles = await this._getExternalFirefoxProfiles();
++    for (let [path, profile] of externalProfiles) {
++      if (!allProfiles.has(path)) {
++        allProfiles.set(path, profile);
++      }
++    }
++
+     return allProfiles;
+   }
+ 
++  async _getExternalFirefoxProfiles() {
++    let profiles = new Map();
++
++    let profilesIniPath;
++    try {
++      if (AppConstants.platform === "win") {
++        let appData = Services.dirsvc.get("AppData", Ci.nsIFile);
++        profilesIniPath = lazy.PathUtils.join(
++          appData.path, "Mozilla", "Firefox", "profiles.ini"
++        );
++      } else if (AppConstants.platform === "macosx") {
++        let home = Services.dirsvc.get("Home", Ci.nsIFile);
++        profilesIniPath = lazy.PathUtils.join(
++          home.path, "Library", "Application Support", "Firefox", "profiles.ini"
++        );
++      } else {
++        let home = Services.dirsvc.get("Home", Ci.nsIFile);
++        profilesIniPath = lazy.PathUtils.join(
++          home.path, ".mozilla", "firefox", "profiles.ini"
++        );
++      }
++    } catch (e) {
++      console.error(e);
++      return profiles;
++    }
++
++    let data;
++    try {
++      if (!(await lazy.IOUtils.exists(profilesIniPath))) {
++        return profiles;
++      }
++      data = await lazy.IOUtils.readUTF8(profilesIniPath);
++    } catch (e) {
++      console.error(e);
++      return profiles;
++    }
++
++    let baseDir = lazy.PathUtils.parent(profilesIniPath);
++    let profileEntries = [];
++    let currentEntry = null;
++
++    for (let line of data.split("\n")) {
++      line = line.trim();
++      if (!line || line.startsWith(";") || line.startsWith("#")) {
++        continue;
++      }
++
++      if (line.startsWith("[") && line.endsWith("]")) {
++        if (currentEntry && currentEntry.name && currentEntry.path !== undefined) {
++          profileEntries.push(currentEntry);
++        }
++        currentEntry = line.slice(1, -1).startsWith("Profile") ? {} : null;
++      } else if (currentEntry) {
++        let eqIdx = line.indexOf("=");
++        if (eqIdx > 0) {
++          let key = line.substring(0, eqIdx).trim();
++          let value = line.substring(eqIdx + 1).trim();
++          switch (key) {
++            case "Name": currentEntry.name = value; break;
++            case "Path": currentEntry.path = value; break;
++            case "IsRelative": currentEntry.isRelative = value === "1"; break;
++          }
++        }
++      }
++    }
++    if (currentEntry && currentEntry.name && currentEntry.path !== undefined) {
++      profileEntries.push(currentEntry);
++    }
++
++    for (let entry of profileEntries) {
++      try {
++        let profilePath = entry.isRelative
++          ? lazy.PathUtils.join(baseDir, entry.path)
++          : entry.path;
++
++        let rootDir = Cc["@mozilla.org/file/local;1"].createInstance(
++          Ci.nsIFile
++        );
++        rootDir.initWithPath(profilePath);
++
++        if (
++          rootDir.exists() &&
++          rootDir.isReadable() &&
++          !rootDir.equals(MigrationUtils.profileStartup.directory)
++        ) {
++          profiles.set(profilePath, {
++            id: profilePath,
++            name: entry.name,
++            rootDir,
++          });
++        }
++      } catch (e) {
++        console.error(e);
++      }
++    }
++
++    return profiles;
++  }
++
+   async getSourceProfiles() {
+     let sorter = (a, b) => {
+       return a.name

--- a/src/external-patches/manifest.json
+++ b/src/external-patches/manifest.json
@@ -26,6 +26,10 @@
     "path": "firefox/no_liquid_glass_icon.patch"
   },
   {
+    "type": "local",
+    "path": "firefox/firefox_profile_migrator_scan_external.patch"
+  },
+  {
     "type": "patch",
     "url": "https://codeberg.org/librewolf/source/raw/branch/main/patches/firefox-in-ua.patch",
     "dest": "librewolf",

--- a/src/zen/welcome/ZenExternalFirefoxProfileScanner.sys.mjs
+++ b/src/zen/welcome/ZenExternalFirefoxProfileScanner.sys.mjs
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const lazy = {};
+ChromeUtils.defineESModuleGetters(lazy, {
+  IOUtils: "resource://gre/modules/IOUtils.sys.mjs",
+  PathUtils: "resource://gre/modules/PathUtils.sys.mjs",
+});
+
+let _migrationUtils = null;
+function getMigrationUtils() {
+  if (!_migrationUtils) {
+    _migrationUtils = ChromeUtils.importESModule(
+      "resource:///modules/MigrationUtils.sys.mjs"
+    ).MigrationUtils;
+  }
+  return _migrationUtils;
+}
+
+function getFirefoxProfilesIniPath() {
+  try {
+    if (AppConstants.platform === "win") {
+      let appData = Services.dirsvc.get("AppData", Ci.nsIFile);
+      return lazy.PathUtils.join(
+        appData.path, "Mozilla", "Firefox", "profiles.ini"
+      );
+    }
+    if (AppConstants.platform === "macosx") {
+      let home = Services.dirsvc.get("Home", Ci.nsIFile);
+      return lazy.PathUtils.join(
+        home.path, "Library", "Application Support", "Firefox", "profiles.ini"
+      );
+    }
+    let home = Services.dirsvc.get("Home", Ci.nsIFile);
+    return lazy.PathUtils.join(home.path, ".mozilla", "firefox", "profiles.ini");
+  } catch (e) {
+    console.error("Failed to determine Firefox profiles.ini path:", e);
+    return null;
+  }
+}
+
+function parseProfilesIni(data) {
+  let entries = [];
+  let current = null;
+
+  for (let line of data.split("\n")) {
+    line = line.trim();
+    if (!line || line.startsWith(";") || line.startsWith("#")) {
+      continue;
+    }
+
+    if (line.startsWith("[") && line.endsWith("]")) {
+      if (current && current.name && current.path !== undefined) {
+        entries.push(current);
+      }
+      current = line.slice(1, -1).startsWith("Profile") ? {} : null;
+    } else if (current) {
+      let eqIdx = line.indexOf("=");
+      if (eqIdx > 0) {
+        let key = line.substring(0, eqIdx).trim();
+        let value = line.substring(eqIdx + 1).trim();
+        switch (key) {
+          case "Name":
+            current.name = value;
+            break;
+          case "Path":
+            current.path = value;
+            break;
+          case "IsRelative":
+            current.isRelative = value === "1";
+            break;
+        }
+      }
+    }
+  }
+
+  if (current && current.name && current.path !== undefined) {
+    entries.push(current);
+  }
+
+  return entries;
+}
+
+async function scanExternalProfiles(profilesIniPath, baseDir) {
+  let profiles = new Map();
+
+  let data;
+  try {
+    if (!(await lazy.IOUtils.exists(profilesIniPath))) {
+      return profiles;
+    }
+    data = await lazy.IOUtils.readUTF8(profilesIniPath);
+  } catch (e) {
+    console.error("Failed to read Firefox profiles.ini:", e);
+    return profiles;
+  }
+
+  let entries = parseProfilesIni(data);
+  let currentProfileDir = getMigrationUtils().profileStartup.directory;
+
+  for (let entry of entries) {
+    try {
+      let profilePath = entry.isRelative
+        ? lazy.PathUtils.join(baseDir, entry.path)
+        : entry.path;
+
+      let rootDir = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
+      rootDir.initWithPath(profilePath);
+
+      if (
+        rootDir.exists() &&
+        rootDir.isReadable() &&
+        !rootDir.equals(currentProfileDir)
+      ) {
+        if (!profiles.has(profilePath)) {
+          profiles.set(profilePath, {
+            id: profilePath,
+            name: entry.name,
+            rootDir,
+          });
+        }
+      }
+    } catch (e) {
+      console.error("Failed to resolve external Firefox profile:", e);
+    }
+  }
+
+  return profiles;
+}
+
+export function installFirefoxProfileScanner() {
+  let { FirefoxProfileMigrator } = ChromeUtils.importESModule(
+    "resource:///modules/FirefoxProfileMigrator.sys.mjs"
+  );
+
+  if (FirefoxProfileMigrator.prototype.__zenExternalScanInstalled) {
+    return;
+  }
+  FirefoxProfileMigrator.prototype.__zenExternalScanInstalled = true;
+
+  let originalGetAllProfiles =
+    FirefoxProfileMigrator.prototype.getAllProfiles;
+
+  FirefoxProfileMigrator.prototype.getAllProfiles = async function () {
+    let allProfiles = await originalGetAllProfiles.call(this);
+
+    let profilesIniPath = getFirefoxProfilesIniPath();
+    if (profilesIniPath) {
+      let baseDir = lazy.PathUtils.parent(profilesIniPath);
+      let externalProfiles = await scanExternalProfiles(
+        profilesIniPath,
+        baseDir
+      );
+
+      for (let [path, profile] of externalProfiles) {
+        if (!allProfiles.has(path)) {
+          allProfiles.set(path, profile);
+        }
+      }
+    }
+
+    return allProfiles;
+  };
+}

--- a/src/zen/welcome/ZenWelcome.mjs
+++ b/src/zen/welcome/ZenWelcome.mjs
@@ -789,6 +789,15 @@
   }
 
   function startZenWelcome() {
+    try {
+      let { installFirefoxProfileScanner } = ChromeUtils.importESModule(
+        "chrome://browser/content/zen-components/ZenExternalFirefoxProfileScanner.sys.mjs"
+      );
+      installFirefoxProfileScanner();
+    } catch (e) {
+      console.error(e);
+    }
+
     clearBrowserElements();
     centerWindowOnScreen();
     initializeZenWelcome();

--- a/src/zen/welcome/jar.inc.mn
+++ b/src/zen/welcome/jar.inc.mn
@@ -3,4 +3,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
         content/browser/zen-components/ZenWelcome.mjs                           (../../zen/welcome/ZenWelcome.mjs)
+        content/browser/zen-components/ZenExternalFirefoxProfileScanner.sys.mjs (../../zen/welcome/ZenExternalFirefoxProfileScanner.sys.mjs)
         content/browser/zen-styles/zen-welcome.css                              (../../zen/welcome/zen-welcome.css)


### PR DESCRIPTION
import wizard at first launch cant see Firefox even when its installed on the same machine, falls back to manual file picker. this has been an open complaint since early 2024
the bug: FirefoxProfileMigrator.getAllProfiles uses nsIToolkitProfileService to list profiles but that service only knows about Zen profiles since Zen has its own profile directory. Firefox profiles are invisible to it
the fix: monkey patches getAllProfiles to also scan Firefoxs profiles.ini from the standard os directories, parses ProfileX sections with Name and Path and IsRelative, resolves them to real directories, merges into results. build time patch does the same thing baked into the source as a backup
tested locally with various profiles.ini inputs
Fixes: #881