### PR TITLE
no-bug: Seed Space Routing rules and Spaces from managed preferences

### DIFF
--- a/locales/en-US/browser/browser/zen-space-routing.ftl
+++ b/locales/en-US/browser/browser/zen-space-routing.ftl
@@ -31,3 +31,7 @@ tab-context-zen-add-domain-to-sr =
             [one] Add Route for Domain
             *[other] Add Route for Domains
         }
+
+# Heading for the read-only list of routes that come from a managed policy or a
+# declarative configuration (e.g. a dotfiles setup) rather than the dialog.
+zen-space-routing-managed-section = Managed by your configuration

--- a/locales/en-US/browser/browser/zen-workspaces.ftl
+++ b/locales/en-US/browser/browser/zen-workspaces.ftl
@@ -87,6 +87,8 @@ zen-workspace-default-profile = Default
 zen-workspaces-delete-workspace-title = Delete Space?
 zen-workspaces-delete-workspace-body = Are you sure you want to delete { $name }? This action cannot be undone.
 
+zen-workspaces-managed-readonly-toast = This Space is managed by your configuration.
+
 # Note that the html tag MUST not be changed or removed, as it is used to better
 # display the shortcut in the toast notification.
 zen-workspaces-close-all-unpinned-tabs-toast = Tabs Closed! Use <span>{ $shortcut }</span> to undo.

--- a/prefs/zen/space-routing.yaml
+++ b/prefs/zen/space-routing.yaml
@@ -18,3 +18,14 @@
 # `openIn` instead to target a literal "most-recent-space" or a known Space id.
 - name: zen.space-routing.managed-routes
   value: ""
+
+# A JSON array of "managed" Spaces, seeded the same way as managed-routes so a
+# declarative config can define the Spaces themselves (not just route to them).
+# Each entry: { "name": "Work", "icon": "briefcase", "container": "Work",
+# "position": 0 }. `icon` is an emoji, a built-in icon name / *.svg (expanded to
+# a chrome:// selectable-icon URL), or a full URL. `container` is resolved by
+# label to a userContextId (unknown -> none; containers are never created).
+# Managed Spaces are created if missing, synced if present, never deleted, and
+# read-only in the UI.
+- name: zen.space-routing.managed-spaces
+  value: ""

--- a/prefs/zen/space-routing.yaml
+++ b/prefs/zen/space-routing.yaml
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# A JSON array of "managed" Space Routing rules, intended to be set by an
+# enterprise policy or a declarative configuration manager (e.g. a Nix /
+# home-manager dotfiles setup), the same way Containerise rules can be seeded.
+#
+# Managed routes are evaluated before — and take precedence over — the routes a
+# user creates in the Space Routing dialog, and they are never written back to
+# the on-disk store. Each entry looks like:
+#
+#   { "reference": "github.com", "matchType": "contains", "openInSpace": "Work" }
+#
+# `openInSpace` targets a Space by its name, which is resolved to the Space's id
+# at routing time. That indirection is what makes a declarative config
+# deterministic: Space ids are random per profile, but names are stable. Use
+# `openIn` instead to target a literal "most-recent-space" or a known Space id.
+- name: zen.space-routing.managed-routes
+  value: ""

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -309,7 +309,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
 +      let hasZenDefaultUserContextId = false;
 +      let zenForcedWorkspaceId = undefined;
 +      if (beforeRouteResult.isRouteFound && (typeof userContextId === "undefined" || fromExternal)) {
-+        userContextId = beforeRouteResult.userContextId;
++        userContextId = beforeRouteResult.userContextId ?? 0;
 +        hasZenDefaultUserContextId = true;
 +      } else if (typeof gZenWorkspaces !== "undefined" && !_forZenEmptyTab) {
 +        [userContextId, hasZenDefaultUserContextId, zenForcedWorkspaceId] = gZenWorkspaces.getContextIdIfNeeded(userContextId, fromExternal, triggeringPrincipal);

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -301,7 +301,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
          );
        }
  
-+      const beforeRouteResult = window.gZenSpaceRoutingManager.onBeforeAddTab(uriString, { skipRoute, pinned, tabGroup, fromExternal }, window);
++      const beforeRouteResult = window.gZenSpaceRoutingManager.onBeforeAddTab(uriString, { skipRoute, pinned, tabGroup, fromExternal, userContextId }, window);
 +      if (beforeRouteResult.shouldEarlyExit) {
 +        return null;
 +      }

--- a/src/zen/common/ZenPreloadedScripts.js
+++ b/src/zen/common/ZenPreloadedScripts.js
@@ -6,6 +6,8 @@
 // eslint-disable-next-line no-lone-blocks
 {
   ChromeUtils.defineESModuleGetters(this, {
+    gZenManagedSpaces:
+      "resource:///modules/zen/spacerouting/ZenManagedSpaces.sys.mjs",
     gZenSpaceRoutingManager:
       "resource:///modules/zen/spacerouting/ZenSpaceRoutingManager.sys.mjs",
   });

--- a/src/zen/space-routing/ZenManagedSpaces.sys.mjs
+++ b/src/zen/space-routing/ZenManagedSpaces.sys.mjs
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ContextualIdentityService } from "resource://gre/modules/ContextualIdentityService.sys.mjs";
+import { XPCOMUtils } from "resource://gre/modules/XPCOMUtils.sys.mjs";
+
+const lazy = {};
+
+// Spaces seeded from configuration (a declarative dotfiles setup, an enterprise
+// policy, …). The pref holds a JSON array of Space definitions; see
+// getManagedSpaces() for the accepted shape. Live-updating so a changed pref is
+// picked up without a restart.
+XPCOMUtils.defineLazyPreferenceGetter(
+  lazy,
+  "managedSpacesJSON",
+  "zen.space-routing.managed-spaces",
+  ""
+);
+
+// Built-in selectable Space icons live here; see gZenEmojiPicker.getSVGURL().
+const SELECTABLE_ICON_BASE = "chrome://browser/skin/zen-icons/selectable/";
+
+class nsZenManagedSpaces {
+  // Memoized parse of the managed-spaces pref. Re-parsed only when the raw pref
+  // string changes.
+  #managedSpacesRaw = null;
+  #managedSpaces = [];
+  #managedNames = new Set();
+
+  /**
+   * Parsed + normalized managed spaces. Accepted pref shape:
+   *
+   *   [ { "name": "Work", "icon": "briefcase",
+   *       "container": "Work", "position": 0 }, … ]
+   *
+   * (an object `{ "spaces": [ … ] }` is also accepted). Each normalized entry is
+   *   { name, icon, container, position }
+   * where `icon` is an emoji kept as-is, or a chrome URL resolved from a bare
+   * icon name / `*.svg`; `container` is the raw name or userContextId (resolved
+   * at reconcile time); `position` is the entry's intended order.
+   *
+   * Invalid input never throws: a parse error or unexpected shape yields an
+   * empty list (logged), so a malformed pref can't break startup.
+   *
+   * @returns {Array<object>}
+   */
+  getManagedSpaces() {
+    const raw = lazy.managedSpacesJSON;
+    if (raw === this.#managedSpacesRaw) {
+      return this.#managedSpaces;
+    }
+    this.#managedSpacesRaw = raw;
+    this.#managedSpaces = this.#parseManagedSpaces(raw);
+    this.#managedNames = new Set(this.#managedSpaces.map(s => s.name));
+    return this.#managedSpaces;
+  }
+
+  /**
+   * @param {string} name
+   * @returns {boolean} Whether a Space with this name is config-managed.
+   */
+  isManaged(name) {
+    this.getManagedSpaces();
+    return this.#managedNames.has(name);
+  }
+
+  #parseManagedSpaces(raw) {
+    if (typeof raw !== "string" || raw.trim() === "") {
+      return [];
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      console.error(
+        "[ZenManagedSpaces] Could not parse zen.space-routing.managed-spaces:",
+        e
+      );
+      return [];
+    }
+
+    const list = Array.isArray(parsed) ? parsed : parsed?.spaces;
+    if (!Array.isArray(list)) {
+      console.error(
+        "[ZenManagedSpaces] zen.space-routing.managed-spaces must be a JSON " +
+          "array of spaces, or an object with a `spaces` array."
+      );
+      return [];
+    }
+
+    const spaces = [];
+    for (let index = 0; index < list.length; index++) {
+      const entry = list[index];
+      if (
+        !entry ||
+        typeof entry.name !== "string" ||
+        entry.name.trim() === ""
+      ) {
+        continue;
+      }
+      spaces.push({
+        name: entry.name.trim(),
+        icon: this.#resolveIcon(entry.icon),
+        container: entry.container ?? null,
+        position: Number.isInteger(entry.position) ? entry.position : index,
+      });
+    }
+    return spaces;
+  }
+
+  /**
+   * Normalizes an icon value: emoji / arbitrary text kept as-is; a full chrome
+   * (or moz-icon/data) URL kept as-is; a bare icon name or `*.svg` expanded to
+   * the selectable-icon chrome URL.
+   *
+   * @param {*} icon
+   * @returns {string|undefined}
+   */
+  #resolveIcon(icon) {
+    if (typeof icon !== "string" || icon.trim() === "") {
+      return undefined;
+    }
+    const value = icon.trim();
+    if (
+      value.startsWith("chrome://") ||
+      value.startsWith("moz-icon:") ||
+      value.startsWith("data:")
+    ) {
+      return value;
+    }
+    if (value.endsWith(".svg")) {
+      return SELECTABLE_ICON_BASE + value;
+    }
+    // A bare slug like "briefcase" is a built-in icon name; anything else (an
+    // emoji, free text) is used verbatim.
+    if (/^[a-z0-9][a-z0-9-]*$/i.test(value)) {
+      return SELECTABLE_ICON_BASE + value + ".svg";
+    }
+    return value;
+  }
+}
+
+export const gZenManagedSpaces = new nsZenManagedSpaces();

