### PR TITLE
gh-14409: Fix compact sidebar activation at right screen edge

### DIFF
--- a/src/zen/common/styles/zen-browser-ui.css
+++ b/src/zen/common/styles/zen-browser-ui.css
@@ -353,3 +353,11 @@ body,
 :root[zen-right-side="true"] #zen-appcontent-navbar-wrapper #PanelUI-button {
   order: 2;
 }
+
+/* See #14409: firefox 150's body paint containment prevents the right side compact
+ sidebar from remaining active at the screen edge in macOS fullscreen */
+@media (-moz-platform: macos) {
+  :root[macOSNativeFullscreen][zen-compact-mode][zen-right-side] body {
+    contain: none;
+  }
+}


### PR DESCRIPTION
Firefox 150 added `contain: paint` to the browser body, which prevents the right-side compact sidebar from staying active at the screen edge in macOS fullscreen

Scoped override restores it for that case

Fixes #14409 #11638