### PR TITLE
gh-14057: Fix unclosable tab when dropping files into the browser area

### DIFF
--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -236,7 +236,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        }
  
 -      if (replace) {
-+      if (replace && !(!targetTab && this.selectedTab?.hasAttribute('zen-empty-tab'))) {
++      if (replace && !((targetTab || this.selectedTab)?.hasAttribute('zen-empty-tab'))) {
          if (this.isTabGroupLabel(targetTab)) {
            throw new Error(
              "Replacing a tab group label with a tab is not supported"


### PR DESCRIPTION
when no visible tabs are open, file drops were replacing Zen’s hidden empty tab instead of creating a normal tab because the target tab’s empty state wasn’t checked. this keeps the empty tab available while preserving normal tab replacement behavior.

tested Finder drops, Open With in Nightly, Cmd+W, and URL drops onto normal tabs.

demo showing issue case and replacement still working

https://github.com/user-attachments/assets/15878f2e-2f6a-476b-a246-7a3951305149

also noticed this bug while creating other demo's but finally found the issue
closes #14057 