### PR TITLE
no-bug: Native tree-style tabs for the vertical sidebar

### DIFF
--- a/prefs/zen/tab-tree.yaml
+++ b/prefs/zen/tab-tree.yaml
@@ -19,7 +19,10 @@
   value: 4 # maximum level; root = 0; 0 disables the cap
 
 - name: zen.tab-tree.drag-nest-to-split-delayMC
-  value: 300 # ms hold before nest escalates to split
+  value: 500 # ms hold in a tab's right edge zone before it escalates to split
+
+- name: zen.tab-tree.drag-split-zone
+  value: 25 # rightmost % of a tab that arms the split gesture
 
 - name: zen.tabs.middle-drag-select.enabled
   value: true

--- a/prefs/zen/tab-tree.yaml
+++ b/prefs/zen/tab-tree.yaml
@@ -13,7 +13,7 @@
   value: promote
 
 - name: zen.tab-tree.indent
-  value: 20 # px per nesting level
+  value: 14 # px per nesting level
 
 - name: zen.tab-tree.max-depth
   value: 4 # maximum level; root = 0; 0 disables the cap

--- a/prefs/zen/tab-tree.yaml
+++ b/prefs/zen/tab-tree.yaml
@@ -13,7 +13,7 @@
   value: promote
 
 - name: zen.tab-tree.indent
-  value: 14 # px per nesting level
+  value: 20 # px per nesting level
 
 - name: zen.tab-tree.max-depth
   value: 4 # maximum level; root = 0; 0 disables the cap

--- a/prefs/zen/tab-tree.yaml
+++ b/prefs/zen/tab-tree.yaml
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+- name: zen.tab-tree.enabled
+  value: true
+
+- name: zen.tab-tree.auto-nest-by-opener
+  value: true
+
+# "promote" (children move up) or "close-subtree" (close descendants too)
+- name: zen.tab-tree.close-parent-behavior
+  value: promote
+
+- name: zen.tab-tree.indent
+  value: 14 # px per nesting level
+
+- name: zen.tab-tree.max-depth
+  value: 4 # maximum level; root = 0; 0 disables the cap
+
+- name: zen.tab-tree.drag-nest-to-split-delayMC
+  value: 300 # ms hold before nest escalates to split
+
+- name: zen.tabs.middle-drag-select.enabled
+  value: true

--- a/prefs/zen/tab-tree.yaml
+++ b/prefs/zen/tab-tree.yaml
@@ -24,5 +24,8 @@
 - name: zen.tab-tree.drag-split-zone
   value: 25 # rightmost % of a tab that arms the split gesture
 
+- name: zen.tab-tree.drag-reorder-edge
+  value: 15 # top/bottom % of a tab that reorders; the rest of the row nests
+
 - name: zen.tabs.middle-drag-select.enabled
   value: true

--- a/src/browser/base/content/zen-assets.inc.xhtml
+++ b/src/browser/base/content/zen-assets.inc.xhtml
@@ -19,6 +19,7 @@
 <link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-workspaces.css" />
 <link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-split-view.css" />
 <link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-folders.css" />
+<link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-tab-tree.css" />
 <link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-glance.css" />
 <link rel="stylesheet" type="text/css" href="chrome://browser/content/zen-styles/zen-popup.css" />
 

--- a/src/browser/base/content/zen-assets.jar.inc.mn
+++ b/src/browser/base/content/zen-assets.jar.inc.mn
@@ -12,6 +12,7 @@
 #include ../../../zen/kbs/jar.inc.mn
 #include ../../../zen/glance/jar.inc.mn
 #include ../../../zen/folders/jar.inc.mn
+#include ../../../zen/tab-tree/jar.inc.mn
 #include ../../../zen/welcome/jar.inc.mn
 #include ../../../zen/media/jar.inc.mn
 #include ../../../zen/downloads/jar.inc.mn

--- a/src/browser/components/sessionstore/SessionStore-sys-mjs.patch
+++ b/src/browser/components/sessionstore/SessionStore-sys-mjs.patch
@@ -175,7 +175,7 @@ index 183543c5f29ff4c879d3058e4c09faf376a69cb7..ab482c32cc697ccef82bf0aeaa0e3a1d
        return;
      }
 -    if (aTab == aWindow.FirefoxViewHandler.tab) {
-+    if (aTab == aWindow.FirefoxViewHandler.tab || aTab.hasAttribute("zen-empty-tab")) {
++    if (aTab == aWindow.FirefoxViewHandler.tab || aTab.hasAttribute("zen-empty-tab") || (aTab._zenSyncClosing && !aTab._zenContentsVisible)) {
        return;
      }
  

--- a/src/browser/components/sessionstore/TabAttributes-sys-mjs.patch
+++ b/src/browser/components/sessionstore/TabAttributes-sys-mjs.patch
@@ -1,0 +1,23 @@
+diff --git a/browser/components/sessionstore/TabAttributes.sys.mjs b/browser/components/sessionstore/TabAttributes.sys.mjs
+index ea53156d12..1cce173df3 100644
+--- a/browser/components/sessionstore/TabAttributes.sys.mjs
++++ b/browser/components/sessionstore/TabAttributes.sys.mjs
+@@ -3,7 +3,17 @@
+  * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ 
+ // Tab attributes which are persisted & restored by SessionStore.
+-const PERSISTED_ATTRIBUTES = ["customizemode"];
++// The zen-tree-* attributes are restored on every path (including undo-close,
++// which doesn't run restoreInitialTabData) so the tree structure survives
++// Ctrl+Shift+T, not just full session restore. zen-tree-id carries the tab's
++// stable tree identity: window-sync reassigns the live `id` on restore, so the
++// tree matches parents by this persisted id instead.
++const PERSISTED_ATTRIBUTES = [
++  "customizemode",
++  "zen-tree-id",
++  "zen-tree-parent-id",
++  "zen-tree-collapsed",
++];
+ 
+ // A set of tab attributes to persist. We will read a given list of tab
+ // attributes when collecting tab data and will re-set those attributes when

--- a/src/browser/components/sessionstore/TabState-sys-mjs.patch
+++ b/src/browser/components/sessionstore/TabState-sys-mjs.patch
@@ -2,7 +2,7 @@ diff --git a/browser/components/sessionstore/TabState.sys.mjs b/browser/componen
 index 4ba4dda363b602cb6f4445ef056f2f9abb1b0e1e..6b4b407e05e26faca69d9d7ac6f31510620898fe 100644
 --- a/browser/components/sessionstore/TabState.sys.mjs
 +++ b/browser/components/sessionstore/TabState.sys.mjs
-@@ -99,10 +99,28 @@ class _TabState {
+@@ -99,10 +99,30 @@ class _TabState {
        }
      }
  
@@ -20,6 +20,8 @@ index 4ba4dda363b602cb6f4445ef056f2f9abb1b0e1e..6b4b407e05e26faca69d9d7ac6f31510
 +    tabData._zenPinnedInitialState = tab._zenPinnedInitialState;
 +    tabData._zenIsActiveTab = tab._zenContentsVisible;
 +    tabData.zenLiveFolderItemId = tab.getAttribute("zen-live-folder-item-id");
++    tabData.zenTreeParentId = tab.getAttribute("zen-tree-parent-id");
++    tabData.zenTreeCollapsed = tab.hasAttribute("zen-tree-collapsed");
 +
      tabData.searchMode = tab.documentGlobal.gURLBar.getSearchMode(
        browser,

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -535,7 +535,13 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
  
        if (tabs.length > 1 || !tabs[0].selected) {
          this._updateTabsAfterInsert();
-@@ -4836,11 +5002,17 @@
+@@ -4836,11 +5002,23 @@
++      // Durable opener for the tree feature: Firefox clears tab.owner on each
++      // successive related tab opened from the same opener, so only the first
++      // would keep it. Capture the opener here, where it's still known.
++      if (openerTab) {
++        tab._zenOpenerTab = openerTab;
++      }
        if (ownerTab) {
          tab.owner = ownerTab;
        }
@@ -554,7 +560,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
          if (
            !bulkOrderedOpen &&
            ((openerTab &&
-@@ -4852,7 +5024,7 @@
+@@ -4852,7 +5030,7 @@
            let lastRelatedTab =
              openerTab && this.#lastRelatedTabMap.get(openerTab);
            let previousTab = lastRelatedTab || openerTab || this.selectedTab;
@@ -563,7 +569,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
              tabGroup = previousTab.group;
            }
            if (
-@@ -4868,7 +5040,7 @@
+@@ -4868,7 +5046,7 @@
                  previousTab.splitview
                ) + 1;
            } else if (previousTab.visible) {
@@ -572,7 +578,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
            } else if (previousTab == FirefoxViewHandler.tab) {
              elementIndex = 0;
            }
-@@ -4896,14 +5068,14 @@
+@@ -4896,14 +5074,14 @@
        }
        // Ensure index is within bounds.
        if (tab.pinned) {
@@ -591,7 +597,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
  
        if (pinned && !itemAfter?.pinned) {
          itemAfter = null;
-@@ -4920,7 +5092,7 @@
+@@ -4920,7 +5098,7 @@
  
        this.tabContainer._invalidateCachedTabs();
  
@@ -600,7 +606,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
          if (
            (this.isTab(itemAfter) && itemAfter.group == tabGroup) ||
            this.isSplitViewWrapper(itemAfter)
-@@ -4951,7 +5123,11 @@
+@@ -4951,7 +5129,11 @@
          const tabContainer = pinned
            ? this.tabContainer.pinnedTabsContainer
            : this.tabContainer;
@@ -612,7 +618,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        }
  
        if (tab.group?.collapsed) {
-@@ -4966,6 +5142,7 @@
+@@ -4966,6 +5148,7 @@
        if (pinned) {
          this._updateTabBarForPinnedTabs();
        }
@@ -620,7 +626,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
  
        TabBarVisibility.update();
      }
-@@ -5514,6 +5691,7 @@
+@@ -5514,6 +5697,7 @@
          telemetrySource,
        } = {}
      ) {
@@ -628,7 +634,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        // When 'closeWindowWithLastTab' pref is enabled, closing all tabs
        // can be considered equivalent to closing the window.
        if (
-@@ -5603,6 +5781,7 @@
+@@ -5603,6 +5787,7 @@
          if (lastToClose) {
            this.removeTab(lastToClose, aParams);
          }
@@ -636,7 +642,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        } catch (e) {
          console.error(e);
        }
-@@ -5648,6 +5827,14 @@
+@@ -5648,6 +5833,14 @@
          return;
        }
  
@@ -651,7 +657,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        let isVisibleTab = aTab.visible;
        // We have to sample the tab width now, since _beginRemoveTab might
        // end up modifying the DOM in such a way that aTab gets a new
-@@ -5655,6 +5842,9 @@
+@@ -5655,6 +5848,9 @@
        // state).
        let tabWidth = window.windowUtils.getBoundsWithoutFlushing(aTab).width;
        let isLastTab = this.#isLastTabInWindow(aTab);
@@ -661,7 +667,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        if (
          !this._beginRemoveTab(aTab, {
            closeWindowFastpath: true,
-@@ -5666,13 +5856,14 @@
+@@ -5666,13 +5862,14 @@
            telemetrySource,
          })
        ) {
@@ -677,7 +683,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        let lockTabSizing =
          !this.tabContainer.verticalMode &&
          !aTab.pinned &&
-@@ -5703,7 +5894,13 @@
+@@ -5703,7 +5900,13 @@
          // We're not animating, so we can cancel the animation stopwatch.
          Glean.browserTabclose.timeAnim.cancel(aTab._closeTimeAnimTimerId);
          aTab._closeTimeAnimTimerId = null;
@@ -692,7 +698,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
          return;
        }
  
-@@ -5746,7 +5943,7 @@
+@@ -5746,7 +5949,7 @@
       */
      #isLastTabInWindow(tab) {
        for (const otherTab of this.tabs) {
@@ -701,7 +707,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
            return false;
          }
        }
-@@ -5837,7 +6034,7 @@
+@@ -5837,7 +6040,7 @@
            closeWindowWithLastTab != null
              ? closeWindowWithLastTab
              : !window.toolbar.visible ||
@@ -710,7 +716,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
  
          if (closeWindow) {
            // We've already called beforeunload on all the relevant tabs if we get here,
-@@ -5861,6 +6058,7 @@
+@@ -5861,6 +6064,7 @@
  
          newTab = true;
        }
@@ -718,7 +724,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        aTab._endRemoveArgs = [closeWindow, newTab];
  
        // swapBrowsersAndCloseOther will take care of closing the window without animation.
-@@ -5901,13 +6099,7 @@
+@@ -5901,13 +6105,7 @@
        aTab._mouseleave();
  
        if (newTab) {
@@ -733,7 +739,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        } else {
          TabBarVisibility.update();
        }
-@@ -6040,6 +6232,7 @@
+@@ -6040,6 +6238,7 @@
          this.tabs[i]._tPos = i;
        }
  
@@ -741,7 +747,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        if (!this.#windowIsClosing) {
          // update tab close buttons state
          this.tabContainer._updateCloseButtons();
-@@ -6225,6 +6418,7 @@
+@@ -6225,6 +6424,7 @@
          memory_after: await getTotalMemoryUsage(),
          time_to_unload_in_ms: timeElapsed,
        });
@@ -749,7 +755,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
      }
  
      /**
-@@ -6270,6 +6464,7 @@
+@@ -6270,6 +6470,7 @@
        }
  
        let excludeTabs = new Set(aExcludeTabs);
@@ -757,7 +763,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
  
        // If this tab has a successor, it should be selectable, since
        // hiding or closing a tab removes that tab as a successor.
-@@ -6282,15 +6477,22 @@
+@@ -6282,15 +6483,22 @@
          !excludeTabs.has(aTab.owner) &&
          Services.prefs.getBoolPref("browser.tabs.selectOwnerOnClose")
        ) {
@@ -782,7 +788,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        let tab = this.tabContainer.findNextTab(aTab, {
          direction: 1,
          filter: _tab => remainingTabs.includes(_tab),
-@@ -6304,7 +6506,7 @@
+@@ -6304,7 +6512,7 @@
        }
  
        if (tab) {
@@ -791,7 +797,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        }
  
        // If no qualifying visible tab was found, see if there is a tab in
-@@ -6325,7 +6527,7 @@
+@@ -6325,7 +6533,7 @@
          });
        }
  
@@ -800,7 +806,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
      }
  
      _blurTab(aTab) {
-@@ -6336,7 +6538,7 @@
+@@ -6336,7 +6544,7 @@
       * @returns {boolean}
       *   False if swapping isn't permitted, true otherwise.
       */
@@ -809,7 +815,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        // Do not allow transfering a private tab to a non-private window
        // and vice versa.
        if (
-@@ -6390,6 +6592,7 @@
+@@ -6390,6 +6598,7 @@
        // fire the beforeunload event in the process.  Close the other
        // window if this was its last tab.
        if (
@@ -817,7 +823,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
          !remoteBrowser._beginRemoveTab(aOtherTab, {
            adoptedByTab: aOurTab,
            closeWindowWithLastTab: true,
-@@ -6401,7 +6604,7 @@
+@@ -6401,7 +6610,7 @@
        // If this is the last tab of the window, hide the window
        // immediately without animation before the docshell swap, to avoid
        // about:blank being painted.
@@ -826,7 +832,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        if (closeWindow) {
          let win = aOtherTab.documentGlobal;
          win.windowUtils.suppressAnimation(true);
-@@ -6535,11 +6738,13 @@
+@@ -6535,11 +6744,13 @@
        }
  
        // Finish tearing down the tab that's going away.
@@ -840,7 +846,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
  
        this.setTabTitle(aOurTab);
  
-@@ -6759,10 +6964,10 @@
+@@ -6759,10 +6970,10 @@
        SessionStore.deleteCustomTabValue(aTab, "hiddenBy");
      }
  
@@ -853,7 +859,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
          aTab.selected ||
          aTab.closing ||
          // Tabs that are sharing the screen, microphone or camera cannot be hidden.
-@@ -6822,7 +7027,8 @@
+@@ -6822,7 +7033,8 @@
       * @param {object} [aOptions={}]
       *   Key-value pairs that will be serialized into the features string.
       */
@@ -863,7 +869,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        if (this.tabs.length == 1) {
          return null;
        }
-@@ -6839,7 +7045,7 @@
+@@ -6839,7 +7051,7 @@
        // tell a new window to take the "dropped" tab
        let args = Cc["@mozilla.org/array;1"].createInstance(Ci.nsIMutableArray);
        args.appendElement(aTab.splitview ?? aTab);
@@ -872,7 +878,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
          private: PrivateBrowsingUtils.isWindowPrivate(window),
          features: Object.entries(aOptions)
            .map(([key, value]) => `${key}=${value}`)
-@@ -6847,6 +7053,8 @@
+@@ -6847,6 +7059,8 @@
          openerWindow: window,
          args,
        });
@@ -881,7 +887,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
      }
  
      /**
-@@ -6959,7 +7167,7 @@
+@@ -6959,7 +7173,7 @@
       *   `true` if element is a `<tab-group>`
       */
      isTabGroup(element) {
@@ -890,7 +896,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
      }
  
      /**
-@@ -7044,8 +7252,8 @@
+@@ -7044,8 +7258,8 @@
        }
  
        // Don't allow mixing pinned and unpinned tabs.
@@ -901,7 +907,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        } else {
          tabIndex = Math.max(tabIndex, this.pinnedTabCount);
        }
-@@ -7091,8 +7299,8 @@
+@@ -7091,8 +7305,8 @@
        this.#handleTabMove(
          element,
          () => {
@@ -912,7 +918,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
              neighbor = neighbor.group;
            }
            if (neighbor?.splitview) {
-@@ -7103,6 +7311,12 @@
+@@ -7103,6 +7317,12 @@
                return;
              }
            }
@@ -925,7 +931,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
  
            if (movingForwards && neighbor) {
              neighbor.after(element);
-@@ -7161,23 +7375,31 @@
+@@ -7161,23 +7381,31 @@
      #moveTabNextTo(element, targetElement, moveBefore = false, metricsContext) {
        if (this.isTabGroupLabel(targetElement)) {
          targetElement = targetElement.group;
@@ -963,7 +969,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        } else if (!element.pinned && targetElement && targetElement.pinned) {
          // If the caller asks to move an unpinned element next to a pinned
          // tab, move the unpinned element to be the first unpinned element
-@@ -7190,12 +7412,35 @@
+@@ -7190,12 +7418,35 @@
          //    move the tab group right before the first unpinned tab.
          // 4. Moving a tab group and the first unpinned tab is grouped:
          //    move the tab group right before the first unpinned tab's tab group.
@@ -1000,7 +1006,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
  
        // We want to include the splitview wrapper if it's the targetElement, but
        // not in the case where we want to reverse tabs within the same splitview.
-@@ -7204,6 +7449,7 @@
+@@ -7204,6 +7455,7 @@
        }
  
        let getContainer = () =>
@@ -1008,7 +1014,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
          element.pinned
            ? this.tabContainer.pinnedTabsContainer
            : this.tabContainer;
-@@ -7212,11 +7458,15 @@
+@@ -7212,11 +7464,15 @@
          element,
          () => {
            if (moveBefore) {
@@ -1025,7 +1031,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
            }
          },
          metricsContext
-@@ -7290,11 +7540,15 @@
+@@ -7290,11 +7546,15 @@
       * @param {TabMetricsContext} [metricsContext]
       */
      moveTabToExistingGroup(aTab, aGroup, metricsContext) {
@@ -1044,7 +1050,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        }
        if (aTab.group && aTab.group.id === aGroup.id) {
          return;
-@@ -7366,6 +7620,7 @@
+@@ -7366,6 +7626,7 @@
  
        let state = {
          tabIndex: tab._tPos,
@@ -1052,7 +1058,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        };
        if (tab.visible) {
          state.elementIndex = tab.elementIndex;
-@@ -7397,7 +7652,7 @@
+@@ -7397,7 +7658,7 @@
        let changedSplitView =
          previousTabState.splitViewId != currentTabState.splitViewId;
  
@@ -1061,7 +1067,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
          tab.dispatchEvent(
            new CustomEvent("TabMove", {
              bubbles: true,
-@@ -7444,6 +7699,10 @@
+@@ -7444,6 +7705,10 @@
  
        moveActionCallback();
  
@@ -1072,7 +1078,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        // Clear tabs cache after moving nodes because the order of tabs may have
        // changed.
        this.tabContainer._invalidateCachedTabs();
-@@ -7494,7 +7753,22 @@
+@@ -7494,7 +7759,22 @@
       * @returns {object}
       *    The new tab in the current window, null if the tab couldn't be adopted.
       */
@@ -1096,7 +1102,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        // Swap the dropped tab with a new one we create and then close
        // it in the other window (making it seem to have moved between
        // windows). We also ensure that the tab we create to swap into has
-@@ -7537,6 +7811,8 @@
+@@ -7537,6 +7817,8 @@
        }
        params.skipLoad = true;
        let newTab = this.addWebTab("about:blank", params);
@@ -1105,7 +1111,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
  
        aTab.container.tabDragAndDrop.finishAnimateTabMove();
  
-@@ -8247,7 +8523,7 @@
+@@ -8247,7 +8529,7 @@
          // preventDefault(). It will still raise the window if appropriate.
          return;
        }
@@ -1114,7 +1120,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        window.focus();
        aEvent.preventDefault();
      }
-@@ -8264,7 +8540,6 @@
+@@ -8264,7 +8546,6 @@
  
      on_TabGroupCollapse(aEvent) {
        aEvent.target.tabs.forEach(tab => {
@@ -1122,7 +1128,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        });
      }
  
-@@ -8618,7 +8893,9 @@
+@@ -8618,7 +8899,9 @@
  
          let filter = this.#tabFilters.get(tab);
          if (filter) {
@@ -1132,7 +1138,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
  
            let listener = this.#tabListeners.get(tab);
            if (listener) {
-@@ -9423,6 +9700,7 @@
+@@ -9423,6 +9706,7 @@
              aWebProgress.isTopLevel
            ) {
              this._tab.setAttribute("busy", "true");
@@ -1140,7 +1146,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
              gBrowser._tabAttrModified(this._tab, ["busy"]);
              this._tab._notselectedsinceload = !this._tab.selected;
            }
-@@ -9503,6 +9781,7 @@
+@@ -9503,6 +9787,7 @@
          // known defaults. Note we use the original URL since about:newtab
          // redirects to a prerendered page.
          const shouldRemoveFavicon =
@@ -1148,7 +1154,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
            !this._browser.mIconURL &&
            !ignoreBlank &&
            !(originalLocation.spec in FAVICON_DEFAULTS);
-@@ -9677,13 +9956,6 @@
+@@ -9677,13 +9962,6 @@
              this._browser.originalURI = aRequest.originalURI;
            }
  
@@ -1162,7 +1168,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
          }
  
          let userContextId = this._browser.getAttribute("usercontextid") || 0;
-@@ -10532,7 +10804,8 @@ var TabContextMenu = {
+@@ -10532,7 +10810,8 @@ var TabContextMenu = {
      );
      contextUnpinSelectedTabs.hidden =
        !this.contextTab.pinned || !this.multiselected;

--- a/src/zen/common/ZenPreloadedScripts.js
+++ b/src/zen/common/ZenPreloadedScripts.js
@@ -25,6 +25,8 @@
     "chrome://browser/content/zen-components/ZenPinnedTabManager.mjs",
     "chrome://browser/content/zen-components/ZenViewSplitter.mjs",
     "chrome://browser/content/zen-components/ZenFolders.mjs",
+    "chrome://browser/content/zen-components/ZenTabTree.mjs",
+    "chrome://browser/content/zen-components/ZenTabMultiSelectDrag.mjs",
     "chrome://browser/content/zen-components/ZenEmojiPicker.mjs",
     "chrome://browser/content/zen-components/ZenLiveFoldersUI.mjs",
     "chrome://browser/content/zen-components/ZenDownloadAnimation.mjs",

--- a/src/zen/common/modules/ZenSessionStore.mjs
+++ b/src/zen/common/modules/ZenSessionStore.mjs
@@ -20,6 +20,12 @@ class ZenSessionStore extends nsZenPreloadedFeature {
     if (tabData.zenLiveFolderItemId) {
       tab.setAttribute("zen-live-folder-item-id", tabData.zenLiveFolderItemId);
     }
+    if (tabData.zenTreeParentId) {
+      tab.setAttribute("zen-tree-parent-id", tabData.zenTreeParentId);
+    }
+    if (tabData.zenTreeCollapsed) {
+      tab.setAttribute("zen-tree-collapsed", "true");
+    }
     // Keep for now, for backward compatibility for window sync to work.
     if (tabData.zenSyncId || tabData.zenPinnedId) {
       tab.setAttribute("id", tabData.zenSyncId || tabData.zenPinnedId);

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -1410,10 +1410,15 @@
       if (!draggedTab || !target) {
         return;
       }
+      // movingTabsSet isn't always populated for a manual multiselection drag,
+      // so fall back to the live selection when the dragged tab is multiselected
+      // — otherwise only the primary tab would nest.
       const movingTabsSet = draggedTab._dragData?.movingTabsSet;
       const draggedTabs = movingTabsSet?.size
         ? [...movingTabsSet]
-        : [draggedTab];
+        : draggedTab.multiselected
+          ? gBrowser.selectedTabs
+          : [draggedTab];
       this._dontAnimateTabMove = true;
       this._clearDragOverNest();
       window.gZenTabTree.handleNestDrop(draggedTabs, target);
@@ -1431,7 +1436,9 @@
       const movingTabsSet = draggedTab._dragData?.movingTabsSet;
       const draggedTabs = movingTabsSet?.size
         ? [...movingTabsSet]
-        : [draggedTab];
+        : draggedTab.multiselected
+          ? gBrowser.selectedTabs
+          : [draggedTab];
       const r = this.#dragOverReorder;
       if (r.canDrop) {
         // Apply the exact anchor + level the indicator resolved.

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -108,13 +108,32 @@
         this,
         "_dndNestToSplitDelay",
         "zen.tab-tree.drag-nest-to-split-delayMC",
-        300
+        500
       );
       XPCOMUtils.defineLazyPreferenceGetter(
         this,
         "_dndSwitchSpaceDelay",
         "zen.tabs.dnd-switch-space-delay",
         1000
+      );
+      // Read on every dragover/indicator update, so cache them.
+      XPCOMUtils.defineLazyPreferenceGetter(
+        this,
+        "_treeIndentStep",
+        "zen.tab-tree.indent",
+        20
+      );
+      XPCOMUtils.defineLazyPreferenceGetter(
+        this,
+        "_treeSplitZone",
+        "zen.tab-tree.drag-split-zone",
+        25
+      );
+      XPCOMUtils.defineLazyPreferenceGetter(
+        this,
+        "_treeReorderEdge",
+        "zen.tab-tree.drag-reorder-edge",
+        15
       );
 
       ChromeUtils.defineESModuleGetters(
@@ -928,7 +947,7 @@
       // preview whose level follows the cursor horizontally — drag left to
       // outdent, all the way to root level 0.
       const edgeZoneThreshold =
-        Services.prefs.getIntPref("zen.tab-tree.drag-reorder-edge", 15) / 100;
+        this._treeReorderEdge / 100;
       const overlapRatioY = (clientY - rect.top) / rect.height;
       if (
         overlapRatioY < edgeZoneThreshold ||
@@ -959,7 +978,7 @@
       // indicator no matter where in the row you release.
       const unNest = canNest && clientX < rect.x - 2;
       const splitZone =
-        Services.prefs.getIntPref("zen.tab-tree.drag-split-zone", 25) / 100;
+        this._treeSplitZone / 100;
       // Either horizontal edge zone arms a split: left puts the dragged tab on
       // the left, right on the right; the middle stays a nest.
       const inLeftZone = clientX < rect.x + rect.width * splitZone;
@@ -1032,7 +1051,7 @@
     // Re-indent the existing native drop indicator to the level the dragged node
     // will land at, so there's a single accurate line rather than a second one.
     #setNativeIndicatorIndent(level0Left, level, rightEdge) {
-      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 20);
+      const indentStep = this._treeIndentStep;
       const left = level0Left + level * indentStep;
       const indicator = gZenPinnedTabManager.dragIndicator;
       indicator.style.setProperty("--indicator-left", `${left}px`);
@@ -1058,7 +1077,7 @@
       while (next && (!tree.isTreeEligible(next) || draggedNodes.has(next))) {
         next = next.nextElementSibling;
       }
-      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 20);
+      const indentStep = this._treeIndentStep;
       const { minLevel, maxLevel, prevLevel } = tree.reorderLevelRange(
         prev,
         next
@@ -1126,7 +1145,7 @@
     // child indent. Re-applied every dragover since the native pass resets it.
     #showNestIndicator(node, rect) {
       const tree = window.gZenTabTree;
-      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 20);
+      const indentStep = this._treeIndentStep;
       const level0Left = rect.left - tree.getLevel(node) * indentStep;
       const indicator = gZenPinnedTabManager.dragIndicator;
       indicator.setAttribute("orientation", "horizontal");
@@ -1593,6 +1612,9 @@
       thisFromGlobal._clearDragOverSplit();
       thisFromGlobal._clearDragOverNest();
       thisFromGlobal._clearDragOverReorder();
+      // Drop the dragstart FLIP snapshot here too, so an aborted drag (never
+      // reaching handle_drop) doesn't hold it until the next drag.
+      thisFromGlobal.#flipStart = null;
       const tree = ownerGlobal.gZenTabTree;
       if (tree?.enabled) {
         tree._dragActive = false;

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -823,13 +823,46 @@
 
       const dt = event.dataTransfer;
       const draggedTab = dt.mozGetDataAt(TAB_DROP_TYPE, 0);
-      if (!isTab(draggedTab)) {
+      // A split group is dragged via its tab-group label element; resolve that to
+      // the group so it can be nested/reordered as one node.
+      const draggedNode = isTabGroupLabel(draggedTab)
+        ? draggedTab.group
+        : draggedTab;
+      if (
+        !isTab(draggedTab) &&
+        !window.gZenTabTree?.isSplitGroup(draggedNode)
+      ) {
         return;
       }
 
       const dragData = draggedTab._dragData;
       const movingTabsSet = dragData.movingTabsSet;
-      const dropElement = event.target.closest(".tabbrowser-tab");
+      const tree = window.gZenTabTree;
+      const nodeOf = t => (tree?.enabled ? tree.treeNodeFor(t) : t);
+      // A split/group drag leaves movingTabsSet empty, so fall back to the primary
+      // dragged node (matching the drop handlers); otherwise the tree path resolves
+      // to nothing for splits.
+      const draggedSource = movingTabsSet?.size
+        ? [...movingTabsSet]
+        : [draggedNode];
+      const draggedNodes = new Set(draggedSource.map(nodeOf));
+
+      let dropElement = event.target.closest(".tabbrowser-tab");
+      // Below the last non-dragged tab there's nothing to hit, so target its bottom
+      // edge — that's what lets you reorder/outdent at the very bottom even when the
+      // list ends in a nested branch (and works when dragging the last tab itself).
+      // Once the cursor is clearly below the list it's the root area, so snap to 0.
+      let belowList = false;
+      if (!dropElement && tree?.enabled) {
+        const lastTab = tree.lastDropTab(draggedNodes);
+        if (lastTab) {
+          const r = window.windowUtils.getBoundsWithoutFlushing(lastTab);
+          if (event.clientY >= r.bottom) {
+            dropElement = lastTab;
+            belowList = event.clientY >= r.bottom + 6;
+          }
+        }
+      }
 
       // TODO: After Cheff adds split view support for essentials, don't forget to remove the check
       if (
@@ -840,11 +873,14 @@
         dropElement.hasAttribute("zen-live-folder-item-id") ||
         draggedTab.hasAttribute("zen-live-folder-item-id")
       ) {
-        this.#clearAllDragOverTree();
+        this._clearDragOverSplit();
+        this._clearDragOverNest();
+        // Keep the last reorder level: when the cursor moves into the empty space
+        // past the last tab, the drop should still honor the level you dialed in
+        // (e.g. outdent to root), not snap back to nesting under the last tab.
         return;
       }
 
-      const tree = window.gZenTabTree;
       // With the tree on, a split group is a single node: target/drag its group
       // element. With the tree off, keep the old behavior of ignoring splits.
       if (
@@ -855,9 +891,7 @@
         this.#clearAllDragOverTree();
         return;
       }
-      const nodeOf = t => (tree?.enabled ? tree.treeNodeFor(t) : t);
       const targetNode = nodeOf(dropElement);
-      const draggedNodes = new Set([...movingTabsSet].map(nodeOf));
       if (draggedNodes.has(targetNode)) {
         this.#clearAllDragOverTree();
         return;
@@ -884,7 +918,8 @@
             targetNode,
             overlapRatioY < edgeZoneThreshold,
             clientX,
-            draggedNodes
+            draggedNodes,
+            belowList ? 0 : null
           );
         } else {
           this._clearDragOverReorder();
@@ -899,30 +934,42 @@
       const canNest = treeOk && tree.isTreeEligible(targetNode);
       const splitZone =
         Services.prefs.getIntPref("zen.tab-tree.drag-split-zone", 25) / 100;
-      const inSplitZone = clientX > rect.x + rect.width * (1 - splitZone);
-      const canSplit = movingTabsSet.size <= 1 && !tree?.isSplitGroup(targetNode);
+      // Either horizontal edge zone arms a split: left puts the dragged tab on
+      // the left, right on the right; the middle stays a nest.
+      const inLeftZone = clientX < rect.x + rect.width * splitZone;
+      const inRightZone = clientX > rect.x + rect.width * (1 - splitZone);
+      const inSplitZone = inLeftZone || inRightZone;
+      const dropSide = inLeftZone ? "left" : "right";
+      const draggedIsSplit = [...draggedNodes].some(n =>
+        tree?.isSplitGroup(n)
+      );
+      const canSplit =
+        draggedSource.length <= 1 &&
+        !draggedIsSplit &&
+        !tree?.isSplitGroup(targetNode);
 
-      if (this.#dragOverSplit.data?.dropElement !== dropElement) {
+      if (
+        this.#dragOverSplit.data?.dropElement !== dropElement ||
+        this.#dragOverSplit.data?.dropSide !== dropSide
+      ) {
         this._clearDragOverSplit();
       }
       const splitEscalated = !!this.#dragOverSplit.canDrop;
 
       if (canNest && !splitEscalated) {
-        if (this.#dragOverNest.dropElement !== targetNode) {
-          this.#createNestIndicator(targetNode);
-        }
+        this.#showNestIndicator(targetNode, rect);
       } else if (!canNest) {
         this._clearDragOverNest();
       }
 
       if (inSplitZone && canSplit) {
         if (!this.#dragOverSplit.timer && !splitEscalated) {
-          this.#dragOverSplit.data = { dropElement, dropSide: "right" };
+          this.#dragOverSplit.data = { dropElement, dropSide };
           this.#dragOverSplit.timer = setTimeout(
             () => {
               this.#dragOverSplit.timer = null;
               this._clearDragOverNest();
-              this.#createFakeTabSplit(dropElement, "right");
+              this.#createFakeTabSplit(dropElement, dropSide);
             },
             canNest ? this._dndNestToSplitDelay : this._dndSplitDelay
           );
@@ -930,8 +977,8 @@
       } else if (!inSplitZone) {
         // Left the split zone: cancel any pending/active split, restore nest.
         this._clearDragOverSplit();
-        if (canNest && this.#dragOverNest.dropElement !== targetNode) {
-          this.#createNestIndicator(targetNode);
+        if (canNest) {
+          this.#showNestIndicator(targetNode, rect);
         }
       }
     }
@@ -942,45 +989,58 @@
       this._clearDragOverReorder();
     }
 
-    // Show the reorder drop line in the gap above (`before`) or below the target
-    // node, indented to the level chosen by the cursor's horizontal position. The
-    // eligible node just above that gap bounds how deep the drop can nest.
-    #updateReorderIndicator(node, before, clientX, draggedNodes) {
+    // Re-indent the existing native drop indicator to the level the dragged node
+    // will land at, so there's a single accurate line rather than a second one.
+    #setNativeIndicatorIndent(level0Left, level, rightEdge) {
+      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 14);
+      const left = level0Left + level * indentStep;
+      const indicator = gZenPinnedTabManager.dragIndicator;
+      indicator.style.setProperty("--indicator-left", `${left}px`);
+      indicator.style.setProperty(
+        "--indicator-width",
+        `${Math.max(40, rightEdge - left)}px`
+      );
+    }
+
+    // Reorder: the native drag already placed its line in the gap; shift only its
+    // indent to the level chosen by the cursor's horizontal position. Default is
+    // a sibling of the node above the gap; drag right to nest under it, left to
+    // outdent toward root level 0.
+    #updateReorderIndicator(node, before, clientX, draggedNodes, forceLevel) {
       const tree = window.gZenTabTree;
       let prev = before ? node.previousElementSibling : node;
       while (prev && (!tree.isTreeEligible(prev) || draggedNodes.has(prev))) {
         prev = prev.previousElementSibling;
       }
+      // The eligible node just below the gap bounds how shallow the drop can go:
+      // dropping shallower than it would orphan it from its branch.
+      let next = before ? node : node.nextElementSibling;
+      while (next && (!tree.isTreeEligible(next) || draggedNodes.has(next))) {
+        next = next.nextElementSibling;
+      }
       const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 14);
-      const maxLevel = prev ? tree.getLevel(prev) + 1 : 0;
-      let level = 0;
+      const prevLevel = prev ? tree.getLevel(prev) : 0;
+      const maxLevel = prev ? prevLevel + 1 : 0;
+      const minLevel = Math.min(next ? tree.getLevel(next) : 0, maxLevel);
+      let level = prevLevel;
       if (prev) {
         const prevRect = window.windowUtils.getBoundsWithoutFlushing(prev);
-        const baseX = prevRect.x - tree.getLevel(prev) * indentStep;
-        level = Math.round((clientX - baseX) / indentStep);
+        // forceLevel pins the level (e.g. root, when dragging below the list);
+        // otherwise anchor "sibling" at the tab-above's content so hovering its
+        // row keeps the sibling level, a clear drag right nests, left outdents.
+        const steps =
+          forceLevel != null
+            ? forceLevel - prevLevel
+            : Math.round((clientX - (prevRect.x + indentStep)) / indentStep);
+        level = Math.max(minLevel, Math.min(prevLevel + steps, maxLevel));
+        const level0Left = prevRect.left - prevLevel * indentStep;
+        this.#setNativeIndicatorIndent(level0Left, level, prevRect.right);
       }
-      level = Math.max(0, Math.min(level, maxLevel));
-
-      this.#clearReorderIndicatorElement();
-      const indicator = document.createXULElement("zen-tree-nest-indicator");
-      indicator.style.marginInlineStart = `${level * indentStep}px`;
-      if (before) {
-        node.before(indicator);
-      } else {
-        node.after(indicator);
-      }
-      this.#dragOverReorder.indicator = indicator;
       this.#dragOverReorder.level = level;
       this.#dragOverReorder.canDrop = true;
     }
 
-    #clearReorderIndicatorElement() {
-      this.#dragOverReorder.indicator?.remove();
-      this.#dragOverReorder.indicator = null;
-    }
-
     _clearDragOverReorder() {
-      this.#clearReorderIndicatorElement();
       this.#dragOverReorder.level = null;
       this.#dragOverReorder.canDrop = null;
     }
@@ -1018,27 +1078,30 @@
       this.#dragOverSplit.canDrop = null;
     }
 
-    #createNestIndicator(node) {
-      this.#clearNestIndicatorElement();
-      const indicator = document.createXULElement("zen-tree-nest-indicator");
-      const level = (window.gZenTabTree?.getLevel(node) ?? 0) + 1;
+    // Nest: outline the target row and move the native line just below it, at the
+    // child indent. Re-applied every dragover since the native pass resets it.
+    #showNestIndicator(node, rect) {
+      const tree = window.gZenTabTree;
       const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 14);
-      indicator.style.marginInlineStart = `${level * indentStep}px`;
-      node.after(indicator);
-      node.toggleAttribute("zen-tree-nest-target", true);
-      this.#dragOverNest.indicator = indicator;
+      const level0Left = rect.left - tree.getLevel(node) * indentStep;
+      const indicator = gZenPinnedTabManager.dragIndicator;
+      indicator.setAttribute("orientation", "horizontal");
+      indicator.style.top = `${Math.round(rect.bottom)}px`;
+      this.#setNativeIndicatorIndent(
+        level0Left,
+        tree.getLevel(node) + 1,
+        rect.right
+      );
+      if (this.#dragOverNest.dropElement !== node) {
+        this.#dragOverNest.dropElement?.removeAttribute("zen-tree-nest-target");
+        node.toggleAttribute("zen-tree-nest-target", true);
+      }
       this.#dragOverNest.dropElement = node;
       this.#dragOverNest.canDrop = true;
     }
 
-    #clearNestIndicatorElement() {
-      this.#dragOverNest.indicator?.remove();
-      this.#dragOverNest.indicator = null;
-      this.#dragOverNest.dropElement?.removeAttribute("zen-tree-nest-target");
-    }
-
     _clearDragOverNest() {
-      this.#clearNestIndicatorElement();
+      this.#dragOverNest.dropElement?.removeAttribute("zen-tree-nest-target");
       this.#dragOverNest.dropElement = null;
       this.#dragOverNest.canDrop = null;
     }

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -193,10 +193,9 @@
       if (!descendants.length) {
         return;
       }
-      // Select the whole branch so the move-together machinery drags it as one
-      // block. Remember the root so dragend can restore the selection. The
-      // container is marked so this auto-selection doesn't render as a manual
-      // multiselect highlight on the in-place tabs.
+      // Select the whole branch so move-together drags it as one block. Remember
+      // the root for dragend, and mark the container so this auto-selection isn't
+      // rendered as a manual multiselect highlight.
       tree._branchDragRoot = tab;
       gBrowser.clearMultiSelectedTabs();
       gBrowser.addToMultiSelectedTabs(tab);

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -1033,7 +1033,7 @@
     // Re-indent the existing native drop indicator to the level the dragged node
     // will land at, so there's a single accurate line rather than a second one.
     #setNativeIndicatorIndent(level0Left, level, rightEdge) {
-      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 14);
+      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 20);
       const left = level0Left + level * indentStep;
       const indicator = gZenPinnedTabManager.dragIndicator;
       indicator.style.setProperty("--indicator-left", `${left}px`);
@@ -1059,7 +1059,7 @@
       while (next && (!tree.isTreeEligible(next) || draggedNodes.has(next))) {
         next = next.nextElementSibling;
       }
-      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 14);
+      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 20);
       const { minLevel, maxLevel, prevLevel } = tree.reorderLevelRange(
         prev,
         next
@@ -1127,7 +1127,7 @@
     // child indent. Re-applied every dragover since the native pass resets it.
     #showNestIndicator(node, rect) {
       const tree = window.gZenTabTree;
-      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 14);
+      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 20);
       const level0Left = rect.left - tree.getLevel(node) * indentStep;
       const indicator = gZenPinnedTabManager.dragIndicator;
       indicator.setAttribute("orientation", "horizontal");

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -146,6 +146,12 @@
       this.ZenDragAndDropService.onDragStart(1);
       this.#isOutOfWindow = false;
       gZenCompactModeManager._isTabBeingDragged = true;
+      // Dragging a tree parent grabs its whole branch (selected as a group so
+      // it moves together visually). Tree structure is retained on drop.
+      this.#maybeSelectTreeBranch(tab);
+      if (window.gZenTabTree?.enabled) {
+        window.gZenTabTree._dragActive = true;
+      }
       super.startTabDrag(event, tab, ...args);
       const dt = event.dataTransfer;
       if (isTabGroupLabel(tab)) {
@@ -163,6 +169,31 @@
       if (tab.hasAttribute("zen-essential")) {
         tab.style.visibility = "hidden";
       }
+    }
+
+    #maybeSelectTreeBranch(tab) {
+      const tree = window.gZenTabTree;
+      if (
+        !tree?.enabled ||
+        tab.multiselected ||
+        isTabGroupLabel(tab) ||
+        !tree.isTreeEligible(tab)
+      ) {
+        return;
+      }
+      const descendants = tree.getDescendants(tab);
+      if (!descendants.length) {
+        return;
+      }
+      // Select the whole branch so the move-together machinery drags it as one
+      // block. Remember the root so dragend can restore the selection.
+      tree._branchDragRoot = tab;
+      gBrowser.clearMultiSelectedTabs();
+      gBrowser.addToMultiSelectedTabs(tab);
+      for (const d of descendants) {
+        gBrowser.addToMultiSelectedTabs(d);
+      }
+      gBrowser.lastMultiSelectedTab = tab;
     }
 
     #createDragImageForTabs(movingTabs) {
@@ -1024,11 +1055,13 @@
       super.handle_drop(event);
       this.#maybeClearVerticalPinnedGridDragOver();
       this.#handle_dropSwitchSpace(event);
-      // Split wins if the hold escalated; otherwise try a nest.
+      // Split wins if the hold escalated; else nest; else a tree-aware reorder.
       if (this.#dragOverSplit.canDrop) {
         this.#handle_dropCreateSplit(event);
-      } else {
+      } else if (this.#dragOverNest.canDrop) {
         this.#handle_dropNest(event);
+      } else {
+        this.#handle_dropReorder(event);
       }
       this._clearDragOverSplit();
       this._clearDragOverNest();
@@ -1105,6 +1138,22 @@
       this._dontAnimateTabMove = true;
       this._clearDragOverNest();
       window.gZenTabTree.handleNestDrop(draggedTabs, target);
+    }
+
+    #handle_dropReorder(event) {
+      if (!window.gZenTabTree?.enabled) {
+        return;
+      }
+      const dt = event.dataTransfer;
+      const draggedTab = dt.mozGetDataAt(TAB_DROP_TYPE, 0);
+      if (!draggedTab) {
+        return;
+      }
+      const movingTabsSet = draggedTab._dragData?.movingTabsSet;
+      const draggedTabs = movingTabsSet?.size
+        ? [...movingTabsSet]
+        : [draggedTab];
+      window.gZenTabTree.handleReorderDrop(draggedTabs);
     }
 
     handle_drop_transition(dropElement, draggedTab, movingTabs, dropBefore) {
@@ -1269,6 +1318,19 @@
       ownerGlobal.gZenPinnedTabManager.removeTabContainersDragoverClass();
       thisFromGlobal._clearDragOverSplit();
       thisFromGlobal._clearDragOverNest();
+      const tree = ownerGlobal.gZenTabTree;
+      if (tree?.enabled) {
+        tree._dragActive = false;
+        if (tree._branchDragRoot) {
+          const root = tree._branchDragRoot;
+          tree._branchDragRoot = null;
+          // Restore selection to just the branch root after a branch drag.
+          ownerGlobal.gBrowser.clearMultiSelectedTabs();
+          if (root.isConnected) {
+            ownerGlobal.gBrowser.lastMultiSelectedTab = root;
+          }
+        }
+      }
       this.#maybeClearVerticalPinnedGridDragOver();
       thisFromGlobal.originalDragImageArgs = [];
       this.#firstHapticFeedbackPlayed = false;

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -850,6 +850,7 @@
       });
     }
 
+    // eslint-disable-next-line complexity -- inherently branchy drag-over-split state machine
     #handle_tabDragOverToSplit(event) {
       if (!this._dndSplitEnabled) {
         return;
@@ -947,8 +948,7 @@
       // Vertical edges reorder (drop in the gap above/below), with a live indent
       // preview whose level follows the cursor horizontally — drag left to
       // outdent, all the way to root level 0.
-      const edgeZoneThreshold =
-        this._treeReorderEdge / 100;
+      const edgeZoneThreshold = this._treeReorderEdge / 100;
       const overlapRatioY = (clientY - rect.top) / rect.height;
       if (
         overlapRatioY < edgeZoneThreshold ||
@@ -978,17 +978,14 @@
       // reorder line instead of nesting under the target, so the drop matches the
       // indicator no matter where in the row you release.
       const unNest = canNest && clientX < rect.x - 2;
-      const splitZone =
-        this._treeSplitZone / 100;
+      const splitZone = this._treeSplitZone / 100;
       // Either horizontal edge zone arms a split: left puts the dragged tab on
       // the left, right on the right; the middle stays a nest.
       const inLeftZone = clientX < rect.x + rect.width * splitZone;
       const inRightZone = clientX > rect.x + rect.width * (1 - splitZone);
       const inSplitZone = inLeftZone || inRightZone;
       const dropSide = inLeftZone ? "left" : "right";
-      const draggedIsSplit = [...draggedNodes].some(n =>
-        tree?.isSplitGroup(n)
-      );
+      const draggedIsSplit = [...draggedNodes].some(n => tree?.isSplitGroup(n));
       const canSplit =
         draggedSource.length <= 1 &&
         !draggedIsSplit &&
@@ -1026,7 +1023,13 @@
         // Left the split zone: cancel any pending/active split, restore nest.
         this._clearDragOverSplit();
         if (canNest) {
-          this.#showNestOrUnnest(targetNode, rect, clientX, draggedNodes, unNest);
+          this.#showNestOrUnnest(
+            targetNode,
+            rect,
+            clientX,
+            draggedNodes,
+            unNest
+          );
         }
       }
     }
@@ -1238,7 +1241,8 @@
       const seen = new Set();
       for (const tab of gBrowser.tabs) {
         if (
-          tab.getAttribute("zen-workspace-id") != gZenWorkspaces.activeWorkspace ||
+          tab.getAttribute("zen-workspace-id") !=
+            gZenWorkspaces.activeWorkspace ||
           !tab.visible
         ) {
           continue;
@@ -1318,7 +1322,8 @@
         !gReduceMotion &&
         draggedTab?.ownerGlobal === window &&
         (isTab(draggedTab) || isTabGroupLabel(draggedTab)) &&
-        wsRef?.getAttribute("zen-workspace-id") == gZenWorkspaces.activeWorkspace;
+        wsRef?.getAttribute("zen-workspace-id") ==
+          gZenWorkspaces.activeWorkspace;
       if (doFlip) {
         this.#flipInProgress = true;
       }
@@ -1401,6 +1406,17 @@
       );
     }
 
+    // The tabs a drag actually moves: an explicit movingTabsSet, else the live
+    // multiselection (a manual multiselect drag doesn't always populate the set,
+    // so the primary tab alone would be wrong), else just the dragged tab.
+    #draggedTabsFrom(draggedTab) {
+      const movingTabsSet = draggedTab._dragData?.movingTabsSet;
+      if (movingTabsSet?.size) {
+        return [...movingTabsSet];
+      }
+      return draggedTab.multiselected ? gBrowser.selectedTabs : [draggedTab];
+    }
+
     #handle_dropNest(event) {
       if (!this.#dragOverNest.canDrop || !window.gZenTabTree?.enabled) {
         return;
@@ -1411,15 +1427,7 @@
       if (!draggedTab || !target) {
         return;
       }
-      // movingTabsSet isn't always populated for a manual multiselection drag,
-      // so fall back to the live selection when the dragged tab is multiselected
-      // — otherwise only the primary tab would nest.
-      const movingTabsSet = draggedTab._dragData?.movingTabsSet;
-      const draggedTabs = movingTabsSet?.size
-        ? [...movingTabsSet]
-        : draggedTab.multiselected
-          ? gBrowser.selectedTabs
-          : [draggedTab];
+      const draggedTabs = this.#draggedTabsFrom(draggedTab);
       this._dontAnimateTabMove = true;
       this._clearDragOverNest();
       window.gZenTabTree.handleNestDrop(draggedTabs, target);
@@ -1434,12 +1442,7 @@
       if (!draggedTab) {
         return;
       }
-      const movingTabsSet = draggedTab._dragData?.movingTabsSet;
-      const draggedTabs = movingTabsSet?.size
-        ? [...movingTabsSet]
-        : draggedTab.multiselected
-          ? gBrowser.selectedTabs
-          : [draggedTab];
+      const draggedTabs = this.#draggedTabsFrom(draggedTab);
       const r = this.#dragOverReorder;
       if (r.canDrop) {
         // Apply the exact anchor + level the indicator resolved.
@@ -1449,6 +1452,7 @@
       }
     }
 
+    // eslint-disable-next-line complexity -- linear element-shape settle reads clearer unsplit
     handle_drop_transition(dropElement, draggedTab, movingTabs, dropBefore) {
       // A tree drop owns its own FLIP animation; here just settle transforms so
       // it starts from clean positions (no native per-tab slide to fight with).

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -121,7 +121,7 @@
         this,
         "_treeIndentStep",
         "zen.tab-tree.indent",
-        20
+        14
       );
       XPCOMUtils.defineLazyPreferenceGetter(
         this,

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -73,6 +73,8 @@
     #dragOverSplit = {};
     #dragOverNest = {};
     #dragOverReorder = {};
+    #flipInProgress = false;
+    #flipStart = null;
 
     constructor(tabbrowserTabs) {
       super(tabbrowserTabs);
@@ -147,6 +149,11 @@
       this.ZenDragAndDropService.onDragStart(1);
       this.#isOutOfWindow = false;
       gZenCompactModeManager._isTabBeingDragged = true;
+      // Snapshot the resting layout now, before the native drag shifts anything,
+      // so a tree drop can FLIP-animate from where tabs actually were.
+      this.#flipStart = window.gZenTabTree?.enabled
+        ? this.#captureTreeFlip()
+        : null;
       // Dragging a tree parent grabs its whole branch (selected as a group so
       // it moves together visually). Tree structure is retained on drop.
       this.#maybeSelectTreeBranch(tab);
@@ -187,14 +194,23 @@
         return;
       }
       // Select the whole branch so the move-together machinery drags it as one
-      // block. Remember the root so dragend can restore the selection.
+      // block. Remember the root so dragend can restore the selection. The
+      // container is marked so this auto-selection doesn't render as a manual
+      // multiselect highlight on the in-place tabs.
       tree._branchDragRoot = tab;
       gBrowser.clearMultiSelectedTabs();
       gBrowser.addToMultiSelectedTabs(tab);
       for (const d of descendants) {
-        gBrowser.addToMultiSelectedTabs(d);
+        if (tree.isSplitGroup(d)) {
+          for (const t of d.tabs) {
+            gBrowser.addToMultiSelectedTabs(t);
+          }
+        } else {
+          gBrowser.addToMultiSelectedTabs(d);
+        }
       }
       gBrowser.lastMultiSelectedTab = tab;
+      this._tabbrowserTabs.setAttribute("zen-branch-dragging", "true");
     }
 
     #createDragImageForTabs(movingTabs) {
@@ -893,7 +909,14 @@
       }
       const targetNode = nodeOf(dropElement);
       if (draggedNodes.has(targetNode)) {
-        this.#clearAllDragOverTree();
+        // Hovering over the tree we're dragging is not a drop target: hide the
+        // live nest/split visuals and the reorder line so there's no misleading
+        // preview over our own branch. KEEP the last resolved reorder anchor,
+        // though, so releasing here still honors the level already dialed in over
+        // a valid neighbor instead of falling back to re-nesting under it.
+        this._clearDragOverSplit();
+        this._clearDragOverNest();
+        gZenPinnedTabManager.removeTabContainersDragoverClass();
         return;
       }
 
@@ -905,7 +928,8 @@
       // Vertical edges reorder (drop in the gap above/below), with a live indent
       // preview whose level follows the cursor horizontally — drag left to
       // outdent, all the way to root level 0.
-      const edgeZoneThreshold = this._dndSplitThreshold / 100;
+      const edgeZoneThreshold =
+        Services.prefs.getIntPref("zen.tab-tree.drag-reorder-edge", 15) / 100;
       const overlapRatioY = (clientY - rect.top) / rect.height;
       if (
         overlapRatioY < edgeZoneThreshold ||
@@ -930,8 +954,11 @@
       // Central band nests under the target. Only a normal tab's rightmost zone
       // arms split (you can't split into an existing split), and only after a
       // deliberate hold; everywhere else stays a tree action.
-      this._clearDragOverReorder();
       const canNest = treeOk && tree.isTreeEligible(targetNode);
+      // Left of the (indented) target row means dragging shallower: un-nest via a
+      // reorder line instead of nesting under the target, so the drop matches the
+      // indicator no matter where in the row you release.
+      const unNest = canNest && clientX < rect.x - 2;
       const splitZone =
         Services.prefs.getIntPref("zen.tab-tree.drag-split-zone", 25) / 100;
       // Either horizontal edge zone arms a split: left puts the dragged tab on
@@ -957,9 +984,10 @@
       const splitEscalated = !!this.#dragOverSplit.canDrop;
 
       if (canNest && !splitEscalated) {
-        this.#showNestIndicator(targetNode, rect);
+        this.#showNestOrUnnest(targetNode, rect, clientX, draggedNodes, unNest);
       } else if (!canNest) {
         this._clearDragOverNest();
+        this._clearDragOverReorder();
       }
 
       if (inSplitZone && canSplit) {
@@ -969,6 +997,7 @@
             () => {
               this.#dragOverSplit.timer = null;
               this._clearDragOverNest();
+              this._clearDragOverReorder();
               this.#createFakeTabSplit(dropElement, dropSide);
             },
             canNest ? this._dndNestToSplitDelay : this._dndSplitDelay
@@ -978,8 +1007,20 @@
         // Left the split zone: cancel any pending/active split, restore nest.
         this._clearDragOverSplit();
         if (canNest) {
-          this.#showNestIndicator(targetNode, rect);
+          this.#showNestOrUnnest(targetNode, rect, clientX, draggedNodes, unNest);
         }
+      }
+    }
+
+    // In the central band, nest under the target, or — when dragged left of its
+    // row — show a reorder line to un-nest, so the indicator and the drop agree.
+    #showNestOrUnnest(targetNode, rect, clientX, draggedNodes, unNest) {
+      if (unNest) {
+        this._clearDragOverNest();
+        this.#updateReorderIndicator(targetNode, false, clientX, draggedNodes);
+      } else {
+        this._clearDragOverReorder();
+        this.#showNestIndicator(targetNode, rect);
       }
     }
 
@@ -1019,9 +1060,10 @@
         next = next.nextElementSibling;
       }
       const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 14);
-      const prevLevel = prev ? tree.getLevel(prev) : 0;
-      const maxLevel = prev ? prevLevel + 1 : 0;
-      const minLevel = Math.min(next ? tree.getLevel(next) : 0, maxLevel);
+      const { minLevel, maxLevel, prevLevel } = tree.reorderLevelRange(
+        prev,
+        next
+      );
       let level = prevLevel;
       if (prev) {
         const prevRect = window.windowUtils.getBoundsWithoutFlushing(prev);
@@ -1036,11 +1078,14 @@
         const level0Left = prevRect.left - prevLevel * indentStep;
         this.#setNativeIndicatorIndent(level0Left, level, prevRect.right);
       }
+      // Remember the resolved anchor + level so the drop lands exactly here.
+      this.#dragOverReorder.prev = prev;
       this.#dragOverReorder.level = level;
       this.#dragOverReorder.canDrop = true;
     }
 
     _clearDragOverReorder() {
+      this.#dragOverReorder.prev = null;
       this.#dragOverReorder.level = null;
       this.#dragOverReorder.canDrop = null;
     }
@@ -1165,11 +1210,70 @@
       });
     }
 
+    // The movable elements of the active strip: a normal tab moves itself, a
+    // split tab moves its whole group. Derived from the tab list (not
+    // ariaFocusableItems) so split groups, which aren't aria-focusable, are
+    // included and get animated too.
+    #flipMovableElements() {
+      const els = [];
+      const seen = new Set();
+      for (const tab of gBrowser.tabs) {
+        if (
+          tab.getAttribute("zen-workspace-id") != gZenWorkspaces.activeWorkspace ||
+          !tab.visible
+        ) {
+          continue;
+        }
+        const el = elementToMove(tab);
+        if (el && !seen.has(el)) {
+          seen.add(el);
+          els.push(el);
+        }
+      }
+      return els;
+    }
+
+    // Snapshot every movable element's on-screen box so a tree drop can
+    // FLIP-animate each one from here to wherever it lands.
+    #captureTreeFlip() {
+      const before = new Map();
+      for (const el of this.#flipMovableElements()) {
+        before.set(el, window.windowUtils.getBoundsWithoutFlushing(el));
+      }
+      return before;
+    }
+
+    // Animate each element from its pre-drop box to its final one in a single
+    // motion, so the dragged branch (including split groups) and the tabs it
+    // displaces all slide straight to their places instead of through the tree.
+    #playTreeFlip(before) {
+      // The drop just moved tabs in the DOM; force a layout flush so the final
+      // boxes are real (getBoundsWithoutFlushing would otherwise read stale 0s).
+      this._tabbrowserTabs.getBoundingClientRect();
+      for (const el of this.#flipMovableElements()) {
+        const old = before.get(el);
+        if (!old) {
+          continue;
+        }
+        const now = window.windowUtils.getBoundsWithoutFlushing(el);
+        const dx = old.left - now.left;
+        const dy = old.top - now.top;
+        if (Math.abs(dx) < 1 && Math.abs(dy) < 1) {
+          continue;
+        }
+        el.animate(
+          [
+            { transform: `translate(${dx}px, ${dy}px)` },
+            { transform: "translate(0, 0)" },
+          ],
+          { duration: 160, easing: "ease-out" }
+        );
+      }
+    }
+
     handle_drop(event) {
-      const ownerGlobal = event.dataTransfer.mozGetDataAt(
-        TAB_DROP_TYPE,
-        0
-      )?.documentGlobal;
+      const draggedTab = event.dataTransfer.mozGetDataAt(TAB_DROP_TYPE, 0);
+      const ownerGlobal = draggedTab?.documentGlobal;
       if (ownerGlobal?.gZenCompactModeManager) {
         // Sometimes, dragend doesn't always get called when dragging
         // to different windows, see gh-8643.
@@ -1180,6 +1284,26 @@
       }
       this.clearSpaceSwitchTimer();
       gZenFolders.highlightGroupOnDragOver(null);
+
+      // A same-window, same-space tab/split drop animates as one block via FLIP.
+      // A split is dragged via its group label, which has no workspace id, so
+      // read it from the group's tab instead.
+      const wsRef = isTabGroupLabel(draggedTab)
+        ? draggedTab.group?.querySelector(".tabbrowser-tab")
+        : draggedTab;
+      const flipBefore = this.#flipStart;
+      this.#flipStart = null;
+      const doFlip =
+        flipBefore &&
+        window.gZenTabTree?.enabled &&
+        !gReduceMotion &&
+        draggedTab?.ownerGlobal === window &&
+        (isTab(draggedTab) || isTabGroupLabel(draggedTab)) &&
+        wsRef?.getAttribute("zen-workspace-id") == gZenWorkspaces.activeWorkspace;
+      if (doFlip) {
+        this.#flipInProgress = true;
+      }
+
       super.handle_drop(event);
       this.#maybeClearVerticalPinnedGridDragOver();
       this.#handle_dropSwitchSpace(event);
@@ -1192,6 +1316,16 @@
         this.#handle_dropReorder(event);
       }
       this.#clearAllDragOverTree();
+
+      if (doFlip) {
+        this.#flipInProgress = false;
+        // Settle any leftover drag transforms so the final boxes are measured
+        // cleanly, then FLIP from the resting layout captured at dragstart.
+        for (const el of this.#flipMovableElements()) {
+          el.style.transform = "";
+        }
+        this.#playTreeFlip(flipBefore);
+      }
     }
 
     #handle_dropSwitchSpace(event) {
@@ -1280,13 +1414,24 @@
       const draggedTabs = movingTabsSet?.size
         ? [...movingTabsSet]
         : [draggedTab];
-      const level = this.#dragOverReorder.canDrop
-        ? this.#dragOverReorder.level
-        : null;
-      window.gZenTabTree.handleReorderDrop(draggedTabs, level);
+      const r = this.#dragOverReorder;
+      if (r.canDrop) {
+        // Apply the exact anchor + level the indicator resolved.
+        window.gZenTabTree.handleReorderDropAt(draggedTabs, r.prev, r.level);
+      } else {
+        window.gZenTabTree.handleReorderDrop(draggedTabs, null);
+      }
     }
 
     handle_drop_transition(dropElement, draggedTab, movingTabs, dropBefore) {
+      // A tree drop owns its own FLIP animation; here just settle transforms so
+      // it starts from clean positions (no native per-tab slide to fight with).
+      if (this.#flipInProgress) {
+        for (let item of this._tabbrowserTabs.ariaFocusableItems) {
+          elementToMove(item).style.transform = "";
+        }
+        return;
+      }
       if (
         dropElement?.hasAttribute("zen-empty-tab") &&
         dropElement.group?.isZenFolder
@@ -1452,6 +1597,7 @@
       const tree = ownerGlobal.gZenTabTree;
       if (tree?.enabled) {
         tree._dragActive = false;
+        thisFromGlobal._tabbrowserTabs.removeAttribute("zen-branch-dragging");
         if (tree._branchDragRoot) {
           const root = tree._branchDragRoot;
           tree._branchDragRoot = null;

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -72,6 +72,7 @@
 
     #dragOverSplit = {};
     #dragOverNest = {};
+    #dragOverReorder = {};
 
     constructor(tabbrowserTabs) {
       super(tabbrowserTabs);
@@ -836,89 +837,152 @@
         !isTab(dropElement) ||
         dropElement.hasAttribute("zen-essential") ||
         dropElement.hasAttribute("zen-glance-tab") ||
-        dropElement?.group?.hasAttribute("split-view-group")
+        dropElement.hasAttribute("zen-live-folder-item-id") ||
+        draggedTab.hasAttribute("zen-live-folder-item-id")
       ) {
-        this._clearDragOverSplit();
-        this._clearDragOverNest();
+        this.#clearAllDragOverTree();
         return;
       }
 
+      const tree = window.gZenTabTree;
+      // With the tree on, a split group is a single node: target/drag its group
+      // element. With the tree off, keep the old behavior of ignoring splits.
       if (
-        movingTabsSet.has(dropElement) ||
-        !isTab(draggedTab) ||
-        draggedTab?.group?.hasAttribute("split-view-group") ||
-        draggedTab.hasAttribute("zen-live-folder-item-id") ||
-        dropElement.hasAttribute("zen-live-folder-item-id")
+        !tree?.enabled &&
+        (dropElement.group?.hasAttribute("split-view-group") ||
+          draggedTab.group?.hasAttribute("split-view-group"))
       ) {
-        this._clearDragOverSplit();
-        this._clearDragOverNest();
+        this.#clearAllDragOverTree();
+        return;
+      }
+      const nodeOf = t => (tree?.enabled ? tree.treeNodeFor(t) : t);
+      const targetNode = nodeOf(dropElement);
+      const draggedNodes = new Set([...movingTabsSet].map(nodeOf));
+      if (draggedNodes.has(targetNode)) {
+        this.#clearAllDragOverTree();
         return;
       }
 
-      const rect = window.windowUtils.getBoundsWithoutFlushing(dropElement);
+      const rect = window.windowUtils.getBoundsWithoutFlushing(targetNode);
       const { clientX, clientY } = event;
-      const targetX = rect.x;
-      const targetTop = rect.top;
-      const targetWidth = rect.width;
-      const targetHeight = rect.height;
+      const treeOk =
+        tree?.enabled && [...draggedNodes].every(n => tree.isTreeEligible(n));
 
+      // Vertical edges reorder (drop in the gap above/below), with a live indent
+      // preview whose level follows the cursor horizontally — drag left to
+      // outdent, all the way to root level 0.
       const edgeZoneThreshold = this._dndSplitThreshold / 100;
-
-      const overlapRatioY = (clientY - targetTop) / targetHeight;
+      const overlapRatioY = (clientY - rect.top) / rect.height;
       if (
         overlapRatioY < edgeZoneThreshold ||
         overlapRatioY > 1 - edgeZoneThreshold
       ) {
         this._clearDragOverSplit();
         this._clearDragOverNest();
+        if (treeOk) {
+          this.#updateReorderIndicator(
+            targetNode,
+            overlapRatioY < edgeZoneThreshold,
+            clientX,
+            draggedNodes
+          );
+        } else {
+          this._clearDragOverReorder();
+        }
         return;
       }
 
-      const isLeft = clientX < targetX + targetWidth / 2;
-      const dropSide = isLeft ? "left" : "right";
+      // Central band nests under the target. Only a normal tab's rightmost zone
+      // arms split (you can't split into an existing split), and only after a
+      // deliberate hold; everywhere else stays a tree action.
+      this._clearDragOverReorder();
+      const canNest = treeOk && tree.isTreeEligible(targetNode);
+      const splitZone =
+        Services.prefs.getIntPref("zen.tab-tree.drag-split-zone", 25) / 100;
+      const inSplitZone = clientX > rect.x + rect.width * (1 - splitZone);
+      const canSplit = movingTabsSet.size <= 1 && !tree?.isSplitGroup(targetNode);
 
-      // Central band reached: offer NEST immediately, escalate to SPLIT on hold.
-      const draggedTabs = [...movingTabsSet];
-      const canNest =
-        window.gZenTabTree?.enabled &&
-        window.gZenTabTree.isTreeEligible(dropElement) &&
-        draggedTabs.every(t => window.gZenTabTree.isTreeEligible(t)) &&
-        !movingTabsSet.has(dropElement);
-
-      // If the target/side changed, reset both machines.
-      if (
-        this.#dragOverSplit.data?.dropElement !== dropElement ||
-        this.#dragOverSplit.data?.dropSide !== dropSide
-      ) {
+      if (this.#dragOverSplit.data?.dropElement !== dropElement) {
         this._clearDragOverSplit();
+      }
+      const splitEscalated = !!this.#dragOverSplit.canDrop;
+
+      if (canNest && !splitEscalated) {
+        if (this.#dragOverNest.dropElement !== targetNode) {
+          this.#createNestIndicator(targetNode);
+        }
+      } else if (!canNest) {
         this._clearDragOverNest();
       }
 
-      if (canNest && this.#dragOverNest.dropElement !== dropElement) {
-        this.#createNestIndicator(dropElement);
-      }
-
-      // (Re)arm the escalation-to-split timer (split only supports one tab).
-      const canSplit = movingTabsSet.size <= 1;
-      if (
-        canSplit &&
-        (!this.#dragOverSplit.timer ||
-          this.#dragOverSplit.data?.dropElement !== dropElement ||
-          this.#dragOverSplit.data?.dropSide !== dropSide)
-      ) {
-        if (this.#dragOverSplit.timer) {
-          clearTimeout(this.#dragOverSplit.timer);
+      if (inSplitZone && canSplit) {
+        if (!this.#dragOverSplit.timer && !splitEscalated) {
+          this.#dragOverSplit.data = { dropElement, dropSide: "right" };
+          this.#dragOverSplit.timer = setTimeout(
+            () => {
+              this.#dragOverSplit.timer = null;
+              this._clearDragOverNest();
+              this.#createFakeTabSplit(dropElement, "right");
+            },
+            canNest ? this._dndNestToSplitDelay : this._dndSplitDelay
+          );
         }
-        this.#dragOverSplit.data = { dropElement, dropSide };
-        this.#dragOverSplit.timer = setTimeout(
-          () => {
-            // Escalate: drop the nest offer, show the split fake-tab.
-            this._clearDragOverNest();
-            this.#createFakeTabSplit(dropElement, dropSide);
-          },
-          canNest ? this._dndNestToSplitDelay : this._dndSplitDelay
-        );
+      } else if (!inSplitZone) {
+        // Left the split zone: cancel any pending/active split, restore nest.
+        this._clearDragOverSplit();
+        if (canNest && this.#dragOverNest.dropElement !== targetNode) {
+          this.#createNestIndicator(targetNode);
+        }
       }
+    }
+
+    #clearAllDragOverTree() {
+      this._clearDragOverSplit();
+      this._clearDragOverNest();
+      this._clearDragOverReorder();
+    }
+
+    // Show the reorder drop line in the gap above (`before`) or below the target
+    // node, indented to the level chosen by the cursor's horizontal position. The
+    // eligible node just above that gap bounds how deep the drop can nest.
+    #updateReorderIndicator(node, before, clientX, draggedNodes) {
+      const tree = window.gZenTabTree;
+      let prev = before ? node.previousElementSibling : node;
+      while (prev && (!tree.isTreeEligible(prev) || draggedNodes.has(prev))) {
+        prev = prev.previousElementSibling;
+      }
+      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 14);
+      const maxLevel = prev ? tree.getLevel(prev) + 1 : 0;
+      let level = 0;
+      if (prev) {
+        const prevRect = window.windowUtils.getBoundsWithoutFlushing(prev);
+        const baseX = prevRect.x - tree.getLevel(prev) * indentStep;
+        level = Math.round((clientX - baseX) / indentStep);
+      }
+      level = Math.max(0, Math.min(level, maxLevel));
+
+      this.#clearReorderIndicatorElement();
+      const indicator = document.createXULElement("zen-tree-nest-indicator");
+      indicator.style.marginInlineStart = `${level * indentStep}px`;
+      if (before) {
+        node.before(indicator);
+      } else {
+        node.after(indicator);
+      }
+      this.#dragOverReorder.indicator = indicator;
+      this.#dragOverReorder.level = level;
+      this.#dragOverReorder.canDrop = true;
+    }
+
+    #clearReorderIndicatorElement() {
+      this.#dragOverReorder.indicator?.remove();
+      this.#dragOverReorder.indicator = null;
+    }
+
+    _clearDragOverReorder() {
+      this.#clearReorderIndicatorElement();
+      this.#dragOverReorder.level = null;
+      this.#dragOverReorder.canDrop = null;
     }
 
     #createFakeTabSplit(dropElement, dropSide) {
@@ -954,21 +1018,23 @@
       this.#dragOverSplit.canDrop = null;
     }
 
-    #createNestIndicator(dropElement) {
+    #createNestIndicator(node) {
       this.#clearNestIndicatorElement();
       const indicator = document.createXULElement("zen-tree-nest-indicator");
-      const level = (window.gZenTabTree?.getLevel(dropElement) ?? 0) + 1;
+      const level = (window.gZenTabTree?.getLevel(node) ?? 0) + 1;
       const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 14);
       indicator.style.marginInlineStart = `${level * indentStep}px`;
-      dropElement.after(indicator);
+      node.after(indicator);
+      node.toggleAttribute("zen-tree-nest-target", true);
       this.#dragOverNest.indicator = indicator;
-      this.#dragOverNest.dropElement = dropElement;
+      this.#dragOverNest.dropElement = node;
       this.#dragOverNest.canDrop = true;
     }
 
     #clearNestIndicatorElement() {
       this.#dragOverNest.indicator?.remove();
       this.#dragOverNest.indicator = null;
+      this.#dragOverNest.dropElement?.removeAttribute("zen-tree-nest-target");
     }
 
     _clearDragOverNest() {
@@ -1062,8 +1128,7 @@
       } else {
         this.#handle_dropReorder(event);
       }
-      this._clearDragOverSplit();
-      this._clearDragOverNest();
+      this.#clearAllDragOverTree();
     }
 
     #handle_dropSwitchSpace(event) {
@@ -1152,7 +1217,10 @@
       const draggedTabs = movingTabsSet?.size
         ? [...movingTabsSet]
         : [draggedTab];
-      window.gZenTabTree.handleReorderDrop(draggedTabs);
+      const level = this.#dragOverReorder.canDrop
+        ? this.#dragOverReorder.level
+        : null;
+      window.gZenTabTree.handleReorderDrop(draggedTabs, level);
     }
 
     handle_drop_transition(dropElement, draggedTab, movingTabs, dropBefore) {
@@ -1317,6 +1385,7 @@
       ownerGlobal.gZenPinnedTabManager.removeTabContainersDragoverClass();
       thisFromGlobal._clearDragOverSplit();
       thisFromGlobal._clearDragOverNest();
+      thisFromGlobal._clearDragOverReorder();
       const tree = ownerGlobal.gZenTabTree;
       if (tree?.enabled) {
         tree._dragActive = false;
@@ -1391,6 +1460,8 @@
       if (clearSplitDropIndicator) {
         this._clearDragOverSplit();
       }
+      this._clearDragOverNest();
+      this._clearDragOverReorder();
       gZenPinnedTabManager.removeTabContainersDragoverClass();
     }
 

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -71,6 +71,7 @@
     #firstHapticFeedbackPlayed = false;
 
     #dragOverSplit = {};
+    #dragOverNest = {};
 
     constructor(tabbrowserTabs) {
       super(tabbrowserTabs);
@@ -98,6 +99,12 @@
         this,
         "_dndSplitDelay",
         "zen.splitView.drag-over-split-delayMC",
+        300
+      );
+      XPCOMUtils.defineLazyPreferenceGetter(
+        this,
+        "_dndNestToSplitDelay",
+        "zen.tab-tree.drag-nest-to-split-delayMC",
         300
       );
       XPCOMUtils.defineLazyPreferenceGetter(
@@ -798,10 +805,10 @@
         !isTab(dropElement) ||
         dropElement.hasAttribute("zen-essential") ||
         dropElement.hasAttribute("zen-glance-tab") ||
-        dropElement?.group?.hasAttribute("split-view-group") ||
-        movingTabsSet.size > 1
+        dropElement?.group?.hasAttribute("split-view-group")
       ) {
         this._clearDragOverSplit();
+        this._clearDragOverNest();
         return;
       }
 
@@ -813,6 +820,7 @@
         dropElement.hasAttribute("zen-live-folder-item-id")
       ) {
         this._clearDragOverSplit();
+        this._clearDragOverNest();
         return;
       }
 
@@ -831,36 +839,56 @@
         overlapRatioY > 1 - edgeZoneThreshold
       ) {
         this._clearDragOverSplit();
+        this._clearDragOverNest();
         return;
       }
 
       const isLeft = clientX < targetX + targetWidth / 2;
       const dropSide = isLeft ? "left" : "right";
 
-      // If the drop side or element changes, clear dragOverSplit
+      // Central band reached: offer NEST immediately, escalate to SPLIT on hold.
+      const draggedTabs = [...movingTabsSet];
+      const canNest =
+        window.gZenTabTree?.enabled &&
+        window.gZenTabTree.isTreeEligible(dropElement) &&
+        draggedTabs.every(t => window.gZenTabTree.isTreeEligible(t)) &&
+        !movingTabsSet.has(dropElement);
+
+      // If the target/side changed, reset both machines.
       if (
         this.#dragOverSplit.data?.dropElement !== dropElement ||
         this.#dragOverSplit.data?.dropSide !== dropSide
       ) {
         this._clearDragOverSplit();
+        this._clearDragOverNest();
       }
 
+      // Show the nest indicator right away (no delay) when nesting is allowed.
+      if (canNest && this.#dragOverNest.dropElement !== dropElement) {
+        this.#createNestIndicator(dropElement);
+      }
+
+      // (Re)arm the escalation-to-split timer (split only supports one tab).
+      const canSplit = movingTabsSet.size <= 1;
       if (
-        this.#dragOverSplit.timer &&
-        this.#dragOverSplit.data?.dropElement === dropElement &&
-        this.#dragOverSplit.data?.dropSide === dropSide
+        canSplit &&
+        (!this.#dragOverSplit.timer ||
+          this.#dragOverSplit.data?.dropElement !== dropElement ||
+          this.#dragOverSplit.data?.dropSide !== dropSide)
       ) {
-        // Timer already running for the same target and side, do nothing
-        return;
+        if (this.#dragOverSplit.timer) {
+          clearTimeout(this.#dragOverSplit.timer);
+        }
+        this.#dragOverSplit.data = { dropElement, dropSide };
+        this.#dragOverSplit.timer = setTimeout(
+          () => {
+            // Escalate: drop the nest offer, show the split fake-tab.
+            this._clearDragOverNest();
+            this.#createFakeTabSplit(dropElement, dropSide);
+          },
+          canNest ? this._dndNestToSplitDelay : this._dndSplitDelay
+        );
       }
-
-      this.#dragOverSplit.data = {
-        dropElement,
-        dropSide,
-      };
-      this.#dragOverSplit.timer = setTimeout(() => {
-        this.#createFakeTabSplit(dropElement, dropSide);
-      }, this._dndSplitDelay);
     }
 
     #createFakeTabSplit(dropElement, dropSide) {
@@ -894,6 +922,29 @@
       this.#dragOverSplit.fakeTab = null;
       this.#dragOverSplit.data = null;
       this.#dragOverSplit.canDrop = null;
+    }
+
+    #createNestIndicator(dropElement) {
+      this.#clearNestIndicatorElement();
+      const indicator = document.createXULElement("zen-tree-nest-indicator");
+      const level = (window.gZenTabTree?.getLevel(dropElement) ?? 0) + 1;
+      const indentStep = Services.prefs.getIntPref("zen.tab-tree.indent", 14);
+      indicator.style.marginInlineStart = `${level * indentStep}px`;
+      dropElement.after(indicator);
+      this.#dragOverNest.indicator = indicator;
+      this.#dragOverNest.dropElement = dropElement;
+      this.#dragOverNest.canDrop = true;
+    }
+
+    #clearNestIndicatorElement() {
+      this.#dragOverNest.indicator?.remove();
+      this.#dragOverNest.indicator = null;
+    }
+
+    _clearDragOverNest() {
+      this.#clearNestIndicatorElement();
+      this.#dragOverNest.dropElement = null;
+      this.#dragOverNest.canDrop = null;
     }
 
     handle_windowDragEnter(event) {
@@ -973,8 +1024,14 @@
       super.handle_drop(event);
       this.#maybeClearVerticalPinnedGridDragOver();
       this.#handle_dropSwitchSpace(event);
-      this.#handle_dropCreateSplit(event);
+      // Split wins if the hold escalated; otherwise try a nest.
+      if (this.#dragOverSplit.canDrop) {
+        this.#handle_dropCreateSplit(event);
+      } else {
+        this.#handle_dropNest(event);
+      }
       this._clearDragOverSplit();
+      this._clearDragOverNest();
     }
 
     #handle_dropSwitchSpace(event) {
@@ -1029,6 +1086,25 @@
         "vsep",
         isLeft ? 0 : 1
       );
+    }
+
+    #handle_dropNest(event) {
+      if (!this.#dragOverNest.canDrop || !window.gZenTabTree?.enabled) {
+        return;
+      }
+      const dt = event.dataTransfer;
+      const draggedTab = dt.mozGetDataAt(TAB_DROP_TYPE, 0);
+      const target = this.#dragOverNest.dropElement;
+      if (!draggedTab || !target) {
+        return;
+      }
+      const movingTabsSet = draggedTab._dragData?.movingTabsSet;
+      const draggedTabs = movingTabsSet?.size
+        ? [...movingTabsSet]
+        : [draggedTab];
+      this._dontAnimateTabMove = true;
+      this._clearDragOverNest();
+      window.gZenTabTree.handleNestDrop(draggedTabs, target);
     }
 
     handle_drop_transition(dropElement, draggedTab, movingTabs, dropBefore) {
@@ -1192,6 +1268,7 @@
       thisFromGlobal.clearDragOverVisuals();
       ownerGlobal.gZenPinnedTabManager.removeTabContainersDragoverClass();
       thisFromGlobal._clearDragOverSplit();
+      thisFromGlobal._clearDragOverNest();
       this.#maybeClearVerticalPinnedGridDragOver();
       thisFromGlobal.originalDragImageArgs = [];
       this.#firstHapticFeedbackPlayed = false;

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -894,7 +894,6 @@
         this._clearDragOverNest();
       }
 
-      // Show the nest indicator right away (no delay) when nesting is allowed.
       if (canNest && this.#dragOverNest.dropElement !== dropElement) {
         this.#createNestIndicator(dropElement);
       }

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -904,6 +904,7 @@
         !isTab(dropElement) ||
         dropElement.hasAttribute("zen-essential") ||
         dropElement.hasAttribute("zen-glance-tab") ||
+        dropElement.hasAttribute("zen-empty-tab") ||
         dropElement.hasAttribute("zen-live-folder-item-id") ||
         draggedTab.hasAttribute("zen-live-folder-item-id")
       ) {

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -559,7 +559,7 @@ class nsZenWindowSync {
           // URI) over the image attribute: the attribute may hold a derived
           // URL (e.g. moz-remote-image:) that setIcon rejects as remote.
           const icon =
-            aOriginalItem.ownerGlobal.gBrowser.getIcon(aOriginalItem) ||
+            aOriginalItem.documentGlobal?.gBrowser.getIcon(aOriginalItem) ||
             aOriginalItem.getAttribute("image") ||
             "";
           const targetIcon =

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -553,9 +553,17 @@ class nsZenWindowSync {
       );
       this.#syncItemPosition(aOriginalItem, aTargetItem, aWindow);
     }
-    if (aWindow.gZenTabTree?.enabled && gBrowser.isTab(aOriginalItem)) {
-      // Replicate the tree relationship + collapse state, then rebuild the
-      // target window's pointers/visual state from the mirrored attributes.
+    // Split-view groups are tree nodes too, so sync them as well as tabs.
+    const isTreeNode =
+      gBrowser.isTab(aOriginalItem) ||
+      (gBrowser.isTabGroup(aOriginalItem) &&
+        aOriginalItem.hasAttribute("split-view-group"));
+    if (aWindow.gZenTabTree?.enabled && isTreeNode) {
+      // Replicate the stable id + tree relationship + collapse state, then
+      // rebuild the target window's pointers/visual state from the mirrored
+      // attributes. zen-tree-id is mirrored so parent matching survives the
+      // target window reassigning ids on restore.
+      this.#maybeSyncAttributeChange(aOriginalItem, aTargetItem, "zen-tree-id");
       this.#maybeSyncAttributeChange(
         aOriginalItem,
         aTargetItem,

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -54,11 +54,17 @@ const UNSYNCED_WINDOW_EVENTS = ["TabOpen"];
 // leaves the mirror copies open forever with no later event to clean them up.
 // Its handler is idempotent because it looks the mirror up by id and does
 // nothing when it has already gone.
+//
+// TabOpen likewise. It is what assigns the tab its sync id, so dropping it
+// doesn't just skip one update, it leaves the tab unsyncable for the rest of
+// its life with nothing to retry it. Running it late is safe because it
+// returns early once the tab has an id.
 const CROSS_WINDOW_QUEUED_EVENTS = [
   "ZenTabIconChanged",
   "ZenTabLabelChanged",
   "TabAttrModified",
   "TabClose",
+  "TabOpen",
 ];
 const EVENTS = [
   "TabClose",
@@ -1455,7 +1461,12 @@ class nsZenWindowSync {
 
   on_TabOpen(aEvent, { ignoreExistingId = false } = {}) {
     const tab = aEvent.target;
-    const window = tab.documentGlobal;
+    // Queued behind another window, this can run after the tab is gone, and
+    // #runOnAllWindows treats a null window as "no window to exclude".
+    const window = tab.documentGlobal ?? aEvent._zenSourceWindow;
+    if (!window) {
+      return;
+    }
     const isUnsyncedWindow = window.gZenWorkspaces.privateWindowOrDisabled;
     if (tab.id && !ignoreExistingId) {
       // This tab was opened as part of a sync operation.

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -44,11 +44,22 @@ const OBSERVING = [
 ];
 const INSTANT_EVENTS = ["SSWindowClosing", "TabSelect", "focus"];
 const UNSYNCED_WINDOW_EVENTS = ["TabOpen"];
+// Events that may be queued even while we're handling an event for another
+// window. These handlers are idempotent (they bail out when the target
+// already matches the original), so processing them late can't start a
+// sync loop, while dropping them would permanently lose the change (a
+// favicon is usually only set once per page load).
+const CROSS_WINDOW_QUEUED_EVENTS = [
+  "ZenTabIconChanged",
+  "ZenTabLabelChanged",
+  "TabAttrModified",
+];
 const EVENTS = [
   "TabClose",
 
   "ZenTabIconChanged",
   "ZenTabLabelChanged",
+  "TabAttrModified",
   "ZenTreeChanged",
 
   "TabMove",
@@ -396,21 +407,31 @@ class nsZenWindowSync {
     ) {
       return;
     }
+    if (
+      aEvent.type === "TabAttrModified" &&
+      !aEvent.detail?.changed?.includes("image")
+    ) {
+      // We only care about icon updates that don't go through setIcon
+      // (e.g. the progress listener removing a stale favicon).
+      return;
+    }
     if (INSTANT_EVENTS.includes(aEvent.type)) {
       this.#handleNextEventInternal(aEvent);
       return;
     }
-    if (
-      this.#eventHandlingContext.window &&
-      this.#eventHandlingContext.window !== window
-    ) {
+    const contextWindow = this.#eventHandlingContext.window;
+    if (contextWindow && contextWindow !== window) {
       // We're already handling an event for another window.
-      // To avoid re-entrancy issues, we skip this event.
-      return;
+      // To avoid re-entrancy issues, we skip this event, unless its
+      // handler is known to be idempotent and safe to run late.
+      if (!CROSS_WINDOW_QUEUED_EVENTS.includes(aEvent.type)) {
+        return;
+      }
+    } else {
+      this.#eventHandlingContext.window = window;
     }
     const lastHandlerPromise = this.#eventHandlingContext.lastHandlerPromise;
     this.#eventHandlingContext.eventCount++;
-    this.#eventHandlingContext.window = window;
     let resolveNewPromise;
     this.#eventHandlingContext.lastHandlerPromise = new Promise(resolve => {
       resolveNewPromise = resolve;
@@ -524,11 +545,23 @@ class nsZenWindowSync {
       aTargetItem.zenStaticIcon = aOriginalItem.zenStaticIcon;
       if (gBrowser.isTab(aOriginalItem)) {
         try {
-          gBrowser.setIcon(
-            aTargetItem,
+          // Prefer the canonical icon URL (browser.mIconURL, usually a data:
+          // URI) over the image attribute: the attribute may hold a derived
+          // URL (e.g. moz-remote-image:) that setIcon rejects as remote.
+          const icon =
+            aOriginalItem.ownerGlobal.gBrowser.getIcon(aOriginalItem) ||
             aOriginalItem.getAttribute("image") ||
-              gBrowser.getIcon(aOriginalItem)
-          );
+            "";
+          const targetIcon =
+            gBrowser.getIcon(aTargetItem) ||
+            aTargetItem.getAttribute("image") ||
+            "";
+          // Only call setIcon for actual changes. setIcon dispatches
+          // ZenTabIconChanged even for no-op calls, so this also guarantees
+          // icon sync chains between windows always terminate.
+          if (icon !== targetIcon) {
+            gBrowser.setIcon(aTargetItem, icon);
+          }
         } catch {}
       } else if (aOriginalItem.isZenFolder) {
         // Icons are a zen-only feature for tab groups.
@@ -537,10 +570,18 @@ class nsZenWindowSync {
     }
     if (flags & SYNC_FLAG_LABEL) {
       if (gBrowser.isTab(aOriginalItem)) {
-        aTargetItem._zenChangeLabelFlag = true;
-        aTargetItem.zenStaticLabel = aOriginalItem.zenStaticLabel;
-        gBrowser._setTabLabel(aTargetItem, aOriginalItem.label);
-        delete aTargetItem._zenChangeLabelFlag;
+        // Skip no-op label syncs; _setTabLabel dispatches ZenTabLabelChanged
+        // before its own equality check, so syncing an unchanged label would
+        // keep bouncing events between windows.
+        if (
+          aTargetItem.label !== aOriginalItem.label ||
+          aTargetItem.zenStaticLabel !== aOriginalItem.zenStaticLabel
+        ) {
+          aTargetItem._zenChangeLabelFlag = true;
+          aTargetItem.zenStaticLabel = aOriginalItem.zenStaticLabel;
+          gBrowser._setTabLabel(aTargetItem, aOriginalItem.label);
+          delete aTargetItem._zenChangeLabelFlag;
+        }
       } else if (gBrowser.isTabGroup(aOriginalItem)) {
         aTargetItem.label = aOriginalItem.label;
       }
@@ -1427,6 +1468,14 @@ class nsZenWindowSync {
     return this.#delegateGenericSyncEvent(aEvent, SYNC_FLAG_ICON);
   }
 
+  on_TabAttrModified(aEvent) {
+    // Only reached for "image" changes (filtered in handleEvent). Some icon
+    // updates don't go through setIcon and thus never fire ZenTabIconChanged,
+    // for example the tab progress listener removing a stale favicon when a
+    // page without one finishes loading.
+    return this.on_ZenTabIconChanged(aEvent);
+  }
+
   on_ZenTabLabelChanged(aEvent) {
     if (!aEvent.target?._zenContentsVisible) {
       // No need to sync label changes for tabs that aren't active in this window.
@@ -1521,7 +1570,18 @@ class nsZenWindowSync {
     this.#runOnAllWindows(window, win => {
       const targetTab = this.getItemFromWindow(win, tab.id);
       if (targetTab) {
+        // Mark the tab so the session store doesn't record this propagated
+        // close in its closed tabs list (and undo-close stack). Otherwise
+        // every synced close would record one closed tab per window, and
+        // undo close tab would restore the mirror copy (often blank or
+        // stale) instead of the tab the user actually closed.
+        targetTab._zenSyncClosing = true;
         win.gBrowser.removeTab(targetTab, { animate: true });
+        if (!targetTab.closing) {
+          // The close was vetoed (e.g. by glance); don't leave the marker
+          // around for a future user-initiated close.
+          delete targetTab._zenSyncClosing;
+        }
       }
     });
   }

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -1180,6 +1180,19 @@ class nsZenWindowSync {
   }
 
   /**
+   * Whether a tab currently holds real loaded content (as opposed to a blank /
+   * not-yet-restored browser). Used to decide cross-window docshell swaps so we
+   * never swap a blank browser in over a tab the user just activated.
+   *
+   * @param {object} aTab - The tab to check.
+   * @returns {boolean} True if the tab's browser has non-blank content.
+   */
+  #hasLiveContent(aTab) {
+    const spec = aTab?.linkedBrowser?.currentURI?.spec;
+    return !!(spec && spec !== "about:blank");
+  }
+
+  /**
    * Handles tab switch or window focus events to synchronize tab contents visibility.
    *
    * @param {Window} aWindow - The window that triggered the event.
@@ -1225,12 +1238,21 @@ class nsZenWindowSync {
         aWindow,
         selectedTab.id
       );
+      const selHasContent = this.#hasLiveContent(selectedTab);
+      const otherHasContent = this.#hasLiveContent(otherSelectedTab);
       selectedTab._zenContentsVisible = true;
-      if (otherSelectedTab) {
+      if (otherSelectedTab && !selHasContent && otherHasContent) {
+        // This tab is blank and the other window holds the live content: pull
+        // it in.
         delete otherSelectedTab._zenContentsVisible;
         promises.push(
           this.#swapBrowserDocShellsAsync(selectedTab, otherSelectedTab)
         );
+      } else if (otherSelectedTab && !otherHasContent && !selHasContent) {
+        // Neither side has live content yet: hand over the visibility flag but
+        // don't swap, so we never pull a blank browser in over this tab (which
+        // is what left the activated tab grey/blank). It will load its own URL.
+        delete otherSelectedTab._zenContentsVisible;
       }
     }
     await Promise.all(promises);
@@ -1442,6 +1464,11 @@ class nsZenWindowSync {
         animate: true,
         createLazyBrowser: true,
         _forZenEmptyTab: tab.hasAttribute("zen-empty-tab"),
+        // Mirror the source tab's container. Without this the synced tab is
+        // created with no container, and getContextIdIfNeeded() fills it from
+        // THIS window's active Space — so a tab opened in a No-Container Space
+        // wrongly inherits the other window's container.
+        userContextId: tab.userContextId,
       });
       newTab.id = tab.id;
       if (!tab.hasAttribute("pending")) {

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -49,10 +49,16 @@ const UNSYNCED_WINDOW_EVENTS = ["TabOpen"];
 // already matches the original), so processing them late can't start a
 // sync loop, while dropping them would permanently lose the change (a
 // favicon is usually only set once per page load).
+//
+// TabClose belongs here for the same reason, and more urgently: dropping it
+// leaves the mirror copies open forever with no later event to clean them up.
+// Its handler is idempotent because it looks the mirror up by id and does
+// nothing when it has already gone.
 const CROSS_WINDOW_QUEUED_EVENTS = [
   "ZenTabIconChanged",
   "ZenTabLabelChanged",
   "TabAttrModified",
+  "TabClose",
 ];
 const EVENTS = [
   "TabClose",
@@ -394,6 +400,10 @@ class nsZenWindowSync {
 
   handleEvent(aEvent) {
     const window = aEvent.currentTarget.documentGlobal ?? aEvent.currentTarget;
+    // A queued handler can run after its tab has been detached, at which point
+    // tab.documentGlobal is null. Remember which window the event came from
+    // while we still know, so handlers can still exclude it.
+    aEvent._zenSourceWindow ??= window;
     if (
       !window.gZenStartup.isReady ||
       !window.gZenWorkspaces?.shouldHaveWorkspaces ||
@@ -1593,7 +1603,11 @@ class nsZenWindowSync {
 
   on_TabClose(aEvent) {
     const tab = aEvent.target;
-    const window = tab.documentGlobal;
+    // Falls back to the window recorded at dispatch: by the time a queued
+    // close runs, the tab is already detached and has no documentGlobal, and
+    // a null here would make #runOnAllWindows include the closing tab's own
+    // window and mark the user's close as a sync-propagated one.
+    const window = tab.documentGlobal ?? aEvent._zenSourceWindow;
     this.#runOnAllWindows(window, win => {
       const targetTab = this.getItemFromWindow(win, tab.id);
       if (targetTab) {

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -49,6 +49,7 @@ const EVENTS = [
 
   "ZenTabIconChanged",
   "ZenTabLabelChanged",
+  "ZenTreeChanged",
 
   "TabMove",
   "TabPinned",
@@ -76,6 +77,7 @@ const EVENTS = [
 const SYNC_FLAG_LABEL = 1 << 0;
 const SYNC_FLAG_ICON = 1 << 1;
 const SYNC_FLAG_MOVE = 1 << 2;
+const SYNC_FLAG_TREE = 1 << 3;
 
 class nsZenWindowSync {
   #initialized = false;
@@ -550,6 +552,23 @@ class nsZenWindowSync {
         "zen-workspace-id"
       );
       this.#syncItemPosition(aOriginalItem, aTargetItem, aWindow);
+    }
+    if (aWindow.gZenTabTree?.enabled && gBrowser.isTab(aOriginalItem)) {
+      // Replicate the tree relationship + collapse state, then rebuild the
+      // target window's pointers/visual state from the mirrored attributes.
+      this.#maybeSyncAttributeChange(
+        aOriginalItem,
+        aTargetItem,
+        "zen-tree-parent-id"
+      );
+      this.#maybeSyncAttributeChange(
+        aOriginalItem,
+        aTargetItem,
+        "zen-tree-collapsed"
+      );
+      if (flags & (SYNC_FLAG_TREE | SYNC_FLAG_MOVE)) {
+        aWindow.gZenTabTree.rebuildFromAttributes();
+      }
     }
     if (aOriginalItem.hasAttribute("zen-live-folder-item-id")) {
       this.#maybeSyncAttributeChange(
@@ -1438,6 +1457,11 @@ class nsZenWindowSync {
 
   on_TabMove(aEvent) {
     this.#delegateGenericSyncEvent(aEvent, SYNC_FLAG_MOVE);
+    return Promise.resolve();
+  }
+
+  on_ZenTreeChanged(aEvent) {
+    this.#delegateGenericSyncEvent(aEvent, SYNC_FLAG_TREE);
     return Promise.resolve();
   }
 

--- a/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
+++ b/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
@@ -212,6 +212,21 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
     // Abort the close and let the native tab context menu open on the current
     // multiselection. The trailing middle release becomes a no-op.
     s.aborted = true;
+    // The selection is still "pending" under the open menu, so keep the per-tab
+    // close (X) buttons suppressed until that menu is dismissed — otherwise the
+    // trailing release reveals an X on a selected/active tab nobody is hovering.
+    // popuphidden bubbles up from submenus, so only act on the menu itself.
+    const menu = document.getElementById("tabContextMenu");
+    if (menu) {
+      const onHidden = e => {
+        if (e.target !== menu) {
+          return;
+        }
+        menu.removeEventListener("popuphidden", onHidden);
+        this.#strip?.removeAttribute("zen-multi-drag-selecting");
+      };
+      menu.addEventListener("popuphidden", onHidden);
+    }
   }
 
   #removeClickSwallowers() {
@@ -220,11 +235,16 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
   }
 
   #cancel() {
+    const aborted = this.#state?.aborted;
     window.removeEventListener("mousemove", this, true);
     window.removeEventListener("mouseup", this, true);
     window.removeEventListener("contextmenu", this, true);
     window.removeEventListener("keydown", this, true);
-    this.#strip?.removeAttribute("zen-multi-drag-selecting");
+    // On abort the open context menu owns this (cleared on its popuphidden), so
+    // the close buttons stay hidden while the menu is up; otherwise clear now.
+    if (!aborted) {
+      this.#strip?.removeAttribute("zen-multi-drag-selecting");
+    }
     this.#state = null;
     // Keep the click swallowers until the trailing click fires (next tick).
     window.setTimeout(() => this.#removeClickSwallowers(), 0);

--- a/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
+++ b/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
@@ -157,11 +157,28 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
       return;
     }
 
-    if (!s.dragging) {
-      // Clean middle-click: replicate the native single-tab close.
+    // Decide what to close by where the gesture is RELEASED, not by incidental
+    // mid-gesture motion. The live range built during mousemove is only a
+    // preview; a jittery middle-click can briefly flick onto a neighbour (e.g. a
+    // tree parent in the row above) and leave it multiselected. Re-resolving from
+    // the release point makes the outcome consistent: a release on the press tab
+    // (a plain click, however shaky) closes only that tab; a release over a
+    // different tab closes the whole anchor..release range.
+    const over =
+      this.#tabFrom(event) ||
+      this.#tabUnderPoint(event.clientX, event.clientY);
+
+    if (!s.dragging || !over || over === s.anchor) {
       const tab = s.anchor;
+      // A non-additive drag that ends back on the anchor only built a PREVIEW
+      // range (each move clears + rebuilds it), so collapse it to the anchor
+      // before closing — otherwise the flicked-over neighbour stays selected and
+      // would be closed too. A clean click keeps any pre-existing multiselection.
+      if (s.dragging && !s.additive) {
+        gBrowser.clearMultiSelectedTabs();
+      }
       this.#cancel();
-      if (tab?.isConnected) {
+      if (tab?.isConnected && !tab.closing) {
         if (tab.multiselected) {
           gBrowser.removeMultiSelectedTabs();
         } else {
@@ -171,8 +188,15 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
       return;
     }
 
-    // Close exactly the gesture's selection. gBrowser.selectedTabs would also
-    // append the active tab when it's outside the dragged range.
+    // Released over another tab: close exactly anchor..release. Rebuild from the
+    // release point so a flick that wandered and came back can't widen it.
+    if (!s.additive) {
+      gBrowser.clearMultiSelectedTabs();
+    }
+    gBrowser.addToMultiSelectedTabs(s.anchor);
+    gBrowser.addRangeToMultiSelectedTabs(s.anchor, over);
+    // gBrowser.selectedTabs would also append the active tab when it's outside
+    // the dragged range, so close the multiselection explicitly.
     const toClose = gBrowser.tabs.filter(
       t => t.multiselected && t.isConnected && !t.closing
     );

--- a/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
+++ b/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
@@ -131,22 +131,6 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
     if (over !== s.anchor) {
       gBrowser.addRangeToMultiSelectedTabs(s.anchor, over);
     }
-    this.#markPendingClose();
-  }
-
-  #markPendingClose() {
-    for (const tab of gBrowser.tabs) {
-      tab.toggleAttribute(
-        "zen-pending-close",
-        !this.#state?.aborted && tab.multiselected
-      );
-    }
-  }
-
-  #clearPendingClose() {
-    for (const tab of gBrowser.tabs) {
-      tab.removeAttribute("zen-pending-close");
-    }
   }
 
   #onMouseUp(event) {
@@ -197,7 +181,6 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
     // Abort the close and let the native tab context menu open on the current
     // multiselection. The trailing middle release becomes a no-op.
     s.aborted = true;
-    this.#clearPendingClose();
   }
 
   #removeClickSwallowers() {
@@ -206,7 +189,6 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
   }
 
   #cancel() {
-    this.#clearPendingClose();
     window.removeEventListener("mousemove", this, true);
     window.removeEventListener("mouseup", this, true);
     window.removeEventListener("contextmenu", this, true);

--- a/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
+++ b/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
@@ -4,12 +4,9 @@
 
 import { nsZenDOMOperatedFeature } from "chrome://browser/content/zen-components/ZenCommonUtils.mjs";
 
-// Middle-mouse drag-select gesture on the vertical tab strip:
-//   middle-drag        -> select the contiguous range from anchor to cursor
-//   release            -> close the selected range
-//   right-click (held) -> abort the close, open the tab context menu on the
-//                         selection; the trailing release is then a no-op
-//   clean middle-click -> close just that tab (native behavior, replicated)
+// Middle-mouse drag-select gesture on the vertical tab strip: middle-drag
+// selects the range from anchor to cursor, release closes it, a held
+// right-click aborts to the tab context menu, a clean middle-click closes one.
 class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
   #enabled = false;
   #strip = null;
@@ -80,7 +77,7 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
 
   #onMouseDown(event) {
     if (event.button !== 1) {
-      return; // middle button only
+      return;
     }
     const tab = this.#tabFrom(event);
     if (!tab) {
@@ -183,7 +180,6 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
       return;
     }
 
-    // Drag release: close the whole selection.
     const toClose = gBrowser.selectedTabs.filter(
       t => t.isConnected && !t.closing
     );

--- a/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
+++ b/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
@@ -113,8 +113,7 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
     }
     if (!s.dragging) {
       const moved =
-        Math.abs(event.screenX - s.startX) +
-        Math.abs(event.screenY - s.startY);
+        Math.abs(event.screenX - s.startX) + Math.abs(event.screenY - s.startY);
       if (moved < nsZenTabMultiSelectDrag.#THRESHOLD) {
         return;
       }
@@ -165,8 +164,7 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
     // (a plain click, however shaky) closes only that tab; a release over a
     // different tab closes the whole anchor..release range.
     const over =
-      this.#tabFrom(event) ||
-      this.#tabUnderPoint(event.clientX, event.clientY);
+      this.#tabFrom(event) || this.#tabUnderPoint(event.clientX, event.clientY);
 
     if (!s.dragging || !over || over === s.anchor) {
       const tab = s.anchor;
@@ -206,7 +204,7 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
     }
   }
 
-  #onContextMenu(event) {
+  #onContextMenu() {
     const s = this.#state;
     if (!s || !s.dragging) {
       return;

--- a/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
+++ b/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { nsZenDOMOperatedFeature } from "chrome://browser/content/zen-components/ZenCommonUtils.mjs";
+
+class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
+  #enabled = false;
+
+  init() {
+    this.#enabled = Services.prefs.getBoolPref(
+      "zen.tabs.middle-drag-select.enabled",
+      true
+    );
+    if (!this.#enabled) {
+      return;
+    }
+    // Gesture listeners are wired up in a later task (middle-mouse drag-select).
+  }
+
+  get enabled() {
+    return this.#enabled;
+  }
+}
+
+window.gZenTabMultiSelectDrag = new nsZenTabMultiSelectDrag();

--- a/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
+++ b/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
@@ -83,6 +83,9 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
     if (!tab) {
       return; // let native "open tab on empty strip space" behavior run
     }
+    if (this.#state) {
+      this.#cancel(); // a prior gesture whose mouseup was missed (e.g. focus loss)
+    }
     // Own the middle button on tabs: suppress autoscroll + native handling.
     event.preventDefault();
     event.stopPropagation();
@@ -164,8 +167,10 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
       return;
     }
 
-    const toClose = gBrowser.selectedTabs.filter(
-      t => t.isConnected && !t.closing
+    // Close exactly the gesture's selection. gBrowser.selectedTabs would also
+    // append the active tab when it's outside the dragged range.
+    const toClose = gBrowser.tabs.filter(
+      t => t.multiselected && t.isConnected && !t.closing
     );
     this.#cancel();
     if (toClose.length) {

--- a/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
+++ b/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
@@ -4,8 +4,18 @@
 
 import { nsZenDOMOperatedFeature } from "chrome://browser/content/zen-components/ZenCommonUtils.mjs";
 
+// Middle-mouse drag-select gesture on the vertical tab strip:
+//   middle-drag        -> select the contiguous range from anchor to cursor
+//   release            -> close the selected range
+//   right-click (held) -> abort the close, open the tab context menu on the
+//                         selection; the trailing release is then a no-op
+//   clean middle-click -> close just that tab (native behavior, replicated)
 class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
   #enabled = false;
+  #strip = null;
+  // null | { anchor, startX, startY, dragging, aborted, additive }
+  #state = null;
+  static #THRESHOLD = 4; // px of movement before a click becomes a drag
 
   init() {
     this.#enabled = Services.prefs.getBoolPref(
@@ -15,11 +25,199 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
     if (!this.#enabled) {
       return;
     }
-    // Gesture listeners are wired up in a later task (middle-mouse drag-select).
+    this.#strip = document.getElementById("tabbrowser-tabs");
+    if (!this.#strip) {
+      return;
+    }
+    // Capture phase so we run before the native middle-click-close handler.
+    this.#strip.addEventListener("mousedown", this, true);
   }
 
   get enabled() {
     return this.#enabled;
+  }
+
+  handleEvent(event) {
+    switch (event.type) {
+      case "mousedown":
+        this.#onMouseDown(event);
+        break;
+      case "mousemove":
+        this.#onMouseMove(event);
+        break;
+      case "mouseup":
+        this.#onMouseUp(event);
+        break;
+      case "click":
+      case "auxclick":
+        // Swallow the click that follows our owned middle press so the native
+        // middle-click-close can't double-fire, then stop swallowing.
+        if (event.button === 1) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+        this.#removeClickSwallowers();
+        break;
+      case "contextmenu":
+        this.#onContextMenu(event);
+        break;
+      case "keydown":
+        if (event.key === "Escape") {
+          this.#cancel();
+        }
+        break;
+    }
+  }
+
+  #tabFrom(event) {
+    return event.target?.closest?.(".tabbrowser-tab") || null;
+  }
+
+  #tabUnderPoint(x, y) {
+    const el = document.elementFromPoint(x, y);
+    return el?.closest?.(".tabbrowser-tab") || null;
+  }
+
+  #onMouseDown(event) {
+    if (event.button !== 1) {
+      return; // middle button only
+    }
+    const tab = this.#tabFrom(event);
+    if (!tab) {
+      return; // let native "open tab on empty strip space" behavior run
+    }
+    // Own the middle button on tabs: suppress autoscroll + native handling.
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.#state = {
+      anchor: tab,
+      startX: event.screenX,
+      startY: event.screenY,
+      dragging: false,
+      aborted: false,
+      additive: event.getModifierState("Accel"),
+    };
+    window.addEventListener("mousemove", this, true);
+    window.addEventListener("mouseup", this, true);
+    window.addEventListener("contextmenu", this, true);
+    window.addEventListener("keydown", this, true);
+    window.addEventListener("click", this, true);
+    window.addEventListener("auxclick", this, true);
+  }
+
+  #onMouseMove(event) {
+    const s = this.#state;
+    if (!s || s.aborted) {
+      return;
+    }
+    if (!s.dragging) {
+      const moved =
+        Math.abs(event.screenX - s.startX) +
+        Math.abs(event.screenY - s.startY);
+      if (moved < nsZenTabMultiSelectDrag.#THRESHOLD) {
+        return;
+      }
+      s.dragging = true;
+    }
+    const over =
+      event.target?.closest?.(".tabbrowser-tab") ||
+      this.#tabUnderPoint(event.clientX, event.clientY);
+    if (!over) {
+      return;
+    }
+    // Rebuild the range from the anchor each move so shrinking deselects.
+    if (!s.additive) {
+      gBrowser.clearMultiSelectedTabs();
+    }
+    gBrowser.addToMultiSelectedTabs(s.anchor);
+    if (over !== s.anchor) {
+      gBrowser.addRangeToMultiSelectedTabs(s.anchor, over);
+    }
+    this.#markPendingClose();
+  }
+
+  #markPendingClose() {
+    for (const tab of gBrowser.tabs) {
+      tab.toggleAttribute(
+        "zen-pending-close",
+        !this.#state?.aborted && tab.multiselected
+      );
+    }
+  }
+
+  #clearPendingClose() {
+    for (const tab of gBrowser.tabs) {
+      tab.removeAttribute("zen-pending-close");
+    }
+  }
+
+  #onMouseUp(event) {
+    if (event.button !== 1) {
+      return;
+    }
+    const s = this.#state;
+    if (!s) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (s.aborted) {
+      // Right-click already opened the menu; the release does nothing.
+      this.#cancel();
+      return;
+    }
+
+    if (!s.dragging) {
+      // Clean middle-click: replicate the native single-tab close.
+      const tab = s.anchor;
+      this.#cancel();
+      if (tab?.isConnected) {
+        if (tab.multiselected) {
+          gBrowser.removeMultiSelectedTabs();
+        } else {
+          gBrowser.removeTab(tab, { animate: true });
+        }
+      }
+      return;
+    }
+
+    // Drag release: close the whole selection.
+    const toClose = gBrowser.selectedTabs.filter(
+      t => t.isConnected && !t.closing
+    );
+    this.#cancel();
+    if (toClose.length) {
+      gBrowser.removeTabs(toClose, { animate: true });
+    }
+  }
+
+  #onContextMenu(event) {
+    const s = this.#state;
+    if (!s || !s.dragging) {
+      return;
+    }
+    // Abort the close and let the native tab context menu open on the current
+    // multiselection. The trailing middle release becomes a no-op.
+    s.aborted = true;
+    this.#clearPendingClose();
+  }
+
+  #removeClickSwallowers() {
+    window.removeEventListener("click", this, true);
+    window.removeEventListener("auxclick", this, true);
+  }
+
+  #cancel() {
+    this.#clearPendingClose();
+    window.removeEventListener("mousemove", this, true);
+    window.removeEventListener("mouseup", this, true);
+    window.removeEventListener("contextmenu", this, true);
+    window.removeEventListener("keydown", this, true);
+    this.#state = null;
+    // Keep the click swallowers until the trailing click fires (next tick).
+    window.setTimeout(() => this.#removeClickSwallowers(), 0);
   }
 }
 

--- a/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
+++ b/src/zen/tab-tree/ZenTabMultiSelectDrag.mjs
@@ -119,6 +119,10 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
         return;
       }
       s.dragging = true;
+      // While drag-selecting, suppress per-tab close (X) buttons: the gesture
+      // selects a range (closed together on release), so a hover/selected close
+      // affordance on individual tabs is misleading mid-drag.
+      this.#strip?.setAttribute("zen-multi-drag-selecting", "true");
     }
     const over =
       event.target?.closest?.(".tabbrowser-tab") ||
@@ -198,6 +202,7 @@ class nsZenTabMultiSelectDrag extends nsZenDOMOperatedFeature {
     window.removeEventListener("mouseup", this, true);
     window.removeEventListener("contextmenu", this, true);
     window.removeEventListener("keydown", this, true);
+    this.#strip?.removeAttribute("zen-multi-drag-selecting");
     this.#state = null;
     // Keep the click swallowers until the trailing click fires (next tick).
     window.setTimeout(() => this.#removeClickSwallowers(), 0);

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -65,7 +65,7 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
   }
 
   get #indentStep() {
-    return Services.prefs.getIntPref("zen.tab-tree.indent", 14);
+    return Services.prefs.getIntPref("zen.tab-tree.indent", 20);
   }
 
   get #maxDepth() {
@@ -185,9 +185,14 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
   }
 
   reindex(root) {
-    const apply = (node, level) => {
+    const apply = (node, level, hidden) => {
       node._zenTreeLevel = level;
       this.#applyIndent(node, level);
+      // Keep collapse-visibility in sync here too, so a node nested/moved under
+      // an already-collapsed parent hides immediately (and a node moved out of a
+      // collapsed branch sheds a stale zen-tree-hidden), without waiting for the
+      // next setCollapsed.
+      node.toggleAttribute("zen-tree-hidden", hidden);
       const parent = this.getParent(node);
       if (parent) {
         node.setAttribute("zen-tree-parent-id", parent.id || "");
@@ -195,11 +200,12 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
         node.removeAttribute("zen-tree-parent-id");
       }
       this.#updateTwisty(node);
+      const childHidden = hidden || !!node._zenTreeCollapsed;
       for (const child of this.getChildren(node)) {
-        apply(child, level + 1);
+        apply(child, level + 1, childHidden);
       }
     };
-    apply(root, this.getLevel(root));
+    apply(root, this.getLevel(root), this.#isHiddenByCollapse(root));
   }
 
   #applyIndent(node, level) {
@@ -652,7 +658,15 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     if (!this.enabled) {
       return;
     }
-    const node = this.#nodeOf(event.target);
+    const tab = event.target;
+    // A tab inside a split view is just one member of the group node, not the
+    // node itself: closing it must not promote/close the group's tree-children
+    // while the group is still alive. The group only leaves the tree when it
+    // fully dissolves, which on_TabUngrouped -> #reconcileDissolvedSplit handles.
+    if (tab.group?.hasAttribute("split-view-group")) {
+      return;
+    }
+    const node = this.#nodeOf(tab);
     const children = this.getChildren(node);
     if (!children.length) {
       // A leaf is closing: once it's gone, refresh its parent so the parent

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -4,8 +4,8 @@
 
 import { nsZenDOMOperatedFeature } from "chrome://browser/content/zen-components/ZenCommonUtils.mjs";
 
-function domOrderOf(tabs) {
-  return [...tabs].sort((a, b) => {
+function domOrderOf(nodes) {
+  return [...nodes].sort((a, b) => {
     const pos = a.compareDocumentPosition(b);
     if (pos & Node.DOCUMENT_POSITION_FOLLOWING) {
       return -1;
@@ -17,6 +17,9 @@ function domOrderOf(tabs) {
   });
 }
 
+// A tree "node" is either a standalone tab or a split-view group element. The
+// split group is treated as one unit: it nests, indents, moves and collapses as
+// a single row, and its inner tabs never participate in the tree on their own.
 class nsZenTabTree extends nsZenDOMOperatedFeature {
   #enabled = false;
 
@@ -49,6 +52,8 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     window.addEventListener("TabClose", this);
     window.addEventListener("TabMove", this);
     window.addEventListener("TabPinned", this);
+    window.addEventListener("TabGrouped", this);
+    window.addEventListener("TabUngrouped", this);
     window.addEventListener("SSWindowStateReady", this);
   }
 
@@ -67,91 +72,152 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return Services.prefs.getIntPref("zen.tab-tree.max-depth", 4);
   }
 
-  isTreeEligible(tab) {
+  #isSplitGroup(el) {
+    return !!el && gBrowser.isTabGroup(el) && el.hasAttribute("split-view-group");
+  }
+
+  // The node that owns a tab: its split group if it is in one, else the tab.
+  #nodeOf(tab) {
+    const group = tab?.group;
+    return group?.hasAttribute("split-view-group") ? group : tab;
+  }
+
+  // Every tree node (standalone tabs + split groups) in DOM order.
+  #nodes() {
+    const out = [];
+    const seen = new Set();
+    for (const tab of gBrowser.tabs) {
+      const node = this.#nodeOf(tab);
+      if (node && !seen.has(node)) {
+        seen.add(node);
+        out.push(node);
+      }
+    }
+    return out;
+  }
+
+  // A tab to activate when a node is selected (split group's active/first tab).
+  #representativeTab(node) {
+    if (this.#isSplitGroup(node)) {
+      return (
+        node.querySelector(".tabbrowser-tab[visuallyselected]") ||
+        node.querySelector(".tabbrowser-tab")
+      );
+    }
+    return node;
+  }
+
+  #workspaceIdOf(node) {
     return (
-      gBrowser.isTab(tab) &&
-      !tab.pinned &&
-      !tab.hasAttribute("zen-essential") &&
-      !tab.hasAttribute("zen-glance-tab") &&
-      !tab.hasAttribute("zen-empty-tab") &&
-      !tab.hasAttribute("zen-live-folder-item-id") &&
-      !tab.group?.hasAttribute("split-view-group")
+      node.getAttribute?.("zen-workspace-id") ||
+      this.#representativeTab(node)?.getAttribute("zen-workspace-id") ||
+      null
     );
   }
 
-  getParent(tab) {
-    const parent = tab?._zenTreeParent;
+  // The tree node that owns a tab (its split group, or the tab itself). Public
+  // so the drag handler can target split groups as single nodes.
+  treeNodeFor(tab) {
+    return this.#nodeOf(tab);
+  }
+
+  isSplitGroup(el) {
+    return this.#isSplitGroup(el);
+  }
+
+  isTreeEligible(node) {
+    if (this.#isSplitGroup(node)) {
+      return !node.pinned && !node.hasAttribute("zen-essential");
+    }
+    return (
+      gBrowser.isTab(node) &&
+      !node.group &&
+      !node.pinned &&
+      !node.hasAttribute("zen-essential") &&
+      !node.hasAttribute("zen-glance-tab") &&
+      !node.hasAttribute("zen-empty-tab") &&
+      !node.hasAttribute("zen-live-folder-item-id")
+    );
+  }
+
+  getParent(node) {
+    const parent = node?._zenTreeParent;
     return parent && parent.isConnected ? parent : null;
   }
 
-  getLevel(tab) {
+  getLevel(node) {
     let level = 0;
-    let node = this.getParent(tab);
-    while (node) {
+    let current = this.getParent(node);
+    while (current) {
       level++;
-      node = this.getParent(node);
+      current = this.getParent(current);
     }
     return level;
   }
 
-  getChildren(tab) {
-    return domOrderOf(gBrowser.tabs.filter(t => this.getParent(t) === tab));
+  getChildren(node) {
+    return domOrderOf(this.#nodes().filter(n => this.getParent(n) === node));
   }
 
-  getDescendants(tab) {
+  getDescendants(node) {
     const out = [];
-    for (const child of this.getChildren(tab)) {
+    for (const child of this.getChildren(node)) {
       out.push(child, ...this.getDescendants(child));
     }
     return out;
   }
 
+  // Nodes pointing at `node` by raw parent pointer (used during lifecycle fixup,
+  // before eligibility is settled).
+  #childrenByPointer(node) {
+    return this.#nodes().filter(n => n._zenTreeParent === node);
+  }
+
   reindex(root) {
-    const apply = (tab, level) => {
-      tab._zenTreeLevel = level;
-      this.#applyIndent(tab, level);
-      const parent = this.getParent(tab);
+    const apply = (node, level) => {
+      node._zenTreeLevel = level;
+      this.#applyIndent(node, level);
+      const parent = this.getParent(node);
       if (parent) {
-        tab.setAttribute("zen-tree-parent-id", parent.id || "");
+        node.setAttribute("zen-tree-parent-id", parent.id || "");
       } else {
-        tab.removeAttribute("zen-tree-parent-id");
+        node.removeAttribute("zen-tree-parent-id");
       }
-      this.#updateTwisty(tab);
-      for (const child of this.getChildren(tab)) {
+      this.#updateTwisty(node);
+      for (const child of this.getChildren(node)) {
         apply(child, level + 1);
       }
     };
     apply(root, this.getLevel(root));
   }
 
-  #applyIndent(tab, level) {
-    tab.style.setProperty(
+  #applyIndent(node, level) {
+    node.style.setProperty(
       "--zen-folder-indent",
       `${level * this.#indentStep}px`
     );
   }
 
-  nestTab(tab, parent, { position = "end" } = {}) {
+  nestTab(node, parent, { position = "end" } = {}) {
     if (
-      tab === parent ||
-      !this.isTreeEligible(tab) ||
+      node === parent ||
+      !this.isTreeEligible(node) ||
       !this.isTreeEligible(parent) ||
-      this.#isAncestor(tab, parent) || // prevent cycles
-      tab.getAttribute("zen-workspace-id") !==
-        parent.getAttribute("zen-workspace-id")
+      this.#isAncestor(node, parent) || // prevent cycles
+      this.#workspaceIdOf(node) !== this.#workspaceIdOf(parent)
     ) {
       return false;
     }
 
-    const previousParent = this.getParent(tab);
-    const subtree = [tab, ...this.getDescendants(tab)]; // already DFS order
-    tab._zenTreeParent = parent;
+    const previousParent = this.getParent(node);
+    const subtree = [node, ...this.getDescendants(node)]; // already DFS order
+    node._zenTreeParent = parent;
 
     let reference;
     if (position === "start") {
       reference = parent;
     } else {
-      const existing = this.getChildren(parent).filter(c => c !== tab);
+      const existing = this.getChildren(parent).filter(c => c !== node);
       const lastChild = existing[existing.length - 1];
       reference = lastChild ? this.#lastSubtreeNode(lastChild) : parent;
     }
@@ -163,35 +229,35 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     if (previousParent && previousParent !== parent) {
       this.reindex(this.#rootOf(previousParent));
     }
-    this.#onTreeChanged(tab);
+    this.#onTreeChanged(node);
     return true;
   }
 
-  promoteSubtree(tab) {
-    const grandparent = this.getParent(this.getParent(tab));
+  promoteSubtree(node) {
+    const grandparent = this.getParent(this.getParent(node));
     if (grandparent) {
-      this.nestTab(tab, grandparent, { position: "end" });
+      this.nestTab(node, grandparent, { position: "end" });
     } else {
-      this.detachTab(tab);
+      this.detachTab(node);
     }
   }
 
-  detachTab(tab) {
-    if (!this.getParent(tab)) {
+  detachTab(node) {
+    if (!this.getParent(node)) {
       return;
     }
-    tab._zenTreeParent = null;
-    this.reindex(tab);
-    this.#onTreeChanged(tab);
+    node._zenTreeParent = null;
+    this.reindex(node);
+    this.#onTreeChanged(node);
   }
 
-  nestTabsAsChildren(tabs, parent) {
-    const eligible = tabs.filter(
-      t =>
-        t !== parent && this.isTreeEligible(t) && !this.#isAncestor(t, parent)
+  nestTabsAsChildren(nodes, parent) {
+    const eligible = nodes.filter(
+      n =>
+        n !== parent && this.isTreeEligible(n) && !this.#isAncestor(n, parent)
     );
-    for (const t of eligible) {
-      this.nestTab(t, parent, { position: "end" });
+    for (const n of eligible) {
+      this.nestTab(n, parent, { position: "end" });
     }
   }
 
@@ -218,17 +284,26 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     }
   }
 
-  // The "roots" of a dragged set: dragged tabs whose parent is NOT also in the
+  // The "roots" of a dragged set: dragged nodes whose parent is NOT also in the
   // set. Their subtrees travel with them and keep their internal hierarchy.
   #draggedRoots(draggedTabs) {
-    const tabs = draggedTabs.filter(t => this.isTreeEligible(t));
-    const set = new Set(tabs);
-    return domOrderOf(tabs.filter(t => !set.has(this.getParent(t))));
+    const nodes = [];
+    const seen = new Set();
+    for (const tab of draggedTabs) {
+      const node = this.#nodeOf(tab);
+      if (this.isTreeEligible(node) && !seen.has(node)) {
+        seen.add(node);
+        nodes.push(node);
+      }
+    }
+    const set = new Set(nodes);
+    return domOrderOf(nodes.filter(n => !set.has(this.getParent(n))));
   }
 
   // NEST drop: a single dragged root nests under target keeping its hierarchy;
   // multiple roots each become a direct child of target (subtrees follow).
   handleNestDrop(draggedTabs, target) {
+    target = this.#nodeOf(target);
     if (!this.enabled || !this.isTreeEligible(target)) {
       return false;
     }
@@ -243,9 +318,11 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return true;
   }
 
-  // REORDER drop: native move already placed the tabs; make each dragged root a
-  // sibling there (parent = the eligible tab just above the moved block).
-  handleReorderDrop(draggedTabs) {
+  // REORDER drop: native move already placed the nodes. The eligible node just
+  // above the moved block (`prev`) anchors the level: with no explicit level the
+  // dragged roots become its siblings; with one (set by the drag's horizontal
+  // position) they land at that indent, where level 0 unparents to the root.
+  handleReorderDrop(draggedTabs, targetLevel = null) {
     if (!this.enabled) {
       return;
     }
@@ -253,12 +330,19 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     if (!roots.length) {
       return;
     }
-    const set = new Set(draggedTabs);
+    const draggedNodes = new Set(
+      roots.flatMap(r => [r, ...this.getDescendants(r)])
+    );
     let prev = roots[0].previousElementSibling;
-    while (prev && (!this.isTreeEligible(prev) || set.has(prev))) {
+    while (prev && (!this.isTreeEligible(prev) || draggedNodes.has(prev))) {
       prev = prev.previousElementSibling;
     }
-    const newParent = prev ? this.getParent(prev) : null;
+    let newParent;
+    if (targetLevel == null) {
+      newParent = prev ? this.getParent(prev) : null;
+    } else {
+      newParent = this.#parentForLevel(prev, targetLevel);
+    }
     const affected = new Set();
     for (const root of roots) {
       if (
@@ -278,95 +362,122 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     this.#onTreeChanged(roots[0]);
   }
 
-  setCollapsed(tab, collapsed) {
-    if (!this.getChildren(tab).length) {
+  setCollapsed(node, collapsed) {
+    if (!this.getChildren(node).length) {
       return;
     }
-    tab._zenTreeCollapsed = collapsed;
-    tab.toggleAttribute("zen-tree-collapsed", collapsed);
+    node._zenTreeCollapsed = collapsed;
+    node.toggleAttribute("zen-tree-collapsed", collapsed);
 
-    const descendants = this.getDescendants(tab);
+    const descendants = this.getDescendants(node);
     for (const d of descendants) {
-      // A descendant is hidden if ANY ancestor up to `tab` is collapsed.
+      // A descendant is hidden if ANY ancestor up to `node` is collapsed.
       d.toggleAttribute("zen-tree-hidden", this.#isHiddenByCollapse(d));
     }
 
-    if (
-      collapsed &&
-      gBrowser.selectedTab &&
-      descendants.includes(gBrowser.selectedTab)
-    ) {
-      gBrowser.selectedTab = tab; // nearest visible ancestor
+    const selectedNode = this.#nodeOf(gBrowser.selectedTab);
+    if (collapsed && selectedNode && descendants.includes(selectedNode)) {
+      gBrowser.selectedTab = this.#representativeTab(node); // nearest visible
     }
 
-    this.#updateTwisty(tab);
-    this.#onTreeChanged(tab);
+    this.#updateTwisty(node);
+    this.#onTreeChanged(node);
   }
 
-  toggleCollapse(tab) {
-    this.setCollapsed(tab, !tab._zenTreeCollapsed);
+  toggleCollapse(node) {
+    this.setCollapsed(node, !node._zenTreeCollapsed);
   }
 
-  #isHiddenByCollapse(tab) {
-    let node = this.getParent(tab);
-    while (node) {
-      if (node._zenTreeCollapsed) {
+  #isHiddenByCollapse(node) {
+    let current = this.getParent(node);
+    while (current) {
+      if (current._zenTreeCollapsed) {
         return true;
       }
-      node = this.getParent(node);
+      current = this.getParent(current);
     }
     return false;
   }
 
-  // Ensure a clickable twisty exists on parent tabs (and not on leaves).
-  #updateTwisty(tab) {
-    const hasChildren = this.getChildren(tab).length > 0;
-    let twisty = tab.querySelector(".zen-tree-twisty");
+  // Keep a clickable twisty on parent nodes (and not on leaves). On a tab it
+  // overlays the favicon inside the icon stack; on a split group it floats over
+  // the group's inline-start edge.
+  #updateTwisty(node) {
+    const hasChildren = this.getChildren(node).length > 0;
+    const isGroup = this.#isSplitGroup(node);
+    let twisty = isGroup
+      ? node.querySelector(":scope > .zen-tree-twisty")
+      : node.querySelector(".tab-icon-stack > .zen-tree-twisty");
     if (hasChildren && !twisty) {
       twisty = document.createXULElement("image");
       twisty.className = "zen-tree-twisty";
       twisty.addEventListener("mousedown", e => {
         e.stopPropagation();
         e.preventDefault();
-        this.toggleCollapse(tab);
+        this.toggleCollapse(node);
       });
-      tab.insertBefore(twisty, tab.firstChild);
+      if (isGroup) {
+        twisty.classList.add("zen-tree-twisty-group");
+        // The group overrides appendChild to route children into its tab
+        // container (which feeds `.tabs`); bypass it so the twisty is a real
+        // direct child and isn't mistaken for a tab.
+        Node.prototype.appendChild.call(node, twisty);
+      } else {
+        const iconStack = node.querySelector(".tab-icon-stack");
+        const favicon = iconStack?.querySelector(".tab-icon-image");
+        if (favicon) {
+          favicon.after(twisty);
+        } else {
+          (iconStack || node).appendChild(twisty);
+        }
+      }
     } else if (!hasChildren && twisty) {
       twisty.remove();
     }
-    tab.toggleAttribute("zen-tree-parent", hasChildren);
+    node.toggleAttribute("zen-tree-parent", hasChildren);
   }
 
-  #isAncestor(maybeAncestor, tab) {
-    let node = this.getParent(tab);
-    while (node) {
-      if (node === maybeAncestor) {
+  #isAncestor(maybeAncestor, node) {
+    let current = this.getParent(node);
+    while (current) {
+      if (current === maybeAncestor) {
         return true;
       }
-      node = this.getParent(node);
+      current = this.getParent(current);
     }
     return false;
   }
 
-  #rootOf(tab) {
-    let node = tab;
-    while (this.getParent(node)) {
-      node = this.getParent(node);
+  #rootOf(node) {
+    let current = node;
+    while (this.getParent(current)) {
+      current = this.getParent(current);
     }
-    return node;
+    return current;
   }
 
-  #lastSubtreeNode(tab) {
-    const desc = this.getDescendants(tab);
-    return desc.length ? desc[desc.length - 1] : tab;
+  #lastSubtreeNode(node) {
+    const desc = this.getDescendants(node);
+    return desc.length ? desc[desc.length - 1] : node;
   }
 
-  #ancestorAtLevel(tab, level) {
-    let node = tab;
-    while (node && this.getLevel(node) > level) {
-      node = this.getParent(node);
+  #ancestorAtLevel(node, level) {
+    let current = node;
+    while (current && this.getLevel(current) > level) {
+      current = this.getParent(current);
     }
-    return node;
+    return current;
+  }
+
+  // Parent that puts a node at `level` when dropped just below `prev`: level 0 is
+  // the root, the deepest allowed (prev's level + 1) makes it prev's child, and
+  // values between climb prev's ancestor chain. Clamped to that valid range.
+  #parentForLevel(prev, level) {
+    if (!prev || level <= 0) {
+      return null;
+    }
+    const max = this.getLevel(prev) + 1;
+    return this.#ancestorAtLevel(prev, Math.min(level, max) - 1);
   }
 
   // Insert each subtree node, in order, immediately after `reference`,
@@ -384,32 +495,66 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     this._suppressMoveHandling = false;
   }
 
-  // After a plain reorder, set tab's parent to that of its previous visible
+  // After a plain reorder, set node's parent to that of its previous visible
   // sibling (or root at container start).
-  #reparentFromNeighbor(tab) {
-    if (!this.isTreeEligible(tab)) {
+  #reparentFromNeighbor(node) {
+    if (!this.isTreeEligible(node)) {
       return;
     }
-    let prev = tab.previousElementSibling;
+    let prev = node.previousElementSibling;
     while (prev && !this.isTreeEligible(prev)) {
       prev = prev.previousElementSibling;
     }
     const newParent = prev ? this.getParent(prev) : null;
-    if (newParent === tab || this.#isAncestor(tab, newParent)) {
+    if (newParent === node || this.#isAncestor(node, newParent)) {
       return; // never create a cycle
     }
-    if (this.getParent(tab) !== newParent) {
-      tab._zenTreeParent = newParent;
-      this.reindex(this.#rootOf(tab));
-      this.#onTreeChanged(tab);
+    if (this.getParent(node) !== newParent) {
+      node._zenTreeParent = newParent;
+      this.reindex(this.#rootOf(node));
+      this.#onTreeChanged(node);
     }
   }
 
   // Fire a change so window-sync can replicate the new tree state.
-  #onTreeChanged(tab) {
-    if (tab && tab.isConnected) {
-      tab.dispatchEvent(new CustomEvent("ZenTreeChanged", { bubbles: true }));
+  #onTreeChanged(node) {
+    if (node && node.isConnected) {
+      node.dispatchEvent(new CustomEvent("ZenTreeChanged", { bubbles: true }));
     }
+  }
+
+  // Drop a node out of the tree, promoting its children to its former parent and
+  // clearing its own tree state/attributes.
+  #clearNodeState(node) {
+    node._zenTreeParent = null;
+    node._zenTreeCollapsed = false;
+    node.removeAttribute?.("zen-tree-parent-id");
+    node.removeAttribute?.("zen-tree-collapsed");
+    node.removeAttribute?.("zen-tree-hidden");
+    node.style?.removeProperty("--zen-folder-indent");
+    this.#updateTwisty(node);
+  }
+
+  #evictFromTree(node) {
+    const children = this.getChildren(node);
+    const newParent = this.getParent(node);
+    for (const child of children) {
+      child._zenTreeParent = newParent;
+    }
+    this.#clearNodeState(node);
+
+    const roots = new Set();
+    if (newParent) {
+      roots.add(this.#rootOf(newParent));
+    } else {
+      for (const child of children) {
+        roots.add(child);
+      }
+    }
+    for (const root of roots) {
+      this.reindex(root);
+    }
+    this.#onTreeChanged(node);
   }
 
   on_TabOpen(event) {
@@ -422,13 +567,12 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     const tab = event.target;
     // `owner` is Firefox's opener-tab relationship for tabs opened from
     // another tab (link-in-new-tab, ctrl/middle click).
-    const opener = tab.owner;
+    const opener = tab.owner ? this.#nodeOf(tab.owner) : null;
     if (
       !opener ||
       !this.isTreeEligible(tab) ||
       !this.isTreeEligible(opener) ||
-      tab.getAttribute("zen-workspace-id") !==
-        opener.getAttribute("zen-workspace-id")
+      this.#workspaceIdOf(tab) !== this.#workspaceIdOf(opener)
     ) {
       return;
     }
@@ -439,8 +583,8 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     if (!this.enabled) {
       return;
     }
-    const tab = event.target;
-    const children = this.getChildren(tab);
+    const node = this.#nodeOf(event.target);
+    const children = this.getChildren(node);
     if (!children.length) {
       return;
     }
@@ -449,7 +593,9 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       "promote"
     );
     if (behavior === "close-subtree") {
-      const subtree = this.getDescendants(tab);
+      const subtree = this.getDescendants(node).flatMap(n =>
+        this.#isSplitGroup(n) ? [...n.tabs] : [n]
+      );
       // Defer so the current close finishes first.
       window.setTimeout(() => {
         gBrowser.removeTabs(
@@ -459,7 +605,7 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       }, 0);
       return;
     }
-    const newParent = this.getParent(tab);
+    const newParent = this.getParent(node);
     for (const child of children) {
       child._zenTreeParent = newParent;
     }
@@ -474,39 +620,71 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     for (const root of roots) {
       this.reindex(root);
     }
-    this.#onTreeChanged(tab);
+    this.#onTreeChanged(node);
   }
 
   on_TabPinned(event) {
-    if (!this.enabled) {
+    if (this.enabled) {
+      this.#evictFromTree(event.target);
+    }
+  }
+
+  // A tab joining a split view hands its tree role to the split group node: the
+  // group inherits the tab's parent, adopts its children, and the tab is cleared.
+  on_TabGrouped(event) {
+    const tab = event.detail;
+    const group = event.target;
+    if (!this.enabled || !this.#isSplitGroup(group)) {
       return;
     }
-    const tab = event.target;
-    const children = this.getChildren(tab);
-    const newParent = this.getParent(tab);
-    for (const child of children) {
-      child._zenTreeParent = newParent;
+    const tabParent = this.getParent(tab);
+    if (
+      tabParent &&
+      !this.getParent(group) &&
+      group !== tabParent &&
+      !this.#isAncestor(group, tabParent)
+    ) {
+      group._zenTreeParent = tabParent;
     }
-    tab._zenTreeParent = null;
-    tab._zenTreeCollapsed = false;
-    tab.removeAttribute("zen-tree-parent-id");
-    tab.removeAttribute("zen-tree-collapsed");
-    tab.removeAttribute("zen-tree-hidden");
-    tab.style.removeProperty("--zen-folder-indent");
-    this.#updateTwisty(tab);
-
-    const roots = new Set();
-    if (newParent) {
-      roots.add(this.#rootOf(newParent));
-    } else {
-      for (const child of children) {
-        roots.add(child);
+    for (const child of this.#childrenByPointer(tab)) {
+      if (child !== group && !this.#isAncestor(child, group)) {
+        child._zenTreeParent = group;
       }
     }
-    for (const root of roots) {
-      this.reindex(root);
+    this.#clearNodeState(tab);
+    this.reindex(this.#rootOf(group));
+    this.#onTreeChanged(group);
+  }
+
+  // A split shrinking below two tabs is no longer a node: promote its children
+  // to its parent and clear it. Deferred so the DOM settles first.
+  on_TabUngrouped(event) {
+    const group = event.target;
+    if (!this.enabled || !this.#isSplitGroup(group)) {
+      return;
     }
-    this.#onTreeChanged(tab);
+    window.setTimeout(() => this.#reconcileDissolvedSplit(group), 0);
+  }
+
+  #reconcileDissolvedSplit(group) {
+    const stillSplit =
+      group?.isConnected &&
+      this.#isSplitGroup(group) &&
+      (group.tabs || []).filter(t => t.isConnected).length >= 2;
+    if (stillSplit) {
+      return;
+    }
+    const groupParent = this.getParent(group);
+    const children = this.#childrenByPointer(group);
+    for (const child of children) {
+      child._zenTreeParent = groupParent;
+    }
+    this.#clearNodeState(group);
+    const root = groupParent ? this.#rootOf(groupParent) : children[0];
+    if (root) {
+      this.reindex(root);
+      this.#onTreeChanged(root);
+    }
   }
 
   on_TabMove(event) {
@@ -515,17 +693,17 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     if (!this.enabled || this._suppressMoveHandling || this._dragActive) {
       return;
     }
-    const tab = event.target;
-    if (!this.isTreeEligible(tab)) {
+    const node = this.#nodeOf(event.target);
+    if (!this.isTreeEligible(node)) {
       return;
     }
-    // A programmatic move relocates only this tab. If it has a subtree, bring
+    // A programmatic move relocates only this node. If it has a subtree, bring
     // the whole subtree along so it stays contiguous, then re-derive the parent.
-    const descendants = this.getDescendants(tab);
+    const descendants = this.getDescendants(node);
     if (descendants.length) {
-      this.#moveSubtreeAfter([tab, ...descendants], tab);
+      this.#moveSubtreeAfter([node, ...descendants], node);
     }
-    this.#reparentFromNeighbor(tab);
+    this.#reparentFromNeighbor(node);
   }
 
   on_SSWindowStateReady() {
@@ -538,26 +716,26 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       return;
     }
     const byId = new Map();
-    for (const tab of gBrowser.tabs) {
-      if (tab.id) {
-        byId.set(tab.id, tab);
+    for (const node of this.#nodes()) {
+      if (node.id) {
+        byId.set(node.id, node);
       }
     }
-    for (const tab of gBrowser.tabs) {
-      const pid = tab.getAttribute("zen-tree-parent-id");
+    for (const node of this.#nodes()) {
+      const pid = node.getAttribute("zen-tree-parent-id");
       const parent = pid ? byId.get(pid) : null;
-      tab._zenTreeParent =
-        parent && parent !== tab && this.isTreeEligible(tab) ? parent : null;
-      tab._zenTreeCollapsed = tab.hasAttribute("zen-tree-collapsed");
+      node._zenTreeParent =
+        parent && parent !== node && this.isTreeEligible(node) ? parent : null;
+      node._zenTreeCollapsed = node.hasAttribute("zen-tree-collapsed");
     }
-    for (const tab of gBrowser.tabs) {
-      if (this.isTreeEligible(tab) && !this.getParent(tab)) {
-        this.reindex(tab);
+    for (const node of this.#nodes()) {
+      if (this.isTreeEligible(node) && !this.getParent(node)) {
+        this.reindex(node);
       }
     }
-    for (const tab of gBrowser.tabs) {
-      if (tab._zenTreeCollapsed) {
-        for (const d of this.getDescendants(tab)) {
+    for (const node of this.#nodes()) {
+      if (node._zenTreeCollapsed) {
+        for (const d of this.getDescendants(node)) {
           d.toggleAttribute("zen-tree-hidden", this.#isHiddenByCollapse(d));
         }
       }

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -463,7 +463,13 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
   // Clickable twisty on parent nodes only. On a tab it overlays the favicon in
   // the icon stack; on a split group it floats at the group's inline-start edge.
   #updateTwisty(node) {
-    const hasChildren = !!this.getChildren(node).length;
+    // A tab that is mid-close still lives in `gBrowser.tabs` (and keeps its
+    // parent pointer) until its close animation finishes, so exclude closing
+    // children here — otherwise a parent keeps its twisty after its last child
+    // is gone, since no further reindex runs once the tab is finally removed.
+    const hasChildren = this.getChildren(node).some(
+      child => !this.#isClosing(child)
+    );
     const isGroup = this.#isSplitGroup(node);
     let twisty = isGroup
       ? node.querySelector(":scope > .zen-tree-twisty")

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -260,15 +260,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return true;
   }
 
-  promoteSubtree(node) {
-    const grandparent = this.getParent(this.getParent(node));
-    if (grandparent) {
-      this.nestTab(node, grandparent, { position: "end" });
-    } else {
-      this.detachTab(node);
-    }
-  }
-
   detachTab(node) {
     if (!this.getParent(node)) {
       return;
@@ -415,6 +406,7 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     }
     for (const r of affected) {
       this.reindex(r);
+      this.clampDepth(r);
       this.#enforceDomOrder(r);
     }
     this.#onTreeChanged(roots[0]);
@@ -681,6 +673,7 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
         window.setTimeout(() => {
           if (parent.isConnected) {
             this.reindex(this.#rootOf(parent));
+            this.#onTreeChanged(parent);
           }
         }, 0);
       }
@@ -822,6 +815,12 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     }
     const node = this.#nodeOf(event.target);
     if (!this.isTreeEligible(node)) {
+      return;
+    }
+    // A split group's tree position is owned by the group lifecycle (grouping,
+    // ungrouping, drag-drop), not derived from neighbors. Skip it so a move
+    // during split formation can't clobber the parent the handoff just set.
+    if (this.#isSplitGroup(node)) {
       return;
     }
     // A programmatic move relocates only this node. If it has a subtree, bring

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -329,10 +329,29 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return true;
   }
 
-  // REORDER drop: native move already placed the nodes. The eligible node just
-  // above the moved block (`prev`) anchors the level: with no explicit level the
-  // dragged roots become its siblings; with one (set by the drag's horizontal
-  // position) they land at that indent, where level 0 unparents to the root.
+  // The valid level range for inserting just below `prev` and above `next`: at
+  // most prev's child, and no shallower than next (else next is orphaned).
+  reorderLevelRange(prev, next) {
+    const prevLevel = prev ? this.getLevel(prev) : 0;
+    const maxLevel = prev ? prevLevel + 1 : 0;
+    const minLevel = Math.min(next ? this.getLevel(next) : 0, maxLevel);
+    return { minLevel, maxLevel, prevLevel };
+  }
+
+  // REORDER drop driven by the indicator: apply the exact anchor (`prev`) and
+  // level it resolved, so the drop always lands where the preview showed.
+  handleReorderDropAt(draggedTabs, prev, level) {
+    if (!this.enabled) {
+      return;
+    }
+    const roots = this.#draggedRoots(draggedTabs);
+    if (roots.length) {
+      this.#applyReorder(roots, this.#parentForLevel(prev, level ?? 0));
+    }
+  }
+
+  // REORDER drop with no indicator (e.g. programmatic): derive the anchor from
+  // the post-move neighbors and drop the roots as siblings of the node above.
   handleReorderDrop(draggedTabs, targetLevel = null) {
     if (!this.enabled) {
       return;
@@ -348,18 +367,17 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     while (prev && (!this.isTreeEligible(prev) || draggedNodes.has(prev))) {
       prev = prev.previousElementSibling;
     }
-    // The eligible node just below the moved block floors how shallow the drop
-    // can land, so dropping between nested tabs can't bisect the branch at root.
     let next = this.#lastSubtreeNode(roots[roots.length - 1]).nextElementSibling;
     while (next && (!this.isTreeEligible(next) || draggedNodes.has(next))) {
       next = next.nextElementSibling;
     }
-    const prevLevel = prev ? this.getLevel(prev) : 0;
-    const maxLevel = prev ? prevLevel + 1 : 0;
-    const minLevel = Math.min(next ? this.getLevel(next) : 0, maxLevel);
+    const { minLevel, maxLevel, prevLevel } = this.reorderLevelRange(prev, next);
     let level = targetLevel == null ? prevLevel : targetLevel;
     level = Math.max(minLevel, Math.min(level, maxLevel));
-    const newParent = this.#parentForLevel(prev, level);
+    this.#applyReorder(roots, this.#parentForLevel(prev, level));
+  }
+
+  #applyReorder(roots, newParent) {
     const affected = new Set();
     for (const root of roots) {
       const oldParent = this.getParent(root);

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -70,7 +70,7 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
   }
 
   get #indentStep() {
-    return Services.prefs.getIntPref("zen.tab-tree.indent", 20);
+    return Services.prefs.getIntPref("zen.tab-tree.indent", 14);
   }
 
   get #maxDepth() {

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -23,6 +23,14 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
   // Guard so our own DOM moves don't re-enter on_TabMove.
   _suppressMoveHandling = false;
 
+  // True while a user drag is in flight; the drop handler owns tree fixup then,
+  // so the per-move neighbor heuristic is suppressed (it would flatten a branch
+  // moved as a group). Programmatic moves (no drag) still go through on_TabMove.
+  _dragActive = false;
+
+  // The root tab of an auto-selected branch drag, so dragend can restore it.
+  _branchDragRoot = null;
+
   init() {
     this.#enabled =
       Services.prefs.getBoolPref("zen.tab-tree.enabled", true) &&
@@ -224,22 +232,67 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     }
   }
 
-  // Entry point used by the drag-and-drop drop handler.
-  // `draggedTabs` is the set of tabs being dragged (1 = subtree move,
-  // >1 = multi-selection one-level nest). Returns true if it nested anything.
+  // The "roots" of a dragged set: dragged tabs whose parent is NOT also in the
+  // set. Their subtrees travel with them and keep their internal hierarchy.
+  #draggedRoots(draggedTabs) {
+    const tabs = draggedTabs.filter(t => this.isTreeEligible(t));
+    const set = new Set(tabs);
+    return domOrderOf(tabs.filter(t => !set.has(this.getParent(t))));
+  }
+
+  // Entry point used by the drag-and-drop drop handler for a NEST drop.
+  // A single dragged root nests under the target keeping its hierarchy;
+  // multiple roots each become a direct child of the target (subtrees follow).
   handleNestDrop(draggedTabs, target) {
     if (!this.enabled || !this.isTreeEligible(target)) {
       return false;
     }
-    const tabs = draggedTabs.filter(t => this.isTreeEligible(t));
-    if (!tabs.length) {
+    const roots = this.#draggedRoots(draggedTabs);
+    if (!roots.length) {
       return false;
     }
-    if (tabs.length === 1) {
-      return this.nestTab(tabs[0], target);
+    if (roots.length === 1) {
+      return this.nestTab(roots[0], target);
     }
-    this.nestTabsAsChildren(tabs, target);
+    this.nestTabsAsChildren(roots, target);
     return true;
+  }
+
+  // Entry point for a plain REORDER drop. The native move already placed the
+  // dragged tabs at the new spot; make each dragged root a sibling there
+  // (parent = the eligible tab just above the moved block), preserving each
+  // root's internal subtree. Used for both single-tab and multi-tab reorders.
+  handleReorderDrop(draggedTabs) {
+    if (!this.enabled) {
+      return;
+    }
+    const roots = this.#draggedRoots(draggedTabs);
+    if (!roots.length) {
+      return;
+    }
+    const set = new Set(draggedTabs);
+    let prev = roots[0].previousElementSibling;
+    while (prev && (!this.isTreeEligible(prev) || set.has(prev))) {
+      prev = prev.previousElementSibling;
+    }
+    const newParent = prev ? this.getParent(prev) : null;
+    const affected = new Set();
+    for (const root of roots) {
+      if (
+        newParent === root ||
+        this.#isAncestor(root, newParent) ||
+        this.getParent(root) === newParent
+      ) {
+        affected.add(this.#rootOf(root));
+        continue;
+      }
+      root._zenTreeParent = newParent;
+      affected.add(this.#rootOf(root));
+    }
+    for (const r of affected) {
+      this.reindex(r);
+    }
+    this.#onTreeChanged(roots[0]);
   }
 
   // --- collapse / expand ---
@@ -483,10 +536,22 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
   }
 
   on_TabMove(event) {
-    if (!this.enabled || this._suppressMoveHandling) {
+    // During a user drag the drop handler owns tree fixup (handleReorderDrop /
+    // handleNestDrop). Only handle programmatic moves (e.g. gBrowser.moveTabTo).
+    if (!this.enabled || this._suppressMoveHandling || this._dragActive) {
       return;
     }
-    this.#reparentFromNeighbor(event.target);
+    const tab = event.target;
+    if (!this.isTreeEligible(tab)) {
+      return;
+    }
+    // A programmatic move relocates only this tab. If it has a subtree, bring
+    // the whole subtree along so it stays contiguous, then re-derive the parent.
+    const descendants = this.getDescendants(tab);
+    if (descendants.length) {
+      this.#moveSubtreeAfter([tab, ...descendants], tab);
+    }
+    this.#reparentFromNeighbor(tab);
   }
 
   // --- persistence ---

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -130,9 +130,8 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return this.#isSplitGroup(el);
   }
 
-  // The representative tab of the last eligible node not being dragged, so a drag
-  // below the list (including a drag of the last tab itself) can target the bottom
-  // edge and reorder/outdent there.
+  // Representative tab of the last eligible non-dragged node, so a drag below the
+  // list can target its bottom edge to reorder/outdent there.
   lastDropTab(exclude) {
     const nodes = this.#nodes().filter(
       n => this.isTreeEligible(n) && !exclude?.has(n)
@@ -193,14 +192,11 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     const apply = (node, level, hidden) => {
       node._zenTreeLevel = level;
       this.#applyIndent(node, level);
-      // Keep collapse-visibility in sync here too, so a node nested/moved under
-      // an already-collapsed parent hides immediately (and a node moved out of a
-      // collapsed branch sheds a stale zen-tree-hidden), without waiting for the
-      // next setCollapsed.
+      // Hide a node nested under a collapsed parent immediately (and shed a stale
+      // flag when moved out), without waiting for the next setCollapsed.
       node.toggleAttribute("zen-tree-hidden", hidden);
-      // Persist a stable tree identity. The live `id` is reassigned by
-      // window-sync when a tab is restored (undo-close), so children reference
-      // their parent by this id, which survives restore as a tab attribute.
+      // Stable identity for parent references: window-sync reassigns the live
+      // `id` on restore, so children match their parent by this persisted id.
       if (node.id) {
         node.setAttribute("zen-tree-id", node.id);
       }
@@ -461,9 +457,8 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return false;
   }
 
-  // Keep a clickable twisty on parent nodes (and not on leaves). On a tab it
-  // overlays the favicon inside the icon stack; on a split group it floats over
-  // the group's inline-start edge.
+  // Clickable twisty on parent nodes only. On a tab it overlays the favicon in
+  // the icon stack; on a split group it floats at the group's inline-start edge.
   #updateTwisty(node) {
     const hasChildren = this.getChildren(node).length > 0;
     const isGroup = this.#isSplitGroup(node);
@@ -542,9 +537,8 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return this.#ancestorAtLevel(prev, Math.min(level, max) - 1);
   }
 
-  // Re-assert DFS DOM order for a tree from its parent pointers, so a node the
-  // native drag misplaced (e.g. a split group inside a moved branch) sits right
-  // after its DFS predecessor instead of breaking the visual order.
+  // Re-assert DFS DOM order from parent pointers, so a node the native drag
+  // misplaced sits right after its DFS predecessor.
   #enforceDomOrder(root) {
     const dfs = [];
     const visit = node => {
@@ -603,7 +597,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       this.#onTreeChanged(node);
     }
   }
-
 
   // Fire a change so window-sync can replicate the new tree state.
   #onTreeChanged(node) {
@@ -673,10 +666,8 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       return;
     }
     const tab = event.target;
-    // A tab inside a split view is just one member of the group node, not the
-    // node itself: closing it must not promote/close the group's tree-children
-    // while the group is still alive. The group only leaves the tree when it
-    // fully dissolves, which on_TabUngrouped -> #reconcileDissolvedSplit handles.
+    // A split-view member closing isn't the group node closing; leave its
+    // tree-children alone (on_TabUngrouped handles a fully dissolved split).
     if (tab.group?.hasAttribute("split-view-group")) {
       return;
     }
@@ -712,11 +703,9 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       }, 0);
       return;
     }
-    // Promote surviving children to the nearest ancestor that isn't also closing
-    // in this batch. Children that are themselves closing are left untouched, so
-    // their persisted zen-tree-parent-id keeps describing the original branch and
-    // a later undo-close (Ctrl+Shift+T) can rebuild the hierarchy instead of
-    // restoring the tabs flat.
+    // Promote only surviving children, to the nearest non-closing ancestor.
+    // Co-closing members keep their parent-id so undo-close can rebuild the
+    // branch instead of restoring it flat.
     const survivingParent = this.#nearestSurvivingParent(node);
     const survivors = children.filter(child => !this.#isClosing(child));
     for (const child of survivors) {
@@ -736,9 +725,8 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     this.#onTreeChanged(node);
   }
 
-  // A tab is "closing" if it's mid-removal or was tagged as part of a
-  // multiselection close batch (set before any TabClose fires), so we can tell
-  // co-closing branch members from survivors during promotion.
+  // Mid-removal, or tagged for a multiselection close batch (before any
+  // TabClose fires) — lets us tell co-closing members from survivors.
   #isClosing(node) {
     return !!(node?.closing || node?._closedInMultiselection);
   }
@@ -849,11 +837,9 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     this.rebuildFromAttributes();
   }
 
-  // A tab restored on its own (undo-close / Ctrl+Shift+T) gets its persisted
-  // zen-tree-parent-id reapplied as a tab attribute, but nothing has reconnected
-  // the live parent pointers yet. Rebuild from attributes so it lands back in its
-  // branch instead of flat. Coalesce so a multi-tab restore only rebuilds once,
-  // after the whole burst has settled.
+  // Undo-close restores the persisted attributes but not the live pointers, so
+  // rebuild to put the tab back in its branch. Coalesced so a multi-tab restore
+  // only rebuilds once.
   on_SSTabRestored() {
     if (!this.enabled || this.#rebuildScheduled) {
       return;
@@ -870,9 +856,8 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     if (!this.enabled) {
       return;
     }
-    // Index by both the live id and the persisted stable tree id, so a parent
-    // still resolves after window-sync reassigned its live id on restore (the
-    // child's parent-id references the pre-restore id).
+    // Index by both the live id and the persisted zen-tree-id, so a parent
+    // resolves even after window-sync reassigned its id on restore.
     const byId = new Map();
     for (const node of this.#nodes()) {
       const treeId = node.getAttribute("zen-tree-id");
@@ -894,18 +879,14 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       if (!this.isTreeEligible(node) || this.getParent(node)) {
         continue;
       }
-      // A node whose persisted parent-id points at a tab that isn't present yet
-      // (e.g. mid incremental restore) is left pending: don't reindex it, since
-      // reindex would strip its zen-tree-parent-id and a later rebuild — once the
-      // parent is finally back — could never reconnect it.
+      // Parent not present yet (mid incremental restore): leave it pending —
+      // reindexing here would strip the parent-id a later rebuild needs.
       if (node.getAttribute("zen-tree-parent-id")) {
         continue;
       }
       this.reindex(node);
-      // A restored/synced subtree can land out of depth-first order in the strip
-      // (undo-close reinserts a child at its old index, with unrelated tabs
-      // between it and its parent); re-assert contiguous DFS order so the branch
-      // isn't visually split by other tabs.
+      // A restored subtree can land out of order (a child reinserted at its old
+      // index); re-assert DFS order so the branch isn't split by other tabs.
       if (this.getChildren(node).length) {
         this.#enforceDomOrder(node);
       }

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -4,6 +4,9 @@
 
 import { nsZenDOMOperatedFeature } from "chrome://browser/content/zen-components/ZenCommonUtils.mjs";
 
+/* eslint-disable no-shadow -- the `parent`/`opener` locals in this file are tree
+   nodes, never the window.parent / window.opener globals. */
+
 function domOrderOf(nodes) {
   return [...nodes].sort((a, b) => {
     const pos = a.compareDocumentPosition(b);
@@ -78,7 +81,9 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
   }
 
   #isSplitGroup(el) {
-    return !!el && gBrowser.isTabGroup(el) && el.hasAttribute("split-view-group");
+    return (
+      !!el && gBrowser.isTabGroup(el) && el.hasAttribute("split-view-group")
+    );
   }
 
   // The node that owns a tab: its split group if it is in one, else the tab.
@@ -375,11 +380,16 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     while (prev && (!this.isTreeEligible(prev) || draggedNodes.has(prev))) {
       prev = prev.previousElementSibling;
     }
-    let next = this.#lastSubtreeNode(roots[roots.length - 1]).nextElementSibling;
+    let next = this.#lastSubtreeNode(
+      roots[roots.length - 1]
+    ).nextElementSibling;
     while (next && (!this.isTreeEligible(next) || draggedNodes.has(next))) {
       next = next.nextElementSibling;
     }
-    const { minLevel, maxLevel, prevLevel } = this.reorderLevelRange(prev, next);
+    const { minLevel, maxLevel, prevLevel } = this.reorderLevelRange(
+      prev,
+      next
+    );
     let level = targetLevel == null ? prevLevel : targetLevel;
     level = Math.max(minLevel, Math.min(level, maxLevel));
     this.#applyReorder(roots, this.#parentForLevel(prev, level));
@@ -453,7 +463,7 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
   // Clickable twisty on parent nodes only. On a tab it overlays the favicon in
   // the icon stack; on a split group it floats at the group's inline-start edge.
   #updateTwisty(node) {
-    const hasChildren = this.getChildren(node).length > 0;
+    const hasChildren = !!this.getChildren(node).length;
     const isGroup = this.#isSplitGroup(node);
     let twisty = isGroup
       ? node.querySelector(":scope > .zen-tree-twisty")

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -125,6 +125,17 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return this.#isSplitGroup(el);
   }
 
+  // The representative tab of the last eligible node not being dragged, so a drag
+  // below the list (including a drag of the last tab itself) can target the bottom
+  // edge and reorder/outdent there.
+  lastDropTab(exclude) {
+    const nodes = this.#nodes().filter(
+      n => this.isTreeEligible(n) && !exclude?.has(n)
+    );
+    const last = nodes[nodes.length - 1];
+    return last ? this.#representativeTab(last) : null;
+  }
+
   isTreeEligible(node) {
     if (this.#isSplitGroup(node)) {
       return !node.pinned && !node.hasAttribute("zen-essential");
@@ -337,27 +348,40 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     while (prev && (!this.isTreeEligible(prev) || draggedNodes.has(prev))) {
       prev = prev.previousElementSibling;
     }
-    let newParent;
-    if (targetLevel == null) {
-      newParent = prev ? this.getParent(prev) : null;
-    } else {
-      newParent = this.#parentForLevel(prev, targetLevel);
+    // The eligible node just below the moved block floors how shallow the drop
+    // can land, so dropping between nested tabs can't bisect the branch at root.
+    let next = this.#lastSubtreeNode(roots[roots.length - 1]).nextElementSibling;
+    while (next && (!this.isTreeEligible(next) || draggedNodes.has(next))) {
+      next = next.nextElementSibling;
     }
+    const prevLevel = prev ? this.getLevel(prev) : 0;
+    const maxLevel = prev ? prevLevel + 1 : 0;
+    const minLevel = Math.min(next ? this.getLevel(next) : 0, maxLevel);
+    let level = targetLevel == null ? prevLevel : targetLevel;
+    level = Math.max(minLevel, Math.min(level, maxLevel));
+    const newParent = this.#parentForLevel(prev, level);
     const affected = new Set();
     for (const root of roots) {
+      const oldParent = this.getParent(root);
       if (
         newParent === root ||
         this.#isAncestor(root, newParent) ||
-        this.getParent(root) === newParent
+        oldParent === newParent
       ) {
         affected.add(this.#rootOf(root));
         continue;
       }
       root._zenTreeParent = newParent;
       affected.add(this.#rootOf(root));
+      // Refresh the former parent too, so it loses its twisty if this was its
+      // last child.
+      if (oldParent) {
+        affected.add(this.#rootOf(oldParent));
+      }
     }
     for (const r of affected) {
       this.reindex(r);
+      this.#enforceDomOrder(r);
     }
     this.#onTreeChanged(roots[0]);
   }
@@ -480,6 +504,28 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return this.#ancestorAtLevel(prev, Math.min(level, max) - 1);
   }
 
+  // Re-assert DFS DOM order for a tree from its parent pointers, so a node the
+  // native drag misplaced (e.g. a split group inside a moved branch) sits right
+  // after its DFS predecessor instead of breaking the visual order.
+  #enforceDomOrder(root) {
+    const dfs = [];
+    const visit = node => {
+      dfs.push(node);
+      for (const child of this.getChildren(node)) {
+        visit(child);
+      }
+    };
+    visit(root);
+    this._suppressMoveHandling = true;
+    for (let i = 1; i < dfs.length; i++) {
+      if (dfs[i].previousElementSibling !== dfs[i - 1]) {
+        dfs[i - 1].after(dfs[i]);
+      }
+    }
+    gBrowser.tabContainer._invalidateCachedTabs();
+    this._suppressMoveHandling = false;
+  }
+
   // Insert each subtree node, in order, immediately after `reference`,
   // advancing the reference so the block stays contiguous.
   #moveSubtreeAfter(subtree, reference) {
@@ -509,12 +555,17 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     if (newParent === node || this.#isAncestor(node, newParent)) {
       return; // never create a cycle
     }
-    if (this.getParent(node) !== newParent) {
+    const oldParent = this.getParent(node);
+    if (oldParent !== newParent) {
       node._zenTreeParent = newParent;
       this.reindex(this.#rootOf(node));
+      if (oldParent) {
+        this.reindex(this.#rootOf(oldParent));
+      }
       this.#onTreeChanged(node);
     }
   }
+
 
   // Fire a change so window-sync can replicate the new tree state.
   #onTreeChanged(node) {
@@ -586,6 +637,16 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     const node = this.#nodeOf(event.target);
     const children = this.getChildren(node);
     if (!children.length) {
+      // A leaf is closing: once it's gone, refresh its parent so the parent
+      // drops its twisty if this was its last child.
+      const parent = this.getParent(node);
+      if (parent) {
+        window.setTimeout(() => {
+          if (parent.isConnected) {
+            this.reindex(this.#rootOf(parent));
+          }
+        }, 0);
+      }
       return;
     }
     const behavior = Services.prefs.getStringPref(
@@ -653,6 +714,16 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     }
     this.#clearNodeState(tab);
     this.reindex(this.#rootOf(group));
+    // The split element was just inserted at the original tab's spot; once the DOM
+    // settles, re-assert DFS order so adopted children sit below the group, not
+    // above it.
+    window.setTimeout(() => {
+      if (group.isConnected) {
+        this.reindex(this.#rootOf(group));
+        this.#enforceDomOrder(this.#rootOf(group));
+        this.#onTreeChanged(group);
+      }
+    }, 0);
     this.#onTreeChanged(group);
   }
 
@@ -683,6 +754,7 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     const root = groupParent ? this.#rootOf(groupParent) : children[0];
     if (root) {
       this.reindex(root);
+      this.#enforceDomOrder(root);
       this.#onTreeChanged(root);
     }
   }

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -28,7 +28,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
   // moved as a group). Programmatic moves (no drag) still go through on_TabMove.
   _dragActive = false;
 
-  // The root tab of an auto-selected branch drag, so dragend can restore it.
   _branchDragRoot = null;
 
   init() {
@@ -68,8 +67,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return Services.prefs.getIntPref("zen.tab-tree.max-depth", 4);
   }
 
-  // --- queries ---
-
   isTreeEligible(tab) {
     return (
       gBrowser.isTab(tab) &&
@@ -98,7 +95,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
   }
 
   getChildren(tab) {
-    // Children in DOM order. Tree relationships only span same-workspace tabs.
     return domOrderOf(gBrowser.tabs.filter(t => this.getParent(t) === tab));
   }
 
@@ -110,7 +106,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return out;
   }
 
-  // Recompute cached level + indentation + twisty for `root` and descendants.
   reindex(root) {
     const apply = (tab, level) => {
       tab._zenTreeLevel = level;
@@ -136,9 +131,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     );
   }
 
-  // --- tree mutations ---
-
-  // Move `tab` (and its entire subtree) to become the last child of `parent`.
   nestTab(tab, parent, { position = "end" } = {}) {
     if (
       tab === parent ||
@@ -155,10 +147,9 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     const subtree = [tab, ...this.getDescendants(tab)]; // already DFS order
     tab._zenTreeParent = parent;
 
-    // Determine insertion reference within the strip.
     let reference;
     if (position === "start") {
-      reference = parent; // first child goes right after the parent
+      reference = parent;
     } else {
       const existing = this.getChildren(parent).filter(c => c !== tab);
       const lastChild = existing[existing.length - 1];
@@ -176,7 +167,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return true;
   }
 
-  // Re-parent `tab` to its grandparent (or root). Subtree follows.
   promoteSubtree(tab) {
     const grandparent = this.getParent(this.getParent(tab));
     if (grandparent) {
@@ -186,7 +176,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     }
   }
 
-  // Make `tab` a root: clear its parent, leave its subtree intact beneath it.
   detachTab(tab) {
     if (!this.getParent(tab)) {
       return;
@@ -196,8 +185,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     this.#onTreeChanged(tab);
   }
 
-  // Make every tab in `tabs` a DIRECT child (one level) of `parent`.
-  // Each tab keeps its own subtree. Order follows `tabs` order.
   nestTabsAsChildren(tabs, parent) {
     const eligible = tabs.filter(
       t =>
@@ -208,13 +195,12 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     }
   }
 
-  // Flatten any descendants of `root` whose level exceeds max-depth.
-  // Deepest-first: a node beyond the cap is re-parented to the nearest
+  // Flatten overflow: a node beyond max-depth is re-parented to the nearest
   // ancestor at (max-depth - 1), collapsing overflow at the cap boundary.
   clampDepth(root) {
     const max = this.#maxDepth;
     if (max <= 0) {
-      return; // cap disabled
+      return;
     }
     let changed = false;
     // getDescendants() returns DFS order so parents precede their children.
@@ -240,9 +226,8 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return domOrderOf(tabs.filter(t => !set.has(this.getParent(t))));
   }
 
-  // Entry point used by the drag-and-drop drop handler for a NEST drop.
-  // A single dragged root nests under the target keeping its hierarchy;
-  // multiple roots each become a direct child of the target (subtrees follow).
+  // NEST drop: a single dragged root nests under target keeping its hierarchy;
+  // multiple roots each become a direct child of target (subtrees follow).
   handleNestDrop(draggedTabs, target) {
     if (!this.enabled || !this.isTreeEligible(target)) {
       return false;
@@ -258,10 +243,8 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return true;
   }
 
-  // Entry point for a plain REORDER drop. The native move already placed the
-  // dragged tabs at the new spot; make each dragged root a sibling there
-  // (parent = the eligible tab just above the moved block), preserving each
-  // root's internal subtree. Used for both single-tab and multi-tab reorders.
+  // REORDER drop: native move already placed the tabs; make each dragged root a
+  // sibling there (parent = the eligible tab just above the moved block).
   handleReorderDrop(draggedTabs) {
     if (!this.enabled) {
       return;
@@ -295,11 +278,9 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     this.#onTreeChanged(roots[0]);
   }
 
-  // --- collapse / expand ---
-
   setCollapsed(tab, collapsed) {
     if (!this.getChildren(tab).length) {
-      return; // nothing to collapse
+      return;
     }
     tab._zenTreeCollapsed = collapsed;
     tab.toggleAttribute("zen-tree-collapsed", collapsed);
@@ -356,8 +337,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     tab.toggleAttribute("zen-tree-parent", hasChildren);
   }
 
-  // --- internal helpers ---
-
   #isAncestor(maybeAncestor, tab) {
     let node = this.getParent(tab);
     while (node) {
@@ -377,7 +356,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     return node;
   }
 
-  // Last tab (deepest, last) in `tab`'s subtree, in DFS order.
   #lastSubtreeNode(tab) {
     const desc = this.getDescendants(tab);
     return desc.length ? desc[desc.length - 1] : tab;
@@ -434,8 +412,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     }
   }
 
-  // --- lifecycle event handlers ---
-
   on_TabOpen(event) {
     if (
       !this.enabled ||
@@ -483,7 +459,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       }, 0);
       return;
     }
-    // promote: re-parent each direct child to the closing tab's parent.
     const newParent = this.getParent(tab);
     for (const child of children) {
       child._zenTreeParent = newParent;
@@ -509,7 +484,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     const tab = event.target;
     const children = this.getChildren(tab);
     const newParent = this.getParent(tab);
-    // Promote children to the tab's parent, then detach the tab itself.
     for (const child of children) {
       child._zenTreeParent = newParent;
     }
@@ -526,7 +500,7 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       roots.add(this.#rootOf(newParent));
     } else {
       for (const child of children) {
-        roots.add(child); // each promoted to root
+        roots.add(child);
       }
     }
     for (const root of roots) {
@@ -554,14 +528,11 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     this.#reparentFromNeighbor(tab);
   }
 
-  // --- persistence ---
-
   on_SSWindowStateReady() {
     this.rebuildFromAttributes();
   }
 
-  // Reconnect _zenTreeParent pointers from persisted zen-tree-parent-id, then
-  // re-apply levels, indentation, collapse hiding, and twisties.
+  // Reconnect _zenTreeParent pointers from persisted zen-tree-parent-id.
   rebuildFromAttributes() {
     if (!this.enabled) {
       return;
@@ -579,7 +550,6 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
         parent && parent !== tab && this.isTreeEligible(tab) ? parent : null;
       tab._zenTreeCollapsed = tab.hasAttribute("zen-tree-collapsed");
     }
-    // Reindex all roots, then re-apply collapse hiding for collapsed nodes.
     for (const tab of gBrowser.tabs) {
       if (this.isTreeEligible(tab) && !this.getParent(tab)) {
         this.reindex(tab);

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -195,9 +195,10 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       // Hide a node nested under a collapsed parent immediately (and shed a stale
       // flag when moved out), without waiting for the next setCollapsed.
       node.toggleAttribute("zen-tree-hidden", hidden);
-      // Stable identity for parent references: window-sync reassigns the live
-      // `id` on restore, so children match their parent by this persisted id.
-      if (node.id) {
+      // Stable identity for parent references, set once: window-sync reassigns
+      // the live `id` on restore, so children match their parent by this
+      // persisted id — overwriting it from the new `id` would defeat that.
+      if (node.id && !node.hasAttribute("zen-tree-id")) {
         node.setAttribute("zen-tree-id", node.id);
       }
       const parent = this.getParent(node);
@@ -871,8 +872,17 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     for (const node of this.#nodes()) {
       const pid = node.getAttribute("zen-tree-parent-id");
       const parent = pid ? byId.get(pid) : null;
+      // Only reattach to a valid parent: an eligible node, in the same
+      // workspace, and not the node itself — same guards as nestTab, so restore
+      // and sync can't recreate a link under a pinned tab or across workspaces.
       node._zenTreeParent =
-        parent && parent !== node && this.isTreeEligible(node) ? parent : null;
+        parent &&
+        parent !== node &&
+        this.isTreeEligible(node) &&
+        this.isTreeEligible(parent) &&
+        this.#workspaceIdOf(node) === this.#workspaceIdOf(parent)
+          ? parent
+          : null;
       node._zenTreeCollapsed = node.hasAttribute("zen-tree-collapsed");
     }
     for (const node of this.#nodes()) {

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -640,9 +640,14 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       return;
     }
     const tab = event.target;
-    // The tab a new tab was opened from. `_zenOpenerTab` is our durable capture
-    // (Firefox clears `owner` on successive related tabs); fall back to `owner`.
-    const ownerTab = tab._zenOpenerTab || tab.owner;
+    // Only auto-nest under the tab a link was opened from IN CONTENT.
+    // `_zenOpenerTab` is our durable capture of Firefox's in-content opener
+    // (`openerBrowser`'s tab, or a same-referrer related tab); it's null when the
+    // tab has no in-content origin — a bookmark, the address bar, the new-tab
+    // button, or another app — and those must open at root. We deliberately do
+    // NOT fall back to `tab.owner`: Firefox sets that to the current tab for
+    // *any* foreground open, so it would wrongly nest bookmarks/external opens.
+    const ownerTab = tab._zenOpenerTab;
     const opener = ownerTab ? this.#nodeOf(ownerTab) : null;
     if (
       !opener ||

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -639,9 +639,10 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       return;
     }
     const tab = event.target;
-    // `owner` is Firefox's opener-tab relationship for tabs opened from
-    // another tab (link-in-new-tab, ctrl/middle click).
-    const opener = tab.owner ? this.#nodeOf(tab.owner) : null;
+    // The tab a new tab was opened from. `_zenOpenerTab` is our durable capture
+    // (Firefox clears `owner` on successive related tabs); fall back to `owner`.
+    const ownerTab = tab._zenOpenerTab || tab.owner;
+    const opener = ownerTab ? this.#nodeOf(ownerTab) : null;
     if (
       !opener ||
       !this.isTreeEligible(tab) ||

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -33,6 +33,10 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
 
   _branchDragRoot = null;
 
+  // Coalesces the attribute-driven rebuild across a burst of tab restores
+  // (Ctrl+Shift+T can bring several closed tabs back in quick succession).
+  #rebuildScheduled = false;
+
   init() {
     this.#enabled =
       Services.prefs.getBoolPref("zen.tab-tree.enabled", true) &&
@@ -55,6 +59,7 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     window.addEventListener("TabGrouped", this);
     window.addEventListener("TabUngrouped", this);
     window.addEventListener("SSWindowStateReady", this);
+    window.addEventListener("SSTabRestored", this);
   }
 
   handleEvent(aEvent) {
@@ -193,9 +198,18 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       // collapsed branch sheds a stale zen-tree-hidden), without waiting for the
       // next setCollapsed.
       node.toggleAttribute("zen-tree-hidden", hidden);
+      // Persist a stable tree identity. The live `id` is reassigned by
+      // window-sync when a tab is restored (undo-close), so children reference
+      // their parent by this id, which survives restore as a tab attribute.
+      if (node.id) {
+        node.setAttribute("zen-tree-id", node.id);
+      }
       const parent = this.getParent(node);
       if (parent) {
-        node.setAttribute("zen-tree-parent-id", parent.id || "");
+        node.setAttribute(
+          "zen-tree-parent-id",
+          parent.getAttribute("zen-tree-id") || parent.id || ""
+        );
       } else {
         node.removeAttribute("zen-tree-parent-id");
       }
@@ -698,15 +712,21 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       }, 0);
       return;
     }
-    const newParent = this.getParent(node);
-    for (const child of children) {
-      child._zenTreeParent = newParent;
+    // Promote surviving children to the nearest ancestor that isn't also closing
+    // in this batch. Children that are themselves closing are left untouched, so
+    // their persisted zen-tree-parent-id keeps describing the original branch and
+    // a later undo-close (Ctrl+Shift+T) can rebuild the hierarchy instead of
+    // restoring the tabs flat.
+    const survivingParent = this.#nearestSurvivingParent(node);
+    const survivors = children.filter(child => !this.#isClosing(child));
+    for (const child of survivors) {
+      child._zenTreeParent = survivingParent;
     }
     const roots = new Set();
-    if (newParent) {
-      roots.add(this.#rootOf(newParent));
+    if (survivingParent) {
+      roots.add(this.#rootOf(survivingParent));
     } else {
-      for (const child of children) {
+      for (const child of survivors) {
         roots.add(child);
       }
     }
@@ -714,6 +734,21 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       this.reindex(root);
     }
     this.#onTreeChanged(node);
+  }
+
+  // A tab is "closing" if it's mid-removal or was tagged as part of a
+  // multiselection close batch (set before any TabClose fires), so we can tell
+  // co-closing branch members from survivors during promotion.
+  #isClosing(node) {
+    return !!(node?.closing || node?._closedInMultiselection);
+  }
+
+  #nearestSurvivingParent(node) {
+    let parent = this.getParent(node);
+    while (parent && this.#isClosing(parent)) {
+      parent = this.getParent(parent);
+    }
+    return parent || null;
   }
 
   on_TabPinned(event) {
@@ -814,13 +849,36 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
     this.rebuildFromAttributes();
   }
 
+  // A tab restored on its own (undo-close / Ctrl+Shift+T) gets its persisted
+  // zen-tree-parent-id reapplied as a tab attribute, but nothing has reconnected
+  // the live parent pointers yet. Rebuild from attributes so it lands back in its
+  // branch instead of flat. Coalesce so a multi-tab restore only rebuilds once,
+  // after the whole burst has settled.
+  on_SSTabRestored() {
+    if (!this.enabled || this.#rebuildScheduled) {
+      return;
+    }
+    this.#rebuildScheduled = true;
+    window.setTimeout(() => {
+      this.#rebuildScheduled = false;
+      this.rebuildFromAttributes();
+    }, 0);
+  }
+
   // Reconnect _zenTreeParent pointers from persisted zen-tree-parent-id.
   rebuildFromAttributes() {
     if (!this.enabled) {
       return;
     }
+    // Index by both the live id and the persisted stable tree id, so a parent
+    // still resolves after window-sync reassigned its live id on restore (the
+    // child's parent-id references the pre-restore id).
     const byId = new Map();
     for (const node of this.#nodes()) {
+      const treeId = node.getAttribute("zen-tree-id");
+      if (treeId) {
+        byId.set(treeId, node);
+      }
       if (node.id) {
         byId.set(node.id, node);
       }
@@ -833,8 +891,23 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
       node._zenTreeCollapsed = node.hasAttribute("zen-tree-collapsed");
     }
     for (const node of this.#nodes()) {
-      if (this.isTreeEligible(node) && !this.getParent(node)) {
-        this.reindex(node);
+      if (!this.isTreeEligible(node) || this.getParent(node)) {
+        continue;
+      }
+      // A node whose persisted parent-id points at a tab that isn't present yet
+      // (e.g. mid incremental restore) is left pending: don't reindex it, since
+      // reindex would strip its zen-tree-parent-id and a later rebuild — once the
+      // parent is finally back — could never reconnect it.
+      if (node.getAttribute("zen-tree-parent-id")) {
+        continue;
+      }
+      this.reindex(node);
+      // A restored/synced subtree can land out of depth-first order in the strip
+      // (undo-close reinserts a child at its old index, with unrelated tabs
+      // between it and its parent); re-assert contiguous DFS order so the branch
+      // isn't visually split by other tabs.
+      if (this.getChildren(node).length) {
+        this.#enforceDomOrder(node);
       }
     }
     for (const node of this.#nodes()) {

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -1,0 +1,533 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { nsZenDOMOperatedFeature } from "chrome://browser/content/zen-components/ZenCommonUtils.mjs";
+
+function domOrderOf(tabs) {
+  return [...tabs].sort((a, b) => {
+    const pos = a.compareDocumentPosition(b);
+    if (pos & Node.DOCUMENT_POSITION_FOLLOWING) {
+      return -1;
+    }
+    if (pos & Node.DOCUMENT_POSITION_PRECEDING) {
+      return 1;
+    }
+    return 0;
+  });
+}
+
+class nsZenTabTree extends nsZenDOMOperatedFeature {
+  #enabled = false;
+
+  // Guard so our own DOM moves don't re-enter on_TabMove.
+  _suppressMoveHandling = false;
+
+  init() {
+    this.#enabled =
+      Services.prefs.getBoolPref("zen.tab-tree.enabled", true) &&
+      !gZenWorkspaces.privateWindowOrDisabled;
+    if (!this.#enabled) {
+      return;
+    }
+    this.#initEventListeners();
+  }
+
+  get enabled() {
+    return this.#enabled;
+  }
+
+  #initEventListeners() {
+    window.addEventListener("TabOpen", this);
+    window.addEventListener("TabClose", this);
+    window.addEventListener("TabMove", this);
+    window.addEventListener("TabPinned", this);
+    window.addEventListener("SSWindowStateReady", this);
+  }
+
+  handleEvent(aEvent) {
+    const methodName = `on_${aEvent.type}`;
+    if (methodName in this) {
+      this[methodName](aEvent);
+    }
+  }
+
+  get #indentStep() {
+    return Services.prefs.getIntPref("zen.tab-tree.indent", 14);
+  }
+
+  get #maxDepth() {
+    return Services.prefs.getIntPref("zen.tab-tree.max-depth", 4);
+  }
+
+  // --- queries ---
+
+  isTreeEligible(tab) {
+    return (
+      gBrowser.isTab(tab) &&
+      !tab.pinned &&
+      !tab.hasAttribute("zen-essential") &&
+      !tab.hasAttribute("zen-glance-tab") &&
+      !tab.hasAttribute("zen-empty-tab") &&
+      !tab.hasAttribute("zen-live-folder-item-id") &&
+      !tab.group?.hasAttribute("split-view-group")
+    );
+  }
+
+  getParent(tab) {
+    const parent = tab._zenTreeParent;
+    return parent && parent.isConnected ? parent : null;
+  }
+
+  getLevel(tab) {
+    let level = 0;
+    let node = this.getParent(tab);
+    while (node) {
+      level++;
+      node = this.getParent(node);
+    }
+    return level;
+  }
+
+  getChildren(tab) {
+    // Children in DOM order. Tree relationships only span same-workspace tabs.
+    return domOrderOf(gBrowser.tabs.filter(t => this.getParent(t) === tab));
+  }
+
+  getDescendants(tab) {
+    const out = [];
+    for (const child of this.getChildren(tab)) {
+      out.push(child, ...this.getDescendants(child));
+    }
+    return out;
+  }
+
+  // Recompute cached level + indentation + twisty for `root` and descendants.
+  reindex(root) {
+    const apply = (tab, level) => {
+      tab._zenTreeLevel = level;
+      this.#applyIndent(tab, level);
+      const parent = this.getParent(tab);
+      if (parent) {
+        tab.setAttribute("zen-tree-parent-id", parent.id || "");
+      } else {
+        tab.removeAttribute("zen-tree-parent-id");
+      }
+      this.#updateTwisty(tab);
+      for (const child of this.getChildren(tab)) {
+        apply(child, level + 1);
+      }
+    };
+    apply(root, this.getLevel(root));
+  }
+
+  #applyIndent(tab, level) {
+    tab.style.setProperty(
+      "--zen-folder-indent",
+      `${level * this.#indentStep}px`
+    );
+  }
+
+  // --- tree mutations ---
+
+  // Move `tab` (and its entire subtree) to become the last child of `parent`.
+  nestTab(tab, parent, { position = "end" } = {}) {
+    if (
+      tab === parent ||
+      !this.isTreeEligible(tab) ||
+      !this.isTreeEligible(parent) ||
+      this.#isAncestor(tab, parent) || // prevent cycles
+      tab.getAttribute("zen-workspace-id") !==
+        parent.getAttribute("zen-workspace-id")
+    ) {
+      return false;
+    }
+
+    const previousParent = this.getParent(tab);
+    const subtree = [tab, ...this.getDescendants(tab)]; // already DFS order
+    tab._zenTreeParent = parent;
+
+    // Determine insertion reference within the strip.
+    let reference;
+    if (position === "start") {
+      reference = parent; // first child goes right after the parent
+    } else {
+      const existing = this.getChildren(parent).filter(c => c !== tab);
+      const lastChild = existing[existing.length - 1];
+      reference = lastChild ? this.#lastSubtreeNode(lastChild) : parent;
+    }
+
+    this.#moveSubtreeAfter(subtree, reference);
+    const root = this.#rootOf(parent);
+    this.reindex(root);
+    this.clampDepth(root);
+    if (previousParent && previousParent !== parent) {
+      this.reindex(this.#rootOf(previousParent));
+    }
+    this.#onTreeChanged(tab);
+    return true;
+  }
+
+  // Re-parent `tab` to its grandparent (or root). Subtree follows.
+  promoteSubtree(tab) {
+    const grandparent = this.getParent(this.getParent(tab));
+    if (grandparent) {
+      this.nestTab(tab, grandparent, { position: "end" });
+    } else {
+      this.detachTab(tab);
+    }
+  }
+
+  // Make `tab` a root: clear its parent, leave its subtree intact beneath it.
+  detachTab(tab) {
+    if (!this.getParent(tab)) {
+      return;
+    }
+    tab._zenTreeParent = null;
+    this.reindex(tab);
+    this.#onTreeChanged(tab);
+  }
+
+  // Make every tab in `tabs` a DIRECT child (one level) of `parent`.
+  // Each tab keeps its own subtree. Order follows `tabs` order.
+  nestTabsAsChildren(tabs, parent) {
+    const eligible = tabs.filter(
+      t =>
+        t !== parent && this.isTreeEligible(t) && !this.#isAncestor(t, parent)
+    );
+    for (const t of eligible) {
+      this.nestTab(t, parent, { position: "end" });
+    }
+  }
+
+  // Flatten any descendants of `root` whose level exceeds max-depth.
+  // Deepest-first: a node beyond the cap is re-parented to the nearest
+  // ancestor at (max-depth - 1), collapsing overflow at the cap boundary.
+  clampDepth(root) {
+    const max = this.#maxDepth;
+    if (max <= 0) {
+      return; // cap disabled
+    }
+    let changed = false;
+    // getDescendants() returns DFS order so parents precede their children.
+    for (const node of this.getDescendants(root)) {
+      if (this.getLevel(node) > max) {
+        const anchor = this.#ancestorAtLevel(node, max - 1);
+        if (anchor && this.getParent(node) !== anchor) {
+          node._zenTreeParent = anchor;
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      this.reindex(root);
+    }
+  }
+
+  // Entry point used by the drag-and-drop drop handler.
+  // `draggedTabs` is the set of tabs being dragged (1 = subtree move,
+  // >1 = multi-selection one-level nest). Returns true if it nested anything.
+  handleNestDrop(draggedTabs, target) {
+    if (!this.enabled || !this.isTreeEligible(target)) {
+      return false;
+    }
+    const tabs = draggedTabs.filter(t => this.isTreeEligible(t));
+    if (!tabs.length) {
+      return false;
+    }
+    if (tabs.length === 1) {
+      return this.nestTab(tabs[0], target);
+    }
+    this.nestTabsAsChildren(tabs, target);
+    return true;
+  }
+
+  // --- collapse / expand ---
+
+  setCollapsed(tab, collapsed) {
+    if (!this.getChildren(tab).length) {
+      return; // nothing to collapse
+    }
+    tab._zenTreeCollapsed = collapsed;
+    tab.toggleAttribute("zen-tree-collapsed", collapsed);
+
+    const descendants = this.getDescendants(tab);
+    for (const d of descendants) {
+      // A descendant is hidden if ANY ancestor up to `tab` is collapsed.
+      d.toggleAttribute("zen-tree-hidden", this.#isHiddenByCollapse(d));
+    }
+
+    if (
+      collapsed &&
+      gBrowser.selectedTab &&
+      descendants.includes(gBrowser.selectedTab)
+    ) {
+      gBrowser.selectedTab = tab; // nearest visible ancestor
+    }
+
+    this.#updateTwisty(tab);
+    this.#onTreeChanged(tab);
+  }
+
+  toggleCollapse(tab) {
+    this.setCollapsed(tab, !tab._zenTreeCollapsed);
+  }
+
+  #isHiddenByCollapse(tab) {
+    let node = this.getParent(tab);
+    while (node) {
+      if (node._zenTreeCollapsed) {
+        return true;
+      }
+      node = this.getParent(node);
+    }
+    return false;
+  }
+
+  // Ensure a clickable twisty exists on parent tabs (and not on leaves).
+  #updateTwisty(tab) {
+    const hasChildren = this.getChildren(tab).length > 0;
+    let twisty = tab.querySelector(".zen-tree-twisty");
+    if (hasChildren && !twisty) {
+      twisty = document.createXULElement("image");
+      twisty.className = "zen-tree-twisty";
+      twisty.addEventListener("mousedown", e => {
+        e.stopPropagation();
+        e.preventDefault();
+        this.toggleCollapse(tab);
+      });
+      tab.insertBefore(twisty, tab.firstChild);
+    } else if (!hasChildren && twisty) {
+      twisty.remove();
+    }
+    tab.toggleAttribute("zen-tree-parent", hasChildren);
+  }
+
+  // --- internal helpers ---
+
+  #isAncestor(maybeAncestor, tab) {
+    let node = this.getParent(tab);
+    while (node) {
+      if (node === maybeAncestor) {
+        return true;
+      }
+      node = this.getParent(node);
+    }
+    return false;
+  }
+
+  #rootOf(tab) {
+    let node = tab;
+    while (this.getParent(node)) {
+      node = this.getParent(node);
+    }
+    return node;
+  }
+
+  // Last tab (deepest, last) in `tab`'s subtree, in DFS order.
+  #lastSubtreeNode(tab) {
+    const desc = this.getDescendants(tab);
+    return desc.length ? desc[desc.length - 1] : tab;
+  }
+
+  #ancestorAtLevel(tab, level) {
+    let node = tab;
+    while (node && this.getLevel(node) > level) {
+      node = this.getParent(node);
+    }
+    return node;
+  }
+
+  // Insert each subtree node, in order, immediately after `reference`,
+  // advancing the reference so the block stays contiguous.
+  #moveSubtreeAfter(subtree, reference) {
+    this._suppressMoveHandling = true;
+    let ref = reference;
+    for (const node of subtree) {
+      if (node !== ref && node.previousElementSibling !== ref) {
+        ref.after(node);
+      }
+      ref = node;
+    }
+    gBrowser.tabContainer._invalidateCachedTabs();
+    this._suppressMoveHandling = false;
+  }
+
+  // After a plain reorder, set tab's parent to that of its previous visible
+  // sibling (or root at container start).
+  #reparentFromNeighbor(tab) {
+    if (!this.isTreeEligible(tab)) {
+      return;
+    }
+    let prev = tab.previousElementSibling;
+    while (prev && !this.isTreeEligible(prev)) {
+      prev = prev.previousElementSibling;
+    }
+    const newParent = prev ? this.getParent(prev) : null;
+    if (newParent === tab || this.#isAncestor(tab, newParent)) {
+      return; // never create a cycle
+    }
+    if (this.getParent(tab) !== newParent) {
+      tab._zenTreeParent = newParent;
+      this.reindex(this.#rootOf(tab));
+      this.#onTreeChanged(tab);
+    }
+  }
+
+  // Fire a change so window-sync can replicate the new tree state.
+  #onTreeChanged(tab) {
+    if (tab && tab.isConnected) {
+      tab.dispatchEvent(new CustomEvent("ZenTreeChanged", { bubbles: true }));
+    }
+  }
+
+  // --- lifecycle event handlers ---
+
+  on_TabOpen(event) {
+    if (
+      !this.enabled ||
+      !Services.prefs.getBoolPref("zen.tab-tree.auto-nest-by-opener", true)
+    ) {
+      return;
+    }
+    const tab = event.target;
+    // `owner` is Firefox's opener-tab relationship for tabs opened from
+    // another tab (link-in-new-tab, ctrl/middle click).
+    const opener = tab.owner;
+    if (
+      !opener ||
+      !this.isTreeEligible(tab) ||
+      !this.isTreeEligible(opener) ||
+      tab.getAttribute("zen-workspace-id") !==
+        opener.getAttribute("zen-workspace-id")
+    ) {
+      return;
+    }
+    this.nestTab(tab, opener);
+  }
+
+  on_TabClose(event) {
+    if (!this.enabled) {
+      return;
+    }
+    const tab = event.target;
+    const children = this.getChildren(tab);
+    if (!children.length) {
+      return;
+    }
+    const behavior = Services.prefs.getStringPref(
+      "zen.tab-tree.close-parent-behavior",
+      "promote"
+    );
+    if (behavior === "close-subtree") {
+      const subtree = this.getDescendants(tab);
+      // Defer so the current close finishes first.
+      window.setTimeout(() => {
+        gBrowser.removeTabs(
+          subtree.filter(t => t.isConnected && !t.closing),
+          { animate: true }
+        );
+      }, 0);
+      return;
+    }
+    // promote: re-parent each direct child to the closing tab's parent.
+    const newParent = this.getParent(tab);
+    for (const child of children) {
+      child._zenTreeParent = newParent;
+    }
+    const roots = new Set();
+    if (newParent) {
+      roots.add(this.#rootOf(newParent));
+    } else {
+      for (const child of children) {
+        roots.add(child);
+      }
+    }
+    for (const root of roots) {
+      this.reindex(root);
+    }
+    this.#onTreeChanged(tab);
+  }
+
+  on_TabPinned(event) {
+    if (!this.enabled) {
+      return;
+    }
+    const tab = event.target;
+    const children = this.getChildren(tab);
+    const newParent = this.getParent(tab);
+    // Promote children to the tab's parent, then detach the tab itself.
+    for (const child of children) {
+      child._zenTreeParent = newParent;
+    }
+    tab._zenTreeParent = null;
+    tab._zenTreeCollapsed = false;
+    tab.removeAttribute("zen-tree-parent-id");
+    tab.removeAttribute("zen-tree-collapsed");
+    tab.removeAttribute("zen-tree-hidden");
+    tab.style.removeProperty("--zen-folder-indent");
+    this.#updateTwisty(tab);
+
+    const roots = new Set();
+    if (newParent) {
+      roots.add(this.#rootOf(newParent));
+    } else {
+      for (const child of children) {
+        roots.add(child); // each promoted to root
+      }
+    }
+    for (const root of roots) {
+      this.reindex(root);
+    }
+    this.#onTreeChanged(tab);
+  }
+
+  on_TabMove(event) {
+    if (!this.enabled || this._suppressMoveHandling) {
+      return;
+    }
+    this.#reparentFromNeighbor(event.target);
+  }
+
+  // --- persistence ---
+
+  on_SSWindowStateReady() {
+    this.rebuildFromAttributes();
+  }
+
+  // Reconnect _zenTreeParent pointers from persisted zen-tree-parent-id, then
+  // re-apply levels, indentation, collapse hiding, and twisties.
+  rebuildFromAttributes() {
+    if (!this.enabled) {
+      return;
+    }
+    const byId = new Map();
+    for (const tab of gBrowser.tabs) {
+      if (tab.id) {
+        byId.set(tab.id, tab);
+      }
+    }
+    for (const tab of gBrowser.tabs) {
+      const pid = tab.getAttribute("zen-tree-parent-id");
+      const parent = pid ? byId.get(pid) : null;
+      tab._zenTreeParent =
+        parent && parent !== tab && this.isTreeEligible(tab) ? parent : null;
+      tab._zenTreeCollapsed = tab.hasAttribute("zen-tree-collapsed");
+    }
+    // Reindex all roots, then re-apply collapse hiding for collapsed nodes.
+    for (const tab of gBrowser.tabs) {
+      if (this.isTreeEligible(tab) && !this.getParent(tab)) {
+        this.reindex(tab);
+      }
+    }
+    for (const tab of gBrowser.tabs) {
+      if (tab._zenTreeCollapsed) {
+        for (const d of this.getDescendants(tab)) {
+          d.toggleAttribute("zen-tree-hidden", this.#isHiddenByCollapse(d));
+        }
+      }
+    }
+  }
+}
+
+window.gZenTabTree = new nsZenTabTree();

--- a/src/zen/tab-tree/ZenTabTree.mjs
+++ b/src/zen/tab-tree/ZenTabTree.mjs
@@ -83,7 +83,7 @@ class nsZenTabTree extends nsZenDOMOperatedFeature {
   }
 
   getParent(tab) {
-    const parent = tab._zenTreeParent;
+    const parent = tab?._zenTreeParent;
     return parent && parent.isConnected ? parent : null;
   }
 

--- a/src/zen/tab-tree/jar.inc.mn
+++ b/src/zen/tab-tree/jar.inc.mn
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+        content/browser/zen-components/ZenTabTree.mjs                           (../../zen/tab-tree/ZenTabTree.mjs)
+        content/browser/zen-components/ZenTabMultiSelectDrag.mjs                (../../zen/tab-tree/ZenTabMultiSelectDrag.mjs)
+        content/browser/zen-styles/zen-tab-tree.css                             (../../zen/tab-tree/zen-tab-tree.css)

--- a/src/zen/tab-tree/zen-tab-tree.css
+++ b/src/zen/tab-tree/zen-tab-tree.css
@@ -7,6 +7,13 @@ tab-group[split-view-group][zen-tree-hidden] {
   display: none !important;
 }
 
+/* During a middle-mouse drag-select, hide per-tab close (X) buttons. The
+   gesture selects a range that's closed together on release, so a hover/
+   multiselected close affordance on individual tabs is misleading mid-drag. */
+#tabbrowser-tabs[zen-multi-drag-selecting] .tab-close-button {
+  display: none !important;
+}
+
 /* Shared twisty look. It's hidden until the parent row is hovered (or stays
    visible while collapsed so the branch can be reopened). */
 .zen-tree-twisty {

--- a/src/zen/tab-tree/zen-tab-tree.css
+++ b/src/zen/tab-tree/zen-tab-tree.css
@@ -47,3 +47,9 @@ zen-tree-nest-indicator {
   background-color: var(--zen-primary-color, AccentColor);
   pointer-events: none;
 }
+
+/* Middle-mouse drag-select: hint that releasing will close these tabs. */
+.tabbrowser-tab[zen-pending-close] {
+  outline: 1px solid color-mix(in srgb, red 60%, transparent);
+  outline-offset: -1px;
+}

--- a/src/zen/tab-tree/zen-tab-tree.css
+++ b/src/zen/tab-tree/zen-tab-tree.css
@@ -107,9 +107,3 @@ tab-group[split-view-group][zen-tree-nest-target] {
   box-shadow: none !important;
   outline: none !important;
 }
-
-/* Middle-mouse drag-select: hint that releasing will close these tabs. */
-.tabbrowser-tab[zen-pending-close] {
-  outline: 1px solid color-mix(in srgb, red 60%, transparent);
-  outline-offset: -1px;
-}

--- a/src/zen/tab-tree/zen-tab-tree.css
+++ b/src/zen/tab-tree/zen-tab-tree.css
@@ -68,29 +68,6 @@ tab-group[split-view-group][zen-tree-collapsed] > .zen-tree-twisty {
   display: none;
 }
 
-/* Drop indicator line: under the target at child indent for a nest, or in the
-   gap at the chosen indent for a reorder. A dot marks the indent anchor. */
-zen-tree-nest-indicator {
-  display: block;
-  height: 2px;
-  margin-block: 1px;
-  margin-inline-end: 8px;
-  border-radius: 1px;
-  background-color: var(--zen-primary-color, AccentColor);
-  pointer-events: none;
-}
-
-zen-tree-nest-indicator::before {
-  content: "";
-  display: block;
-  width: 6px;
-  height: 6px;
-  margin-block: -2px;
-  margin-inline-start: -3px;
-  border-radius: 50%;
-  background-color: var(--zen-primary-color, AccentColor);
-}
-
 /* The node a quick-drop will nest under is outlined so the target is obvious. */
 .tabbrowser-tab[zen-tree-nest-target],
 tab-group[split-view-group][zen-tree-nest-target] {

--- a/src/zen/tab-tree/zen-tab-tree.css
+++ b/src/zen/tab-tree/zen-tab-tree.css
@@ -52,9 +52,18 @@ tab-group[split-view-group][zen-tree-collapsed] > .zen-tree-twisty {
   opacity: 1;
 }
 
-/* Favicon steps aside while the twisty is shown over it. */
+/* Favicon steps aside while the twisty is shown over it. On a split group the
+   twisty sits over the leftmost tab's favicon, so hide that one. */
 .tabbrowser-tab[zen-tree-parent]:hover .tab-icon-image,
-.tabbrowser-tab[zen-tree-collapsed] .tab-icon-image {
+.tabbrowser-tab[zen-tree-collapsed] .tab-icon-image,
+tab-group[split-view-group][zen-tree-parent]:hover
+  .tab-group-container
+  > .tabbrowser-tab:first-child
+  .tab-icon-image,
+tab-group[split-view-group][zen-tree-collapsed]
+  .tab-group-container
+  > .tabbrowser-tab:first-child
+  .tab-icon-image {
   opacity: 0;
 }
 
@@ -74,6 +83,23 @@ tab-group[split-view-group][zen-tree-nest-target] {
   outline: 2px solid var(--zen-primary-color, AccentColor);
   outline-offset: -2px;
   border-radius: var(--border-radius-medium, 8px);
+}
+
+/* A dragged tree branch is auto-multiselected so it moves as one block, but it
+   shouldn't render as a manual multiselect highlight on the in-place tabs. */
+#tabbrowser-tabs[zen-branch-dragging]
+  .tabbrowser-tab[multiselected]:not([visuallyselected]),
+#tabbrowser-tabs[zen-branch-dragging]
+  tab-group[split-view-group]:has([multiselected]) {
+  --tab-selected-bgcolor: transparent;
+}
+
+#tabbrowser-tabs[zen-branch-dragging]
+  .tabbrowser-tab[multiselected]:not([visuallyselected])
+  .tab-background {
+  background: transparent !important;
+  box-shadow: none !important;
+  outline: none !important;
 }
 
 /* Middle-mouse drag-select: hint that releasing will close these tabs. */

--- a/src/zen/tab-tree/zen-tab-tree.css
+++ b/src/zen/tab-tree/zen-tab-tree.css
@@ -2,39 +2,74 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.tabbrowser-tab[zen-tree-hidden] {
+.tabbrowser-tab[zen-tree-hidden],
+tab-group[split-view-group][zen-tree-hidden] {
   display: none !important;
 }
 
-.tabbrowser-tab .zen-tree-twisty {
-  width: 12px;
-  height: 12px;
-  margin-inline: 2px;
-  flex-shrink: 0;
+/* Shared twisty look. It's hidden until the parent row is hovered (or stays
+   visible while collapsed so the branch can be reopened). */
+.zen-tree-twisty {
+  width: 16px;
+  height: 16px;
   -moz-context-properties: fill;
   fill: currentColor;
-  opacity: 0.7;
   list-style-image: url("chrome://global/skin/icons/arrow-down.svg");
+  opacity: 0;
+  pointer-events: none;
+  cursor: pointer;
   transition:
     transform 0.15s ease,
     opacity 0.15s ease;
-  cursor: pointer;
 }
 
-.tabbrowser-tab .zen-tree-twisty:hover {
+/* On a tab the twisty is a favicon sibling inside the icon <stack>, so it
+   overlays the favicon with no layout width and the parent keeps its own indent.
+   The icon-stack margins keep it left-aligned over the favicon. */
+.tabbrowser-tab .zen-tree-twisty {
+  margin-inline-end: var(--toolbarbutton-inner-padding) !important;
+  margin-inline-start: calc(var(--toolbarbutton-inner-padding) / 3) !important;
+}
+
+/* On a split group it floats over the group's inline-start edge. */
+tab-group[split-view-group] > .zen-tree-twisty {
+  position: absolute;
+  inset-inline-start: 4px;
+  inset-block: 0;
+  margin-block: auto;
+  z-index: 3;
+}
+
+.tabbrowser-tab[zen-tree-parent]:hover .zen-tree-twisty,
+.tabbrowser-tab[zen-tree-collapsed] .zen-tree-twisty,
+tab-group[split-view-group][zen-tree-parent]:hover > .zen-tree-twisty,
+tab-group[split-view-group][zen-tree-collapsed] > .zen-tree-twisty {
+  opacity: 0.85;
+  pointer-events: auto;
+}
+
+.zen-tree-twisty:hover {
   opacity: 1;
 }
 
+/* Favicon steps aside while the twisty is shown over it. */
+.tabbrowser-tab[zen-tree-parent]:hover .tab-icon-image,
+.tabbrowser-tab[zen-tree-collapsed] .tab-icon-image {
+  opacity: 0;
+}
+
 /* Point right when collapsed, down when expanded. */
-.tabbrowser-tab[zen-tree-collapsed] .zen-tree-twisty {
+.tabbrowser-tab[zen-tree-collapsed] .zen-tree-twisty,
+tab-group[split-view-group][zen-tree-collapsed] > .zen-tree-twisty {
   transform: rotate(-90deg);
 }
 
-:root:not([zen-sidebar-expanded="true"]) .tabbrowser-tab .zen-tree-twisty {
+:root:not([zen-sidebar-expanded="true"]) .zen-tree-twisty {
   display: none;
 }
 
-/* Drop-as-child indicator shown under the target tab during a nest drag. */
+/* Drop indicator line: under the target at child indent for a nest, or in the
+   gap at the chosen indent for a reorder. A dot marks the indent anchor. */
 zen-tree-nest-indicator {
   display: block;
   height: 2px;
@@ -43,6 +78,25 @@ zen-tree-nest-indicator {
   border-radius: 1px;
   background-color: var(--zen-primary-color, AccentColor);
   pointer-events: none;
+}
+
+zen-tree-nest-indicator::before {
+  content: "";
+  display: block;
+  width: 6px;
+  height: 6px;
+  margin-block: -2px;
+  margin-inline-start: -3px;
+  border-radius: 50%;
+  background-color: var(--zen-primary-color, AccentColor);
+}
+
+/* The node a quick-drop will nest under is outlined so the target is obvious. */
+.tabbrowser-tab[zen-tree-nest-target],
+tab-group[split-view-group][zen-tree-nest-target] {
+  outline: 2px solid var(--zen-primary-color, AccentColor);
+  outline-offset: -2px;
+  border-radius: var(--border-radius-medium, 8px);
 }
 
 /* Middle-mouse drag-select: hint that releasing will close these tabs. */

--- a/src/zen/tab-tree/zen-tab-tree.css
+++ b/src/zen/tab-tree/zen-tab-tree.css
@@ -2,12 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* Hide collapsed descendants. */
 .tabbrowser-tab[zen-tree-hidden] {
   display: none !important;
 }
 
-/* Collapse twisty on parent tabs. */
 .tabbrowser-tab .zen-tree-twisty {
   width: 12px;
   height: 12px;
@@ -32,12 +30,11 @@
   transform: rotate(-90deg);
 }
 
-/* Only show the twisty on parent tabs when the sidebar is expanded. */
 :root:not([zen-sidebar-expanded="true"]) .tabbrowser-tab .zen-tree-twisty {
   display: none;
 }
 
-/* Drop-as-child indicator: a thin indented line under the target tab. */
+/* Drop-as-child indicator shown under the target tab during a nest drag. */
 zen-tree-nest-indicator {
   display: block;
   height: 2px;

--- a/src/zen/tab-tree/zen-tab-tree.css
+++ b/src/zen/tab-tree/zen-tab-tree.css
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* Hide collapsed descendants. */
+.tabbrowser-tab[zen-tree-hidden] {
+  display: none !important;
+}
+
+/* Collapse twisty on parent tabs. */
+.tabbrowser-tab .zen-tree-twisty {
+  width: 12px;
+  height: 12px;
+  margin-inline: 2px;
+  flex-shrink: 0;
+  -moz-context-properties: fill;
+  fill: currentColor;
+  opacity: 0.7;
+  list-style-image: url("chrome://global/skin/icons/arrow-down.svg");
+  transition:
+    transform 0.15s ease,
+    opacity 0.15s ease;
+  cursor: pointer;
+}
+
+.tabbrowser-tab .zen-tree-twisty:hover {
+  opacity: 1;
+}
+
+/* Point right when collapsed, down when expanded. */
+.tabbrowser-tab[zen-tree-collapsed] .zen-tree-twisty {
+  transform: rotate(-90deg);
+}
+
+/* Only show the twisty on parent tabs when the sidebar is expanded. */
+:root:not([zen-sidebar-expanded="true"]) .tabbrowser-tab .zen-tree-twisty {
+  display: none;
+}
+
+/* Drop-as-child indicator: a thin indented line under the target tab. */
+zen-tree-nest-indicator {
+  display: block;
+  height: 2px;
+  margin-block: 1px;
+  margin-inline-end: 8px;
+  border-radius: 1px;
+  background-color: var(--zen-primary-color, AccentColor);
+  pointer-events: none;
+}

--- a/src/zen/tab-tree/zen-tab-tree.css
+++ b/src/zen/tab-tree/zen-tab-tree.css
@@ -31,10 +31,12 @@ tab-group[split-view-group][zen-tree-hidden] {
   margin-inline-start: calc(var(--toolbarbutton-inner-padding) / 3) !important;
 }
 
-/* On a split group it floats over the group's inline-start edge. */
+/* On a split group it floats over the leftmost tab's favicon. That favicon sits
+   at the tab's inner padding from the edge, so match it (a bare few px reads as
+   left-of-center against the favicon). */
 tab-group[split-view-group] > .zen-tree-twisty {
   position: absolute;
-  inset-inline-start: 4px;
+  inset-inline-start: var(--toolbarbutton-inner-padding, 8px);
   inset-block: 0;
   margin-block: auto;
   z-index: 3;
@@ -53,16 +55,20 @@ tab-group[split-view-group][zen-tree-collapsed] > .zen-tree-twisty {
 }
 
 /* Favicon steps aside while the twisty is shown over it. On a split group the
-   twisty sits over the leftmost tab's favicon, so hide that one. */
+   twisty sits over the leftmost tab's favicon, so hide that one. The container's
+   first child is a .zen-tab-group-start spacer, so the leftmost tab is the one
+   right after it (not :first-child). */
 .tabbrowser-tab[zen-tree-parent]:hover .tab-icon-image,
 .tabbrowser-tab[zen-tree-collapsed] .tab-icon-image,
 tab-group[split-view-group][zen-tree-parent]:hover
   .tab-group-container
-  > .tabbrowser-tab:first-child
+  > .zen-tab-group-start
+  + .tabbrowser-tab
   .tab-icon-image,
 tab-group[split-view-group][zen-tree-collapsed]
   .tab-group-container
-  > .tabbrowser-tab:first-child
+  > .zen-tab-group-start
+  + .tabbrowser-tab
   .tab-icon-image {
   opacity: 0;
 }

--- a/src/zen/tab-tree/zen-tab-tree.css
+++ b/src/zen/tab-tree/zen-tab-tree.css
@@ -49,10 +49,14 @@ tab-group[split-view-group] > .zen-tree-twisty {
   z-index: 3;
 }
 
-.tabbrowser-tab[zen-tree-parent]:hover .zen-tree-twisty,
-.tabbrowser-tab[zen-tree-collapsed] .zen-tree-twisty,
-tab-group[split-view-group][zen-tree-parent]:hover > .zen-tree-twisty,
-tab-group[split-view-group][zen-tree-collapsed] > .zen-tree-twisty {
+#tabbrowser-tabs .tabbrowser-tab[zen-tree-parent]:hover .zen-tree-twisty,
+#tabbrowser-tabs .tabbrowser-tab[zen-tree-collapsed] .zen-tree-twisty,
+#tabbrowser-tabs
+  tab-group[split-view-group][zen-tree-parent]:hover
+  > .zen-tree-twisty,
+#tabbrowser-tabs
+  tab-group[split-view-group][zen-tree-collapsed]
+  > .zen-tree-twisty {
   opacity: 0.85;
   pointer-events: auto;
 }
@@ -64,15 +68,23 @@ tab-group[split-view-group][zen-tree-collapsed] > .zen-tree-twisty {
 /* Favicon steps aside while the twisty is shown over it. On a split group the
    twisty sits over the leftmost tab's favicon, so hide that one. The container's
    first child is a .zen-tab-group-start spacer, so the leftmost tab is the one
-   right after it (not :first-child). */
-.tabbrowser-tab[zen-tree-parent]:hover .tab-icon-image,
-.tabbrowser-tab[zen-tree-collapsed] .tab-icon-image,
-tab-group[split-view-group][zen-tree-parent]:hover
+   right after it (not :first-child).
+
+   Scoped through #tabbrowser-tabs on purpose: a tab with no favicon of its own
+   gets a placeholder square from vertical-tabs.css
+   (`.tab-icon-image:not([src])`, nested under #tabbrowser-tabs and so more
+   specific than a bare class chain), which otherwise keeps showing through
+   underneath the twisty. */
+#tabbrowser-tabs .tabbrowser-tab[zen-tree-parent]:hover .tab-icon-image,
+#tabbrowser-tabs .tabbrowser-tab[zen-tree-collapsed] .tab-icon-image,
+#tabbrowser-tabs
+  tab-group[split-view-group][zen-tree-parent]:hover
   .tab-group-container
   > .zen-tab-group-start
   + .tabbrowser-tab
   .tab-icon-image,
-tab-group[split-view-group][zen-tree-collapsed]
+#tabbrowser-tabs
+  tab-group[split-view-group][zen-tree-collapsed]
   .tab-group-container
   > .zen-tab-group-start
   + .tabbrowser-tab

--- a/src/zen/tests/moz.build
+++ b/src/zen/tests/moz.build
@@ -16,6 +16,7 @@ BROWSER_CHROME_MANIFESTS += [
     "space_routing/browser.toml",
     "spaces/browser.toml",
     "split_view/browser.toml",
+    "tab-tree/browser.toml",
     "tabs/browser.toml",
     "ub-actions/browser.toml",
     "urlbar/browser.toml",

--- a/src/zen/tests/tab-tree/browser.toml
+++ b/src/zen/tests/tab-tree/browser.toml
@@ -5,6 +5,7 @@
 [DEFAULT]
 prefs = [
   "zen.tab-tree.enabled=true",
+  "zen.tabs.middle-drag-select.enabled=true",
   "widget.macos.native-context-menus=false",
 ]
 support-files = [
@@ -32,3 +33,7 @@ support-files = [
 ["browser_tree_reorder.js"]
 
 ["browser_tree_persist.js"]
+
+["browser_middledrag_select.js"]
+
+["browser_middledrag_actions.js"]

--- a/src/zen/tests/tab-tree/browser.toml
+++ b/src/zen/tests/tab-tree/browser.toml
@@ -29,4 +29,6 @@ support-files = [
 
 ["browser_tree_pin_reorder.js"]
 
+["browser_tree_reorder.js"]
+
 ["browser_tree_persist.js"]

--- a/src/zen/tests/tab-tree/browser.toml
+++ b/src/zen/tests/tab-tree/browser.toml
@@ -20,6 +20,10 @@ support-files = [
 
 ["browser_tree_depth.js"]
 
+["browser_tree_eligibility.js"]
+
+["browser_tree_workspace.js"]
+
 ["browser_tree_collapse.js"]
 
 ["browser_tree_drag.js"]

--- a/src/zen/tests/tab-tree/browser.toml
+++ b/src/zen/tests/tab-tree/browser.toml
@@ -34,6 +34,8 @@ support-files = [
 
 ["browser_tree_persist.js"]
 
+["browser_tree_split_node.js"]
+
 ["browser_middledrag_select.js"]
 
 ["browser_middledrag_actions.js"]

--- a/src/zen/tests/tab-tree/browser.toml
+++ b/src/zen/tests/tab-tree/browser.toml
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+[DEFAULT]
+prefs = [
+  "zen.tab-tree.enabled=true",
+  "widget.macos.native-context-menus=false",
+]
+support-files = [
+  "head.js",
+]
+
+["browser_tree_model.js"]
+
+["browser_tree_nest.js"]
+
+["browser_tree_detach_multi.js"]
+
+["browser_tree_depth.js"]
+
+["browser_tree_collapse.js"]
+
+["browser_tree_drag.js"]
+
+["browser_tree_opener.js"]
+
+["browser_tree_close.js"]
+
+["browser_tree_pin_reorder.js"]
+
+["browser_tree_persist.js"]

--- a/src/zen/tests/tab-tree/browser.toml
+++ b/src/zen/tests/tab-tree/browser.toml
@@ -12,34 +12,34 @@ support-files = [
   "head.js",
 ]
 
+["browser_middledrag_actions.js"]
+
+["browser_middledrag_select.js"]
+
+["browser_tree_close.js"]
+
+["browser_tree_collapse.js"]
+
+["browser_tree_depth.js"]
+
+["browser_tree_detach_multi.js"]
+
+["browser_tree_drag.js"]
+
+["browser_tree_eligibility.js"]
+
 ["browser_tree_model.js"]
 
 ["browser_tree_nest.js"]
 
-["browser_tree_detach_multi.js"]
-
-["browser_tree_depth.js"]
-
-["browser_tree_eligibility.js"]
-
-["browser_tree_workspace.js"]
-
-["browser_tree_collapse.js"]
-
-["browser_tree_drag.js"]
-
 ["browser_tree_opener.js"]
 
-["browser_tree_close.js"]
+["browser_tree_persist.js"]
 
 ["browser_tree_pin_reorder.js"]
 
 ["browser_tree_reorder.js"]
 
-["browser_tree_persist.js"]
-
 ["browser_tree_split_node.js"]
 
-["browser_middledrag_select.js"]
-
-["browser_middledrag_actions.js"]
+["browser_tree_workspace.js"]

--- a/src/zen/tests/tab-tree/browser_middledrag_actions.js
+++ b/src/zen/tests/tab-tree/browser_middledrag_actions.js
@@ -67,7 +67,22 @@ add_task(async function test_rightclick_aborts_and_opens_menu() {
   );
   ok(t1.isConnected && t2.isConnected, "tabs not closed after abort");
 
+  // The trailing release must NOT reveal the per-tab close (X) buttons while the
+  // aborted context menu is still open on the selection — they stay suppressed
+  // until the menu is dismissed.
+  const strip = document.getElementById("tabbrowser-tabs");
+  ok(
+    strip.hasAttribute("zen-multi-drag-selecting"),
+    "close buttons stay hidden while the aborted context menu is open"
+  );
+  const hidden = BrowserTestUtils.waitForEvent(menu, "popuphidden");
   menu.hidePopup();
+  await hidden;
+  ok(
+    !strip.hasAttribute("zen-multi-drag-selecting"),
+    "close buttons restored once the menu closes"
+  );
+
   gBrowser.clearMultiSelectedTabs();
   await cleanupTabs(t1, t2);
 });

--- a/src/zen/tests/tab-tree/browser_middledrag_actions.js
+++ b/src/zen/tests/tab-tree/browser_middledrag_actions.js
@@ -9,11 +9,23 @@ add_task(async function test_release_closes_selected_range() {
   const t3 = await addNormalTab();
   gBrowser.clearMultiSelectedTabs();
 
-  EventUtils.synthesizeMouseAtCenter(t1, { type: "mousedown", button: 1 }, window);
-  EventUtils.synthesizeMouseAtCenter(t3, { type: "mousemove", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(
+    t1,
+    { type: "mousedown", button: 1 },
+    window
+  );
+  EventUtils.synthesizeMouseAtCenter(
+    t3,
+    { type: "mousemove", button: 1 },
+    window
+  );
   const c1 = BrowserTestUtils.waitForTabClosing(t1);
   const c3 = BrowserTestUtils.waitForTabClosing(t3);
-  EventUtils.synthesizeMouseAtCenter(t3, { type: "mouseup", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(
+    t3,
+    { type: "mouseup", button: 1 },
+    window
+  );
   await Promise.all([c1, c3]);
   ok(t1.closing || !t1.isConnected, "t1 closed on release");
   ok(t3.closing || !t3.isConnected, "t3 closed on release");
@@ -26,8 +38,16 @@ add_task(async function test_rightclick_aborts_and_opens_menu() {
   const t2 = await addNormalTab();
   gBrowser.clearMultiSelectedTabs();
 
-  EventUtils.synthesizeMouseAtCenter(t1, { type: "mousedown", button: 1 }, window);
-  EventUtils.synthesizeMouseAtCenter(t2, { type: "mousemove", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(
+    t1,
+    { type: "mousedown", button: 1 },
+    window
+  );
+  EventUtils.synthesizeMouseAtCenter(
+    t2,
+    { type: "mousemove", button: 1 },
+    window
+  );
 
   const menu = document.getElementById("tabContextMenu");
   const shown = BrowserTestUtils.waitForEvent(menu, "popupshown");
@@ -40,7 +60,11 @@ add_task(async function test_rightclick_aborts_and_opens_menu() {
   ok(true, "context menu opened on right-click during middle-drag");
 
   // After abort, releasing middle does nothing (tabs stay open).
-  EventUtils.synthesizeMouseAtCenter(t2, { type: "mouseup", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(
+    t2,
+    { type: "mouseup", button: 1 },
+    window
+  );
   ok(t1.isConnected && t2.isConnected, "tabs not closed after abort");
 
   menu.hidePopup();
@@ -52,8 +76,16 @@ add_task(async function test_clean_middleclick_closes_one() {
   const t1 = await addNormalTab();
   gBrowser.clearMultiSelectedTabs();
   const closing = BrowserTestUtils.waitForTabClosing(t1);
-  EventUtils.synthesizeMouseAtCenter(t1, { type: "mousedown", button: 1 }, window);
-  EventUtils.synthesizeMouseAtCenter(t1, { type: "mouseup", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(
+    t1,
+    { type: "mousedown", button: 1 },
+    window
+  );
+  EventUtils.synthesizeMouseAtCenter(
+    t1,
+    { type: "mouseup", button: 1 },
+    window
+  );
   await closing;
   ok(t1.closing || !t1.isConnected, "clean middle-click closes the single tab");
 });
@@ -67,11 +99,23 @@ add_task(async function test_drag_close_spares_active_tab_outside_range() {
   gBrowser.selectedTab = active; // active tab is left of the t1..t2 range
   gBrowser.clearMultiSelectedTabs();
 
-  EventUtils.synthesizeMouseAtCenter(t1, { type: "mousedown", button: 1 }, window);
-  EventUtils.synthesizeMouseAtCenter(t2, { type: "mousemove", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(
+    t1,
+    { type: "mousedown", button: 1 },
+    window
+  );
+  EventUtils.synthesizeMouseAtCenter(
+    t2,
+    { type: "mousemove", button: 1 },
+    window
+  );
   const c1 = BrowserTestUtils.waitForTabClosing(t1);
   const c2 = BrowserTestUtils.waitForTabClosing(t2);
-  EventUtils.synthesizeMouseAtCenter(t2, { type: "mouseup", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(
+    t2,
+    { type: "mouseup", button: 1 },
+    window
+  );
   await Promise.all([c1, c2]);
 
   ok(t1.closing || !t1.isConnected, "t1 (in range) closed");

--- a/src/zen/tests/tab-tree/browser_middledrag_actions.js
+++ b/src/zen/tests/tab-tree/browser_middledrag_actions.js
@@ -57,3 +57,29 @@ add_task(async function test_clean_middleclick_closes_one() {
   await closing;
   ok(t1.closing || !t1.isConnected, "clean middle-click closes the single tab");
 });
+
+// A drag-close must close exactly the selected range — not the active tab when
+// it sits outside that range (gBrowser.selectedTabs would wrongly append it).
+add_task(async function test_drag_close_spares_active_tab_outside_range() {
+  const active = await addNormalTab();
+  const t1 = await addNormalTab();
+  const t2 = await addNormalTab();
+  gBrowser.selectedTab = active; // active tab is left of the t1..t2 range
+  gBrowser.clearMultiSelectedTabs();
+
+  EventUtils.synthesizeMouseAtCenter(t1, { type: "mousedown", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(t2, { type: "mousemove", button: 1 }, window);
+  const c1 = BrowserTestUtils.waitForTabClosing(t1);
+  const c2 = BrowserTestUtils.waitForTabClosing(t2);
+  EventUtils.synthesizeMouseAtCenter(t2, { type: "mouseup", button: 1 }, window);
+  await Promise.all([c1, c2]);
+
+  ok(t1.closing || !t1.isConnected, "t1 (in range) closed");
+  ok(t2.closing || !t2.isConnected, "t2 (in range) closed");
+  ok(
+    active.isConnected && !active.closing,
+    "the active tab outside the range is NOT closed"
+  );
+
+  await cleanupTabs(active);
+});

--- a/src/zen/tests/tab-tree/browser_middledrag_actions.js
+++ b/src/zen/tests/tab-tree/browser_middledrag_actions.js
@@ -1,0 +1,59 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_release_closes_selected_range() {
+  const t1 = await addNormalTab();
+  const t2 = await addNormalTab();
+  const t3 = await addNormalTab();
+  gBrowser.clearMultiSelectedTabs();
+
+  EventUtils.synthesizeMouseAtCenter(t1, { type: "mousedown", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(t3, { type: "mousemove", button: 1 }, window);
+  const c1 = BrowserTestUtils.waitForTabClosing(t1);
+  const c3 = BrowserTestUtils.waitForTabClosing(t3);
+  EventUtils.synthesizeMouseAtCenter(t3, { type: "mouseup", button: 1 }, window);
+  await Promise.all([c1, c3]);
+  ok(t1.closing || !t1.isConnected, "t1 closed on release");
+  ok(t3.closing || !t3.isConnected, "t3 closed on release");
+
+  await cleanupTabs(t1, t2, t3);
+});
+
+add_task(async function test_rightclick_aborts_and_opens_menu() {
+  const t1 = await addNormalTab();
+  const t2 = await addNormalTab();
+  gBrowser.clearMultiSelectedTabs();
+
+  EventUtils.synthesizeMouseAtCenter(t1, { type: "mousedown", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(t2, { type: "mousemove", button: 1 }, window);
+
+  const menu = document.getElementById("tabContextMenu");
+  const shown = BrowserTestUtils.waitForEvent(menu, "popupshown");
+  EventUtils.synthesizeMouseAtCenter(
+    t2,
+    { type: "contextmenu", button: 2 },
+    window
+  );
+  await shown;
+  ok(true, "context menu opened on right-click during middle-drag");
+
+  // After abort, releasing middle does nothing (tabs stay open).
+  EventUtils.synthesizeMouseAtCenter(t2, { type: "mouseup", button: 1 }, window);
+  ok(t1.isConnected && t2.isConnected, "tabs not closed after abort");
+
+  menu.hidePopup();
+  gBrowser.clearMultiSelectedTabs();
+  await cleanupTabs(t1, t2);
+});
+
+add_task(async function test_clean_middleclick_closes_one() {
+  const t1 = await addNormalTab();
+  gBrowser.clearMultiSelectedTabs();
+  const closing = BrowserTestUtils.waitForTabClosing(t1);
+  EventUtils.synthesizeMouseAtCenter(t1, { type: "mousedown", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(t1, { type: "mouseup", button: 1 }, window);
+  await closing;
+  ok(t1.closing || !t1.isConnected, "clean middle-click closes the single tab");
+});

--- a/src/zen/tests/tab-tree/browser_middledrag_actions.js
+++ b/src/zen/tests/tab-tree/browser_middledrag_actions.js
@@ -83,3 +83,41 @@ add_task(async function test_drag_close_spares_active_tab_outside_range() {
 
   await cleanupTabs(active);
 });
+
+// Regression: a jittery middle-click that briefly flicks onto a neighbouring tab
+// (e.g. a tree parent in the row above) but is RELEASED back on the pressed tab
+// must close only the pressed tab — the close set follows the release point, not
+// the preview range the flick built.
+add_task(async function test_jittery_middleclick_spares_neighbour() {
+  const neighbour = await addNormalTab();
+  const target = await addNormalTab();
+  gBrowser.clearMultiSelectedTabs();
+
+  EventUtils.synthesizeMouseAtCenter(
+    target,
+    { type: "mousedown", button: 1 },
+    window
+  );
+  // flick onto the neighbour (builds a preview range incl. the neighbour) ...
+  EventUtils.synthesizeMouseAtCenter(
+    neighbour,
+    { type: "mousemove", button: 1 },
+    window
+  );
+  // ... then release back on the pressed tab.
+  const closing = BrowserTestUtils.waitForTabClosing(target);
+  EventUtils.synthesizeMouseAtCenter(
+    target,
+    { type: "mouseup", button: 1 },
+    window
+  );
+  await closing;
+
+  ok(target.closing || !target.isConnected, "the pressed tab closed");
+  ok(
+    neighbour.isConnected && !neighbour.closing,
+    "the flicked-over but released-off neighbour is NOT closed"
+  );
+
+  await cleanupTabs(neighbour);
+});

--- a/src/zen/tests/tab-tree/browser_middledrag_select.js
+++ b/src/zen/tests/tab-tree/browser_middledrag_select.js
@@ -1,0 +1,28 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_middle_drag_selects_range() {
+  const t1 = await addNormalTab();
+  const t2 = await addNormalTab();
+  const t3 = await addNormalTab();
+  gBrowser.clearMultiSelectedTabs();
+
+  EventUtils.synthesizeMouseAtCenter(t1, { type: "mousedown", button: 1 }, window);
+  // Move onto t3 to drag-select the t1..t3 range.
+  EventUtils.synthesizeMouseAtCenter(
+    t3,
+    { type: "mousemove", button: 1 },
+    window
+  );
+
+  Assert.ok(t1.multiselected, "t1 selected");
+  Assert.ok(t2.multiselected, "t2 selected (in range)");
+  Assert.ok(t3.multiselected, "t3 selected");
+
+  // Cancel the gesture without closing.
+  EventUtils.synthesizeKey("KEY_Escape", {}, window);
+  gBrowser.clearMultiSelectedTabs();
+  await cleanupTabs(t1, t2, t3);
+});

--- a/src/zen/tests/tab-tree/browser_middledrag_select.js
+++ b/src/zen/tests/tab-tree/browser_middledrag_select.js
@@ -9,7 +9,11 @@ add_task(async function test_middle_drag_selects_range() {
   const t3 = await addNormalTab();
   gBrowser.clearMultiSelectedTabs();
 
-  EventUtils.synthesizeMouseAtCenter(t1, { type: "mousedown", button: 1 }, window);
+  EventUtils.synthesizeMouseAtCenter(
+    t1,
+    { type: "mousedown", button: 1 },
+    window
+  );
   // Move onto t3 to drag-select the t1..t3 range.
   EventUtils.synthesizeMouseAtCenter(
     t3,

--- a/src/zen/tests/tab-tree/browser_tree_close.js
+++ b/src/zen/tests/tab-tree/browser_tree_close.js
@@ -1,0 +1,43 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_close_parent_promotes_children() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.tab-tree.close-parent-behavior", "promote"]],
+  });
+  const grand = await addNormalTab();
+  const parent = await addNormalTab();
+  const child = await addNormalTab();
+  gZenTabTree.nestTab(parent, grand);
+  gZenTabTree.nestTab(child, parent);
+
+  BrowserTestUtils.removeTab(parent);
+  await TestUtils.waitForCondition(() => !parent.isConnected);
+
+  Assert.equal(
+    gZenTabTree.getParent(child),
+    grand,
+    "child promoted to grandparent when parent closed"
+  );
+
+  await cleanupTabs(grand, child);
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_close_parent_closes_subtree() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.tab-tree.close-parent-behavior", "close-subtree"]],
+  });
+  const parent = await addNormalTab();
+  const child = await addNormalTab();
+  gZenTabTree.nestTab(child, parent);
+
+  BrowserTestUtils.removeTab(parent);
+  await TestUtils.waitForCondition(() => child.closing || !child.isConnected);
+  ok(true, "descendants closed with the parent");
+
+  await cleanupTabs(parent, child);
+  await SpecialPowers.popPrefEnv();
+});

--- a/src/zen/tests/tab-tree/browser_tree_close.js
+++ b/src/zen/tests/tab-tree/browser_tree_close.js
@@ -42,6 +42,39 @@ add_task(async function test_close_parent_closes_subtree() {
   await SpecialPowers.popPrefEnv();
 });
 
+// A parent must drop its twisty once its last child is fully gone. The closing
+// child lingers in gBrowser.tabs (keeping its parent pointer) during its close
+// animation, so the refresh has to ignore closing tabs — otherwise the twisty
+// stays visible after the child is removed and no further reindex runs.
+add_task(async function test_parent_drops_twisty_when_last_child_closes() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.tab-tree.close-parent-behavior", "promote"]],
+  });
+  const parent = await addNormalTab();
+  const child = await addNormalTab();
+  gZenTabTree.nestTab(child, parent);
+
+  Assert.ok(
+    parent.hasAttribute("zen-tree-parent"),
+    "parent shows the twisty while it has a child"
+  );
+
+  BrowserTestUtils.removeTab(child);
+  await TestUtils.waitForCondition(() => !child.isConnected);
+
+  await TestUtils.waitForCondition(
+    () => !parent.hasAttribute("zen-tree-parent"),
+    "parent drops the twisty once its last child is gone"
+  );
+  Assert.ok(
+    !parent.querySelector(".zen-tree-twisty"),
+    "the twisty element is removed from the parent"
+  );
+
+  await cleanupTabs(parent);
+  await SpecialPowers.popPrefEnv();
+});
+
 // close-subtree recurses the whole branch, not just direct children.
 add_task(async function test_close_subtree_closes_grandchildren() {
   await SpecialPowers.pushPrefEnv({

--- a/src/zen/tests/tab-tree/browser_tree_close.js
+++ b/src/zen/tests/tab-tree/browser_tree_close.js
@@ -55,8 +55,7 @@ add_task(async function test_close_subtree_closes_grandchildren() {
 
   BrowserTestUtils.removeTab(a);
   await TestUtils.waitForCondition(
-    () =>
-      (b.closing || !b.isConnected) && (c.closing || !c.isConnected),
+    () => (b.closing || !b.isConnected) && (c.closing || !c.isConnected),
     "both the child and grandchild close with the subtree"
   );
   ok(true, "grandchild closed with the subtree");

--- a/src/zen/tests/tab-tree/browser_tree_close.js
+++ b/src/zen/tests/tab-tree/browser_tree_close.js
@@ -41,3 +41,26 @@ add_task(async function test_close_parent_closes_subtree() {
   await cleanupTabs(parent, child);
   await SpecialPowers.popPrefEnv();
 });
+
+// close-subtree recurses the whole branch, not just direct children.
+add_task(async function test_close_subtree_closes_grandchildren() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.tab-tree.close-parent-behavior", "close-subtree"]],
+  });
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+  const c = await addNormalTab();
+  gZenTabTree.nestTab(b, a);
+  gZenTabTree.nestTab(c, b);
+
+  BrowserTestUtils.removeTab(a);
+  await TestUtils.waitForCondition(
+    () =>
+      (b.closing || !b.isConnected) && (c.closing || !c.isConnected),
+    "both the child and grandchild close with the subtree"
+  );
+  ok(true, "grandchild closed with the subtree");
+
+  await cleanupTabs(a, b, c);
+  await SpecialPowers.popPrefEnv();
+});

--- a/src/zen/tests/tab-tree/browser_tree_collapse.js
+++ b/src/zen/tests/tab-tree/browser_tree_collapse.js
@@ -40,3 +40,30 @@ add_task(async function test_collapse_moves_active_selection_to_ancestor() {
   gZenTabTree.setCollapsed(parent, false);
   await cleanupTabs(parent, child);
 });
+
+// Nested collapse: a descendant is hidden if ANY ancestor is collapsed, so
+// expanding one level keeps a deeper collapsed branch hidden.
+add_task(async function test_nested_collapse_partial_expand() {
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+  const c = await addNormalTab();
+  gZenTabTree.nestTab(b, a); // a > b
+  gZenTabTree.nestTab(c, b); // b > c
+
+  gZenTabTree.toggleCollapse(b);
+  ok(b._zenTreeCollapsed, "toggleCollapse collapses the inner node b");
+  ok(!b.hasAttribute("zen-tree-hidden"), "b itself stays visible");
+  ok(c.hasAttribute("zen-tree-hidden"), "c hides under collapsed b");
+
+  gZenTabTree.toggleCollapse(a);
+  ok(b.hasAttribute("zen-tree-hidden"), "b hides under collapsed a");
+
+  gZenTabTree.toggleCollapse(a); // expand a only
+  ok(!b.hasAttribute("zen-tree-hidden"), "b reappears when a expands");
+  ok(c.hasAttribute("zen-tree-hidden"), "c stays hidden while b is collapsed");
+
+  gZenTabTree.toggleCollapse(b); // expand b
+  ok(!c.hasAttribute("zen-tree-hidden"), "c reappears when b expands");
+
+  await cleanupTabs(a, b, c);
+});

--- a/src/zen/tests/tab-tree/browser_tree_collapse.js
+++ b/src/zen/tests/tab-tree/browser_tree_collapse.js
@@ -1,0 +1,42 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_collapse_hides_descendants() {
+  const parent = await addNormalTab();
+  const child = await addNormalTab();
+  const grandchild = await addNormalTab();
+  gZenTabTree.nestTab(child, parent);
+  gZenTabTree.nestTab(grandchild, child);
+
+  gZenTabTree.setCollapsed(parent, true);
+  ok(parent._zenTreeCollapsed, "parent flagged collapsed");
+  ok(parent.hasAttribute("zen-tree-collapsed"), "collapsed attribute set");
+  ok(child.hasAttribute("zen-tree-hidden"), "child hidden");
+  ok(grandchild.hasAttribute("zen-tree-hidden"), "grandchild hidden");
+
+  gZenTabTree.setCollapsed(parent, false);
+  ok(!parent._zenTreeCollapsed, "parent expanded");
+  ok(!child.hasAttribute("zen-tree-hidden"), "child shown");
+  ok(!grandchild.hasAttribute("zen-tree-hidden"), "grandchild shown");
+
+  await cleanupTabs(parent, child, grandchild);
+});
+
+add_task(async function test_collapse_moves_active_selection_to_ancestor() {
+  const parent = await addNormalTab();
+  const child = await addNormalTab();
+  gZenTabTree.nestTab(child, parent);
+
+  gBrowser.selectedTab = child;
+  gZenTabTree.setCollapsed(parent, true);
+  Assert.equal(
+    gBrowser.selectedTab,
+    parent,
+    "selection moved to nearest visible ancestor when active tab hidden"
+  );
+
+  gZenTabTree.setCollapsed(parent, false);
+  await cleanupTabs(parent, child);
+});

--- a/src/zen/tests/tab-tree/browser_tree_depth.js
+++ b/src/zen/tests/tab-tree/browser_tree_depth.js
@@ -1,0 +1,34 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_depth_clamp_flattens_deepest_first() {
+  await SpecialPowers.pushPrefEnv({ set: [["zen.tab-tree.max-depth", 2]] });
+
+  // Build a chain a > b > c > d (would be levels 0,1,2,3).
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+  const c = await addNormalTab();
+  const d = await addNormalTab();
+  gZenTabTree.nestTab(b, a);
+  gZenTabTree.nestTab(c, b);
+  gZenTabTree.nestTab(d, c); // d would be level 3 > max 2
+
+  Assert.equal(gZenTabTree.getLevel(a), 0, "a level 0");
+  Assert.equal(gZenTabTree.getLevel(b), 1, "b level 1");
+  Assert.equal(gZenTabTree.getLevel(c), 2, "c clamped at level 2");
+  Assert.equal(
+    gZenTabTree.getLevel(d),
+    2,
+    "d flattened up to the cap (level 2)"
+  );
+  Assert.equal(
+    gZenTabTree.getParent(d),
+    b,
+    "d re-parented to the node at max-depth-1 (b)"
+  );
+
+  await cleanupTabs(a, b, c, d);
+  await SpecialPowers.popPrefEnv();
+});

--- a/src/zen/tests/tab-tree/browser_tree_detach_multi.js
+++ b/src/zen/tests/tab-tree/browser_tree_detach_multi.js
@@ -20,7 +20,7 @@ add_task(async function test_nest_multiselection_one_level() {
   const s1 = await addNormalTab();
   const s2 = await addNormalTab();
   const s2child = await addNormalTab();
-  gZenTabTree.nestTab(s2child, s2); // s2 has its own subtree
+  gZenTabTree.nestTab(s2child, s2);
 
   gZenTabTree.nestTabsAsChildren([s1, s2], target);
 

--- a/src/zen/tests/tab-tree/browser_tree_detach_multi.js
+++ b/src/zen/tests/tab-tree/browser_tree_detach_multi.js
@@ -1,0 +1,35 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_promote_subtree_to_root() {
+  const parent = await addNormalTab();
+  const child = await addNormalTab();
+  gZenTabTree.nestTab(child, parent);
+
+  gZenTabTree.detachTab(child);
+  Assert.equal(gZenTabTree.getParent(child), null, "child detached to root");
+  Assert.equal(gZenTabTree.getLevel(child), 0, "detached child is level 0");
+
+  await cleanupTabs(parent, child);
+});
+
+add_task(async function test_nest_multiselection_one_level() {
+  const target = await addNormalTab();
+  const s1 = await addNormalTab();
+  const s2 = await addNormalTab();
+  const s2child = await addNormalTab();
+  gZenTabTree.nestTab(s2child, s2); // s2 has its own subtree
+
+  gZenTabTree.nestTabsAsChildren([s1, s2], target);
+
+  Assert.equal(gZenTabTree.getParent(s1), target, "s1 is direct child");
+  Assert.equal(gZenTabTree.getParent(s2), target, "s2 is direct child");
+  Assert.equal(gZenTabTree.getLevel(s1), 1, "s1 level 1");
+  Assert.equal(gZenTabTree.getLevel(s2), 1, "s2 level 1");
+  Assert.equal(gZenTabTree.getParent(s2child), s2, "s2's subtree followed it");
+  Assert.equal(gZenTabTree.getLevel(s2child), 2, "s2child level 2");
+
+  await cleanupTabs(target, s1, s2, s2child);
+});

--- a/src/zen/tests/tab-tree/browser_tree_drag.js
+++ b/src/zen/tests/tab-tree/browser_tree_drag.js
@@ -1,0 +1,34 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// The drop handler calls gZenTabTree.handleNestDrop with the dragged tabs.
+// Verify that contract holds for a quick "nest" drop, without synthesizing
+// native drag pixels.
+add_task(async function test_drop_quick_nests_single() {
+  const parent = await addNormalTab();
+  const dragged = await addNormalTab();
+
+  const handled = gZenTabTree.handleNestDrop([dragged], parent);
+
+  ok(handled, "nest drop handled");
+  Assert.equal(gZenTabTree.getParent(dragged), parent, "dragged nested");
+
+  await cleanupTabs(parent, dragged);
+});
+
+add_task(async function test_drop_quick_nests_multiselection() {
+  const parent = await addNormalTab();
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+
+  gZenTabTree.handleNestDrop([a, b], parent);
+
+  Assert.equal(gZenTabTree.getParent(a), parent, "a nested as direct child");
+  Assert.equal(gZenTabTree.getParent(b), parent, "b nested as direct child");
+  Assert.equal(gZenTabTree.getLevel(a), 1, "a level 1");
+  Assert.equal(gZenTabTree.getLevel(b), 1, "b level 1");
+
+  await cleanupTabs(parent, a, b);
+});

--- a/src/zen/tests/tab-tree/browser_tree_drag.js
+++ b/src/zen/tests/tab-tree/browser_tree_drag.js
@@ -3,9 +3,8 @@
 
 "use strict";
 
-// The drop handler calls gZenTabTree.handleNestDrop with the dragged tabs.
-// Verify that contract holds for a quick "nest" drop, without synthesizing
-// native drag pixels.
+// Verify the handleNestDrop contract directly, without synthesizing native
+// drag pixels.
 add_task(async function test_drop_quick_nests_single() {
   const parent = await addNormalTab();
   const dragged = await addNormalTab();

--- a/src/zen/tests/tab-tree/browser_tree_eligibility.js
+++ b/src/zen/tests/tab-tree/browser_tree_eligibility.js
@@ -1,0 +1,33 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Tabs the tree must never adopt: essentials, glance tabs, empty tabs, and live
+// folder items are all ineligible and can't be nested.
+add_task(async function test_special_tabs_are_ineligible() {
+  const parent = await addNormalTab();
+  const cases = [
+    ["zen-essential", "true"],
+    ["zen-glance-tab", ""],
+    ["zen-empty-tab", ""],
+    ["zen-live-folder-item-id", "folder:1"],
+  ];
+
+  for (const [attr, value] of cases) {
+    const tab = await addNormalTab();
+    tab.setAttribute(attr, value);
+    Assert.ok(
+      !gZenTabTree.isTreeEligible(tab),
+      `a [${attr}] tab is not tree-eligible`
+    );
+    Assert.ok(
+      !gZenTabTree.nestTab(tab, parent),
+      `a [${attr}] tab cannot be nested`
+    );
+    tab.removeAttribute(attr);
+    await cleanupTabs(tab);
+  }
+
+  await cleanupTabs(parent);
+});

--- a/src/zen/tests/tab-tree/browser_tree_model.js
+++ b/src/zen/tests/tab-tree/browser_tree_model.js
@@ -1,0 +1,29 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_eligibility_and_level() {
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+
+  ok(gZenTabTree.isTreeEligible(a), "normal tab is tree-eligible");
+  Assert.equal(gZenTabTree.getLevel(a), 0, "root tab is level 0");
+  Assert.deepEqual(gZenTabTree.getChildren(a), [], "no children initially");
+
+  // Manually wire a parent pointer to exercise level/children derivation.
+  b._zenTreeParent = a;
+  gZenTabTree.reindex(a);
+
+  Assert.equal(gZenTabTree.getLevel(b), 1, "child tab is level 1");
+  Assert.deepEqual(gZenTabTree.getChildren(a), [b], "a has child b");
+  Assert.deepEqual(gZenTabTree.getDescendants(a), [b], "a has descendant b");
+  Assert.equal(
+    b.style.getPropertyValue("--zen-folder-indent"),
+    "14px",
+    "child indent is one level (14px)"
+  );
+
+  b._zenTreeParent = null;
+  await cleanupTabs(a, b);
+});

--- a/src/zen/tests/tab-tree/browser_tree_model.js
+++ b/src/zen/tests/tab-tree/browser_tree_model.js
@@ -18,10 +18,13 @@ add_task(async function test_eligibility_and_level() {
   Assert.equal(gZenTabTree.getLevel(b), 1, "child tab is level 1");
   Assert.deepEqual(gZenTabTree.getChildren(a), [b], "a has child b");
   Assert.deepEqual(gZenTabTree.getDescendants(a), [b], "a has descendant b");
+  // Indent tracks the configurable step pref, so derive the expectation from it
+  // rather than hardcoding a value that can drift from the default.
+  const step = Services.prefs.getIntPref("zen.tab-tree.indent", 20);
   Assert.equal(
     b.style.getPropertyValue("--zen-folder-indent"),
-    "14px",
-    "child indent is one level (14px)"
+    `${step}px`,
+    `child indent is one level (${step}px)`
   );
 
   b._zenTreeParent = null;

--- a/src/zen/tests/tab-tree/browser_tree_nest.js
+++ b/src/zen/tests/tab-tree/browser_tree_nest.js
@@ -11,7 +11,6 @@ add_task(async function test_nest_single_tab() {
 
   Assert.equal(gZenTabTree.getParent(child), parent, "child re-parented");
   Assert.equal(gZenTabTree.getLevel(child), 1, "child is level 1");
-  // DFS order: child sits immediately after parent.
   Assert.equal(
     parent.nextElementSibling,
     child,
@@ -22,13 +21,13 @@ add_task(async function test_nest_single_tab() {
 });
 
 add_task(async function test_nest_moves_whole_subtree() {
-  const parent = await addNormalTab(); // future grandparent
+  const parent = await addNormalTab();
   const mid = await addNormalTab();
   const leaf = await addNormalTab();
-  gZenTabTree.nestTab(leaf, mid); // mid -> leaf
+  gZenTabTree.nestTab(leaf, mid);
 
   const target = await addNormalTab();
-  gZenTabTree.nestTab(mid, target); // target -> mid -> leaf
+  gZenTabTree.nestTab(mid, target);
 
   Assert.equal(gZenTabTree.getParent(mid), target, "mid re-parented to target");
   Assert.equal(gZenTabTree.getParent(leaf), mid, "leaf still child of mid");

--- a/src/zen/tests/tab-tree/browser_tree_nest.js
+++ b/src/zen/tests/tab-tree/browser_tree_nest.js
@@ -1,0 +1,44 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_nest_single_tab() {
+  const parent = await addNormalTab();
+  const child = await addNormalTab();
+
+  gZenTabTree.nestTab(child, parent);
+
+  Assert.equal(gZenTabTree.getParent(child), parent, "child re-parented");
+  Assert.equal(gZenTabTree.getLevel(child), 1, "child is level 1");
+  // DFS order: child sits immediately after parent.
+  Assert.equal(
+    parent.nextElementSibling,
+    child,
+    "child placed directly after parent in the strip"
+  );
+
+  await cleanupTabs(parent, child);
+});
+
+add_task(async function test_nest_moves_whole_subtree() {
+  const parent = await addNormalTab(); // future grandparent
+  const mid = await addNormalTab();
+  const leaf = await addNormalTab();
+  gZenTabTree.nestTab(leaf, mid); // mid -> leaf
+
+  const target = await addNormalTab();
+  gZenTabTree.nestTab(mid, target); // target -> mid -> leaf
+
+  Assert.equal(gZenTabTree.getParent(mid), target, "mid re-parented to target");
+  Assert.equal(gZenTabTree.getParent(leaf), mid, "leaf still child of mid");
+  Assert.equal(gZenTabTree.getLevel(mid), 1, "mid level 1 under target");
+  Assert.equal(gZenTabTree.getLevel(leaf), 2, "leaf level 2");
+  Assert.deepEqual(
+    domOrder([target, mid, leaf]),
+    [target, mid, leaf],
+    "subtree stays contiguous and ordered after target"
+  );
+
+  await cleanupTabs(parent, mid, leaf, target);
+});

--- a/src/zen/tests/tab-tree/browser_tree_opener.js
+++ b/src/zen/tests/tab-tree/browser_tree_opener.js
@@ -25,6 +25,30 @@ add_task(async function test_opener_autonest_on() {
   await SpecialPowers.popPrefEnv();
 });
 
+// Firefox clears `owner` on each successive related tab opened from one opener,
+// so only the first would keep it. The durable _zenOpenerTab capture lets the
+// later ones still auto-nest.
+add_task(async function test_opener_autonest_uses_durable_opener() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.tab-tree.auto-nest-by-opener", true]],
+  });
+  const opener = await addNormalTab();
+  const child = await addNormalTab();
+  // Mimic the post-clear state: owner is gone, but our durable capture remains.
+  child.owner = null;
+  child._zenOpenerTab = opener;
+  child.dispatchEvent(new CustomEvent("TabOpen", { bubbles: true, detail: child }));
+
+  Assert.equal(
+    gZenTabTree.getParent(child),
+    opener,
+    "auto-nest falls back to the durable opener after Firefox cleared owner"
+  );
+
+  await cleanupTabs(opener, child);
+  await SpecialPowers.popPrefEnv();
+});
+
 add_task(async function test_opener_autonest_off() {
   await SpecialPowers.pushPrefEnv({
     set: [["zen.tab-tree.auto-nest-by-opener", false]],

--- a/src/zen/tests/tab-tree/browser_tree_opener.js
+++ b/src/zen/tests/tab-tree/browser_tree_opener.js
@@ -3,25 +3,56 @@
 
 "use strict";
 
-add_task(async function test_opener_autonest_on() {
+add_task(async function test_opener_autonest_content_link() {
   await SpecialPowers.pushPrefEnv({
     set: [["zen.tab-tree.auto-nest-by-opener", true]],
   });
   const opener = await addNormalTab();
   gBrowser.selectedTab = opener;
 
+  // A link opened in a new tab from the current tab is "related to current"
+  // (it carries an in-content opener), so addTab records `_zenOpenerTab` = the
+  // current tab and the new tab nests under it.
   const child = gBrowser.addTab("about:blank", {
-    ownerTab: opener,
+    relatedToCurrent: true,
     triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
   });
 
   Assert.equal(
     gZenTabTree.getParent(child),
     opener,
-    "tab opened from opener auto-nests as its child"
+    "a link opened in a new tab from the current tab auto-nests as its child"
   );
 
   await cleanupTabs(opener, child);
+  await SpecialPowers.popPrefEnv();
+});
+
+// Regression: a tab opened from a bookmark, the address bar, or another app has
+// no in-content opener (no referrer / openerBrowser). When opened in the
+// foreground Firefox still sets `tab.owner` to the current tab — but that must
+// NOT make it a child; it has to open at root.
+add_task(async function test_no_autonest_without_content_opener() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.tab-tree.auto-nest-by-opener", true]],
+  });
+  const opener = await addNormalTab();
+  const tab = await addNormalTab();
+  // Mimic a foreground bookmark/address-bar/external open: owner points at the
+  // current tab, but there is no in-content opener.
+  tab.owner = opener;
+  tab._zenOpenerTab = null;
+  tab.dispatchEvent(
+    new CustomEvent("TabOpen", { bubbles: true, detail: tab })
+  );
+
+  Assert.equal(
+    gZenTabTree.getParent(tab),
+    null,
+    "a bookmark/address-bar/external open is a root tab, never nested under the current tab"
+  );
+
+  await cleanupTabs(opener, tab);
   await SpecialPowers.popPrefEnv();
 });
 
@@ -42,7 +73,7 @@ add_task(async function test_opener_autonest_uses_durable_opener() {
   Assert.equal(
     gZenTabTree.getParent(child),
     opener,
-    "auto-nest falls back to the durable opener after Firefox cleared owner"
+    "auto-nest uses the durable in-content opener after Firefox cleared owner"
   );
 
   await cleanupTabs(opener, child);
@@ -54,8 +85,9 @@ add_task(async function test_opener_autonest_off() {
     set: [["zen.tab-tree.auto-nest-by-opener", false]],
   });
   const opener = await addNormalTab();
+  gBrowser.selectedTab = opener;
   const child = gBrowser.addTab("about:blank", {
-    ownerTab: opener,
+    relatedToCurrent: true,
     triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
   });
 

--- a/src/zen/tests/tab-tree/browser_tree_opener.js
+++ b/src/zen/tests/tab-tree/browser_tree_opener.js
@@ -14,7 +14,6 @@ add_task(async function test_opener_autonest_on() {
     ownerTab: opener,
     triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
   });
-  await BrowserTestUtils.browserLoaded(gBrowser.getBrowserForTab(child));
 
   Assert.equal(
     gZenTabTree.getParent(child),
@@ -35,7 +34,6 @@ add_task(async function test_opener_autonest_off() {
     ownerTab: opener,
     triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
   });
-  await BrowserTestUtils.browserLoaded(gBrowser.getBrowserForTab(child));
 
   Assert.equal(gZenTabTree.getParent(child), null, "no auto-nest when pref off");
 

--- a/src/zen/tests/tab-tree/browser_tree_opener.js
+++ b/src/zen/tests/tab-tree/browser_tree_opener.js
@@ -1,0 +1,44 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_opener_autonest_on() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.tab-tree.auto-nest-by-opener", true]],
+  });
+  const opener = await addNormalTab();
+  gBrowser.selectedTab = opener;
+
+  const child = gBrowser.addTab("about:blank", {
+    ownerTab: opener,
+    triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
+  });
+  await BrowserTestUtils.browserLoaded(gBrowser.getBrowserForTab(child));
+
+  Assert.equal(
+    gZenTabTree.getParent(child),
+    opener,
+    "tab opened from opener auto-nests as its child"
+  );
+
+  await cleanupTabs(opener, child);
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_opener_autonest_off() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.tab-tree.auto-nest-by-opener", false]],
+  });
+  const opener = await addNormalTab();
+  const child = gBrowser.addTab("about:blank", {
+    ownerTab: opener,
+    triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
+  });
+  await BrowserTestUtils.browserLoaded(gBrowser.getBrowserForTab(child));
+
+  Assert.equal(gZenTabTree.getParent(child), null, "no auto-nest when pref off");
+
+  await cleanupTabs(opener, child);
+  await SpecialPowers.popPrefEnv();
+});

--- a/src/zen/tests/tab-tree/browser_tree_opener.js
+++ b/src/zen/tests/tab-tree/browser_tree_opener.js
@@ -42,9 +42,7 @@ add_task(async function test_no_autonest_without_content_opener() {
   // current tab, but there is no in-content opener.
   tab.owner = opener;
   tab._zenOpenerTab = null;
-  tab.dispatchEvent(
-    new CustomEvent("TabOpen", { bubbles: true, detail: tab })
-  );
+  tab.dispatchEvent(new CustomEvent("TabOpen", { bubbles: true, detail: tab }));
 
   Assert.equal(
     gZenTabTree.getParent(tab),
@@ -68,7 +66,9 @@ add_task(async function test_opener_autonest_uses_durable_opener() {
   // Mimic the post-clear state: owner is gone, but our durable capture remains.
   child.owner = null;
   child._zenOpenerTab = opener;
-  child.dispatchEvent(new CustomEvent("TabOpen", { bubbles: true, detail: child }));
+  child.dispatchEvent(
+    new CustomEvent("TabOpen", { bubbles: true, detail: child })
+  );
 
   Assert.equal(
     gZenTabTree.getParent(child),
@@ -91,7 +91,11 @@ add_task(async function test_opener_autonest_off() {
     triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
   });
 
-  Assert.equal(gZenTabTree.getParent(child), null, "no auto-nest when pref off");
+  Assert.equal(
+    gZenTabTree.getParent(child),
+    null,
+    "no auto-nest when pref off"
+  );
 
   await cleanupTabs(opener, child);
   await SpecialPowers.popPrefEnv();

--- a/src/zen/tests/tab-tree/browser_tree_persist.js
+++ b/src/zen/tests/tab-tree/browser_tree_persist.js
@@ -196,3 +196,23 @@ add_task(async function test_restore_reasserts_dfs_order() {
 
   await cleanupTabs(a, b, x);
 });
+
+// zen-tree-id is the stable identity for parent matching, so it must NOT be
+// overwritten when window-sync reassigns the live id (e.g. on restore).
+add_task(async function test_tree_id_is_stable_across_id_reassignment() {
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+  a.id = "zid-a";
+  gZenTabTree.nestTab(b, a);
+  Assert.equal(a.getAttribute("zen-tree-id"), "zid-a", "zen-tree-id captured");
+
+  a.id = "zid-a-reassigned";
+  gZenTabTree.reindex(a);
+  Assert.equal(
+    a.getAttribute("zen-tree-id"),
+    "zid-a",
+    "zen-tree-id stays stable when the live id is reassigned"
+  );
+
+  await cleanupTabs(a, b);
+});

--- a/src/zen/tests/tab-tree/browser_tree_persist.js
+++ b/src/zen/tests/tab-tree/browser_tree_persist.js
@@ -1,0 +1,28 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_tree_state_in_tab_state() {
+  const parent = await addNormalTab();
+  const child = await addNormalTab();
+  gZenTabTree.nestTab(child, parent);
+  gZenTabTree.setCollapsed(parent, true);
+
+  // Flush and read the persisted tab state for the child.
+  await TabStateFlusher.flush(child.linkedBrowser);
+  const state = JSON.parse(SessionStore.getTabState(child));
+
+  Assert.equal(
+    state.zenTreeParentId,
+    parent.id,
+    "child persists its parent id"
+  );
+
+  await TabStateFlusher.flush(parent.linkedBrowser);
+  const pstate = JSON.parse(SessionStore.getTabState(parent));
+  Assert.ok(pstate.zenTreeCollapsed, "parent persists collapsed state");
+
+  gZenTabTree.setCollapsed(parent, false);
+  await cleanupTabs(parent, child);
+});

--- a/src/zen/tests/tab-tree/browser_tree_persist.js
+++ b/src/zen/tests/tab-tree/browser_tree_persist.js
@@ -84,7 +84,11 @@ add_task(async function test_restore_rebuilds_tree_from_attributes() {
   for (const t of [a, b, c]) {
     t._zenTreeParent = null;
   }
-  Assert.equal(b.getAttribute("zen-tree-parent-id"), a.id, "b still has a's id");
+  Assert.equal(
+    b.getAttribute("zen-tree-parent-id"),
+    a.id,
+    "b still has a's id"
+  );
 
   a.dispatchEvent(new CustomEvent("SSTabRestored", { bubbles: true }));
   await TestUtils.waitForCondition(

--- a/src/zen/tests/tab-tree/browser_tree_persist.js
+++ b/src/zen/tests/tab-tree/browser_tree_persist.js
@@ -9,7 +9,6 @@ add_task(async function test_tree_state_in_tab_state() {
   gZenTabTree.nestTab(child, parent);
   gZenTabTree.setCollapsed(parent, true);
 
-  // Flush and read the persisted tab state for the child.
   await TabStateFlusher.flush(child.linkedBrowser);
   const state = JSON.parse(SessionStore.getTabState(child));
 

--- a/src/zen/tests/tab-tree/browser_tree_persist.js
+++ b/src/zen/tests/tab-tree/browser_tree_persist.js
@@ -18,10 +18,181 @@ add_task(async function test_tree_state_in_tab_state() {
     "child persists its parent id"
   );
 
+  // Also persisted as restorable tab attributes, so they come back on undo-close
+  // (Ctrl+Shift+T), which doesn't run restoreInitialTabData.
+  Assert.equal(
+    state.attributes?.["zen-tree-parent-id"],
+    parent.id,
+    "child persists its parent id as a restorable tab attribute"
+  );
+
   await TabStateFlusher.flush(parent.linkedBrowser);
   const pstate = JSON.parse(SessionStore.getTabState(parent));
   Assert.ok(pstate.zenTreeCollapsed, "parent persists collapsed state");
+  // zen-tree-collapsed is a boolean attribute (toggleAttribute stores ""), so
+  // assert its presence in the restorable set rather than a value.
+  Assert.ok(
+    "zen-tree-collapsed" in (pstate.attributes || {}),
+    "parent persists collapsed as a restorable tab attribute"
+  );
 
   gZenTabTree.setCollapsed(parent, false);
   await cleanupTabs(parent, child);
+});
+
+// Closing a<-b<-c as one batch while d (deepest) survives: d un-nests to root
+// (all its ancestors are gone) instead of clinging to a closing parent.
+add_task(async function test_close_batch_promotes_survivor_to_root() {
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+  const c = await addNormalTab();
+  const d = await addNormalTab();
+  gZenTabTree.nestTab(b, a);
+  gZenTabTree.nestTab(c, b);
+  gZenTabTree.nestTab(d, c);
+
+  const closings = [a, b, c].map(t => BrowserTestUtils.waitForTabClosing(t));
+  gBrowser.removeTabs([a, b, c], { animate: false });
+  await Promise.all(closings);
+
+  Assert.equal(
+    gZenTabTree.getParent(d),
+    null,
+    "surviving deepest tab promotes to root once its ancestors close"
+  );
+  Assert.equal(gZenTabTree.getLevel(d), 0, "survivor sits at root level");
+
+  await cleanupTabs(d);
+});
+
+// Restoring tabs (undo-close) reapplies their persisted zen-tree-parent-id but
+// leaves the live pointers flat; SSTabRestored must rebuild the hierarchy.
+add_task(async function test_restore_rebuilds_tree_from_attributes() {
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+  const c = await addNormalTab();
+  // Production assigns every tab a stable id (window-sync's TabOpen); give these
+  // ones explicit ids so the parent-id attributes are non-empty and rebuild can
+  // match them, mirroring a real restore.
+  a.id = "zen-tree-restore-a";
+  b.id = "zen-tree-restore-b";
+  c.id = "zen-tree-restore-c";
+  gZenTabTree.nestTab(b, a);
+  gZenTabTree.nestTab(c, b);
+  // The parent-id attributes survive (set by nestTab/reindex); simulate the
+  // freshly-restored state where the live pointers haven't been reconnected.
+  for (const t of [a, b, c]) {
+    t._zenTreeParent = null;
+  }
+  Assert.equal(b.getAttribute("zen-tree-parent-id"), a.id, "b still has a's id");
+
+  a.dispatchEvent(new CustomEvent("SSTabRestored", { bubbles: true }));
+  await TestUtils.waitForCondition(
+    () => gZenTabTree.getParent(c) === b && gZenTabTree.getParent(b) === a,
+    "SSTabRestored rebuilds the parent pointers from the attributes"
+  );
+
+  Assert.equal(gZenTabTree.getParent(b), a, "b reconnects under a");
+  Assert.equal(gZenTabTree.getParent(c), b, "c reconnects under b");
+  Assert.equal(gZenTabTree.getLevel(c), 2, "c is two levels deep again");
+
+  await cleanupTabs(a, b, c);
+});
+
+// End-to-end: a real Ctrl+Shift+T (undoCloseTab) brings a closed nested pair
+// back nested, because zen-tree-parent-id rides along as a persisted tab
+// attribute and the SSTabRestored rebuild reconnects the pointers.
+add_task(async function test_undo_close_restores_nesting() {
+  const mk = async name => {
+    const t = BrowserTestUtils.addTab(
+      gBrowser,
+      `data:text/html,<title>${name}</title>`,
+      { skipAnimation: true }
+    );
+    await BrowserTestUtils.browserLoaded(t.linkedBrowser);
+    t.id = name;
+    return t;
+  };
+  const parent = await mk("ztu-parent");
+  const child = await mk("ztu-child");
+  gZenTabTree.nestTab(child, parent);
+  await TabStateFlusher.flush(parent.linkedBrowser);
+  await TabStateFlusher.flush(child.linkedBrowser);
+
+  const closings = [parent, child].map(t =>
+    BrowserTestUtils.waitForTabClosing(t)
+  );
+  gBrowser.removeTabs([parent, child], { animate: false });
+  await Promise.all(closings);
+
+  const restored = [];
+  for (let i = 0; i < 2; i++) {
+    const t = SessionStore.undoCloseTab(window, 0);
+    if (t) {
+      restored.push(t);
+    }
+  }
+  Assert.equal(restored.length, 2, "both closed tabs were restorable");
+
+  // The persisted attributes ride back on the restored tabs through a real
+  // undoCloseTab — this is what the old code lost. The child references its
+  // parent by the stable zen-tree-id, which survives even though window-sync
+  // reassigns the live id on restore.
+  const restoredChild = restored.find(
+    t => t.getAttribute("zen-tree-parent-id") === "ztu-parent"
+  );
+  Assert.ok(restoredChild, "restored child carries its zen-tree-parent-id");
+  const restoredParent = restored.find(t => t !== restoredChild);
+  Assert.equal(
+    restoredParent.getAttribute("zen-tree-id"),
+    "ztu-parent",
+    "restored parent carries its stable zen-tree-id"
+  );
+
+  // The SSTabRestored rebuild reconnects the pointers on its own — no manual
+  // id fix-up needed, because matching is by the persisted zen-tree-id.
+  await TestUtils.waitForCondition(
+    () => gZenTabTree.getParent(restoredChild) === restoredParent,
+    "the restored child reconnects to its parent via zen-tree-id"
+  );
+  Assert.equal(
+    gZenTabTree.getLevel(restoredChild),
+    1,
+    "restored child is nested one level deep, not flat"
+  );
+
+  await cleanupTabs(...restored);
+});
+
+// A restored child can land in the strip with an unrelated tab wedged between it
+// and its parent. The rebuild must re-assert depth-first order so the branch is
+// contiguous, not visually split by other tabs.
+add_task(async function test_restore_reasserts_dfs_order() {
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+  const x = await addNormalTab(); // unrelated
+  a.id = "zdom-a";
+  b.id = "zdom-b";
+  gZenTabTree.nestTab(b, a);
+
+  // Simulate the post-undo-close layout: unrelated x is wedged between a and b
+  // (b reinserted at a stale index) and b's live pointer isn't reconnected yet.
+  a.after(x);
+  gBrowser.tabContainer._invalidateCachedTabs();
+  b._zenTreeParent = null;
+  Assert.equal(x.previousElementSibling, a, "x starts wedged between a and b");
+
+  a.dispatchEvent(new CustomEvent("SSTabRestored", { bubbles: true }));
+  await TestUtils.waitForCondition(
+    () => gZenTabTree.getParent(b) === a && b.previousElementSibling === a,
+    "rebuild reconnects b and pulls it back to depth-first order after a"
+  );
+
+  Assert.equal(
+    b.previousElementSibling,
+    a,
+    "b sits immediately after a; x is no longer wedged between them"
+  );
+
+  await cleanupTabs(a, b, x);
 });

--- a/src/zen/tests/tab-tree/browser_tree_pin_reorder.js
+++ b/src/zen/tests/tab-tree/browser_tree_pin_reorder.js
@@ -1,0 +1,23 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_pin_detaches_and_promotes_children() {
+  const parent = await addNormalTab();
+  const child = await addNormalTab();
+  gZenTabTree.nestTab(child, parent);
+
+  gBrowser.pinTab(parent);
+  await TestUtils.waitForCondition(() => parent.pinned);
+
+  Assert.equal(gZenTabTree.getParent(parent), null, "pinned tab left the tree");
+  Assert.equal(
+    gZenTabTree.getParent(child),
+    null,
+    "orphaned child promoted to root"
+  );
+
+  gBrowser.unpinTab(parent);
+  await cleanupTabs(parent, child);
+});

--- a/src/zen/tests/tab-tree/browser_tree_reorder.js
+++ b/src/zen/tests/tab-tree/browser_tree_reorder.js
@@ -73,7 +73,11 @@ add_task(async function test_reorder_level_clamping() {
 
   // Request a level far above max → clamps to prev's child (level 2).
   gZenTabTree.handleReorderDropAt([c], b, 99);
-  Assert.equal(gZenTabTree.getParent(c), b, "over-deep level clamps to prev's child");
+  Assert.equal(
+    gZenTabTree.getParent(c),
+    b,
+    "over-deep level clamps to prev's child"
+  );
   Assert.equal(gZenTabTree.getLevel(c), 2, "c lands at the clamped level 2");
 
   // Level 0 drops at the root (un-nest), e.g. dragging below the whole list.

--- a/src/zen/tests/tab-tree/browser_tree_reorder.js
+++ b/src/zen/tests/tab-tree/browser_tree_reorder.js
@@ -58,3 +58,28 @@ add_task(async function test_reorder_branch_retains_hierarchy() {
 
   await cleanupTabs(p, pchild, mover, moverChild);
 });
+
+// reorderLevelRange reports the valid drop-level window, and handleReorderDropAt
+// clamps the requested level into it: at most prev's child, no shallower than 0.
+add_task(async function test_reorder_level_clamping() {
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+  gZenTabTree.nestTab(b, a); // a > b, b at level 1
+  const c = await addNormalTab();
+
+  const range = gZenTabTree.reorderLevelRange(b, null);
+  Assert.equal(range.maxLevel, 2, "max level is prev's level + 1");
+  Assert.equal(range.minLevel, 0, "min level is 0 when there is no next");
+
+  // Request a level far above max → clamps to prev's child (level 2).
+  gZenTabTree.handleReorderDropAt([c], b, 99);
+  Assert.equal(gZenTabTree.getParent(c), b, "over-deep level clamps to prev's child");
+  Assert.equal(gZenTabTree.getLevel(c), 2, "c lands at the clamped level 2");
+
+  // Level 0 drops at the root (un-nest), e.g. dragging below the whole list.
+  gZenTabTree.handleReorderDropAt([c], b, 0);
+  Assert.equal(gZenTabTree.getParent(c), null, "level 0 un-nests to the root");
+  Assert.equal(gZenTabTree.getLevel(c), 0, "c sits at root level");
+
+  await cleanupTabs(a, b, c);
+});

--- a/src/zen/tests/tab-tree/browser_tree_reorder.js
+++ b/src/zen/tests/tab-tree/browser_tree_reorder.js
@@ -9,9 +9,8 @@ add_task(async function test_nest_branch_retains_hierarchy() {
   const target = await addNormalTab();
   const root = await addNormalTab();
   const child = await addNormalTab();
-  gZenTabTree.nestTab(child, root); // root > child
+  gZenTabTree.nestTab(child, root);
 
-  // Simulate dropping the whole branch [root, child] onto target.
   gZenTabTree.handleNestDrop([root, child], target);
 
   Assert.equal(gZenTabTree.getParent(root), target, "root nested under target");
@@ -31,11 +30,11 @@ add_task(async function test_nest_branch_retains_hierarchy() {
 add_task(async function test_reorder_branch_retains_hierarchy() {
   const p = await addNormalTab();
   const pchild = await addNormalTab();
-  gZenTabTree.nestTab(pchild, p); // p > pchild  (order: p, pchild)
+  gZenTabTree.nestTab(pchild, p);
 
   const mover = await addNormalTab();
   const moverChild = await addNormalTab();
-  gZenTabTree.nestTab(moverChild, mover); // mover > moverChild
+  gZenTabTree.nestTab(moverChild, mover);
 
   // Physically relocate the mover block to sit right after pchild (as if a
   // native reorder dropped it there), then run the tree-aware reorder fixup.

--- a/src/zen/tests/tab-tree/browser_tree_reorder.js
+++ b/src/zen/tests/tab-tree/browser_tree_reorder.js
@@ -1,0 +1,61 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Dragging a branch onto a tab must nest the ROOT and keep the branch's
+// internal hierarchy — it must NOT flatten the subtree to one level.
+add_task(async function test_nest_branch_retains_hierarchy() {
+  const target = await addNormalTab();
+  const root = await addNormalTab();
+  const child = await addNormalTab();
+  gZenTabTree.nestTab(child, root); // root > child
+
+  // Simulate dropping the whole branch [root, child] onto target.
+  gZenTabTree.handleNestDrop([root, child], target);
+
+  Assert.equal(gZenTabTree.getParent(root), target, "root nested under target");
+  Assert.equal(
+    gZenTabTree.getParent(child),
+    root,
+    "child stays under root (hierarchy retained, not flattened)"
+  );
+  Assert.equal(gZenTabTree.getLevel(root), 1, "root level 1");
+  Assert.equal(gZenTabTree.getLevel(child), 2, "child level 2");
+
+  await cleanupTabs(target, root, child);
+});
+
+// A reorder drop re-parents the dragged root from its new neighbor while
+// keeping the root's own subtree intact.
+add_task(async function test_reorder_branch_retains_hierarchy() {
+  const p = await addNormalTab();
+  const pchild = await addNormalTab();
+  gZenTabTree.nestTab(pchild, p); // p > pchild  (order: p, pchild)
+
+  const mover = await addNormalTab();
+  const moverChild = await addNormalTab();
+  gZenTabTree.nestTab(moverChild, mover); // mover > moverChild
+
+  // Physically relocate the mover block to sit right after pchild (as if a
+  // native reorder dropped it there), then run the tree-aware reorder fixup.
+  pchild.after(mover);
+  mover.after(moverChild);
+  gBrowser.tabContainer._invalidateCachedTabs();
+  gZenTabTree.handleReorderDrop([mover, moverChild]);
+
+  Assert.equal(
+    gZenTabTree.getParent(mover),
+    p,
+    "mover adopts the parent of the tab above it (p)"
+  );
+  Assert.equal(
+    gZenTabTree.getParent(moverChild),
+    mover,
+    "moverChild stays under mover (subtree preserved)"
+  );
+  Assert.equal(gZenTabTree.getLevel(mover), 1, "mover level 1");
+  Assert.equal(gZenTabTree.getLevel(moverChild), 2, "moverChild level 2");
+
+  await cleanupTabs(p, pchild, mover, moverChild);
+});

--- a/src/zen/tests/tab-tree/browser_tree_split_node.js
+++ b/src/zen/tests/tab-tree/browser_tree_split_node.js
@@ -31,7 +31,10 @@ add_task(async function test_split_group_nests_and_indents_as_one_node() {
     group,
     "a split tab resolves to its group node"
   );
-  Assert.ok(gZenTabTree.isTreeEligible(group), "the split group is a tree node");
+  Assert.ok(
+    gZenTabTree.isTreeEligible(group),
+    "the split group is a tree node"
+  );
   Assert.ok(
     !gZenTabTree.isTreeEligible(a),
     "an inner split tab is not an independent node"
@@ -155,7 +158,11 @@ add_task(async function test_split_inherits_parent_and_adopts_children() {
       gZenTabTree.getParent(leaf) === group,
     "the split group inherits the parent and adopts the children"
   );
-  Assert.equal(gZenTabTree.getParent(group), root, "group inherited tab's parent");
+  Assert.equal(
+    gZenTabTree.getParent(group),
+    root,
+    "group inherited tab's parent"
+  );
   Assert.equal(gZenTabTree.getParent(leaf), group, "group adopted tab's child");
 
   await cleanupTabs(tab, other, leaf, root);

--- a/src/zen/tests/tab-tree/browser_tree_split_node.js
+++ b/src/zen/tests/tab-tree/browser_tree_split_node.js
@@ -44,9 +44,10 @@ add_task(async function test_split_group_nests_and_indents_as_one_node() {
     "the split group is parented to the tab"
   );
   Assert.equal(gZenTabTree.getLevel(group), 1, "the split group is at level 1");
+  const step = Services.prefs.getIntPref("zen.tab-tree.indent", 20);
   Assert.equal(
     group.style.getPropertyValue("--zen-folder-indent"),
-    "14px",
+    `${step}px`,
     "the split group element is indented one step"
   );
 
@@ -116,5 +117,46 @@ add_task(async function test_unsplitting_promotes_children() {
   );
   Assert.equal(gZenTabTree.getParent(child), root, "child reparented to root");
 
+  // The unsplit tab and the former split children all land at the level the
+  // split node occupied (siblings under its parent), not flattened to the root.
+  Assert.equal(
+    gZenTabTree.getParent(a),
+    root,
+    "the surviving split member stays under the split's parent"
+  );
+  Assert.equal(
+    gZenTabTree.getLevel(a),
+    1,
+    "the surviving member sits at the split's former level"
+  );
+  Assert.equal(
+    gZenTabTree.getLevel(child),
+    1,
+    "the child rose to the split's former level"
+  );
+
   await cleanupTabs(a, child, root);
+});
+
+// When a nested tab becomes a split, the new group takes over its tree role:
+// it inherits the tab's parent and adopts the tab's children.
+add_task(async function test_split_inherits_parent_and_adopts_children() {
+  const root = await addNormalTab();
+  const tab = await addNormalTab();
+  const leaf = await addNormalTab();
+  const other = await addNormalTab();
+  gZenTabTree.nestTab(tab, root); // root > tab
+  gZenTabTree.nestTab(leaf, tab); // tab > leaf
+
+  const group = await makeSplit(tab, other);
+  await TestUtils.waitForCondition(
+    () =>
+      gZenTabTree.getParent(group) === root &&
+      gZenTabTree.getParent(leaf) === group,
+    "the split group inherits the parent and adopts the children"
+  );
+  Assert.equal(gZenTabTree.getParent(group), root, "group inherited tab's parent");
+  Assert.equal(gZenTabTree.getParent(leaf), group, "group adopted tab's child");
+
+  await cleanupTabs(tab, other, leaf, root);
 });

--- a/src/zen/tests/tab-tree/browser_tree_split_node.js
+++ b/src/zen/tests/tab-tree/browser_tree_split_node.js
@@ -1,0 +1,120 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+async function makeSplit(...tabs) {
+  const activated = BrowserTestUtils.waitForEvent(
+    window,
+    "ZenViewSplitter:SplitViewActivated"
+  );
+  gZenViewSplitter.splitTabs(tabs, "grid");
+  await activated;
+  await new Promise(resolve => setTimeout(resolve, 100));
+  return tabs[0].group;
+}
+
+// A split group is one tree node: its inner tabs aren't independent nodes, and
+// nesting it parents/indents the whole split as a single row.
+add_task(async function test_split_group_nests_and_indents_as_one_node() {
+  const parent = await addNormalTab();
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+  const group = await makeSplit(a, b);
+
+  Assert.ok(
+    group?.hasAttribute("split-view-group"),
+    "a split-view group was formed"
+  );
+  Assert.equal(
+    gZenTabTree.treeNodeFor(a),
+    group,
+    "a split tab resolves to its group node"
+  );
+  Assert.ok(gZenTabTree.isTreeEligible(group), "the split group is a tree node");
+  Assert.ok(
+    !gZenTabTree.isTreeEligible(a),
+    "an inner split tab is not an independent node"
+  );
+
+  Assert.ok(gZenTabTree.nestTab(group, parent), "the split group nests");
+  Assert.equal(
+    gZenTabTree.getParent(group),
+    parent,
+    "the split group is parented to the tab"
+  );
+  Assert.equal(gZenTabTree.getLevel(group), 1, "the split group is at level 1");
+  Assert.equal(
+    group.style.getPropertyValue("--zen-folder-indent"),
+    "14px",
+    "the split group element is indented one step"
+  );
+
+  gZenTabTree.setCollapsed(parent, true);
+  Assert.ok(
+    group.hasAttribute("zen-tree-hidden"),
+    "collapsing the parent hides the whole split node"
+  );
+  gZenTabTree.setCollapsed(parent, false);
+  Assert.ok(
+    !group.hasAttribute("zen-tree-hidden"),
+    "expanding shows the split node again"
+  );
+
+  await cleanupTabs(a, b, parent);
+});
+
+// A split group can itself be a parent.
+add_task(async function test_tab_nests_under_split_group() {
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+  const child = await addNormalTab();
+  const group = await makeSplit(a, b);
+
+  Assert.ok(
+    gZenTabTree.nestTab(child, group),
+    "a tab nests under the split group"
+  );
+  Assert.equal(
+    gZenTabTree.getParent(child),
+    group,
+    "the child is parented to the split node"
+  );
+  Assert.equal(gZenTabTree.getLevel(child), 1, "the child sits at level 1");
+  Assert.ok(
+    group.hasAttribute("zen-tree-parent"),
+    "the split group is marked as a parent"
+  );
+  Assert.ok(
+    group.querySelector(":scope > .zen-tree-twisty"),
+    "the split group renders a collapse twisty"
+  );
+
+  await cleanupTabs(a, b, child);
+});
+
+// Dissolving a nested split promotes its children to the split's parent.
+add_task(async function test_unsplitting_promotes_children() {
+  const root = await addNormalTab();
+  const a = await addNormalTab();
+  const b = await addNormalTab();
+  const child = await addNormalTab();
+  const group = await makeSplit(a, b);
+
+  gZenTabTree.nestTab(group, root);
+  gZenTabTree.nestTab(child, group);
+  Assert.equal(
+    gZenTabTree.getParent(child),
+    group,
+    "the child starts under the split node"
+  );
+
+  BrowserTestUtils.removeTab(b);
+  await TestUtils.waitForCondition(
+    () => gZenTabTree.getParent(child) === root,
+    "the child promotes to the split's parent once the split dissolves"
+  );
+  Assert.equal(gZenTabTree.getParent(child), root, "child reparented to root");
+
+  await cleanupTabs(a, child, root);
+});

--- a/src/zen/tests/tab-tree/browser_tree_workspace.js
+++ b/src/zen/tests/tab-tree/browser_tree_workspace.js
@@ -15,11 +15,7 @@ add_task(async function test_nest_rejected_across_workspaces() {
     !gZenTabTree.nestTab(child, parent),
     "nestTab is rejected across workspaces"
   );
-  Assert.equal(
-    gZenTabTree.getParent(child),
-    null,
-    "the child stays un-nested"
-  );
+  Assert.equal(gZenTabTree.getParent(child), null, "the child stays un-nested");
 
   child.setAttribute("zen-workspace-id", "ws-A");
   Assert.ok(

--- a/src/zen/tests/tab-tree/browser_tree_workspace.js
+++ b/src/zen/tests/tab-tree/browser_tree_workspace.js
@@ -31,3 +31,27 @@ add_task(async function test_nest_rejected_across_workspaces() {
   child._zenTreeParent = null;
   await cleanupTabs(parent, child);
 });
+
+// Rebuilding from persisted attributes (restore / window-sync) must apply the
+// same guards as nestTab: never link across workspaces, even if the attributes
+// say so.
+add_task(async function test_rebuild_rejects_cross_workspace_parent() {
+  const parent = await addNormalTab();
+  const child = await addNormalTab();
+  parent.id = "zws-parent";
+  parent.setAttribute("zen-tree-id", "zws-parent");
+  parent.setAttribute("zen-workspace-id", "ws-A");
+  child.setAttribute("zen-tree-parent-id", "zws-parent");
+  child.setAttribute("zen-workspace-id", "ws-B");
+  child._zenTreeParent = null;
+
+  gZenTabTree.rebuildFromAttributes();
+
+  Assert.equal(
+    gZenTabTree.getParent(child),
+    null,
+    "rebuild does not reattach a child across workspaces"
+  );
+
+  await cleanupTabs(parent, child);
+});

--- a/src/zen/tests/tab-tree/browser_tree_workspace.js
+++ b/src/zen/tests/tab-tree/browser_tree_workspace.js
@@ -1,0 +1,33 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Nesting and opener-nesting only work within a workspace: a tab can't become a
+// child of a tab in a different workspace.
+add_task(async function test_nest_rejected_across_workspaces() {
+  const parent = await addNormalTab();
+  const child = await addNormalTab();
+  parent.setAttribute("zen-workspace-id", "ws-A");
+  child.setAttribute("zen-workspace-id", "ws-B");
+
+  Assert.ok(
+    !gZenTabTree.nestTab(child, parent),
+    "nestTab is rejected across workspaces"
+  );
+  Assert.equal(
+    gZenTabTree.getParent(child),
+    null,
+    "the child stays un-nested"
+  );
+
+  child.setAttribute("zen-workspace-id", "ws-A");
+  Assert.ok(
+    gZenTabTree.nestTab(child, parent),
+    "nestTab is allowed within the same workspace"
+  );
+  Assert.equal(gZenTabTree.getParent(child), parent, "the child nests");
+
+  child._zenTreeParent = null;
+  await cleanupTabs(parent, child);
+});

--- a/src/zen/tests/tab-tree/head.js
+++ b/src/zen/tests/tab-tree/head.js
@@ -9,9 +9,6 @@ const { PromiseTestUtils } = ChromeUtils.importESModule(
 const { TabStateFlusher } = ChromeUtils.importESModule(
   "resource:///modules/sessionstore/TabStateFlusher.sys.mjs"
 );
-// Closing tabs / pinning tears down the pre-existing ZenGlance actor while a
-// query is in flight; that benign rejection is unrelated to the tree feature.
-// Registered in a setup task so it lands in the harness's PromiseTestUtils.
 add_setup(function allowBenignEnvironmentRejections() {
   // Two pre-existing, environment-only rejections unrelated to the tree feature:
   //  - closing tabs tears down the ZenGlance actor mid-query ("destroyed before
@@ -32,7 +29,6 @@ async function addNormalTab(url = "about:blank") {
 }
 
 function domOrder(tabs) {
-  // Returns the subset `tabs` sorted by their position in the tab strip.
   return [...tabs].sort((a, b) => {
     const pos = a.compareDocumentPosition(b);
     if (pos & Node.DOCUMENT_POSITION_FOLLOWING) {

--- a/src/zen/tests/tab-tree/head.js
+++ b/src/zen/tests/tab-tree/head.js
@@ -3,10 +3,32 @@
 
 "use strict";
 
+const { PromiseTestUtils } = ChromeUtils.importESModule(
+  "resource://testing-common/PromiseTestUtils.sys.mjs"
+);
+const { TabStateFlusher } = ChromeUtils.importESModule(
+  "resource:///modules/sessionstore/TabStateFlusher.sys.mjs"
+);
+// Closing tabs / pinning tears down the pre-existing ZenGlance actor while a
+// query is in flight; that benign rejection is unrelated to the tree feature.
+// Registered in a setup task so it lands in the harness's PromiseTestUtils.
+add_setup(function allowBenignEnvironmentRejections() {
+  // Two pre-existing, environment-only rejections unrelated to the tree feature:
+  //  - closing tabs tears down the ZenGlance actor mid-query ("destroyed before
+  //    query");
+  //  - opening the tab context menu in this unofficial/`faster` build hits
+  //    Fluent strings that aren't packaged ("Couldn't find a message: ...").
+  PromiseTestUtils.allowMatchingRejectionsGlobally(
+    /destroyed before query|Couldn't find a message/
+  );
+});
+
 async function addNormalTab(url = "about:blank") {
-  const tab = BrowserTestUtils.addTab(gBrowser, url, { skipAnimation: true });
-  await BrowserTestUtils.browserLoaded(gBrowser.getBrowserForTab(tab));
-  return tab;
+  // NB: don't await browserLoaded() for about:blank — its load event doesn't
+  // fire the way browserLoaded expects, so the wait hangs the whole test. The
+  // tree tests only need the tab to exist in the strip, which addTab provides
+  // synchronously (TabOpen fires before it returns).
+  return BrowserTestUtils.addTab(gBrowser, url, { skipAnimation: true });
 }
 
 function domOrder(tabs) {

--- a/src/zen/tests/tab-tree/head.js
+++ b/src/zen/tests/tab-tree/head.js
@@ -1,0 +1,32 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+async function addNormalTab(url = "about:blank") {
+  const tab = BrowserTestUtils.addTab(gBrowser, url, { skipAnimation: true });
+  await BrowserTestUtils.browserLoaded(gBrowser.getBrowserForTab(tab));
+  return tab;
+}
+
+function domOrder(tabs) {
+  // Returns the subset `tabs` sorted by their position in the tab strip.
+  return [...tabs].sort((a, b) => {
+    const pos = a.compareDocumentPosition(b);
+    if (pos & Node.DOCUMENT_POSITION_FOLLOWING) {
+      return -1;
+    }
+    if (pos & Node.DOCUMENT_POSITION_PRECEDING) {
+      return 1;
+    }
+    return 0;
+  });
+}
+
+async function cleanupTabs(...tabs) {
+  for (const tab of tabs) {
+    if (tab && tab.isConnected && !tab.closing) {
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
+}

--- a/src/zen/tests/window_sync/browser.toml
+++ b/src/zen/tests/window_sync/browser.toml
@@ -8,6 +8,10 @@ support-files = [
   "head.js",
 ]
 
+["browser_sync_tab_close.js"]
+
+["browser_sync_tab_icon.js"]
+
 ["browser_sync_tab_label.js"]
 
 ["browser_sync_tab_open.js"]

--- a/src/zen/tests/window_sync/browser.toml
+++ b/src/zen/tests/window_sync/browser.toml
@@ -11,3 +11,5 @@ support-files = [
 ["browser_sync_tab_label.js"]
 
 ["browser_sync_tab_open.js"]
+
+["browser_sync_tree.js"]

--- a/src/zen/tests/window_sync/browser_sync_tab_close.js
+++ b/src/zen/tests/window_sync/browser_sync_tab_close.js
@@ -12,6 +12,7 @@ const { TabStateFlusher } = ChromeUtils.importESModule(
 // undo close tab (ctrl+shift+t) restores the mirror copy (often blank or
 // stale) instead of the tab the user actually closed.
 add_task(async function test_SyncCloseDoesNotRecordMirrorTabs() {
+  const initialTabs = new Set(gBrowser.tabs);
   await withNewSyncedWindow(async win => {
     let newTab;
     await runSyncAction(
@@ -27,7 +28,15 @@ add_task(async function test_SyncCloseDoesNotRecordMirrorTabs() {
     const otherTab = gZenWindowSync.getItemFromWindow(win, syncId);
     Assert.ok(otherTab, "The opened tab should be found in the synced window");
 
-    await BrowserTestUtils.browserLoaded(newTab.linkedBrowser);
+    // Not browserLoaded(): runSyncAction resolves on the TabOpen sync event,
+    // and the load can finish before we get a listener attached, leaving that
+    // promise waiting for a load that already happened.
+    await TestUtils.waitForCondition(
+      () =>
+        newTab.linkedBrowser.currentURI.spec === "https://example.com/" &&
+        !newTab.linkedBrowser.webProgress.isLoadingDocument,
+      "Waiting for the opened tab to finish loading"
+    );
     await TabStateFlusher.flush(newTab.linkedBrowser);
 
     // Simulate the mirror tab ending up with restorable-looking state, like
@@ -66,12 +75,24 @@ add_task(async function test_SyncCloseDoesNotRecordMirrorTabs() {
       "The sync-propagated close should not be recorded in the other window"
     );
   });
+
+  // Window sync mirrors the synced window's blank tab into this one; drop
+  // whatever it left behind so the harness doesn't flag an unexpected tab.
+  const closing = [];
+  for (const tab of [...gBrowser.tabs]) {
+    if (!initialTabs.has(tab) && !tab.closing) {
+      closing.push(BrowserTestUtils.waitForTabClosing(tab));
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
+  await Promise.all(closing);
 });
 
 // When the user closes the inactive (blank) copy of a synced tab, the close
 // propagated to the window holding the active contents must still be
 // recorded, so undo close tab can restore the page.
 add_task(async function test_SyncCloseRecordsActiveTab() {
+  const initialTabs = new Set(gBrowser.tabs);
   await withNewSyncedWindow(async win => {
     let newTab;
     await runSyncAction(
@@ -91,7 +112,15 @@ add_task(async function test_SyncCloseRecordsActiveTab() {
       "The original tab should hold the contents"
     );
 
-    await BrowserTestUtils.browserLoaded(newTab.linkedBrowser);
+    // Not browserLoaded(): runSyncAction resolves on the TabOpen sync event,
+    // and the load can finish before we get a listener attached, leaving that
+    // promise waiting for a load that already happened.
+    await TestUtils.waitForCondition(
+      () =>
+        newTab.linkedBrowser.currentURI.spec === "https://example.com/" &&
+        !newTab.linkedBrowser.webProgress.isLoadingDocument,
+      "Waiting for the opened tab to finish loading"
+    );
     await TabStateFlusher.flush(newTab.linkedBrowser);
 
     const closedCountBefore = SessionStore.getClosedTabCountForWindow(window);
@@ -115,4 +144,15 @@ add_task(async function test_SyncCloseRecordsActiveTab() {
       "The window holding the active tab contents should record the close"
     );
   });
+
+  // Window sync mirrors the synced window's blank tab into this one; drop
+  // whatever it left behind so the harness doesn't flag an unexpected tab.
+  const closing = [];
+  for (const tab of [...gBrowser.tabs]) {
+    if (!initialTabs.has(tab) && !tab.closing) {
+      closing.push(BrowserTestUtils.waitForTabClosing(tab));
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
+  await Promise.all(closing);
 });

--- a/src/zen/tests/window_sync/browser_sync_tab_close.js
+++ b/src/zen/tests/window_sync/browser_sync_tab_close.js
@@ -1,0 +1,118 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { TabStateFlusher } = ChromeUtils.importESModule(
+  "resource:///modules/sessionstore/TabStateFlusher.sys.mjs"
+);
+
+// Closing a synced tab removes its mirror copies in all other windows. Those
+// propagated closes must not be recorded by the session store, otherwise
+// undo close tab (ctrl+shift+t) restores the mirror copy (often blank or
+// stale) instead of the tab the user actually closed.
+add_task(async function test_SyncCloseDoesNotRecordMirrorTabs() {
+  await withNewSyncedWindow(async win => {
+    let newTab;
+    await runSyncAction(
+      () => {
+        newTab = gBrowser.addTrustedTab("https://example.com/", {
+          inBackground: true,
+        });
+      },
+      async () => {},
+      "TabOpen"
+    );
+    const syncId = newTab.id;
+    const otherTab = gZenWindowSync.getItemFromWindow(win, syncId);
+    Assert.ok(otherTab, "The opened tab should be found in the synced window");
+
+    await BrowserTestUtils.browserLoaded(newTab.linkedBrowser);
+    await TabStateFlusher.flush(newTab.linkedBrowser);
+
+    // Simulate the mirror tab ending up with restorable-looking state, like
+    // a stale tab state cache can leave behind after docshell swaps.
+    SessionStore.setTabState(
+      otherTab,
+      JSON.stringify({
+        entries: [{ url: "https://example.com/", title: "Example" }],
+        index: 1,
+      })
+    );
+
+    const closedCountBefore = SessionStore.getClosedTabCountForWindow(window);
+    const otherClosedCountBefore = SessionStore.getClosedTabCountForWindow(win);
+
+    await runSyncAction(
+      () => {
+        gBrowser.removeTab(newTab);
+      },
+      async () => {},
+      "TabClose"
+    );
+    await TestUtils.waitForCondition(
+      () => !gZenWindowSync.getItemFromWindow(win, syncId),
+      "Waiting for the synced tab to be closed in the other window"
+    );
+
+    Assert.equal(
+      SessionStore.getClosedTabCountForWindow(window),
+      closedCountBefore + 1,
+      "Closing the tab should record one closed tab in its own window"
+    );
+    Assert.equal(
+      SessionStore.getClosedTabCountForWindow(win),
+      otherClosedCountBefore,
+      "The sync-propagated close should not be recorded in the other window"
+    );
+  });
+});
+
+// When the user closes the inactive (blank) copy of a synced tab, the close
+// propagated to the window holding the active contents must still be
+// recorded, so undo close tab can restore the page.
+add_task(async function test_SyncCloseRecordsActiveTab() {
+  await withNewSyncedWindow(async win => {
+    let newTab;
+    await runSyncAction(
+      () => {
+        newTab = gBrowser.addTrustedTab("https://example.com/", {
+          inBackground: true,
+        });
+      },
+      async () => {},
+      "TabOpen"
+    );
+    const syncId = newTab.id;
+    const otherTab = gZenWindowSync.getItemFromWindow(win, syncId);
+    Assert.ok(otherTab, "The opened tab should be found in the synced window");
+    Assert.ok(
+      newTab._zenContentsVisible,
+      "The original tab should hold the contents"
+    );
+
+    await BrowserTestUtils.browserLoaded(newTab.linkedBrowser);
+    await TabStateFlusher.flush(newTab.linkedBrowser);
+
+    const closedCountBefore = SessionStore.getClosedTabCountForWindow(window);
+
+    // Close the blank mirror copy; sync then closes the original tab.
+    await runSyncAction(
+      () => {
+        win.gBrowser.removeTab(otherTab);
+      },
+      async () => {},
+      "TabClose"
+    );
+    await TestUtils.waitForCondition(
+      () => !gZenWindowSync.getItemFromWindow(window, syncId),
+      "Waiting for the synced tab to be closed in the original window"
+    );
+
+    Assert.equal(
+      SessionStore.getClosedTabCountForWindow(window),
+      closedCountBefore + 1,
+      "The window holding the active tab contents should record the close"
+    );
+  });
+});

--- a/src/zen/tests/window_sync/browser_sync_tab_icon.js
+++ b/src/zen/tests/window_sync/browser_sync_tab_icon.js
@@ -1,0 +1,106 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// 1x1 transparent PNG.
+const TEST_ICON =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+add_task(async function test_SimpleIconChange() {
+  await withNewTabAndWindow(async (newTab, win) => {
+    let otherTab = gZenWindowSync.getItemFromWindow(win, newTab.id);
+    Assert.ok(otherTab, "The opened tab should be found in the synced window");
+    // Wait out the page load so a real favicon update can't race the test
+    // icon below.
+    await BrowserTestUtils.browserLoaded(newTab.linkedBrowser);
+    await runSyncAction(
+      () => {
+        gBrowser.setIcon(newTab, TEST_ICON);
+        Assert.equal(
+          gBrowser.getIcon(newTab),
+          TEST_ICON,
+          "The original tab icon should be changed"
+        );
+      },
+      async () => {
+        Assert.equal(
+          otherTab.getAttribute("image"),
+          TEST_ICON,
+          "The synced tab should show the original tab's favicon"
+        );
+        Assert.equal(
+          win.gBrowser.getIcon(otherTab),
+          TEST_ICON,
+          "The synced tab's browser should carry the icon URL"
+        );
+      },
+      "ZenTabIconChanged"
+    );
+  });
+});
+
+add_task(async function test_IconRemovalSyncs() {
+  await withNewTabAndWindow(async (newTab, win) => {
+    let otherTab = gZenWindowSync.getItemFromWindow(win, newTab.id);
+    await BrowserTestUtils.browserLoaded(newTab.linkedBrowser);
+    await runSyncAction(
+      () => {
+        gBrowser.setIcon(newTab, TEST_ICON);
+      },
+      async () => {
+        Assert.equal(
+          otherTab.getAttribute("image"),
+          TEST_ICON,
+          "The synced tab should have the favicon before removal"
+        );
+      },
+      "ZenTabIconChanged"
+    );
+    // Simulate the tab progress listener dropping a stale favicon: it nulls
+    // out mIconURL and removes the image attribute without calling setIcon,
+    // so only TabAttrModified fires.
+    await runSyncAction(
+      () => {
+        newTab.linkedBrowser.mIconURL = null;
+        newTab.removeAttribute("image");
+        gBrowser._tabAttrModified(newTab, ["image"]);
+      },
+      async () => {
+        // The setIcon call above also queued a TabAttrModified event, so this
+        // callback may run for it before the removal got synced.
+        await TestUtils.waitForCondition(
+          () => !otherTab.getAttribute("image"),
+          "Waiting for the synced tab's favicon to be removed"
+        );
+        Assert.ok(
+          !otherTab.getAttribute("image"),
+          "The synced tab's favicon should be removed as well"
+        );
+      },
+      "TabAttrModified"
+    );
+  });
+});
+
+add_task(async function test_DontChangeBluredTabIcon() {
+  await withNewTabAndWindow(async (newTab, win) => {
+    let otherTab = gZenWindowSync.getItemFromWindow(win, newTab.id);
+    Assert.ok(!otherTab._zenContentsVisible, "The synced tab should be blured");
+    // Setting an icon on the inactive synced copy must not propagate back
+    // to the original tab.
+    await runSyncAction(
+      () => {
+        win.gBrowser.setIcon(otherTab, TEST_ICON);
+      },
+      async () => {
+        Assert.notEqual(
+          gBrowser.getIcon(newTab),
+          TEST_ICON,
+          "The original tab icon should NOT change from the synced tab"
+        );
+      },
+      "ZenTabIconChanged"
+    );
+  });
+});

--- a/src/zen/tests/window_sync/browser_sync_tab_icon.js
+++ b/src/zen/tests/window_sync/browser_sync_tab_icon.js
@@ -8,6 +8,7 @@ const TEST_ICON =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
 
 add_task(async function test_SimpleIconChange() {
+  const initialTabs = new Set(gBrowser.tabs);
   await withNewTabAndWindow(async (newTab, win) => {
     let otherTab = gZenWindowSync.getItemFromWindow(win, newTab.id);
     Assert.ok(otherTab, "The opened tab should be found in the synced window");
@@ -38,9 +39,20 @@ add_task(async function test_SimpleIconChange() {
       "ZenTabIconChanged"
     );
   });
+  // withNewTabAndWindow closes the tab it opened, but window sync also mirrors
+  // the synced window's blank tab into this one; drop that too.
+  const closing = [];
+  for (const tab of [...gBrowser.tabs]) {
+    if (!initialTabs.has(tab) && !tab.closing) {
+      closing.push(BrowserTestUtils.waitForTabClosing(tab));
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
+  await Promise.all(closing);
 });
 
 add_task(async function test_IconRemovalSyncs() {
+  const initialTabs = new Set(gBrowser.tabs);
   await withNewTabAndWindow(async (newTab, win) => {
     let otherTab = gZenWindowSync.getItemFromWindow(win, newTab.id);
     await BrowserTestUtils.browserLoaded(newTab.linkedBrowser);
@@ -81,9 +93,20 @@ add_task(async function test_IconRemovalSyncs() {
       "TabAttrModified"
     );
   });
+  // withNewTabAndWindow closes the tab it opened, but window sync also mirrors
+  // the synced window's blank tab into this one; drop that too.
+  const closing = [];
+  for (const tab of [...gBrowser.tabs]) {
+    if (!initialTabs.has(tab) && !tab.closing) {
+      closing.push(BrowserTestUtils.waitForTabClosing(tab));
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
+  await Promise.all(closing);
 });
 
 add_task(async function test_DontChangeBluredTabIcon() {
+  const initialTabs = new Set(gBrowser.tabs);
   await withNewTabAndWindow(async (newTab, win) => {
     let otherTab = gZenWindowSync.getItemFromWindow(win, newTab.id);
     Assert.ok(!otherTab._zenContentsVisible, "The synced tab should be blured");
@@ -103,4 +126,14 @@ add_task(async function test_DontChangeBluredTabIcon() {
       "ZenTabIconChanged"
     );
   });
+  // withNewTabAndWindow closes the tab it opened, but window sync also mirrors
+  // the synced window's blank tab into this one; drop that too.
+  const closing = [];
+  for (const tab of [...gBrowser.tabs]) {
+    if (!initialTabs.has(tab) && !tab.closing) {
+      closing.push(BrowserTestUtils.waitForTabClosing(tab));
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
+  await Promise.all(closing);
 });

--- a/src/zen/tests/window_sync/browser_sync_tab_label.js
+++ b/src/zen/tests/window_sync/browser_sync_tab_label.js
@@ -4,9 +4,20 @@
 "use strict";
 
 add_task(async function test_SimpleLabelChange() {
+  const initialTabs = new Set(gBrowser.tabs);
   let newLabel = "Test Label";
   await withNewTabAndWindow(async (newTab, win) => {
     let otherTab = gZenWindowSync.getItemFromWindow(win, newTab.id);
+    // Let the page load settle first. The load sets the tab's real title, and
+    // if that lands after the label below it overwrites it, and window sync
+    // then faithfully propagates the title to the mirror.
+    await TestUtils.waitForCondition(
+      () =>
+        !newTab.linkedBrowser.webProgress.isLoadingDocument &&
+        newTab.label &&
+        !newTab.label.includes("example.com"),
+      "Waiting for the page title to arrive before setting a label"
+    );
     await runSyncAction(
       () => {
         gBrowser._setTabLabel(newTab, newLabel);
@@ -26,9 +37,19 @@ add_task(async function test_SimpleLabelChange() {
       "ZenTabLabelChanged"
     );
   });
+  // Window sync mirrors the synced window's blank tab into this one.
+  const closing = [];
+  for (const tab of [...gBrowser.tabs]) {
+    if (!initialTabs.has(tab) && !tab.closing) {
+      closing.push(BrowserTestUtils.waitForTabClosing(tab));
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
+  await Promise.all(closing);
 });
 
 add_task(async function test_DontChangeBluredTabLabel() {
+  const initialTabs = new Set(gBrowser.tabs);
   let newLabel = "Test Label";
   await withNewTabAndWindow(async (newTab, win) => {
     let otherTab = gZenWindowSync.getItemFromWindow(win, newTab.id);
@@ -40,4 +61,13 @@ add_task(async function test_DontChangeBluredTabLabel() {
       "The synced tab label should NOT match the changed label"
     );
   });
+  // Window sync mirrors the synced window's blank tab into this one.
+  const closing = [];
+  for (const tab of [...gBrowser.tabs]) {
+    if (!initialTabs.has(tab) && !tab.closing) {
+      closing.push(BrowserTestUtils.waitForTabClosing(tab));
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
+  await Promise.all(closing);
 });

--- a/src/zen/tests/window_sync/browser_sync_tab_open.js
+++ b/src/zen/tests/window_sync/browser_sync_tab_open.js
@@ -4,6 +4,7 @@
 "use strict";
 
 add_task(async function test_SimpleTabOpen() {
+  const initialTabs = new Set(gBrowser.tabs);
   await withNewTabAndWindow(async (newTab, win) => {
     let tabId = newTab.id;
     let otherTab = gZenWindowSync.getItemFromWindow(win, tabId);
@@ -15,4 +16,13 @@ add_task(async function test_SimpleTabOpen() {
       "The opened tab ID should match the synced tab ID"
     );
   });
+  // Window sync mirrors the synced window's blank tab into this one.
+  const closing = [];
+  for (const tab of [...gBrowser.tabs]) {
+    if (!initialTabs.has(tab) && !tab.closing) {
+      closing.push(BrowserTestUtils.waitForTabClosing(tab));
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
+  await Promise.all(closing);
 });

--- a/src/zen/tests/window_sync/browser_sync_tree.js
+++ b/src/zen/tests/window_sync/browser_sync_tree.js
@@ -4,6 +4,7 @@
 "use strict";
 
 add_task(async function test_nest_syncs_to_other_window() {
+  const initialTabs = new Set(gBrowser.tabs);
   await withNewSyncedWindow(async win => {
     // Create two synced tabs (open in this window, mirrored in `win`).
     const parent = gBrowser.addTrustedTab("https://example.com/", {
@@ -41,4 +42,13 @@ add_task(async function test_nest_syncs_to_other_window() {
     BrowserTestUtils.removeTab(child);
     BrowserTestUtils.removeTab(parent);
   });
+
+  // Window-sync can mirror the synced window's initial blank tab into this
+  // window; drop anything that wasn't here before so the harness's
+  // end-of-test tab check stays clean.
+  for (const tab of [...gBrowser.tabs]) {
+    if (!initialTabs.has(tab) && !tab.closing) {
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
 });

--- a/src/zen/tests/window_sync/browser_sync_tree.js
+++ b/src/zen/tests/window_sync/browser_sync_tree.js
@@ -1,0 +1,44 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_nest_syncs_to_other_window() {
+  await withNewSyncedWindow(async win => {
+    // Create two synced tabs (open in this window, mirrored in `win`).
+    const parent = gBrowser.addTrustedTab("https://example.com/", {
+      inBackground: true,
+    });
+    const child = gBrowser.addTrustedTab("https://example.com/", {
+      inBackground: true,
+    });
+    await TestUtils.waitForCondition(
+      () =>
+        win.gZenWindowSync.getItemFromWindow(win, parent.id) &&
+        win.gZenWindowSync.getItemFromWindow(win, child.id)
+    );
+
+    gZenTabTree.nestTab(child, parent);
+
+    await TestUtils.waitForCondition(() => {
+      const mirror = win.gZenWindowSync.getItemFromWindow(win, child.id);
+      return mirror?.getAttribute("zen-tree-parent-id") === parent.id;
+    }, "child mirror gets the parent id");
+
+    const mirrorChild = win.gZenWindowSync.getItemFromWindow(win, child.id);
+    Assert.equal(
+      win.gZenTabTree.getParent(mirrorChild)?.id,
+      parent.id,
+      "mirror window rebuilt the parent pointer"
+    );
+
+    gZenTabTree.setCollapsed(parent, true);
+    await TestUtils.waitForCondition(() => {
+      const m = win.gZenWindowSync.getItemFromWindow(win, parent.id);
+      return m?.hasAttribute("zen-tree-collapsed");
+    }, "collapse syncs to mirror window");
+
+    BrowserTestUtils.removeTab(child);
+    BrowserTestUtils.removeTab(parent);
+  });
+});

--- a/src/zen/tests/window_sync/browser_sync_tree.js
+++ b/src/zen/tests/window_sync/browser_sync_tree.js
@@ -43,9 +43,9 @@ add_task(async function test_nest_syncs_to_other_window() {
     BrowserTestUtils.removeTab(parent);
   });
 
-  // Window-sync can mirror the synced window's initial blank tab into this
-  // window; drop anything that wasn't here before so the harness's
-  // end-of-test tab check stays clean.
+  // Clean up any tab window-sync mirrored into this window (done at the test
+  // level, not in the shared helper — doing it inside withNewSyncedWindow
+  // collides with withNewTabAndWindow's teardown and triggers a sync jam).
   for (const tab of [...gBrowser.tabs]) {
     if (!initialTabs.has(tab) && !tab.closing) {
       BrowserTestUtils.removeTab(tab);

--- a/src/zen/tests/window_sync/browser_sync_tree.js
+++ b/src/zen/tests/window_sync/browser_sync_tree.js
@@ -39,16 +39,24 @@ add_task(async function test_nest_syncs_to_other_window() {
       return m?.hasAttribute("zen-tree-collapsed");
     }, "collapse syncs to mirror window");
 
+    // Await the closes so teardown can't race ahead while these synced tabs are
+    // still closing (which can leak tabs into later tests).
+    const childClosing = BrowserTestUtils.waitForTabClosing(child);
+    const parentClosing = BrowserTestUtils.waitForTabClosing(parent);
     BrowserTestUtils.removeTab(child);
     BrowserTestUtils.removeTab(parent);
+    await Promise.all([childClosing, parentClosing]);
   });
 
   // Clean up any tab window-sync mirrored into this window (done at the test
   // level, not in the shared helper — doing it inside withNewSyncedWindow
   // collides with withNewTabAndWindow's teardown and triggers a sync jam).
+  const closing = [];
   for (const tab of [...gBrowser.tabs]) {
     if (!initialTabs.has(tab) && !tab.closing) {
+      closing.push(BrowserTestUtils.waitForTabClosing(tab));
       BrowserTestUtils.removeTab(tab);
     }
   }
+  await Promise.all(closing);
 });

--- a/src/zen/tests/window_sync/head.js
+++ b/src/zen/tests/window_sync/head.js
@@ -10,10 +10,14 @@ async function withNewSyncedWindow(action) {
   await BrowserTestUtils.closeWindow(win);
 }
 
-async function runSyncAction(action, callback, type) {
+// `matches` narrows which event of `type` we settle on. Matching on the type
+// alone is not enough: sync events are queued rather than dropped when another
+// window is mid-sync, so one left over from earlier work can arrive here first
+// and resolve the wait before the action's own event has been handled.
+async function runSyncAction(action, callback, type, matches = null) {
   await new Promise(resolve => {
     window.gZenWindowSync.addSyncHandler(async function handler(aEvent) {
-      if (aEvent.type === type) {
+      if (aEvent.type === type && (!matches || matches(aEvent))) {
         window.gZenWindowSync.removeSyncHandler(handler);
         await callback(aEvent);
         resolve();
@@ -40,7 +44,8 @@ async function withNewTabAndWindow(action) {
         Assert.equal(aEvent.type, "TabOpen", "Event type should be TabOpen");
         await action(newTab, win);
       },
-      "TabOpen"
+      "TabOpen",
+      aEvent => aEvent.target === newTab
     );
   });
   let portalTabClosing = BrowserTestUtils.waitForTabClosing(newTab);

--- a/src/zen/zen.globals.mjs
+++ b/src/zen/zen.globals.mjs
@@ -32,6 +32,8 @@ export default [
   "gZenEmojiPicker",
   "gZenSessionStore",
   "gZenFolders",
+  "gZenTabTree",
+  "gZenTabMultiSelectDrag",
   "gZenMediaController",
   "gZenGlanceManager",
   "gZenLiveFoldersUI",


### PR DESCRIPTION
Native tree-style tabs for the vertical sidebar. Tabs nest into a real parent/child tree, drag as whole branches, survive restart, undo-close and window sync, and treat split views as first-class tree nodes. Adds a middle-mouse drag-select gesture for closing a range of tabs.

[Discussion #891](https://github.com/zen-browser/desktop/discussions/891) has been asking for this since 2024 (276 upvotes, 30 comments, carried over from issue #114): "tabs nestable under other tabs, along with nestable groups". This covers that nesting, groups included. It doesn't address the other half of that thread, which is about the Zen sidebar coexisting better with Sidebery's own.

## Screenshots

Four levels of nesting, and a branch folded away by its twisty:

| Nested tree | Branch collapsed |
|:--:|:--:|
| <img width="206" alt="Tabs nested four levels deep" src="https://raw.githubusercontent.com/joegoldin/zen-browser-desktop/pr-assets/01-tree-nesting.png" /> | <img width="206" alt="A collapsed branch showing its twisty" src="https://raw.githubusercontent.com/joegoldin/zen-browser-desktop/pr-assets/02-branch-collapsed.png" /> |

A split view sitting in the tree as one row, and a multi-selection spanning a branch:

| Split view as a tree node | Multi-selection |
|:--:|:--:|
| <img width="206" alt="A split view group nested as a single tree row" src="https://raw.githubusercontent.com/joegoldin/zen-browser-desktop/pr-assets/05-split-as-tree-node.png" /> | <img width="206" alt="Three tabs in a branch multi-selected" src="https://raw.githubusercontent.com/joegoldin/zen-browser-desktop/pr-assets/04-multi-selection.png" /> |

## The tree model

`src/zen/tab-tree/ZenTabTree.mjs` holds parent/child state on `_zenTreeParent`, `_zenTreeLevel` and `_zenTreeCollapsed`, mirrored onto `zen-tree-id`, `zen-tree-parent-id`, `zen-tree-collapsed` and `zen-tree-hidden` attributes. The strip is kept in depth-first order, so the DOM order and the visual tree never disagree.

Tabs auto-nest under the tab that opened them. Closing a parent either promotes its children or closes the subtree, controlled by a pref. There's a depth cap (`max-depth`), collapse and expand through a left-aligned twisty, and nesting across workspaces is rejected.

Auto-nesting had to survive one Firefox behaviour: `tab.owner` is cleared on each successive tab opened from the same opener, so only the first would keep it. The opener is captured in `tabbrowser` as `tab._zenOpenerTab`, where it's still known, which is what makes "open five links from one page" nest all five.

## Drag and drop

`src/zen/drag-and-drop/ZenDragAndDrop.js` handles three drop zones. Vertical edges reorder, with a live indent preview clamped to the level you can actually reach, and the tab lands exactly where the indicator showed it would. Dragging left outdents to root. The central band nests. Horizontal edges arm a split-left or split-right, but only on a deliberate hold, so a normal reorder never turns into a split by accident.

Dragging a parent moves its whole branch as one block with the hierarchy intact, and the branch animates from its dragstart layout to its dropped position as a single unit (a block FLIP) rather than tabs sliding through each other. Dragging a multi-selection nests and reorders every selected tab, not just the one under the cursor.

## Split views as tree nodes

A `tab-group[split-view-group]` is one node: it nests, indents, moves and collapses as a single row, and its inner tabs aren't independent nodes. When a nested tab becomes a split it hands its tree role, both parent and children, to the group. Dissolving a split returns the tabs and their children to the split's level.

## Middle-mouse drag-select

`src/zen/tab-tree/ZenTabMultiSelectDrag.mjs` adds a range-select gesture: hold the middle button and drag to select a range, release to close the selection. Right-click aborts to the context menu, and a clean middle-click still closes a single tab. It closes exactly the selection and never the active tab outside that range.

## Persistence, undo-close and window sync

Tree structure persists across restarts, rebuilds from the attributes, and mirrors into synced windows.

Ctrl+Shift+T restores the hierarchy rather than a flat list. The tree attributes ride along as restorable tab attributes, parents are matched by a stable id that survives window sync reassigning live ids, and the rebuild re-asserts depth-first order so restored tabs don't interleave with unrelated ones.

## Engine touchpoints

Two patches outside `src/zen`:

* `src/browser/components/sessionstore`: `TabState` and `TabAttributes` persist
and restore the `zen-tree-*` attributes on every path, including undo-close, which doesn't run `restoreInitialTabData`.
* `src/browser/components/tabbrowser`: captures the opener durably as
`tab._zenOpenerTab`, as described above.

## Prefs

`prefs/zen/tab-tree.yaml` adds indent width, `max-depth`, drag zone sizes, the nest-to-split hold delay, and a toggle for the middle-drag gesture.

## Tests

`src/zen/tests/tab-tree/` has 16 files covering the model, nesting, depth capping, collapse, drag, opener tracking, close behaviour, pinned reordering, reordering, persistence, split-as-node, multi-select detach, eligibility, workspace boundaries and middle-drag. `src/zen/tests/window_sync/browser_sync_tree.js` checks the tree survives window sync.

Built against Firefox 153 and run locally with `npm test -- <dir> --headless`.

`tab-tree`: **142 passed, 0 failed** across the 16 files listed above.

`window_sync`: **28 passed, 0 failed**, over three consecutive runs of the whole directory. Getting there turned up three sync bugs, fixed here: a tab close and a tab open were both being dropped when the other window happened to be mid-sync, and the icon sync read the source tab's window through a property that is undefined on a tab, so every propagation threw inside a bare `catch {}` and the mirror silently kept its old favicon.
