### PR TITLE
gh-14770: Fix Bookmark menu styling

### DIFF
--- a/src/browser/themes/shared/places/organizer-shared-css.patch
+++ b/src/browser/themes/shared/places/organizer-shared-css.patch
@@ -1,0 +1,21 @@
+diff --git a/browser/themes/shared/places/organizer-shared.css b/browser/themes/shared/places/organizer-shared.css
+index fe6b79cfc2453927c324a044bd62040f866def95..a93813c76ba3633c365a739289b39187c0d1e881 100644
+--- a/browser/themes/shared/places/organizer-shared.css
++++ b/browser/themes/shared/places/organizer-shared.css
+@@ -52,6 +52,16 @@
+   }
+ }
+ 
++#places .zenEditBMPanel_fieldContainer {
++  display: contents;
++}
++
++#places label[control="editBMPanel_workspacesSelectorExpander"],
++#places #editBMPanel_workspaceDropdown,
++#places #editBMPanel_workspaceList {
++  display: none;
++}
++
+ #editBMPanel_itemsCountText {
+   grid-column: auto / span 2;
+   justify-self: center;


### PR DESCRIPTION
restores the normal Firefox layout in Bookmarks > Manage Bookmarks.

Zen's field wrappers were treated as single grid cells, misaligning the labels and inputs. it also hides the unused Space selector controls in the Library. `editBookmark.js `disables the selector in this context but its related elements remained visible.

https://github.com/user-attachments/assets/f241f8f5-ff91-450a-9f53-9bfd74e117f4

(the before styling in the original issue is also on macOS which I reproduced on my own)
closes #14770 