### PR TITLE
gh-14292: Fix remote blocklist matching against Zen version instead of Firefox version

### DIFF
--- a/src/toolkit/mozapps/extensions/Blocklist-sys-mjs.patch
+++ b/src/toolkit/mozapps/extensions/Blocklist-sys-mjs.patch
@@ -1,0 +1,22 @@
+diff --git a/toolkit/mozapps/extensions/Blocklist.sys.mjs b/toolkit/mozapps/extensions/Blocklist.sys.mjs
+index 4e1e0aac91612c846bb664efe3dbb50ecf63597d..93eb9a05520198eb3f9af35aa58d789719169434 100644
+--- a/toolkit/mozapps/extensions/Blocklist.sys.mjs
++++ b/toolkit/mozapps/extensions/Blocklist.sys.mjs
+@@ -411,7 +411,7 @@ class TargetAppFilter {
+     if (!Array.isArray(versionRange)) {
+       const { maxVersion = "*" } = versionRange;
+       const matchesRange =
+-        Services.vc.compare(lazy.gApp.version, maxVersion) <= 0;
++        Services.vc.compare(AppConstants.ZEN_FIREFOX_VERSION, maxVersion) <= 0;
+       return matchesRange ? entry : null;
+     }
+ 
+@@ -433,7 +433,7 @@ class TargetAppFilter {
+         const { maxVersion = "*" } = ta;
+         if (
+           guid == lazy.gAppID &&
+-          Services.vc.compare(lazy.gApp.version, maxVersion) <= 0
++          Services.vc.compare(AppConstants.ZEN_FIREFOX_VERSION, maxVersion) <= 0
+         ) {
+           return entry;
+         }


### PR DESCRIPTION
Fixes #14744. Supersedes #14745 with the review feedback applied:

- uses `AppConstants.ZEN_FIREFOX_VERSION` (already imported in this file)
- also fixes the same comparison in the `guid == gAppID` branch at line 436; the `toolkit@mozilla.org` branch below it already uses `platformVersion`, left as is

Quick recap of the bug: the blocklist filter compares each entry's `maxVersion` against `Services.appinfo.version`, which in Zen is `1.21.9b`. So every old version-capped entry — including the NVIDIA/AMD video overlay blocks capped at Firefox `110.*` — matches Zen forever, and `VIDEO_HARDWARE_OVERLAY` gets blocked as soon as a profile finishes its first Remote Settings sync. That's why RTX VSR / RTX Video HDR never engage in Zen while they work in Chrome/Edge. Full analysis and the list of past duplicate reports are in #14744.

Verified on real hardware (Win11, RTX 5070, HDR display): fresh profile → overlay available, VSR/HDR active; after blocklist sync → blocked, features dead; with the overlay force-enabled pref (which bypasses the blocklist, i.e. what this patch effectively restores) → everything engages again, windowed mode included. `ZEN_FIREFOX_VERSION` resolves to the same `153.0` I verified against.

Done with AI assistance (Claude, via Claude Code), reviewed and tested by me.
