### PR TITLE
no-bug: Reopen tabs in the destination Space's container when moving between Spaces

### DIFF
--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -1016,6 +1016,7 @@
         }
       }
       gZenWorkspaces.updateTabsContainers();
+      gZenWorkspaces.updateTabContainerIndicators();
     }
 
     #handle_dropCreateSplit(event) {

--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -988,8 +988,23 @@
         ) {
           if (isTab(draggedTab)) {
             const movingTabs = draggedTab._dragData?.movingTabs || [draggedTab];
-            for (let tab of movingTabs) {
-              tab.setAttribute("zen-workspace-id", activeWorkspace);
+            for (let i = 0; i < movingTabs.length; i++) {
+              const tab = movingTabs[i];
+              // Reopen the tab in the destination space's container (if it has
+              // one) instead of leaving it in its previous container.
+              const reopenedTab =
+                gZenWorkspaces.reopenTabInWorkspaceContainerIfNeeded(
+                  tab,
+                  activeWorkspace
+                );
+              if (reopenedTab !== tab) {
+                movingTabs[i] = reopenedTab;
+                if (tab === draggedTab) {
+                  draggedTab = reopenedTab;
+                }
+              } else {
+                tab.setAttribute("zen-workspace-id", activeWorkspace);
+              }
             }
             gBrowser.selectedTab = draggedTab;
           } else if (isTabGroupLabel(draggedTab)) {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -518,7 +518,10 @@ class nsZenWorkspaces {
     tab,
     spaceContainerId = this.getCurrentSpaceContainerId()
   ) {
-    if (tab.hasAttribute("zen-essential") || tab.hasAttribute("zen-empty-tab")) {
+    if (
+      tab.hasAttribute("zen-essential") ||
+      tab.hasAttribute("zen-empty-tab")
+    ) {
       // Essentials are grouped by container on their own, and the empty/new-tab
       // placeholder shouldn't be marked relative to the space's default
       // container.
@@ -1783,6 +1786,12 @@ class nsZenWorkspaces {
     } catch (ex) {
       console.error("Failed to reopen tab in workspace container:", ex);
       if (newTab) {
+        // The reopen failed partway through; if we had already moved selection
+        // onto the new tab, put it back on the original before discarding it so
+        // the user isn't left on a removed/unintended tab.
+        if (tab.isConnected) {
+          gBrowser.selectedTab = tab;
+        }
         gBrowser.removeTab(newTab, { animate: false, skipSessionStore: true });
       }
       return tab;
@@ -1920,8 +1929,8 @@ class nsZenWorkspaces {
       previousWorkspace,
     });
 
-    // The active space's default container changed, so refresh which tabs show
-    // the container marker.
+    // Switching spaces changes the reference container (the new space's default
+    // container), so refresh which tabs show the container marker.
     this.updateTabContainerIndicators();
   }
 

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -1655,6 +1655,81 @@ class nsZenWorkspaces {
     return true;
   }
 
+  #getWorkspaceContainerId(workspaceID) {
+    const workspace = this.getWorkspaceFromId(workspaceID);
+    return typeof workspace?.containerTabId === "number"
+      ? workspace.containerTabId
+      : 0;
+  }
+
+  /**
+   * Reopens a tab inside the destination space's container (if one is set) so
+   * the tab actually lives in that container instead of staying in its previous
+   * space's container (or no container at all).
+   *
+   * Tabs whose DOM relationships can't be safely recreated by a plain reopen
+   * (glance tabs, split-view groups, essentials and empty tabs) are left
+   * untouched, as are tabs that are already in the right container or when the
+   * destination space has no container.
+   *
+   * @param {MozTabbrowserTab} tab - The tab being moved.
+   * @param {string} workspaceID - The destination workspace id.
+   * @returns {MozTabbrowserTab} The tab to keep working with: the newly reopened
+   *   tab when a reopen happened, otherwise the original tab.
+   */
+  reopenTabInWorkspaceContainerIfNeeded(tab, workspaceID) {
+    const userContextId = this.#getWorkspaceContainerId(workspaceID);
+    if (!userContextId) {
+      return tab;
+    }
+
+    if (
+      tab.hasAttribute("zen-essential") ||
+      tab.hasAttribute("zen-empty-tab") ||
+      tab.hasAttribute("zen-glance-tab") ||
+      tab.querySelector(".tabbrowser-tab[zen-glance-tab]") ||
+      tab.group?.hasAttribute("split-view-group")
+    ) {
+      return tab;
+    }
+
+    const currentContainerId =
+      parseInt(tab.getAttribute("usercontextid"), 10) || 0;
+    if (currentContainerId === userContextId) {
+      return tab;
+    }
+
+    let newTab = null;
+    try {
+      const wasSelected = gBrowser.selectedTab === tab;
+      const tabState = JSON.parse(SessionStore.getTabState(tab));
+      tabState.userContextId = userContextId;
+      tabState.zenWorkspace = workspaceID;
+
+      newTab = gBrowser.addTrustedTab("about:blank", {
+        userContextId,
+        pinned: tab.pinned,
+        index: tab._tPos + 1,
+        skipAnimation: true,
+        createLazyBrowser: !wasSelected,
+      });
+      newTab.setAttribute("zen-workspace-id", workspaceID);
+      SessionStore.setTabState(newTab, JSON.stringify(tabState));
+
+      if (wasSelected) {
+        gBrowser.selectedTab = newTab;
+      }
+      gBrowser.removeTab(tab, { animate: false, skipSessionStore: true });
+      return newTab;
+    } catch (ex) {
+      console.error("Failed to reopen tab in workspace container:", ex);
+      if (newTab) {
+        gBrowser.removeTab(newTab, { animate: false, skipSessionStore: true });
+      }
+      return tab;
+    }
+  }
+
   #prepareNewWorkspace(space) {
     let tabCount = 0;
     for (let tab of gBrowser.tabs) {
@@ -2963,10 +3038,29 @@ class nsZenWorkspaces {
       ? gBrowser.selectedTabs
       : [TabContextMenu.contextTab];
     document.getElementById("tabContextMenu").hidePopup();
-    this.moveTabsToWorkspace(tabs, workspaceID);
+    // Reopen each tab in the destination space's container (if it has one) so it
+    // doesn't stay in the previous space's container. Reopening replaces the
+    // tab, so drop any "last selected" entry still pointing at the original —
+    // moveTabsToWorkspace only clears that for tabs it moves as-is.
+    const movedTabs = tabs.map(tab => {
+      const previousWorkspaceID = tab.getAttribute("zen-workspace-id");
+      const wasLastSelected =
+        this.lastSelectedWorkspaceTabs[previousWorkspaceID] === tab;
+      const movedTab = this.reopenTabInWorkspaceContainerIfNeeded(
+        tab,
+        workspaceID
+      );
+      if (wasLastSelected && movedTab !== tab) {
+        delete this.lastSelectedWorkspaceTabs[previousWorkspaceID];
+      }
+      return movedTab;
+    });
+    // Read the last tab before moving: moveTabsToWorkspace may reverse in place.
+    const lastMovedTab = movedTabs[movedTabs.length - 1];
+    this.moveTabsToWorkspace(movedTabs, workspaceID);
     // Make sure we select the last tab in the new workspace
     this.lastSelectedWorkspaceTabs[workspaceID] =
-      gZenGlanceManager.getTabOrGlanceParent(tabs[tabs.length - 1]);
+      gZenGlanceManager.getTabOrGlanceParent(lastMovedTab);
     const workspaces = this.getWorkspaces();
     await this.changeWorkspace(
       workspaces.find(workspace => workspace.uuid === workspaceID)

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -487,6 +487,61 @@ class nsZenWorkspaces {
       : 0;
   }
 
+  /**
+   * Refreshes the container marker for every tab in the active space. A tab
+   * shows the marker only when its container differs from the active space's
+   * default container; tabs that are in the space's default container hide it.
+   *
+   * This has to run dynamically (not just at tab creation) because the
+   * reference container changes whenever the active space changes, the space's
+   * default container is reconfigured, or a tab is moved between spaces.
+   */
+  updateTabContainerIndicators() {
+    const spaceContainerId = this.getCurrentSpaceContainerId();
+    const activeWorkspace = this.activeWorkspace;
+    for (const tab of this.allStoredTabs) {
+      if (tab.getAttribute("zen-workspace-id") !== activeWorkspace) {
+        continue;
+      }
+      this.#updateTabContainerIndicator(tab, spaceContainerId);
+    }
+  }
+
+  /**
+   * Updates a single tab's container marker relative to the given space
+   * container (defaults to the active space's container).
+   *
+   * @param {MozTabbrowserTab} tab - The tab to update.
+   * @param {number} [spaceContainerId] - The active space's default container.
+   */
+  #updateTabContainerIndicator(
+    tab,
+    spaceContainerId = this.getCurrentSpaceContainerId()
+  ) {
+    if (tab.hasAttribute("zen-essential") || tab.hasAttribute("zen-empty-tab")) {
+      // Essentials are grouped by container on their own, and the empty/new-tab
+      // placeholder shouldn't be marked relative to the space's default
+      // container.
+      return;
+    }
+    const tabContainerId = parseInt(tab.getAttribute("usercontextid"), 10) || 0;
+    const inSpaceDefaultContainer = tabContainerId === spaceContainerId;
+    if (inSpaceDefaultContainer) {
+      tab.setAttribute("zenDefaultUserContextId", "true");
+    } else {
+      tab.removeAttribute("zenDefaultUserContextId");
+    }
+    // Firefox only colours the marker when the tab has a userContextId, so a
+    // container-less tab that lives in a space which *does* have a default
+    // container would otherwise show nothing. Flag it so we can render a
+    // neutral (gray) marker instead.
+    if (!inSpaceDefaultContainer && tabContainerId === 0) {
+      tab.setAttribute("zen-neutral-container-marker", "true");
+    } else {
+      tab.removeAttribute("zen-neutral-container-marker");
+    }
+  }
+
   getCurrentEssentialsContainer() {
     return this.getEssentialsSection(this.getCurrentSpaceContainerId());
   }
@@ -1650,6 +1705,10 @@ class nsZenWorkspaces {
       if (glanceTab) {
         glanceTab.setAttribute("zen-workspace-id", workspaceID);
       }
+      // Refresh the container marker now that the tab belongs to this space.
+      if (workspaceID === this.activeWorkspace) {
+        this.#updateTabContainerIndicator(tab);
+      }
     }
     gBrowser.tabContainer._invalidateCachedTabs();
     return true;
@@ -1860,6 +1919,10 @@ class nsZenWorkspaces {
       previousWorkspaceIndex,
       previousWorkspace,
     });
+
+    // The active space's default container changed, so refresh which tabs show
+    // the container marker.
+    this.updateTabContainerIndicators();
   }
 
   makeSureEmptyTabIsFirst() {
@@ -2872,6 +2935,7 @@ class nsZenWorkspaces {
       await this.changeWorkspaceWithID(tabWorkspaceId);
     } else {
       tab.setAttribute("zen-workspace-id", activeWorkspace.uuid);
+      this.#updateTabContainerIndicator(tab);
     }
   }
 
@@ -2946,6 +3010,10 @@ class nsZenWorkspaces {
     );
     workspace.containerTabId = userContextId + 0; // +0 to convert to number
     this.saveWorkspace(workspace);
+    if (workspace.uuid === this.activeWorkspace) {
+      // The active space's default container changed; refresh tab markers.
+      this.updateTabContainerIndicators();
+    }
   }
 
   async closeAllUnpinnedTabs() {

--- a/src/zen/tabs/zen-tabs.css
+++ b/src/zen/tabs/zen-tabs.css
@@ -15,6 +15,15 @@
   .tabbrowser-tab[zenDefaultUserContextId='true'] .tab-context-line {
     display: none !important;
   }
+
+  /* A container-less tab living in a space that has a default container: there
+     is no container colour to show, so render a neutral marker to signal the
+     tab is outside the space's default container. */
+  .tabbrowser-tab[zen-neutral-container-marker='true'] .tab-context-line {
+    display: revert !important;
+    background-color: light-dark(rgb(120, 120, 130), rgb(170, 170, 180)) !important;
+    opacity: 1 !important;
+  }
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## What this fixes

Moving a tab into a Space that has a default container left the tab in its old container. The tab now sits in a Space whose container it doesn't belong to, and nothing in the UI says so, because the container marker was decided once at tab creation and never recomputed.

Two changes: move the tab into the destination Space's container, and make the marker reflect the Space you're actually looking at.

## Reopening in the destination container

Firefox can't change a tab's `userContextId` in place, so the tab has to be reopened. `reopenTabInWorkspaceContainerIfNeeded()` copies the tab's SessionStore state (URL, full session history, pinned state), sets the new container and Space on the copy, restores it, and closes the original. Selection follows the tab, and a tab that wasn't selected is recreated lazily so moving a batch of background tabs doesn't force a load.

It returns the original tab untouched when there's nothing to do: the destination Space has no default container, the tab is already in that container, or the tab is one whose DOM relationships would break if it were recreated (essentials, the empty-tab placeholder, glance tabs, and members of a split-view group). If the reopen throws partway through, selection is put back on the original tab and the half-built replacement is discarded, so a failure costs you nothing.

Both paths that move tabs between Spaces use it: the tab context menu's "move to Space" action, and dropping a tab onto a Space in the sidebar.

One incidental change in `changeTabWorkspace`: the tab to select afterwards is now read before `moveTabsToWorkspace` rather than after. That function reverses its argument array in place when `zen.view.show-newtab-button-top` is set, which defaults to true, so reading afterwards picked the first of a multi-tab selection instead of the last. Single-tab moves, the common case, are unaffected.

## Making the container marker mean something

The marker was driven by a `zenDefaultUserContextId` attribute written when the tab was created, so it only ever described the Space the tab was born in. Once a Space had a container configured, tabs whose container differed from it showed nothing.

`updateTabContainerIndicators()` now recomputes the marker for the active Space's tabs against that Space's default container, and runs whenever the reference container can change: on Space switch, when a Space's container is reconfigured, and when tabs are added or moved. A tab shows the marker when its container differs from the Space default and hides it when they match.

Container-less tabs needed a separate case. Firefox only colours the marker when a tab has a `userContextId`, so a tab with no container sitting in a Space that does have one would render nothing at all, which is exactly the case the user needs to see. Those get a `zen-neutral-container-marker` attribute and a gray marker, since there's no container colour to borrow.

## Testing

Built against Firefox 153. This branch adds no automated tests; the behaviour is exercised through the Space Routing suite, which covers the container resolution it builds on.