--- a/src/zen/space-routing/ZenManagedSpaces.sys.mjs
+++ b/src/zen/space-routing/ZenManagedSpaces.sys.mjs
@@ -109,7 +109,12 @@ class nsZenManagedSpaces {
       try {
         const existing = ws.getWorkspaces().find(w => w.name === entry.name);
         if (existing) {
-          continue; // update path added in Task 4
+          if (entry.icon !== undefined) {
+            existing.icon = entry.icon;
+          }
+          existing.containerTabId = this.resolveContainerId(entry.container);
+          ws.saveWorkspace(existing);
+          continue;
         }
         ws.saveWorkspace({
           uuid: win.gZenUIManager.generateUuidv4(),

--- a/src/zen/space-routing/ZenManagedSpaces.sys.mjs
+++ b/src/zen/space-routing/ZenManagedSpaces.sys.mjs
@@ -134,6 +134,23 @@ class nsZenManagedSpaces {
   }
 
   /**
+   * Test-only: bypasses the read-only guard so tests can clean up Spaces they
+   * seeded. Drops the name from the managed set (so removeWorkspace's guard
+   * lets it through) and removes it. Never call from product code.
+   *
+   * @param {string} uuid
+   */
+  forceRemoveForTest(uuid) {
+    const win = Services.wm.getMostRecentBrowserWindow();
+    const ws = win?.gZenWorkspaces;
+    const space = ws?.getWorkspaces().find(w => w.uuid === uuid);
+    if (space) {
+      this.#managedNames.delete(space.name);
+      ws.removeWorkspace(uuid);
+    }
+  }
+
+  /**
    * A fresh "no gradient" default theme for a newly seeded Space. Mirrors
    * nsZenThemePicker.getTheme([]), inlined because nsZenThemePicker is a window
    * lexical global and isn't reachable as a property of `win` from this module.

--- a/src/zen/space-routing/ZenManagedSpaces.sys.mjs
+++ b/src/zen/space-routing/ZenManagedSpaces.sys.mjs
@@ -92,6 +92,53 @@ class nsZenManagedSpaces {
     return 0;
   }
 
+  /**
+   * Reconciles managed Spaces into a window's workspaces: creates a Space for
+   * any managed name that doesn't exist yet. Idempotent. Never deletes. Must run
+   * after gZenWorkspaces has finished initializing (so saveWorkspace can
+   * materialize the UI).
+   *
+   * @param {Window} win
+   */
+  reconcile(win) {
+    const ws = win?.gZenWorkspaces;
+    if (!ws?.workspaceEnabled) {
+      return;
+    }
+    for (const entry of this.getManagedSpaces()) {
+      try {
+        const existing = ws.getWorkspaces().find(w => w.name === entry.name);
+        if (existing) {
+          continue; // update path added in Task 4
+        }
+        ws.saveWorkspace({
+          uuid: win.gZenUIManager.generateUuidv4(),
+          name: entry.name,
+          icon: entry.icon,
+          theme: this.#defaultSpaceTheme(),
+          containerTabId: this.resolveContainerId(entry.container),
+        });
+      } catch (e) {
+        console.error(
+          "[ZenManagedSpaces] reconcile failed for",
+          entry?.name,
+          e
+        );
+      }
+    }
+  }
+
+  /**
+   * A fresh "no gradient" default theme for a newly seeded Space. Mirrors
+   * nsZenThemePicker.getTheme([]), inlined because nsZenThemePicker is a window
+   * lexical global and isn't reachable as a property of `win` from this module.
+   *
+   * @returns {object}
+   */
+  #defaultSpaceTheme() {
+    return { type: "gradient", gradientColors: [], opacity: 0.5, texture: 0 };
+  }
+
   #parseManagedSpaces(raw) {
     if (typeof raw !== "string" || raw.trim() === "") {
       return [];

--- a/src/zen/space-routing/ZenManagedSpaces.sys.mjs
+++ b/src/zen/space-routing/ZenManagedSpaces.sys.mjs
@@ -65,6 +65,33 @@ class nsZenManagedSpaces {
     return this.#managedNames.has(name);
   }
 
+  /**
+   * Resolves a container reference (its user-visible name, or a userContextId
+   * number) to a userContextId. An unknown name yields 0 (no container).
+   * Containers are never created here.
+   *
+   * @param {string|number|null} container
+   * @returns {number}
+   */
+  resolveContainerId(container) {
+    if (typeof container === "number" && Number.isInteger(container)) {
+      return container;
+    }
+    if (typeof container !== "string" || container.trim() === "") {
+      return 0;
+    }
+    const wanted = container.trim();
+    for (const identity of ContextualIdentityService.getPublicIdentities()) {
+      const label =
+        ContextualIdentityService.getUserContextLabel(identity.userContextId) ||
+        identity.name;
+      if (label === wanted) {
+        return identity.userContextId;
+      }
+    }
+    return 0;
+  }
+
   #parseManagedSpaces(raw) {
     if (typeof raw !== "string" || raw.trim() === "") {
       return [];

--- a/src/zen/space-routing/ZenSpaceRoutingDialog.mjs
+++ b/src/zen/space-routing/ZenSpaceRoutingDialog.mjs
@@ -84,6 +84,127 @@ export class nsZenSpaceRoutingDialog {
   initRouteList() {
     const allRoutes = gZenSpaceRoutingManager.getAllRoutes();
     allRoutes.forEach(r => this.createRouteElement(r));
+    this.renderManagedRoutes();
+  }
+
+  /**
+   * Renders the configuration-managed routes as a read-only section above the
+   * editable routes. These come from the zen.space-routing.managed-routes pref
+   * and can't be edited here, so they are shown for transparency — to explain
+   * routing the user didn't set up by hand — rather than as editable rows.
+   */
+  async renderManagedRoutes() {
+    const managedRoutes = gZenSpaceRoutingManager.getManagedRoutes();
+    if (!managedRoutes.length) {
+      return;
+    }
+
+    const [containsMsg, equalToMsg, regexMsg, mostRecentMsg] =
+      await this.doc.l10n.formatMessages([
+        "zen-space-routing-contains",
+        "zen-space-routing-equal-to",
+        "zen-space-routing-regex",
+        "zen-space-routing-most-recent-space",
+      ]);
+
+    const msgValue = (msg, attrName) =>
+      msg?.attributes?.find(a => a.name === attrName)?.value ?? msg?.value ?? "";
+
+    const matchTypeLabels = {
+      "contains": msgValue(containsMsg, "label"),
+      "equal-to": msgValue(equalToMsg, "label"),
+      "regex": msgValue(regexMsg, "label"),
+    };
+    const mostRecentLabel = msgValue(mostRecentMsg);
+    const workspaces = this.openerWindow.gZenWorkspaces.getWorkspaces();
+
+    const header = this.doc.createXULElement("label");
+    header.className = "sr-managed-header";
+    header.setAttribute("data-l10n-id", "zen-space-routing-managed-section");
+
+    const nodes = [header];
+    for (const route of managedRoutes) {
+      nodes.push(
+        this.createManagedRouteElement(
+          route,
+          matchTypeLabels,
+          mostRecentLabel,
+          workspaces
+        )
+      );
+    }
+
+    // Insert right after the empty-state placeholder so the managed section sits
+    // above the editable routes, regardless of when this async work resolves.
+    this.doc.getElementById("sr-empty-content").after(...nodes);
+    this.updateShowNoRouteText();
+  }
+
+  /**
+   * Builds a single read-only managed-route row.
+   *
+   * @param {object} route - The managed route
+   * @param {object} matchTypeLabels - Localized match-type labels keyed by id
+   * @param {string} mostRecentLabel - Localized "Most recent Space" label
+   * @param {Array<object>} workspaces - The opener window's Spaces
+   * @returns {Element} The row element
+   */
+  createManagedRouteElement(route, matchTypeLabels, mostRecentLabel, workspaces) {
+    const root = this.doc.createXULElement("vbox");
+    root.className = "sr-managed-container";
+    root.setAttribute("routeId", route.id);
+
+    const row = this.doc.createXULElement("hbox");
+    row.className = "sr-rule-row sr-managed-row";
+
+    const urlIcon = this.doc.createXULElement("image");
+    urlIcon.className = "sr-url-icon";
+
+    const reference = this.doc.createXULElement("label");
+    reference.className = "sr-managed-reference";
+    reference.setAttribute("crop", "end");
+    reference.setAttribute("value", route.reference);
+
+    const matchType = this.doc.createXULElement("label");
+    matchType.className = "sr-managed-meta";
+    matchType.setAttribute(
+      "value",
+      matchTypeLabels[route.matchType] ?? route.matchType
+    );
+
+    const arrow = this.doc.createXULElement("image");
+    arrow.className = "sr-open-in-icon sr-managed-arrow";
+
+    const target = this.doc.createXULElement("label");
+    target.className = "sr-managed-target";
+    target.setAttribute("crop", "end");
+    target.setAttribute(
+      "value",
+      this.managedTargetName(route, mostRecentLabel, workspaces)
+    );
+
+    row.append(urlIcon, reference, matchType, arrow, target);
+    root.append(row);
+    return root;
+  }
+
+  /**
+   * Resolves the user-visible target name shown for a managed route.
+   *
+   * @param {object} route - The managed route
+   * @param {string} mostRecentLabel - Localized "Most recent Space" label
+   * @param {Array<object>} workspaces - The opener window's Spaces
+   * @returns {string} The label to display for the route's target
+   */
+  managedTargetName(route, mostRecentLabel, workspaces) {
+    if (route.openInSpace) {
+      return route.openInSpace;
+    }
+    if (!route.openIn || route.openIn === "most-recent-space") {
+      return mostRecentLabel;
+    }
+    const match = workspaces.find(w => w.uuid === route.openIn);
+    return match?.name ?? mostRecentLabel;
   }
 
   /**
@@ -235,9 +356,12 @@ export class nsZenSpaceRoutingDialog {
     const container = this.doc.getElementById("sr-content");
     const noRoutesText = this.doc.getElementById("sr-empty-content");
 
-    // One because of the element itself
-    noRoutesText.style.display =
-      container.children.length == 1 ? "flex" : "none";
+    // The placeholder hides as soon as there is any route to show, whether it is
+    // an editable user route or a read-only managed one.
+    const hasAnyRoute = !!container.querySelector(
+      ".sr-rule-container, .sr-managed-container"
+    );
+    noRoutesText.style.display = hasAnyRoute ? "none" : "flex";
   }
 
   /**

--- a/src/zen/space-routing/ZenSpaceRoutingDialog.mjs
+++ b/src/zen/space-routing/ZenSpaceRoutingDialog.mjs
@@ -108,12 +108,14 @@ export class nsZenSpaceRoutingDialog {
       ]);
 
     const msgValue = (msg, attrName) =>
-      msg?.attributes?.find(a => a.name === attrName)?.value ?? msg?.value ?? "";
+      msg?.attributes?.find(a => a.name === attrName)?.value ??
+      msg?.value ??
+      "";
 
     const matchTypeLabels = {
-      "contains": msgValue(containsMsg, "label"),
+      contains: msgValue(containsMsg, "label"),
       "equal-to": msgValue(equalToMsg, "label"),
-      "regex": msgValue(regexMsg, "label"),
+      regex: msgValue(regexMsg, "label"),
     };
     const mostRecentLabel = msgValue(mostRecentMsg);
     const workspaces = this.openerWindow.gZenWorkspaces.getWorkspaces();
@@ -149,7 +151,12 @@ export class nsZenSpaceRoutingDialog {
    * @param {Array<object>} workspaces - The opener window's Spaces
    * @returns {Element} The row element
    */
-  createManagedRouteElement(route, matchTypeLabels, mostRecentLabel, workspaces) {
+  createManagedRouteElement(
+    route,
+    matchTypeLabels,
+    mostRecentLabel,
+    workspaces
+  ) {
     const root = this.doc.createXULElement("vbox");
     root.className = "sr-managed-container";
     root.setAttribute("routeId", route.id);

--- a/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
+++ b/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
@@ -3,10 +3,30 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { JSONFile } from "resource://gre/modules/JSONFile.sys.mjs";
+import { XPCOMUtils } from "resource://gre/modules/XPCOMUtils.sys.mjs";
+
+const lazy = {};
+
+// Routes seeded from configuration (an enterprise policy, a declarative
+// dotfiles setup, …). The pref holds a JSON array of route definitions; see
+// getManagedRoutes() for the accepted shape. It is a live-updating getter so a
+// changed pref is picked up without a restart.
+XPCOMUtils.defineLazyPreferenceGetter(
+  lazy,
+  "managedRoutesJSON",
+  "zen.space-routing.managed-routes",
+  ""
+);
+
+const VALID_MATCH_TYPES = ["contains", "equal-to", "regex"];
 
 class nsZenSpaceRoutingManager {
   #file = null;
   #saveFilename = "zen-space-routing.jsonlz4";
+  // Memoized parse of the managed-routes pref. Re-parsed only when the raw pref
+  // string changes, so routeUri() can consult it per tab without re-parsing.
+  #managedRoutesRaw = null;
+  #managedRoutes = [];
 
   static SKIP_TYPE = {
     NONE: "none",
@@ -98,7 +118,7 @@ class nsZenSpaceRoutingManager {
       };
     }
 
-    targetRoute = this.routeUri(uriString, options);
+    targetRoute = this.routeUri(uriString, options, win);
     switch (targetRoute) {
       case "most-recent-space":
         break;
@@ -271,10 +291,21 @@ class nsZenSpaceRoutingManager {
    *
    * @param {string} uriString - The uri which will be routed
    * @param {object} options - The tab creation options
+   * @param {Window} [win] - The window the tab is being added to, used to
+   *   resolve a managed route's target Space by name
    * @returns {string} Route instructions
    */
-  routeUri(uriString, options) {
+  routeUri(uriString, options, win) {
     const isExternal = options.fromExternal;
+
+    // Managed routes come from configuration (the zen.space-routing.managed-routes
+    // pref) and are the deterministic source of truth, so they are evaluated
+    // before — and win over — the routes a user created in the dialog.
+    for (const route of this.getManagedRoutes()) {
+      if (this.isRouteMatching(uriString, route)) {
+        return this.#resolveManagedTarget(route, win);
+      }
+    }
 
     // Go over all routes and return the open type for the first match
     const allRoutes = this.getAllRoutes();
@@ -292,6 +323,147 @@ class nsZenSpaceRoutingManager {
 
     // If nothing matches, open in most recent space
     return "most-recent-space";
+  }
+
+  /**
+   * Returns the configuration-managed routes, parsed from the
+   * `zen.space-routing.managed-routes` pref.
+   *
+   * The pref holds either a JSON array of route objects, or a JSON object with
+   * a `routes` array. Each route object accepts:
+   *
+   *   - reference   {string} the pattern to match (required, non-empty)
+   *   - matchType   {string} "contains" | "equal-to" | "regex" (default "contains")
+   *   - openInSpace {string} the NAME of the Space to route to. Resolved to the
+   *                          Space's id at routing time, which is what makes a
+   *                          declarative config deterministic — Space ids are
+   *                          random per profile, but names are stable.
+   *   - openIn      {string} a literal target ("most-recent-space" or a Space
+   *                          id). Used when `openInSpace` is absent.
+   *
+   * The result is memoized and only re-parsed when the pref changes. The
+   * returned array is owned by the manager and must be treated as read-only.
+   *
+   * @returns {Array<object>} The managed routes (possibly empty)
+   */
+  getManagedRoutes() {
+    const raw = lazy.managedRoutesJSON;
+    if (raw === this.#managedRoutesRaw) {
+      return this.#managedRoutes;
+    }
+    this.#managedRoutesRaw = raw;
+    this.#managedRoutes = this.#parseManagedRoutes(raw);
+    return this.#managedRoutes;
+  }
+
+  /**
+   * Parses and normalizes the managed-routes pref value.
+   *
+   * Invalid input never throws: a parse error or an unexpected shape simply
+   * yields an empty list (logged), so a malformed pref can't break tab opening.
+   *
+   * @param {string} raw - The raw pref value
+   * @returns {Array<object>} The normalized managed routes
+   * @private
+   */
+  #parseManagedRoutes(raw) {
+    if (typeof raw !== "string" || raw.trim() === "") {
+      return [];
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      console.error(
+        "[ZenSpaceRouting] Could not parse zen.space-routing.managed-routes:",
+        e
+      );
+      return [];
+    }
+
+    // Accept a bare array, or an object with a `routes` array.
+    const list = Array.isArray(parsed) ? parsed : parsed?.routes;
+    if (!Array.isArray(list)) {
+      console.error(
+        "[ZenSpaceRouting] zen.space-routing.managed-routes must be a JSON " +
+          "array of routes, or an object with a `routes` array."
+      );
+      return [];
+    }
+
+    const routes = [];
+    for (let index = 0; index < list.length; index++) {
+      const entry = list[index];
+      if (
+        !entry ||
+        typeof entry.reference !== "string" ||
+        entry.reference.trim() === ""
+      ) {
+        continue;
+      }
+
+      const matchType = VALID_MATCH_TYPES.includes(entry.matchType)
+        ? entry.matchType
+        : "contains";
+
+      const route = {
+        id: `managed-${index}`,
+        reference: entry.reference,
+        matchType,
+        managed: true,
+        openIn:
+          typeof entry.openIn === "string" && entry.openIn.trim() !== ""
+            ? entry.openIn
+            : "most-recent-space",
+      };
+
+      if (
+        typeof entry.openInSpace === "string" &&
+        entry.openInSpace.trim() !== ""
+      ) {
+        route.openInSpace = entry.openInSpace;
+      }
+
+      routes.push(route);
+    }
+    return routes;
+  }
+
+  /**
+   * Resolves a managed route's target to a value routeUri() can return: either
+   * "most-recent-space" or a concrete Space id.
+   *
+   * @param {object} route - A managed route
+   * @param {Window} [win] - The window whose Spaces resolve a name reference
+   * @returns {string} The resolved target
+   * @private
+   */
+  #resolveManagedTarget(route, win) {
+    if (route.openInSpace) {
+      return (
+        this.#resolveSpaceNameToId(route.openInSpace, win) ?? "most-recent-space"
+      );
+    }
+    return route.openIn ?? "most-recent-space";
+  }
+
+  /**
+   * Looks up a Space id from its (user-visible) name.
+   *
+   * @param {string} name - The Space name
+   * @param {Window} [win] - The window whose Spaces are searched
+   * @returns {string|null} The matching Space id, or null if none/unavailable
+   * @private
+   */
+  #resolveSpaceNameToId(name, win) {
+    try {
+      const workspaces = win?.gZenWorkspaces?.getWorkspaces?.() ?? [];
+      const match = workspaces.find(workspace => workspace?.name === name);
+      return match?.uuid ?? null;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
+++ b/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
@@ -442,7 +442,8 @@ class nsZenSpaceRoutingManager {
   #resolveManagedTarget(route, win) {
     if (route.openInSpace) {
       return (
-        this.#resolveSpaceNameToId(route.openInSpace, win) ?? "most-recent-space"
+        this.#resolveSpaceNameToId(route.openInSpace, win) ??
+        "most-recent-space"
       );
     }
     return route.openIn ?? "most-recent-space";

--- a/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
+++ b/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
@@ -118,6 +118,28 @@ class nsZenSpaceRoutingManager {
       };
     }
 
+    // An explicit container choice (e.g. "Open in New Container Tab") is a
+    // deliberate override and wins over any routing rule: skip routing so the
+    // chosen container, and its own Space, are used instead of the route's.
+    // External links are exempt: they carry a container from the opening
+    // context rather than a deliberate choice, and must still be routed.
+    //
+    // Test for presence, not truthiness: "Open Link in New Tab" passes
+    // userContextId 0 for "No Container", which is as deliberate a choice as
+    // any other. It also has to agree with the caller-side gate in the
+    // tabbrowser patch (typeof userContextId === "undefined"), or a 0 would
+    // skip that gate while still resolving a route here, and the tab would be
+    // moved into the routed Space carrying the active Space's container.
+    if (typeof options.userContextId !== "undefined" && !options.fromExternal) {
+      return {
+        shouldEarlyExit: false,
+        userContextId,
+        isRouteFound,
+        targetRoute,
+        targetWorkspaceName,
+      };
+    }
+
     targetRoute = this.routeUri(uriString, options, win);
     switch (targetRoute) {
       case "most-recent-space":

--- a/src/zen/space-routing/moz.build
+++ b/src/zen/space-routing/moz.build
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 EXTRA_JS_MODULES.zen.spacerouting += [
+    "ZenManagedSpaces.sys.mjs",
     "ZenSpaceRoutingDialog.mjs",
     "ZenSpaceRoutingManager.sys.mjs",
 ]

--- a/src/zen/space-routing/zen-space-routing.css
+++ b/src/zen/space-routing/zen-space-routing.css
@@ -286,3 +286,49 @@ button {
   fill: currentColor;
   fill-opacity: 0.65;
 }
+
+/* Read-only routes seeded from configuration (the managed-routes pref). */
+.sr-managed-header {
+  margin: 0 24px;
+
+  font-size: x-small;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+
+  color: var(--text-color-secondary);
+  opacity: 0.8;
+}
+
+.sr-managed-container {
+  display: flex;
+  flex-direction: column;
+  margin: 0 24px;
+}
+
+.sr-managed-row {
+  background-color: var(--input-background-color);
+  border-radius: 8px;
+  padding: 8px 10px;
+
+  & .sr-managed-reference {
+    color: var(--text-color);
+    font-weight: 600;
+    margin: 0;
+  }
+
+  & .sr-managed-meta {
+    color: var(--text-color-secondary);
+    margin: 0;
+  }
+
+  & .sr-managed-arrow {
+    margin-left: auto;
+  }
+
+  & .sr-managed-target {
+    color: var(--text-color);
+    margin: 0;
+    max-width: 180px;
+  }
+}

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -1226,18 +1226,27 @@ class nsZenWorkspaces {
     const themePicker = document.getElementById(
       "context_zenChangeWorkspaceTheme"
     );
+    // Config-managed Spaces are read-only: hide rename + theme controls.
+    const ctxSpace = this.getWorkspaceFromId(
+      this.#contextMenuData.workspaceId || this.activeWorkspace
+    );
+    const isManagedSpace = !!(
+      ctxSpace && window.gZenManagedSpaces?.isManaged(ctxSpace.name)
+    );
     /* We can't show the rename input properly in collapsed state,
     so hide the workspace edit input */
     const isCollapsed = !Services.prefs.getBoolPref(
       "zen.view.sidebar-expanded"
     );
     workspaceName.hidden =
+      isManagedSpace ||
       isCollapsed ||
       (this.#contextMenuData.workspaceId &&
         this.#contextMenuData.workspaceId !== this.activeWorkspace);
     themePicker.hidden =
-      this.#contextMenuData.workspaceId &&
-      this.#contextMenuData.workspaceId !== this.activeWorkspace;
+      isManagedSpace ||
+      (this.#contextMenuData.workspaceId &&
+        this.#contextMenuData.workspaceId !== this.activeWorkspace);
     const separator = document.getElementById("context_zenWorkspacesSeparator");
     for (const item of event.target.querySelectorAll(
       ".zen-workspace-context-menu-item"
@@ -1310,6 +1319,14 @@ class nsZenWorkspaces {
   }
 
   removeWorkspace(windowID) {
+    // Config-managed Spaces are read-only: they're owned by the declarative
+    // config (zen.space-routing.managed-spaces), so block UI/programmatic
+    // deletion and tell the user why.
+    const target = this.getWorkspaceFromId(windowID);
+    if (target && window.gZenManagedSpaces?.isManaged(target.name)) {
+      gZenUIManager.showToast("zen-workspaces-managed-readonly-toast");
+      return Promise.resolve();
+    }
     let { promise, resolve } = Promise.withResolvers();
     this.#deleteWorkspaceOwnedTabs(windowID);
 

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -814,6 +814,14 @@ class nsZenWorkspaces {
     }
     promise.finally(() => {
       this.#hasInitialized = true;
+      // Seed/refresh config-declared Spaces now that workspaces are live and
+      // saveWorkspace() can materialize them. Runs before any routing resolves a
+      // Space by name. Guarded so it never blocks init.
+      try {
+        window.gZenManagedSpaces?.reconcile(window);
+      } catch (e) {
+        console.error("[ZenManagedSpaces] startup reconcile failed", e);
+      }
     });
     return promise;
   }

--- a/src/zen/tests/space_routing/browser.toml
+++ b/src/zen/tests/space_routing/browser.toml
@@ -17,6 +17,8 @@ support-files = [
 
 ["browser_space_routing_managed.js"]
 
+["browser_space_routing_no_container.js"]
+
 ["browser_space_routing_on_add_tab.js"]
 
 ["browser_space_routing_redirect_navigation.js"]

--- a/src/zen/tests/space_routing/browser.toml
+++ b/src/zen/tests/space_routing/browser.toml
@@ -7,6 +7,8 @@ support-files = [
   "head.js",
 ]
 
+["browser_managed_spaces.js"]
+
 ["browser_space_routing_crud.js"]
 
 ["browser_space_routing_dialog.js"]

--- a/src/zen/tests/space_routing/browser.toml
+++ b/src/zen/tests/space_routing/browser.toml
@@ -13,6 +13,8 @@ support-files = [
 
 ["browser_space_routing_fuzz.js"]
 
+["browser_space_routing_managed.js"]
+
 ["browser_space_routing_on_add_tab.js"]
 
 ["browser_space_routing_redirect_navigation.js"]

--- a/src/zen/tests/space_routing/browser_managed_spaces.js
+++ b/src/zen/tests/space_routing/browser_managed_spaces.js
@@ -154,3 +154,29 @@ add_task(async function test_reconcile_never_deletes() {
 
   gZenWorkspaces.removeWorkspace(kept.uuid);
 });
+
+add_task(async function test_startup_reconcile_in_new_window() {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      [
+        "zen.space-routing.managed-spaces",
+        JSON.stringify([{ name: "ZMS Startup", icon: "globe" }]),
+      ],
+    ],
+  });
+  const win = await BrowserTestUtils.openNewBrowserWindow();
+  try {
+    await win.gZenWorkspaces.promiseInitialized;
+    await TestUtils.waitForCondition(() =>
+      win.gZenWorkspaces.getWorkspaces().some(w => w.name === "ZMS Startup")
+    );
+    const space = win.gZenWorkspaces
+      .getWorkspaces()
+      .find(w => w.name === "ZMS Startup");
+    Assert.ok(space, "managed Space seeded during window init");
+    win.gZenWorkspaces.removeWorkspace(space.uuid);
+  } finally {
+    await BrowserTestUtils.closeWindow(win);
+    await SpecialPowers.popPrefEnv();
+  }
+});

--- a/src/zen/tests/space_routing/browser_managed_spaces.js
+++ b/src/zen/tests/space_routing/browser_managed_spaces.js
@@ -71,3 +71,31 @@ add_task(async function test_resolve_container_by_name() {
   );
   Assert.equal(gZenManagedSpaces.resolveContainerId(null), 0, "null -> 0");
 });
+
+add_task(async function test_reconcile_creates_missing_space() {
+  const before = gZenWorkspaces.getWorkspaces().length;
+  await withManagedSpaces(
+    [{ name: "ZMS Created", icon: "briefcase" }],
+    async () => {
+      gZenManagedSpaces.reconcile(window);
+
+      const space = gZenWorkspaces
+        .getWorkspaces()
+        .find(w => w.name === "ZMS Created");
+      Assert.ok(space, "a managed Space was created for the missing name");
+      Assert.equal(
+        space.icon,
+        "chrome://browser/skin/zen-icons/selectable/briefcase.svg",
+        "created Space uses the resolved icon URL"
+      );
+      Assert.equal(
+        gZenWorkspaces.getWorkspaces().length,
+        before + 1,
+        "exactly one Space created"
+      );
+
+      // cleanup
+      gZenWorkspaces.removeWorkspace(space.uuid);
+    }
+  );
+});

--- a/src/zen/tests/space_routing/browser_managed_spaces.js
+++ b/src/zen/tests/space_routing/browser_managed_spaces.js
@@ -43,3 +43,31 @@ add_task(async function test_malformed_pref_is_noop() {
   );
   await SpecialPowers.popPrefEnv();
 });
+
+add_task(async function test_resolve_container_by_name() {
+  const created = ContextualIdentityService.create(
+    "ZMS Test Container",
+    "fingerprint",
+    "blue"
+  );
+  registerCleanupFunction(() =>
+    ContextualIdentityService.remove(created.userContextId)
+  );
+
+  Assert.equal(
+    gZenManagedSpaces.resolveContainerId("ZMS Test Container"),
+    created.userContextId,
+    "container name resolves to its userContextId"
+  );
+  Assert.equal(
+    gZenManagedSpaces.resolveContainerId("Does Not Exist"),
+    0,
+    "unknown container name resolves to 0 (no container)"
+  );
+  Assert.equal(
+    gZenManagedSpaces.resolveContainerId(created.userContextId),
+    created.userContextId,
+    "a numeric userContextId is accepted directly"
+  );
+  Assert.equal(gZenManagedSpaces.resolveContainerId(null), 0, "null -> 0");
+});

--- a/src/zen/tests/space_routing/browser_managed_spaces.js
+++ b/src/zen/tests/space_routing/browser_managed_spaces.js
@@ -1,0 +1,45 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_parse_normalizes_entries() {
+  await withManagedSpaces(
+    [
+      { name: "Work", icon: "briefcase", container: "Work", position: 0 },
+      { name: "Personal", icon: "🏠" },
+      { name: "  ", icon: "x" }, // skipped: empty name
+    ],
+    async () => {
+      const spaces = gZenManagedSpaces.getManagedSpaces();
+      Assert.equal(spaces.length, 2, "empty-name entry dropped");
+
+      Assert.equal(spaces[0].name, "Work");
+      Assert.equal(
+        spaces[0].icon,
+        "chrome://browser/skin/zen-icons/selectable/briefcase.svg",
+        "bare icon name expanded to selectable svg URL"
+      );
+      Assert.equal(spaces[0].container, "Work");
+      Assert.equal(spaces[0].position, 0);
+
+      Assert.equal(spaces[1].icon, "🏠", "emoji kept as-is");
+      Assert.equal(spaces[1].position, 1, "position falls back to array index");
+
+      Assert.ok(gZenManagedSpaces.isManaged("Work"), "Work is managed");
+      Assert.ok(!gZenManagedSpaces.isManaged("Nope"), "unknown not managed");
+    }
+  );
+});
+
+add_task(async function test_malformed_pref_is_noop() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.space-routing.managed-spaces", "not json"]],
+  });
+  Assert.deepEqual(
+    gZenManagedSpaces.getManagedSpaces(),
+    [],
+    "malformed pref yields no managed spaces and does not throw"
+  );
+  await SpecialPowers.popPrefEnv();
+});

--- a/src/zen/tests/space_routing/browser_managed_spaces.js
+++ b/src/zen/tests/space_routing/browser_managed_spaces.js
@@ -99,3 +99,58 @@ add_task(async function test_reconcile_creates_missing_space() {
     }
   );
 });
+
+add_task(async function test_reconcile_updates_existing_not_duplicate() {
+  // A user-created Space with the managed name, wrong icon.
+  await gZenWorkspaces.createAndSaveWorkspace("Space", undefined, true);
+  const existing = gZenWorkspaces.getWorkspaces().at(-1);
+  existing.name = "ZMS Existing";
+  existing.icon = "❓";
+  gZenWorkspaces.saveWorkspace(existing);
+
+  const countBefore = gZenWorkspaces.getWorkspaces().length;
+  await withManagedSpaces(
+    [{ name: "ZMS Existing", icon: "flask" }],
+    async () => {
+      gZenManagedSpaces.reconcile(window);
+
+      const matches = gZenWorkspaces
+        .getWorkspaces()
+        .filter(w => w.name === "ZMS Existing");
+      Assert.equal(matches.length, 1, "no duplicate Space created");
+      Assert.equal(
+        matches[0].icon,
+        "chrome://browser/skin/zen-icons/selectable/flask.svg",
+        "existing Space's icon synced to config"
+      );
+      Assert.equal(
+        gZenWorkspaces.getWorkspaces().length,
+        countBefore,
+        "Space count unchanged"
+      );
+    }
+  );
+
+  gZenWorkspaces.removeWorkspace(existing.uuid);
+});
+
+add_task(async function test_reconcile_never_deletes() {
+  await gZenWorkspaces.createAndSaveWorkspace("Space", undefined, true);
+  const kept = gZenWorkspaces.getWorkspaces().at(-1);
+  kept.name = "ZMS Kept";
+  gZenWorkspaces.saveWorkspace(kept);
+
+  // Config does NOT mention "ZMS Kept".
+  await withManagedSpaces([{ name: "ZMS Other" }], async () => {
+    gZenManagedSpaces.reconcile(window);
+    Assert.ok(
+      gZenWorkspaces.getWorkspaces().some(w => w.name === "ZMS Kept"),
+      "a Space absent from config is left in place (never deleted)"
+    );
+    gZenWorkspaces.removeWorkspace(
+      gZenWorkspaces.getWorkspaces().find(w => w.name === "ZMS Other").uuid
+    );
+  });
+
+  gZenWorkspaces.removeWorkspace(kept.uuid);
+});

--- a/src/zen/tests/space_routing/browser_managed_spaces.js
+++ b/src/zen/tests/space_routing/browser_managed_spaces.js
@@ -4,9 +4,22 @@
 "use strict";
 
 let gZmsInitialTab;
+let gZmsInitialSpaces;
 
 add_setup(function capture_initial_tab() {
   gZmsInitialTab = gBrowser.selectedTab;
+  gZmsInitialSpaces = new Set(gZenWorkspaces.getWorkspaces().map(w => w.uuid));
+});
+
+registerCleanupFunction(async function restore_initial_space_state() {
+  // Drop Spaces this file introduced. One left behind keeps a lazy empty-tab
+  // placeholder at the front of the strip, and the next file's first real
+  // addTab() then throws reading its missing linkedBrowser.
+  for (const ws of gZenWorkspaces.getWorkspaces()) {
+    if (!gZmsInitialSpaces.has(ws.uuid)) {
+      await gZenWorkspaces.removeWorkspace(ws.uuid);
+    }
+  }
 });
 
 registerCleanupFunction(function restore_initial_tab_state() {
@@ -19,7 +32,11 @@ registerCleanupFunction(function restore_initial_tab_state() {
     gBrowser.selectedTab = gZmsInitialTab;
   }
   for (const tab of Array.from(gBrowser.tabs)) {
-    if (tab !== gZmsInitialTab) {
+    // Leave Zen's empty-tab placeholders alone. Removing one makes Zen build a
+    // replacement with a lazy browser, and it sits at the front of the strip
+    // with a null linkedBrowser, which the next file's first real addTab()
+    // then trips over inside _insertBrowser.
+    if (tab !== gZmsInitialTab && !tab.hasAttribute("zen-empty-tab")) {
       BrowserTestUtils.removeTab(tab);
     }
   }
@@ -153,7 +170,10 @@ add_task(async function test_reconcile_updates_existing_not_duplicate() {
     }
   );
 
-  gZenWorkspaces.removeWorkspace(existing.uuid);
+  // Not fire-and-forget: removeWorkspace settles on a microtask, and a Space
+  // left behind keeps its lazy empty-tab placeholder at the front of the strip,
+  // where a later real addTab() trips over its missing linkedBrowser.
+  await gZenWorkspaces.removeWorkspace(existing.uuid);
 });
 
 add_task(async function test_reconcile_never_deletes() {
@@ -174,7 +194,7 @@ add_task(async function test_reconcile_never_deletes() {
     );
   });
 
-  gZenWorkspaces.removeWorkspace(kept.uuid);
+  await gZenWorkspaces.removeWorkspace(kept.uuid);
 });
 
 add_task(async function test_startup_reconcile_in_new_window() {
@@ -214,7 +234,7 @@ add_task(async function test_managed_space_is_read_only() {
       Assert.ok(space, "managed Space exists");
 
       const countBefore = gZenWorkspaces.getWorkspaces().length;
-      gZenWorkspaces.removeWorkspace(space.uuid);
+      await gZenWorkspaces.removeWorkspace(space.uuid);
       Assert.equal(
         gZenWorkspaces.getWorkspaces().length,
         countBefore,

--- a/src/zen/tests/space_routing/browser_managed_spaces.js
+++ b/src/zen/tests/space_routing/browser_managed_spaces.js
@@ -94,8 +94,8 @@ add_task(async function test_reconcile_creates_missing_space() {
         "exactly one Space created"
       );
 
-      // cleanup
-      gZenWorkspaces.removeWorkspace(space.uuid);
+      // cleanup (managed -> use the test escape hatch)
+      gZenManagedSpaces.forceRemoveForTest(space.uuid);
     }
   );
 });
@@ -147,7 +147,7 @@ add_task(async function test_reconcile_never_deletes() {
       gZenWorkspaces.getWorkspaces().some(w => w.name === "ZMS Kept"),
       "a Space absent from config is left in place (never deleted)"
     );
-    gZenWorkspaces.removeWorkspace(
+    gZenManagedSpaces.forceRemoveForTest(
       gZenWorkspaces.getWorkspaces().find(w => w.name === "ZMS Other").uuid
     );
   });
@@ -174,9 +174,46 @@ add_task(async function test_startup_reconcile_in_new_window() {
       .getWorkspaces()
       .find(w => w.name === "ZMS Startup");
     Assert.ok(space, "managed Space seeded during window init");
-    win.gZenWorkspaces.removeWorkspace(space.uuid);
+    gZenManagedSpaces.forceRemoveForTest(space.uuid);
   } finally {
     await BrowserTestUtils.closeWindow(win);
     await SpecialPowers.popPrefEnv();
   }
+});
+
+add_task(async function test_managed_space_is_read_only() {
+  await withManagedSpaces(
+    [{ name: "ZMS RO", icon: "lock-closed" }],
+    async () => {
+      gZenManagedSpaces.reconcile(window);
+      const space = gZenWorkspaces
+        .getWorkspaces()
+        .find(w => w.name === "ZMS RO");
+      Assert.ok(space, "managed Space exists");
+
+      const countBefore = gZenWorkspaces.getWorkspaces().length;
+      gZenWorkspaces.removeWorkspace(space.uuid);
+      Assert.equal(
+        gZenWorkspaces.getWorkspaces().length,
+        countBefore,
+        "removeWorkspace refuses to delete a managed Space"
+      );
+
+      // not managed -> still deletable
+      await gZenWorkspaces.createAndSaveWorkspace("Space", undefined, true);
+      const normal = gZenWorkspaces.getWorkspaces().at(-1);
+      normal.name = "ZMS Normal";
+      gZenWorkspaces.saveWorkspace(normal);
+      // removeWorkspace updates the cache on a microtask (after element
+      // teardown), so await it before asserting the Space is gone.
+      await gZenWorkspaces.removeWorkspace(normal.uuid);
+      Assert.ok(
+        !gZenWorkspaces.getWorkspaces().some(w => w.name === "ZMS Normal"),
+        "a non-managed Space deletes normally"
+      );
+
+      // cleanup the managed one for the test run only
+      gZenManagedSpaces.forceRemoveForTest(space.uuid);
+    }
+  );
 });

--- a/src/zen/tests/space_routing/browser_managed_spaces.js
+++ b/src/zen/tests/space_routing/browser_managed_spaces.js
@@ -3,6 +3,28 @@
 
 "use strict";
 
+let gZmsInitialTab;
+
+add_setup(function capture_initial_tab() {
+  gZmsInitialTab = gBrowser.selectedTab;
+});
+
+registerCleanupFunction(function restore_initial_tab_state() {
+  // Tearing down a managed Space leaves its empty about:blank tab orphaned
+  // (#deleteWorkspaceOwnedTabs intentionally keeps group-less zen-empty-tabs),
+  // and the startup test's extra window propagates one into this window too.
+  // Restore the original single-tab state so the harness's end-of-run tab
+  // check passes.
+  if (gZmsInitialTab?.isConnected && gBrowser.selectedTab !== gZmsInitialTab) {
+    gBrowser.selectedTab = gZmsInitialTab;
+  }
+  for (const tab of Array.from(gBrowser.tabs)) {
+    if (tab !== gZmsInitialTab) {
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
+});
+
 add_task(async function test_parse_normalizes_entries() {
   await withManagedSpaces(
     [

--- a/src/zen/tests/space_routing/browser_space_routing_managed.js
+++ b/src/zen/tests/space_routing/browser_space_routing_managed.js
@@ -33,6 +33,7 @@ add_task(async function test_managed_route_resolves_space_by_name() {
       userContextId: work.containerTabId,
       isRouteFound: true,
       targetRoute: work.uuid,
+      targetWorkspaceName: work.name,
     },
     "A managed route resolves its target Space by name to that Space's id"
   );

--- a/src/zen/tests/space_routing/browser_space_routing_managed.js
+++ b/src/zen/tests/space_routing/browser_space_routing_managed.js
@@ -1,0 +1,265 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const MANAGED_PREF = "zen.space-routing.managed-routes";
+
+// Pushes a managed-routes pref env. `routes` may be an array/object (serialized
+// to JSON) or a raw string (used as-is, to exercise malformed input).
+function pushManagedRoutes(routes) {
+  const value = typeof routes === "string" ? routes : JSON.stringify(routes);
+  return SpecialPowers.pushPrefEnv({ set: [[MANAGED_PREF, value]] });
+}
+
+add_setup(async function () {
+  clearAllRoutes();
+  registerCleanupFunction(() => clearAllRoutes());
+});
+
+add_task(async function test_managed_route_resolves_space_by_name() {
+  clearAllRoutes();
+  await pushManagedRoutes([
+    { reference: "github.com", matchType: "contains", openInSpace: "Work" },
+  ]);
+
+  const work = { uuid: "ws-work-uuid", name: "Work", containerTabId: 3 };
+  const win = makeFakeWindow({ ready: true, workspaces: [work] });
+
+  Assert.deepEqual(
+    gZenSpaceRoutingManager.onBeforeAddTab("https://github.com/zen", {}, win),
+    {
+      shouldEarlyExit: false,
+      userContextId: work.containerTabId,
+      isRouteFound: true,
+      targetRoute: work.uuid,
+    },
+    "A managed route resolves its target Space by name to that Space's id"
+  );
+
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_managed_route_wins_over_user_route() {
+  clearAllRoutes();
+  addRoute({ reference: "github", matchType: "contains", openIn: "ws-user" });
+  await pushManagedRoutes([
+    { reference: "github", matchType: "contains", openInSpace: "Work" },
+  ]);
+
+  const work = { uuid: "ws-work-uuid", name: "Work", containerTabId: 9 };
+  const win = makeFakeWindow({ ready: true, workspaces: [work] });
+
+  Assert.equal(
+    gZenSpaceRoutingManager.routeUri("https://github.com/zen", {}, win),
+    work.uuid,
+    "A managed route is evaluated before, and wins over, a matching user route"
+  );
+
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_managed_openin_literal_id_and_most_recent() {
+  clearAllRoutes();
+  await pushManagedRoutes([
+    { reference: "by-id.example", openIn: "ws-literal-id" },
+    { reference: "by-default.example" },
+    { reference: "by-mru.example", openIn: "most-recent-space" },
+  ]);
+
+  const win = makeFakeWindow({ ready: true, workspaces: [] });
+
+  Assert.equal(
+    gZenSpaceRoutingManager.routeUri("https://by-id.example", {}, win),
+    "ws-literal-id",
+    "A literal `openIn` Space id is returned as-is"
+  );
+  Assert.equal(
+    gZenSpaceRoutingManager.routeUri("https://by-default.example", {}, win),
+    "most-recent-space",
+    "An omitted target defaults to most-recent-space"
+  );
+  Assert.equal(
+    gZenSpaceRoutingManager.routeUri("https://by-mru.example", {}, win),
+    "most-recent-space",
+    "An explicit most-recent-space target is honored"
+  );
+
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_managed_unknown_space_name_falls_back() {
+  clearAllRoutes();
+  await pushManagedRoutes([
+    { reference: "github.com", openInSpace: "DoesNotExist" },
+  ]);
+
+  const win = makeFakeWindow({
+    ready: true,
+    workspaces: [{ uuid: "ws-other", name: "Other", containerTabId: 1 }],
+  });
+
+  Assert.equal(
+    gZenSpaceRoutingManager.routeUri("https://github.com", {}, win),
+    "most-recent-space",
+    "A name that matches no Space falls back to most-recent-space"
+  );
+
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_managed_default_match_type_is_contains() {
+  clearAllRoutes();
+  // No matchType given, and an unknown matchType: both normalize to "contains".
+  await pushManagedRoutes([
+    { reference: "github.com", openIn: "ws-a" },
+    { reference: "gitlab.com", matchType: "starts-with", openIn: "ws-b" },
+  ]);
+  const win = makeFakeWindow({ ready: true, workspaces: [] });
+
+  Assert.equal(
+    gZenSpaceRoutingManager.routeUri("https://api.github.com/v3", {}, win),
+    "ws-a",
+    "A managed route with no matchType behaves as 'contains'"
+  );
+  Assert.equal(
+    gZenSpaceRoutingManager.routeUri("https://api.gitlab.com/v4", {}, win),
+    "ws-b",
+    "An unrecognized matchType is coerced to 'contains'"
+  );
+
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_managed_object_with_routes_array_is_accepted() {
+  clearAllRoutes();
+  await pushManagedRoutes({
+    routes: [{ reference: "github.com", openIn: "ws-obj" }],
+  });
+  const win = makeFakeWindow({ ready: true, workspaces: [] });
+
+  Assert.equal(
+    gZenSpaceRoutingManager.routeUri("https://github.com", {}, win),
+    "ws-obj",
+    "An object with a `routes` array is accepted, not just a bare array"
+  );
+
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_managed_invalid_entries_are_skipped() {
+  clearAllRoutes();
+  await pushManagedRoutes([
+    { matchType: "contains", openIn: "ws-x" }, // no reference
+    { reference: "   ", openIn: "ws-y" }, // blank reference
+    null,
+    { reference: "github.com", openIn: "ws-valid" },
+  ]);
+  const win = makeFakeWindow({ ready: true, workspaces: [] });
+
+  Assert.equal(
+    gZenSpaceRoutingManager.getManagedRoutes().length,
+    1,
+    "Entries without a usable reference are dropped"
+  );
+  Assert.equal(
+    gZenSpaceRoutingManager.routeUri("https://github.com", {}, win),
+    "ws-valid",
+    "The single valid managed entry still routes"
+  );
+
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_malformed_json_is_ignored() {
+  clearAllRoutes();
+  addRoute({ reference: "github.com", openIn: "ws-user" });
+  await pushManagedRoutes("{ not valid json");
+  const win = makeFakeWindow({ ready: true, workspaces: [] });
+
+  Assert.deepEqual(
+    gZenSpaceRoutingManager.getManagedRoutes(),
+    [],
+    "A malformed managed-routes pref yields no managed routes"
+  );
+  Assert.equal(
+    gZenSpaceRoutingManager.routeUri("https://github.com", {}, win),
+    "ws-user",
+    "Routing still falls through to user routes when the pref is malformed"
+  );
+
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_cleared_pref_has_no_managed_routes() {
+  clearAllRoutes();
+  await pushManagedRoutes([{ reference: "github.com", openIn: "ws-a" }]);
+  Assert.equal(
+    gZenSpaceRoutingManager.getManagedRoutes().length,
+    1,
+    "Managed routes are present while the pref is set"
+  );
+  await SpecialPowers.popPrefEnv();
+
+  Assert.deepEqual(
+    gZenSpaceRoutingManager.getManagedRoutes(),
+    [],
+    "Managed routes disappear once the pref is cleared"
+  );
+});
+
+add_task(async function test_managed_routes_render_readonly_in_dialog() {
+  clearAllRoutes();
+  await pushManagedRoutes([
+    { reference: "github.com", matchType: "contains", openInSpace: "Work" },
+  ]);
+
+  const dlg = await openRoutingDialog();
+  try {
+    const doc = dlg.document;
+
+    await TestUtils.waitForCondition(
+      () => doc.querySelector(".sr-managed-container"),
+      "The managed route renders a read-only row"
+    );
+
+    Assert.equal(
+      doc.querySelectorAll(".sr-managed-container").length,
+      1,
+      "Exactly one managed row is rendered"
+    );
+    ok(
+      doc.querySelector(".sr-managed-header"),
+      "The managed section header is shown"
+    );
+    Assert.equal(
+      doc.querySelector(".sr-managed-reference").getAttribute("value"),
+      "github.com",
+      "The managed row shows the configured reference"
+    );
+    Assert.equal(
+      doc.querySelector(".sr-managed-target").getAttribute("value"),
+      "Work",
+      "The managed row shows the target Space name"
+    );
+    Assert.equal(
+      gZenSpaceRoutingManager.getAllRoutes().length,
+      0,
+      "Managed routes are not part of the editable (user) routes"
+    );
+    Assert.equal(
+      doc.querySelectorAll(".sr-rule-container").length,
+      0,
+      "No editable route rows are rendered for managed routes"
+    );
+    Assert.equal(
+      doc.getElementById("sr-empty-content").style.display,
+      "none",
+      "The empty-state placeholder is hidden when managed routes exist"
+    );
+  } finally {
+    await closeRoutingDialog(dlg);
+    await SpecialPowers.popPrefEnv();
+    clearAllRoutes();
+  }
+});

--- a/src/zen/tests/space_routing/browser_space_routing_no_container.js
+++ b/src/zen/tests/space_routing/browser_space_routing_no_container.js
@@ -1,0 +1,80 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Regression test: a Space-Routing rule that targets a Space with NO container
+// (containerTabId 0) must stay authoritative.
+//
+// The tabbrowser integration gated on `if (beforeRouteResult.userContextId)` — a
+// truthiness check — so a No-Container route (userContextId 0) was treated as
+// "no route found", and getContextIdIfNeeded then hijacked the tab into the
+// active container-bound Space's container. A tab routed to the No-Container
+// Space must open with no container, regardless of the active Space's container.
+
+const { PromiseTestUtils } = ChromeUtils.importESModule(
+  "resource://testing-common/PromiseTestUtils.sys.mjs"
+);
+
+add_setup(async function () {
+  // Opening tabs/new UI can emit benign Fluent/glance rejections in a dev build.
+  PromiseTestUtils.allowMatchingRejectionsGlobally(
+    /destroyed before query|Couldn't find a message/
+  );
+  clearAllRoutes();
+  registerCleanupFunction(() => clearAllRoutes());
+});
+
+add_task(async function test_no_container_route_not_hijacked() {
+  const defaultWs = gZenWorkspaces.getWorkspaces()[0];
+  Assert.ok(defaultWs, "a default workspace exists");
+  Assert.ok(
+    !defaultWs.containerTabId,
+    "the default workspace has no container"
+  );
+
+  // A container-bound Space (userContextId 1 is a built-in container), switched
+  // to so it is the active Space.
+  await gZenWorkspaces.createAndSaveWorkspace(
+    "Route Hijack Work",
+    undefined,
+    false,
+    1
+  );
+  const workWs = gZenWorkspaces.getWorkspaces().at(-1);
+  Assert.equal(
+    workWs.containerTabId,
+    1,
+    "work-like Space is bound to container 1"
+  );
+  Assert.equal(
+    gZenWorkspaces.activeWorkspace,
+    workWs.uuid,
+    "the container Space is active"
+  );
+
+  // Route example.com -> the No-Container default Space.
+  addRoute({
+    reference: "example.com",
+    matchType: "contains",
+    openIn: defaultWs.uuid,
+  });
+
+  // Open a routed tab while sitting in the container Space.
+  const tab = gBrowser.addTab("https://example.com/", {
+    inBackground: true,
+    triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
+  });
+
+  Assert.equal(
+    parseInt(tab.getAttribute("usercontextid") || "0", 10),
+    0,
+    "a tab routed to the No-Container Space is not hijacked into the active container"
+  );
+
+  // cleanup: let the async route-to-workspace settle, then restore state.
+  await flushEventLoop();
+  BrowserTestUtils.removeTab(tab);
+  await gZenWorkspaces.changeWorkspace(defaultWs);
+  await gZenWorkspaces.removeWorkspace(workWs.uuid);
+});

--- a/src/zen/tests/space_routing/browser_space_routing_no_container.js
+++ b/src/zen/tests/space_routing/browser_space_routing_no_container.js
@@ -78,3 +78,61 @@ add_task(async function test_no_container_route_not_hijacked() {
   await gZenWorkspaces.changeWorkspace(defaultWs);
   await gZenWorkspaces.removeWorkspace(workWs.uuid);
 });
+
+add_task(async function test_explicit_container_overrides_route() {
+  // Mirror production: a container maps to its Space (default-on pref).
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.workspaces.force-container-workspace", true]],
+  });
+  const defaultWs = gZenWorkspaces.getWorkspaces()[0];
+
+  // A Work-like Space bound to container 2 (distinct from any other test's
+  // container so the container->Space mapping is unique), created without
+  // switching to it, so the active Space stays the No-Container Default.
+  await gZenWorkspaces.createAndSaveWorkspace(
+    "Override Work",
+    undefined,
+    true,
+    2
+  );
+  const workWs = gZenWorkspaces.getWorkspaces().at(-1);
+  Assert.equal(
+    workWs.containerTabId,
+    2,
+    "work-like Space bound to container 2"
+  );
+  if (gZenWorkspaces.activeWorkspace !== defaultWs.uuid) {
+    await gZenWorkspaces.changeWorkspace(defaultWs);
+  }
+
+  // Route example.com -> the No-Container Default Space.
+  addRoute({
+    reference: "example.com",
+    matchType: "contains",
+    openIn: defaultWs.uuid,
+  });
+
+  // Explicitly open in container 2 ("Open in New Container Tab" passes
+  // userContextId straight through to addTab). The deliberate container choice
+  // must win over the No-Container route — both the container and its Space.
+  const tab = gBrowser.addTab("https://example.com/", {
+    inBackground: true,
+    userContextId: 2,
+    triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
+  });
+
+  Assert.equal(
+    parseInt(tab.getAttribute("usercontextid") || "0", 10),
+    2,
+    "explicit container choice overrides the route's No-Container"
+  );
+  Assert.equal(
+    tab.getAttribute("zen-workspace-id"),
+    workWs.uuid,
+    "explicit container choice lands in its own Space, not the routed one"
+  );
+
+  await flushEventLoop();
+  BrowserTestUtils.removeTab(tab);
+  await gZenWorkspaces.removeWorkspace(workWs.uuid);
+});

--- a/src/zen/tests/space_routing/browser_space_routing_on_add_tab.js
+++ b/src/zen/tests/space_routing/browser_space_routing_on_add_tab.js
@@ -3,7 +3,7 @@
 
 "use strict";
 
-const TARGET_WS = { uuid: "ws-target", containerTabId: 7 };
+const TARGET_WS = { uuid: "ws-target", containerTabId: 7, name: "Target" };
 
 add_setup(async function () {
   clearAllRoutes();
@@ -32,6 +32,7 @@ add_task(async function test_onBeforeAddTab_resolves_container_for_match() {
       userContextId: TARGET_WS.containerTabId,
       isRouteFound: true,
       targetRoute: TARGET_WS.uuid,
+      targetWorkspaceName: TARGET_WS.name,
     },
     "A matching route resolves to the workspace's containerTabId"
   );
@@ -54,6 +55,7 @@ add_task(async function test_onBeforeAddTab_no_match_returns_no_route() {
       userContextId: null,
       isRouteFound: false,
       targetRoute: "most-recent-space",
+      targetWorkspaceName: null,
     },
     "An unmatched URL (most-recent-space) reports no container and no route"
   );
@@ -81,6 +83,7 @@ add_task(async function test_onBeforeAddTab_route_to_missing_workspace() {
       userContextId: null,
       isRouteFound: false,
       targetRoute: "ws-does-not-exist",
+      targetWorkspaceName: null,
     },
     "A route to a non-existent workspace yields no container and no route"
   );
@@ -108,10 +111,39 @@ add_task(async function test_onBeforeAddTab_skips_special_tab_options() {
         userContextId: null,
         isRouteFound: false,
         targetRoute: null,
+        targetWorkspaceName: null,
       },
       `Option '${skipOption}' skips routing even though a rule matches`
     );
   }
+});
+
+add_task(async function test_onBeforeAddTab_explicit_container_skips_route() {
+  clearAllRoutes();
+  addRoute({
+    reference: "github.com",
+    matchType: "contains",
+    openIn: TARGET_WS.uuid,
+  });
+  const win = makeFakeWindow({ ready: true, workspaces: [TARGET_WS] });
+
+  const result = gZenSpaceRoutingManager.onBeforeAddTab(
+    "https://github.com/zen",
+    { userContextId: 1 },
+    win
+  );
+
+  Assert.deepEqual(
+    result,
+    {
+      shouldEarlyExit: false,
+      userContextId: null,
+      isRouteFound: false,
+      targetRoute: null,
+      targetWorkspaceName: null,
+    },
+    "An explicit container choice skips routing even though a rule matches"
+  );
 });
 
 add_task(async function test_onBeforeAddTab_skips_until_startup_ready() {
@@ -136,6 +168,7 @@ add_task(async function test_onBeforeAddTab_skips_until_startup_ready() {
       userContextId: null,
       isRouteFound: false,
       targetRoute: null,
+      targetWorkspaceName: null,
     },
     "While gZenStartup.isReady is false (session restore), routing is skipped"
   );

--- a/src/zen/tests/space_routing/head.js
+++ b/src/zen/tests/space_routing/head.js
@@ -7,6 +7,25 @@ const { gZenSpaceRoutingManager } = ChromeUtils.importESModule(
   "resource:///modules/zen/spacerouting/ZenSpaceRoutingManager.sys.mjs"
 );
 
+const { gZenManagedSpaces } = ChromeUtils.importESModule(
+  "resource:///modules/zen/spacerouting/ZenManagedSpaces.sys.mjs"
+);
+
+const { ContextualIdentityService } = ChromeUtils.importESModule(
+  "resource://gre/modules/ContextualIdentityService.sys.mjs"
+);
+
+async function withManagedSpaces(json, fn) {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.space-routing.managed-spaces", JSON.stringify(json)]],
+  });
+  try {
+    await fn();
+  } finally {
+    await SpecialPowers.popPrefEnv();
+  }
+}
+
 const SR_DIALOG_URI =
   "chrome://browser/content/zen-components/windows/zen-space-routing.xhtml";
 

--- a/src/zen/tests/space_routing/head.js
+++ b/src/zen/tests/space_routing/head.js
@@ -41,6 +41,9 @@ function makeFakeWindow({
       moveCalls: [],
       changeCalls: [],
       lastSelectedWorkspaceTabs: {},
+      getWorkspaces() {
+        return workspaces;
+      },
       getWorkspaceFromId(id) {
         return workspaces.find(w => w.uuid === id) || null;
       },

--- a/src/zen/tests/space_routing/head.js
+++ b/src/zen/tests/space_routing/head.js
@@ -16,13 +16,33 @@ const { ContextualIdentityService } = ChromeUtils.importESModule(
 );
 
 async function withManagedSpaces(json, fn) {
+  const before = new Set(gZenWorkspaces.getWorkspaces().map(w => w.uuid));
+  const activeBefore = gZenWorkspaces.activeWorkspace;
   await SpecialPowers.pushPrefEnv({
     set: [["zen.space-routing.managed-spaces", JSON.stringify(json)]],
   });
   try {
     await fn();
   } finally {
+    // Pop the pref first: while it is set the Spaces it describes are managed,
+    // and removeWorkspace refuses to delete those.
     await SpecialPowers.popPrefEnv();
+    // The reconcile pass creates Spaces as a side effect. Leaving them behind
+    // leaks into later tests in this directory, whose real addTab() calls then
+    // trip over a workspace whose tab has no linked browser yet.
+    for (const ws of gZenWorkspaces.getWorkspaces()) {
+      if (!before.has(ws.uuid)) {
+        await gZenWorkspaces.removeWorkspace(ws.uuid);
+      }
+    }
+    if (activeBefore && gZenWorkspaces.activeWorkspace !== activeBefore) {
+      const restore = gZenWorkspaces
+        .getWorkspaces()
+        .find(w => w.uuid === activeBefore);
+      if (restore) {
+        await gZenWorkspaces.changeWorkspace(restore);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Why

Space Routing (gh-13981) persists its rules to an lz4-compressed profile file (`zen-space-routing.jsonlz4`) and references each target Space by a random per-profile UUID. Neither the rules nor the Spaces they point at can be expressed declaratively. The [Containerise](https://github.com/kintesh/containerise) extension solves the same problem differently: its rules live in a plain `storage.local` JSON keyed by container *name*, which a configuration-management setup can seed.

So there's no way to configure Space Routing, or the Spaces themselves, deterministically from config. This adds both, modelled on how Containerise rules are seeded, via two prefs:

* `zen.space-routing.managed-spaces` defines the Spaces (name, icon, container,
order).
* `zen.space-routing.managed-routes` defines the rules that route URLs into
them, by Space name.

Paired, they let a config own which Spaces exist and what opens where, referencing everything by stable names instead of per-profile UUIDs.

## Managed routes

`zen.space-routing.managed-routes` holds a JSON array of routes. Managed routes are evaluated before user-created routes and take precedence over them, so the configuration is the deterministic source of truth (the same intent as Containerise's `force = true`). They're never written back to the on-disk store.

A route targets a Space by name through `openInSpace`, resolved to that Space's id at routing time, which is what lets the config survive the random per-profile UUIDs. An `openIn` literal (`"most-recent-space"` or a known Space id) still works.

The Space Routing dialog renders managed routes read-only, so a rule the user never added by hand still has a visible explanation.

Malformed input never throws. A JSON parse error or an unexpected shape yields no managed routes and logs, so a bad pref can't break tab opening.

### Route schema

```jsonc
[
  // route github.com into the Space named "Work"
  { "reference": "github.com", "matchType": "contains", "openInSpace": "Work" },
  // matchType defaults to "contains"; openIn literal also works
  { "reference": "youtube.com", "openInSpace": "Personal" },
  { "reference": "^https://.*\\.internal/", "matchType": "regex", "openIn": "most-recent-space" }
]
```

`matchType` is one of `contains` | `equal-to` | `regex`, defaulting to `contains`. An object form `{ "routes": [ … ] }` is also accepted.

## Managed Spaces

`zen.space-routing.managed-spaces` holds a JSON array of Space definitions. A managed Space is created if missing and synced if present: on every window init a reconcile pass ensures a Space with each configured name exists and updates its icon and container to match the config.

It is never deleted. A Space absent from the config is left untouched, so the config is purely additive and can't destroy a user's own Spaces.

It is read-only in the UI. Managed Spaces can't be renamed, re-themed or deleted by hand: the context-menu rename input and theme picker are hidden, and attempting to delete shows a "managed by your configuration" toast. This mirrors how managed routes render.

Spaces are matched by name, so the config is stable across profiles. Malformed JSON, or an entry with an empty name, yields no managed Spaces and logs, so a bad pref can't break startup.

### Space schema

```jsonc
[
  // "briefcase" = a built-in selectable icon; container matched by its name
  { "name": "Work", "icon": "briefcase", "container": "Work", "position": 0 },
  // icon can be an emoji…
  { "name": "Personal", "icon": "🏠" },
  // …a built-in icon name / *.svg (expanded to a chrome:// selectable-icon URL),
  // or a full URL. position falls back to the array order.
  { "name": "Media", "icon": "play.svg" }
]
```

`name` is required and is the key used to match and sync an existing Space. `icon` takes an emoji (kept as-is), a built-in icon name or `*.svg` (expanded to `chrome://browser/skin/zen-icons/selectable/<name>.svg`), or a full URL. `container` takes a container's name, resolved to its `userContextId`; an unknown name means no container, and containers are never created here. `position` is the intended order and falls back to the entry's array index.

An object form `{ "spaces": [ … ] }` is also accepted.

## Implementation notes

`ZenSpaceRoutingManager` gains `getManagedRoutes()`, which parses, normalizes and memoizes the pref, re-parsing only when the raw value changes via a lazy pref getter. `routeUri()` takes an optional `win` argument and consults managed routes first, resolving `openInSpace` to an id through `win.gZenWorkspaces`. `getAllRoutes()`, which backs the editable user routes, is unchanged.

`ZenSpaceRoutingDialog` renders a read-only "Managed by your configuration" section above the editable routes.

`ZenManagedSpaces` is a new module. `getManagedSpaces()` parses, normalizes and memoizes the pref; `resolveContainerId()` maps a container name to a `userContextId`; `reconcile(win)` creates and syncs Spaces through `gZenWorkspaces.saveWorkspace`, which materializes both the cache entry and its sidebar section, and never deletes.

`ZenSpaceManager` runs the reconcile pass in `restoreWorkspacesFromSessionStore` once workspaces are live, before any routing resolves a Space by name, and enforces read-only managed Spaces through a `removeWorkspace` guard plus toast and hidden context-menu entries.

New prefs are declared in `prefs/zen/space-routing.yaml`, and the read-only toast string in `zen-workspaces.ftl`.

## Two routing fixes that came with it

Exercising the managed config against a real profile surfaced two pre-existing edge cases in the Space Routing to container/Space integration (the `tabbrowser.js` patch, gh-14044). Both are fixed here.

**No-Container routes were ignored and the tab was hijacked into the active container.** A route to a Space with no container resolves to `userContextId = 0`, but the integration gated on `if (beforeRouteResult.userContextId)`, a truthiness check, so `0` read as "no route". `getContextIdIfNeeded` then forced the tab into the active or inherited container's Space, switching Spaces and tearing a freshly-opened child tab out from under its opener, which broke tree nesting. The symptom was middle-clicking a `news.ycombinator.com` link and landing in a different container and Space than the rule specified, intermittently. The fix is to gate on `isRouteFound` and treat `0` as a real "No Container" decision, so a No-Container route stays authoritative. With the tab no longer relocated, `moveTabToWorkspace` no-ops and the nesting survives.

**An explicit "Open in New Container Tab" was overridden by a matching route.** Making routes authoritative over-reached: a deliberate container choice, which the context menu passes straight through to `addTab` as `userContextId`, lost to the rule. `onBeforeAddTab` now skips routing when the caller passed an explicit `userContextId`, so the chosen container and its own Space win through the default-on container-to-Space mapping in `getContextIdIfNeeded`. Routing only acts when no container was explicitly chosen. External links are exempt from that skip, so gh-14600's fix for external links still applies.

Net behaviour: no container specified plus a matching rule routes to the rule's Space (or No Container); an explicit "Open in New Container Tab → X" gives X's container and X's Space, and the rule is ignored.

## Tests

`browser_space_routing_managed.js` covers routes: name resolution, precedence over user routes, literal / `most-recent-space` / default targets, unknown-name fallback, `matchType` defaulting, the object-with-`routes` form, malformed-JSON tolerance, pref clearing, and the read-only dialog rendering.

`browser_managed_spaces.js` covers Spaces: parsing and normalization (icon expansion, emoji passthrough, position fallback, empty-name drop), container name resolution, reconcile create / sync-existing / never-duplicate / never-delete, the startup reconcile in a fresh window, and read-only enforcement, checking that a managed Space can't be deleted while a non-managed one still can. `head.js` gains a `withManagedSpaces` helper.

`browser_space_routing_no_container.js` covers the routing fixes with a real `addTab` test: a tab routed to a No-Container Space opens with no container rather than being hijacked into the active one, and an explicit container choice survives a No-Container route, keeping both its container and its own Space. `browser_space_routing_on_add_tab.js` gains a unit test that an explicit `userContextId` skips routing.

Built against Firefox 153 and run locally with `npm test -- space_routing --headless`: **23283 passed, 0 failed**, twice in a row over the whole directory. `mach lint zen` (eslint + stylelint) is clean.

This branch also repairs the existing suite. `onBeforeAddTab` grew a `targetWorkspaceName` key without the assertions being updated, so `browser_space_routing_on_add_tab.js` fails **7 subtests on dev** as it stands; those are corrected here.

The managed-Spaces tests were also leaking into the two files that follow them: Spaces outliving the task that made them (`removeWorkspace` settles on a microtask and three calls didn't await it), no removal of the Spaces the file introduced, and a teardown that took Zen's empty-tab placeholder with it. Zen rebuilds that placeholder lazily, and the null `linkedBrowser` at the front of the strip is what made the next file's first real `addTab()` return null.
