### PR TITLE
gh-14744: Fix remote gfx blocklist matching against app version instead of platform version

### DIFF
--- a/src/toolkit/mozapps/extensions/Blocklist-sys-mjs.patch
+++ b/src/toolkit/mozapps/extensions/Blocklist-sys-mjs.patch
@@ -1,0 +1,13 @@
+diff --git a/toolkit/mozapps/extensions/Blocklist.sys.mjs b/toolkit/mozapps/extensions/Blocklist.sys.mjs
+index 4e1e0aac91612c846bb664efe3dbb50ecf63597d..5fbdcd6f05363527deeba524e6d8a3137b8925e8 100644
+--- a/toolkit/mozapps/extensions/Blocklist.sys.mjs
++++ b/toolkit/mozapps/extensions/Blocklist.sys.mjs
+@@ -411,7 +411,7 @@ class TargetAppFilter {
+     if (!Array.isArray(versionRange)) {
+       const { maxVersion = "*" } = versionRange;
+       const matchesRange =
+-        Services.vc.compare(lazy.gApp.version, maxVersion) <= 0;
++        Services.vc.compare(lazy.gApp.platformVersion, maxVersion) <= 0;
+       return matchesRange ? entry : null;
+     }
+ 


### PR DESCRIPTION
Fixes #14744

### What

One-line patch to `toolkit/mozapps/extensions/Blocklist.sys.mjs`: the Remote Settings **gfx** blocklist filter now compares entries' `versionRange.maxVersion` against `Services.appinfo.platformVersion` (the Gecko version, `153.0`) instead of `Services.appinfo.version` (the Zen version, e.g. `1.21.9b`).

### Why

The gfx branch of the filter only checks `maxVersion` (minVersion is deliberately ignored upstream). Since `1.x < 110.*`, every version-capped gfx blocklist entry ever published for old Firefox releases permanently matches Zen. In particular the NVIDIA and AMD “video overlay” entries capped at Firefox `110.*` match every Zen release, so `VIDEO_HARDWARE_OVERLAY` is silently blocked (`FEATURE_FAILURE_DL_BLOCKLIST_NO_ID`) on every profile after its first Remote Settings sync. That kills the DirectComposition video overlay path and with it NVIDIA RTX Video Super Resolution / RTX Video HDR, which otherwise work out of the box (they engage in Chrome/Edge on the same machine, and in Zen on a brand-new profile before the blocklist arrives).

Using `platformVersion` restores upstream semantics exactly (in Firefox, `version == platformVersion`) and follows the same approach as the existing `AddonUpdateChecker-sys-mjs.patch`.

### Verification (real hardware: Windows 11 26200, RTX 5070, driver 610.74, HDR display, Zen 1.21.9b)

- Confirmed live: `Services.appinfo.version = "1.21.9b"`, `Services.vc.compare("1.21.9b", "110.*") = -1` (entry wrongly matches), `Services.vc.compare("153.0", "110.*") = 1` (entry correctly rejected).
- Reproduced the causal chain: fresh profile → `VIDEO_HARDWARE_OVERLAY: available` and RTX VSR/HDR engage (Gecko Profiler shows `DCSurfaceVideo` + `SetVpSuperResolution`/`SetVpAutoHDR` with driver state `Enabled 1 InUse 1`; NVIDIA App shows both features **Active**) → after `RemoteSettings.pollChanges()` + restart → `blocked, FEATURE_FAILURE_DL_BLOCKLIST_NO_ID`, zero overlay/VSR markers, NVIDIA App **Inactive**.
- Confirmed the fix semantics via the blocklist-override pref (`gfx.webrender.dcomp-video-hw-overlay-win-force-enabled=true`) on the same blocked profile: overlay returns to `available` and both RTX features engage again, including in a maximized non-fullscreen window with the regular rounded-corner Zen UI.
- `git apply --check` of the patch passes against pristine Firefox 153 sources.

Affected profiles recover automatically on their next Remote Settings sync after updating — the filter is re-evaluated and the stale entries stop matching.

### AI assistance disclosure

This fix and the underlying investigation were produced with the assistance of Anthropic's Claude (Fable 5) via Claude Code, directed and reviewed by the submitter; the commit carries a `Co-Authored-By: Claude Fable 5` trailer. The verification evidence in this PR comes from real runs on the hardware described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
