### PR TITLE
no-bug: Add a Nix flake that builds Zen from source

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-cbindgen": {
+      "locked": {
+        "lastModified": 1784783405,
+        "narHash": "sha256-4IHyyLgLBdKefkljdKod4IMn023pQiDXAWJA187cmdY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7525d999cd850b9a488817abc89c75dc733acf17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7525d999cd850b9a488817abc89c75dc733acf17",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-cbindgen": "nixpkgs-cbindgen"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -16,7 +16,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-cbindgen": {
+    "nixpkgs-newer": {
       "locked": {
         "lastModified": 1784783405,
         "narHash": "sha256-4IHyyLgLBdKefkljdKod4IMn023pQiDXAWJA187cmdY=",
@@ -35,7 +35,7 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "nixpkgs-cbindgen": "nixpkgs-cbindgen"
+        "nixpkgs-newer": "nixpkgs-newer"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,15 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
-    # Firefox 153's configure refuses cbindgen below 0.29.4, and the pin above
-    # still carries 0.29.2. Pinned to the nixpkgs commit that first shipped
-    # 0.29.4 so only this one tool moves, not the whole toolchain.
-    nixpkgs-cbindgen.url = "github:NixOS/nixpkgs/7525d999cd850b9a488817abc89c75dc733acf17";
+    # Firefox 153 outruns nixos-26.05 on two build inputs: configure refuses
+    # cbindgen below 0.29.4 (the pin has 0.29.2) and nss below 3.125 (the pin's
+    # nss_latest is 3.124). Take just those two from a newer nixpkgs rather than
+    # moving the whole toolchain. Both can go once the main pin catches up.
+    nixpkgs-newer.url = "github:NixOS/nixpkgs/7525d999cd850b9a488817abc89c75dc733acf17";
   };
 
   outputs =
-    { self, nixpkgs, nixpkgs-cbindgen }:
+    { self, nixpkgs, nixpkgs-newer }:
     let
       systems = [
         "x86_64-linux"
@@ -24,14 +25,17 @@
       packages = forAllSystems (
         system:
         let
-          # Overlay rather than an extraNativeBuildInputs entry: buildMozillaMach
-          # pulls rust-cbindgen in itself, so it has to be replaced at the pkgs
-          # level for configure to see the newer one.
+          # An overlay rather than extraNativeBuildInputs entries: buildMozillaMach
+          # reaches for rust-cbindgen and nss_latest itself, so they have to be
+          # replaced at the pkgs level for configure to see the newer ones.
           pkgs = import nixpkgs {
             inherit system;
             overlays = [
               (_final: _prev: {
-                inherit (nixpkgs-cbindgen.legacyPackages.${system}) rust-cbindgen;
+                inherit (nixpkgs-newer.legacyPackages.${system})
+                  rust-cbindgen
+                  nss_latest
+                  ;
               })
             ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,53 @@
+{
+  description = "Zen Browser built from source — joegoldin fork (tree-style-tabs)";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
+    # Firefox 153's configure refuses cbindgen below 0.29.4, and the pin above
+    # still carries 0.29.2. Pinned to the nixpkgs commit that first shipped
+    # 0.29.4 so only this one tool moves, not the whole toolchain.
+    nixpkgs-cbindgen.url = "github:NixOS/nixpkgs/7525d999cd850b9a488817abc89c75dc733acf17";
+  };
+
+  outputs =
+    { self, nixpkgs, nixpkgs-cbindgen }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          # Overlay rather than an extraNativeBuildInputs entry: buildMozillaMach
+          # pulls rust-cbindgen in itself, so it has to be replaced at the pkgs
+          # level for configure to see the newer one.
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              (_final: _prev: {
+                inherit (nixpkgs-cbindgen.legacyPackages.${system}) rust-cbindgen;
+              })
+            ];
+          };
+          # `self` is the fork tree itself — the thing the build patches into the
+          # Firefox source — so building this flake builds whatever commit is
+          # referenced (locally: the checkout; from dotfiles: the pinned rev).
+          zen-browser-unwrapped = pkgs.callPackage ./nix/package.nix {
+            zen-src-tree = self;
+          };
+        in
+        {
+          inherit zen-browser-unwrapped;
+          default = zen-browser-unwrapped;
+        }
+      );
+
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
+    };
+}

--- a/nix/assets.nix
+++ b/nix/assets.nix
@@ -1,0 +1,195 @@
+# Zen branding assets, generated from surfer-config. Verbatim from nixpkgs
+# PR #496647 (Hythera) — branding is unchanged in this fork.
+{
+  branding,
+  surfer-config,
+  writeText,
+}:
+{
+  # https://github.com/zen-browser/surfer/blob/main/template/branding.optional/locales/en-US/brand.dtd
+  brandDtd = writeText "brand.dtd" ''
+    <!-- This Source Code Form is subject to the terms of the Mozilla Public
+       - License, v. 2.0. If a copy of the MPL was not distributed with this
+       - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+    <!ENTITY  brandShorterName      "${surfer-config.brands.${branding}.brandShorterName}">
+    <!ENTITY  brandShortName        "${surfer-config.brands.${branding}.brandShortName}">
+    <!ENTITY  brandFullName         "${surfer-config.brands.${branding}.brandFullName}">
+  '';
+
+  # https://github.com/zen-browser/surfer/blob/main/template/branding.optional/locales/en-US/brand.ftl
+  brandFtl = writeText "brand.ftl" ''
+    # This Source Code Form is subject to the terms of the Mozilla Public
+    # License, v. 2.0. If a copy of the MPL was not distributed with this
+    # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    ## Firefox and Mozilla Brand
+    ##
+    ## Firefox and Mozilla must be treated as a brand.
+    ##
+    ## They cannot be:
+    ## - Transliterated.
+    ## - Translated.
+    ##
+    ## Declension should be avoided where possible, leaving the original
+    ## brand unaltered in prominent UI positions.
+    ##
+    ## For further details, consult:
+    ## https://mozilla-l10n.github.io/styleguides/mozilla_general/#brands-copyright-and-trademark
+
+    -brand-shorter-name = ${surfer-config.brands.${branding}.brandShorterName}
+    -brand-short-name = ${surfer-config.brands.${branding}.brandShortName}
+    -brand-full-name = ${surfer-config.brands.${branding}.brandFullName}
+    # This brand name can be used in messages where the product name needs to
+    # remain unchanged across different versions (Nightly, Beta, etc.).
+    -brand-product-name = ${surfer-config.name}
+    -vendor-short-name = ${surfer-config.vendor}
+    trademarkInfo = { " " }
+  '';
+
+  # https://github.com/zen-browser/surfer/blob/main/template/branding.optional/locales/en-US/brand.properties
+  brandProperties = writeText "brand.properties" ''
+    # This Source Code Form is subject to the terms of the Mozilla Public
+    # License, v. 2.0. If a copy of the MPL was not distributed with this
+    # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    brandShorterName=${surfer-config.brands.${branding}.brandShorterName}
+    brandShortName=${surfer-config.brands.${branding}.brandShortName}
+    brandFullName=${surfer-config.brands.${branding}.brandFullName}
+    vendorShortName=${surfer-config.vendor}
+  '';
+
+  # https://github.com/zen-browser/surfer/blob/main/src/commands/patches/branding-patch.ts
+  brandingNsi = writeText "branding.nsi" ''
+    # This Source Code Form is subject to the terms of the Mozilla Public
+    # License, v. 2.0. If a copy of the MPL was not distributed with this
+    # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    # NSIS branding defines for official release builds.
+    # The nightly build branding.nsi is located in browser/installer/windows/nsis/
+    # The unofficial build branding.nsi is located in browser/branding/unofficial/
+
+    # BrandFullNameInternal is used for some registry and file system values
+    # instead of BrandFullName and typically should not be modified.
+    !define BrandFullNameInternal "${surfer-config.brands.${branding}.brandFullName}"
+    !define BrandFullName         "${surfer-config.brands.${branding}.brandFullName}"
+    !define CompanyName           "${surfer-config.vendor}"
+    !define URLInfoAbout          "https://zen-browser.app"
+    !define URLUpdateInfo         "https://zen-browser.app/release-notes/''${AppVersion}"
+    !define HelpLink              "https://github.com/zen-browser/desktop/issues"
+
+    ; The OFFICIAL define is a workaround to support different urls for Release and
+    ; Stable since they share the same branding when building with other branches that
+    ; set the update channel to stable.
+    !define OFFICIAL
+    !define URLStubDownloadX86 "https://download.mozilla.org/?os=win&lang=''${AB_CD}&product=firefox-latest"
+    !define URLStubDownloadAMD64 "https://download.mozilla.org/?os=win64&lang=''${AB_CD}&product=firefox-latest"
+    !define URLStubDownloadAArch64 "https://download.mozilla.org/?os=win64-aarch64&lang=''${AB_CD}&product=firefox-latest"
+    !define URLManualDownload "https://zen-browser.app/download"
+    !define URLSystemRequirements "https://www.mozilla.org/firefox/system-requirements/"
+    !define Channel "stable"
+
+    # The installer's certificate name and issuer expected by the stub installer
+    !define CertNameDownload   "${surfer-config.brands.${branding}.brandFullName}"
+    !define CertIssuerDownload "DigiCert SHA2 Assured ID Code Signing CA"
+
+    # Dialog units are used so the UI displays correctly with the system's DPI
+    # settings. These are tweaked to look good with the en-US strings; ideally
+    # we would customize them for each locale but we don't really have a way to
+    # implement that and it would be a ton of work for the localizers.
+    !define PROFILE_CLEANUP_LABEL_TOP "50u"
+    !define PROFILE_CLEANUP_LABEL_LEFT "22u"
+    !define PROFILE_CLEANUP_LABEL_WIDTH "175u"
+    !define PROFILE_CLEANUP_LABEL_HEIGHT "100u"
+    !define PROFILE_CLEANUP_LABEL_ALIGN "left"
+    !define PROFILE_CLEANUP_CHECKBOX_LEFT "22u"
+    !define PROFILE_CLEANUP_CHECKBOX_WIDTH "175u"
+    !define PROFILE_CLEANUP_BUTTON_LEFT "22u"
+    !define INSTALL_HEADER_TOP "70u"
+    !define INSTALL_HEADER_LEFT "22u"
+    !define INSTALL_HEADER_WIDTH "180u"
+    !define INSTALL_HEADER_HEIGHT "100u"
+    !define INSTALL_BODY_LEFT "22u"
+    !define INSTALL_BODY_WIDTH "180u"
+    !define INSTALL_INSTALLING_TOP "115u"
+    !define INSTALL_INSTALLING_LEFT "270u"
+    !define INSTALL_INSTALLING_WIDTH "150u"
+    !define INSTALL_PROGRESS_BAR_TOP "100u"
+    !define INSTALL_PROGRESS_BAR_LEFT "270u"
+    !define INSTALL_PROGRESS_BAR_WIDTH "150u"
+    !define INSTALL_PROGRESS_BAR_HEIGHT "12u"
+
+    !define PROFILE_CLEANUP_CHECKBOX_TOP_MARGIN "12u"
+    !define PROFILE_CLEANUP_BUTTON_TOP_MARGIN "12u"
+    !define PROFILE_CLEANUP_BUTTON_X_PADDING "80u"
+    !define PROFILE_CLEANUP_BUTTON_Y_PADDING "8u"
+    !define INSTALL_BODY_TOP_MARGIN "20u"
+
+    # Font settings that can be customized for each channel
+    !define INSTALL_HEADER_FONT_SIZE 20
+    !define INSTALL_HEADER_FONT_WEIGHT 600
+    !define INSTALL_INSTALLING_FONT_SIZE 15
+    !define INSTALL_INSTALLING_FONT_WEIGHT 600
+
+    # UI Colors that can be customized for each channel
+    !define COMMON_TEXT_COLOR 0x000000
+    !define COMMON_BACKGROUND_COLOR 0xFFFFFF
+    !define INSTALL_INSTALLING_TEXT_COLOR 0xFFFFFF
+    # This color is written as 0x00BBGGRR because it's actually a COLORREF value.
+    !define PROGRESS_BAR_BACKGROUND_COLOR 0xFFAA00
+  '';
+
+  # https://github.com/zen-browser/surfer/blob/main/template/branding.optional/configure.sh
+  configureSh = writeText "configure.sh" ''
+    # This Source Code Form is subject to the terms of the Mozilla Public
+    # License, v. 2.0. If a copy of the MPL was not distributed with this
+    # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    MOZ_APP_DISPLAYNAME="${surfer-config.brands.${branding}.brandShortName}"
+    MOZ_MACBUNDLE_ID="${surfer-config.appId}"
+
+    # if test "$DEVELOPER_OPTIONS"; then
+    #   if test "$MOZ_DEBUG"; then
+    #     # Local debug builds
+    #     MOZ_HANDLER_CLSID="398ffd8d-5382-48f7-9e3b-19012762d39a"
+    #     MOZ_IHANDLERCONTROL_IID="a218497e-8b10-460b-b668-a92b7ee39ff2"
+    #     MOZ_ASYNCIHANDLERCONTROL_IID="ca18b9ab-04b6-41be-87f7-d99913d6a2e8"
+    #     MOZ_IGECKOBACKCHANNEL_IID="231c4946-4479-4c8e-aadc-8a0e48fc4c51"
+    #   else
+    #     # Local non-debug builds
+    #     MOZ_HANDLER_CLSID="ce573faf-7815-4fc2-a031-b092268ace9e"
+    #     MOZ_IHANDLERCONTROL_IID="2b715cce-1790-4fe1-aef5-48bb5acdf3a1"
+    #     MOZ_ASYNCIHANDLERCONTROL_IID="8e089670-4f57-41a7-89c0-37f17482fa6f"
+    #     MOZ_IGECKOBACKCHANNEL_IID="18e2488d-310f-400f-8339-0e50b513e801"
+    #   fi
+    # fi
+  '';
+
+  # https://github.com/zen-browser/surfer/blob/main/src/commands/patches/branding-patch.ts
+  firefox-brandingJs = writeText "firefox-branding.js" ''
+    /* This Source Code Form is subject to the terms of the Mozilla Public
+     * License, v. 2.0. If a copy of the MPL was not distributed with this
+     * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+    pref("startup.homepage_override_url", "https://zen-browser.app/whatsnew?v=%VERSION%");
+    pref("startup.homepage_welcome_url", "https://zen-browser.app/welcome/");
+    pref("startup.homepage_welcome_url.additional", "https://zen-browser.app/privacy-policy/");
+
+    // Give the user x seconds to react before showing the big UI. default=192 hours
+    pref("app.update.promptWaitTime", 691200);
+    // app.update.url.manual: URL user can browse to manually if for some reason
+    // all update installation attempts fail.
+    // app.update.url.details: a default value for the "More information about this
+    // update" link supplied in the "An update is available" page of the update
+    // wizard.
+    pref("app.update.url.manual", "https://zen-browser.app/download/");
+    pref("app.update.url.details", "https://zen-browser.app/release-notes/latest/");
+    pref("app.releaseNotesURL", "https://zen-browser.app/whatsnew/");
+    pref("app.releaseNotesURL.aboutDialog", "https://www.zen-browser.app/release-notes/%VERSION%/");
+    pref("app.releaseNotesURL.prompt", "https://zen-browser.app/release-notes/%VERSION%/");
+
+    // Number of usages of the web console.
+    // If this is less than 5, then pasting code into the web console is disabled
+    pref("devtools.selfxss.count", 5);
+  '';
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,60 @@
+# buildMozillaMach wrapper for the Zen fork (tree-style-tabs), modelled on the
+# proven nixpkgs PR https://github.com/NixOS/nixpkgs/pull/496647 (Hythera):
+# build the pristine Firefox source + the Zen patchset via the standard
+# buildMozillaMach rather than Zen's own `surfer` tool.
+{
+  lib,
+  buildMozillaMach,
+  callPackage,
+  stdenv,
+  zen-src-tree,
+}:
+let
+  zen-browser-src = callPackage ./zen-browser.nix { inherit zen-src-tree; };
+
+  base =
+    (buildMozillaMach {
+      inherit (zen-browser-src) extraNativeBuildInputs extraPostPatch;
+      pname = "zen-browser";
+      allowAddonSideload = true;
+      applicationName = "Zen";
+      binaryName = "zen";
+      branding = "browser/branding/release";
+      extraPassthru = {
+        inherit (zen-browser-src) ffprefs;
+        inherit zen-browser-src;
+      };
+      packageVersion = zen-browser-src.zen-version;
+      requireSigning = false;
+      src = zen-browser-src.firefox-src;
+      version = zen-browser-src.firefox-version;
+
+      meta = {
+        # since Firefox 60, build on 32-bit platforms fails with "out of memory".
+        broken = stdenv.buildPlatform.is32bit;
+        description = "Firefox fork with a focus on looks and privacy (tree-style-tabs build)";
+        homepage = "https://zen-browser.app";
+        license = lib.licenses.mpl20;
+        mainProgram = "zen";
+        maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
+        # Linux + macOS (aarch64-darwin proven by nixpkgs PR #496647).
+        platforms = lib.platforms.unix;
+      };
+    }).override
+      {
+        crashreporterSupport = false;
+        enableOfficialBranding = false;
+        # ltoSupport + pgoSupport stay at buildMozillaMach's defaults (true on
+        # x86_64-linux): PGO gives profile-guided optimization, and ltoSupport wires
+        # up the LLVM/lld bintools. We only change the LTO *mode* below.
+      };
+in
+# Full cross-LTO (--enable-lto=cross,full, what ltoSupport injects) links libxul
+# in a single ~32 GB process and OOM-thrashed this 62 GB box for 14 h. Rewrite it
+# to thin cross-LTO: per-module, parallel, bounded link memory, for ~90-95% of
+# the runtime perf. PGO (the second compile pass + profile run) stays on.
+base.overrideAttrs (old: {
+  configureFlags = map (
+    f: if f == "--enable-lto=cross,full" then "--enable-lto=cross,thin" else f
+  ) old.configureFlags;
+})

--- a/nix/zen-browser.nix
+++ b/nix/zen-browser.nix
@@ -1,0 +1,178 @@
+# Assembles the patched Firefox source tree for the Zen fork (tree-style-tabs).
+# Mirrors nixpkgs PR #496647 (Hythera) — drives the Zen `import` steps by hand
+# (no `surfer`) so everything runs offline inside the build sandbox.
+#
+# Fork-specific deltas from the upstream recipe:
+#   * Firefox base version is read from surfer.json (`.version.version`) so it
+#     always matches the version the Zen patches target. A hard-coded pin that
+#     lagged surfer.json (we pinned 152.0 while the patches moved to 152.0.4,
+#     which changed UrlbarUtils.sys.mjs) fails patchPhase with "patch does not
+#     apply". Only `firefox-src.hash` is pinned now: when the base version bumps,
+#     the build fails with a clear hash mismatch that prints the correct sha512
+#     to paste below — get it with
+#     `nix store prefetch-file --hash-type sha512 <firefox-<ver>.source.tar.xz>`.
+#   * `zen-src` is the fork tree itself (`zen-src-tree` = the flake `self`),
+#     not a tagged github release — so the tree-style-tabs feature (extra
+#     src/ files + new *.patch files) is picked up generically.
+#   * Linux-only: the macOS-only external patches are excluded.
+{
+  branding ? "release",
+  fetchurl,
+  gitMinimal,
+  rsync,
+  rustPlatform,
+  writeText,
+  zen-src-tree,
+}:
+let
+  zen-src = zen-src-tree;
+
+  assets = import ./assets.nix { inherit branding surfer-config writeText; };
+
+  ffprefs = rustPlatform.buildRustPackage {
+    cargoHash = "sha256-DZMwxeulQiIiSATU0MoyqiUMA0USZq6umhkr67hZH1Q=";
+    pname = "ffprefs";
+    postPatch = ''
+      substituteInPlace src/main.rs \
+        --replace-fail "../engine/" "../"
+    '';
+    src = "${zen-src}/tools/ffprefs";
+    version = zen-version;
+  };
+
+  firefox-src = fetchurl {
+    url = "mirror://mozilla/firefox/releases/${firefox-version}/source/firefox-${firefox-version}.source.tar.xz";
+    hash = "sha512-oa9YZuHJpzKBgSPy8EG/1Zk9CT6W3XQ7WDMS+xHSs51CnfdQ+ewi3tZLWKIJux7KvHqvcwV9emTHNJ5NoEPWbQ==";
+  };
+
+  # Read from surfer.json so the fetched Firefox source always matches the base
+  # the Zen patches target (see the header comment). Only the hash above is
+  # pinned manually.
+  firefox-version =
+    (builtins.fromJSON (builtins.readFile "${zen-src}/surfer.json")).version.version;
+
+  # Hard-coded from the fork's surfer.json (kept in sync manually; these values
+  # change very rarely). Drives the branding strings in assets.nix.
+  surfer-config = {
+    name = "Zen Browser";
+    vendor = "Zen OSS Team";
+    appId = "zen";
+    brands = {
+      release = {
+        backgroundColor = "#282A33";
+        brandShorterName = "Zen";
+        brandShortName = "Zen";
+        brandFullName = "Zen Browser";
+      };
+      twilight = {
+        backgroundColor = "#282A33";
+        brandShorterName = "Zen";
+        brandShortName = "Twilight";
+        brandFullName = "Zen Twilight";
+      };
+    };
+  };
+
+  # Zen's own version lives in the release tag rather than a tracked file
+  # (package.json is a placeholder 1.0.0), so this is hand-maintained and
+  # wants bumping alongside a release. It only names the store path and the
+  # reported application version; the Firefox base above is read from
+  # surfer.json and stays correct on its own.
+  zen-version = "1.21.9b";
+in
+{
+  inherit
+    ffprefs
+    firefox-src
+    firefox-version
+    zen-version
+    ;
+
+  extraNativeBuildInputs = [
+    gitMinimal
+    rsync
+  ];
+
+  extraPostPatch = ''
+    # Compile the Zen pref YAMLs into the engine's static/dynamic pref files.
+    # --chmod=u+w: the source is a read-only Nix store path, and plain `rsync -r`
+    # would recreate its directories read-only, so the nested mkdir/copy fails
+    # ("Permission denied"). Force user-write on everything we copy in.
+    rsync -r --chmod=u+w ${zen-src}/prefs/ prefs
+    ${ffprefs}/bin/ffprefs .
+
+    # Copy the Zen source overlay in, then apply every Zen *.patch against the
+    # Firefox tree with `git apply -p1` — the same tool upstream's `surfer` uses.
+    # We deliberately avoid GNU `patch`: it rejects hunks whose trailing context
+    # is a bare struct-closing `}` with no anchor after it (e.g. allow_backdrop's
+    # init.rs hunk — "Hunk #1 FAILED at 204", fails even at -F3), which git apply
+    # and surfer apply cleanly. git apply also requires exact context, so a
+    # Firefox-base drift surfaces as a clean failure rather than a silent fuzz.
+    # Skip the two external webrender backports that already landed upstream in
+    # Firefox ${firefox-version} (their code is present in the pristine source, so
+    # re-applying fails as "already applied"). Re-check this skip list whenever the
+    # pinned Firefox version changes.
+    rsync -r --chmod=u+w --exclude "*.patch" "${zen-src}/src/" .
+
+    find "${zen-src}/src" -type f -name "*.patch" \
+      ! -name "bug_2013682_allow_stacking_contexts_to_be_promoted.patch" \
+      ! -name "gh-12979_clip_dirty_rect_to_device_size.patch" \
+      | sort | while read -r patch_name; do
+      git apply -p1 "$patch_name"
+    done
+
+    # Locales: en-US plus every supported language (mapped through language-maps).
+    rsync -r --chmod=u+w "${zen-src}/locales/en-US/browser/" browser/locales/en-US/
+    for language in $(cat ${zen-src}/locales/supported-languages); do
+      loc="$(grep -m1 "^$language:" "${zen-src}/locales/language-maps" | cut -d: -f2 || true)"
+      loc="''${loc:-$language}"
+      rsync -r --chmod=u+w "${zen-src}/locales/$language/." browser/locales/$loc
+    done
+
+    # Branding: seed from Firefox's unofficial branding, then overlay Zen's.
+    rsync -r --exclude='branding.nsi' browser/branding/unofficial/. browser/branding/${branding}
+
+    cp -r ${zen-src}/configs/branding/${branding} browser/branding
+    for size in 16 22 24 32 48 64 128 256 512; do
+      cp ${zen-src}/configs/branding/${branding}/logo"$size".png browser/branding/${branding}/default"$size".png
+    done
+
+    rsync ${assets.brandDtd} browser/branding/${branding}/locales/en-US/brand.dtd
+    rsync ${assets.brandFtl} browser/branding/${branding}/locales/en-US/brand.ftl
+    rsync ${assets.brandProperties} browser/branding/${branding}/locales/en-US/brand.properties
+    rsync ${assets.brandingNsi} browser/branding/${branding}/branding.nsi
+    rsync ${assets.configureSh} browser/branding/${branding}/configure.sh
+    rsync ${assets.firefox-brandingJs} browser/branding/${branding}/pref/firefox-branding.js
+
+    find "browser/branding/${branding}" -type f -name "*.css" | while read -r style; do
+      echo ":root { --theme-bg: ${surfer-config.brands.${branding}.backgroundColor} }" >> $style
+      sed -i -E 's/#130829|hsla\(235, 43%, 10%, 0\.5\)/var(--theme-bg)/g' $style
+    done
+
+    # Point the in-app updater at Zen's update host (no-op for us: updates are
+    # policy-disabled, so warn-don't-fail if the upstream string drifts).
+    substituteInPlace build/application.ini.in \
+      --replace-warn 'URL=https://@MOZ_APPUPDATE_HOST@/update/6/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%SYSTEM_CAPABILITIES%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/update.xml' 'URL=https://@MOZ_APPUPDATE_HOST@/updates/browser/%BUILD_TARGET%/%CHANNEL%/update.xml'
+
+    substituteInPlace browser/installer/windows/nsis/shared.nsh \
+      --replace-warn '"Publisher" "Mozilla"' '"Publisher" "${surfer-config.vendor}"'
+
+    # Merge the vendored remote-settings dumps into the engine offline. Copy the
+    # scripts out of the read-only store, then rewrite the two folder constants
+    # (the source folder -> the vendored configs/dumps; the engine folder ->
+    # relative, since we are already at the Firefox source root).
+    scripts="$(mktemp -d)"
+    cp -r "${zen-src}/scripts/." "$scripts"
+    # Rewrite the folder constants without relying on hard-coded line numbers.
+    sed -i \
+      -e '/^DUMPS_FOLDER =/,/^)$/c\DUMPS_FOLDER = "${zen-src}/configs/dumps"' \
+      -e '/^ENGINE_DUMPS_FOLDER =/,/^)$/c\ENGINE_DUMPS_FOLDER = "services/settings/dumps/main"' \
+      "$scripts/update_service_dumps.py"
+
+    python $scripts/update_service_dumps.py
+
+    for file in browser/config/version.txt browser/config/version_display.txt; do
+      echo "${zen-version}" > $file
+    done
+  '';
+}


### PR DESCRIPTION
A Nix flake that builds Zen from source through nixpkgs' `buildMozillaMach`, so `nix build` produces a Zen binary without going near `surfer` or the network mid-build. It is modelled on the nixpkgs packaging effort in [NixOS/nixpkgs#496647](https://github.com/NixOS/nixpkgs/pull/496647).

## What it adds

`flake.nix` plus `nix/{package,zen-browser,assets}.nix`, exposing `packages.<system>.zen-browser-unwrapped` for x86_64 and aarch64 Linux and Darwin. Nothing outside those files is touched, and nothing in the existing build path changes: `surfer` and the npm scripts keep working exactly as they do today.

The build runs entirely inside the Nix sandbox, which means every input has to be fixed up front:

* The Firefox base is a fixed-output `fetchurl`, and its version is read from `surfer.json` so it tracks the tree rather than drifting in a second place.
* `ffprefs` is built as a Rust package and run to compile the pref YAMLs, standing in for `npm run ffprefs`.
* Service dumps are merged offline from `configs/dumps` instead of being fetched.
* The full `src/` patchset is applied with `git apply`.

## Using it

```
nix build github:zen-browser/desktop#zen-browser-unwrapped
nix run github:zen-browser/desktop
```

## Notes for review

`nix/zen-browser.nix` hand-maintains two values. `firefox-src.hash` is the sha512 of the Firefox tarball and has to move when the base version does; the build fails loudly with the expected hash when it doesn't match, so it can't silently build the wrong source. `zen-version` names the store path and the reported application version, and is hand-maintained because Zen's version lives in the release tag rather than a tracked file.

`rust-cbindgen` comes from a pinned nixpkgs rather than the main input: Firefox 153 requires 0.29.4 and nixos-26.05 still carries 0.29.2, so configure rejects it. That pin can go away once the main nixpkgs catches up.
