### PR TITLE
no-bug: Add keyboard shortcut for adding a tab to Essentials

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -360,3 +360,4 @@ zen-close-all-unpinned-tabs-shortcut = Close All Unpinned Tabs
 zen-new-unsynced-window-shortcut = New Blank Window
 zen-duplicate-tab-shortcut = Duplicate Tab
 zen-key-find-selection = Find Selection
+zen-add-to-essentials-shortcut = Add Current Tab to Essentials

--- a/src/browser/base/content/zen-commands.inc.xhtml
+++ b/src/browser/base/content/zen-commands.inc.xhtml
@@ -38,6 +38,7 @@
   <command id="cmd_zenEditPinnedUrl" />
   <command id="cmd_contextZenAddToEssentials" />
   <command id="cmd_contextZenRemoveFromEssentials" />
+  <command id="cmd_zenAddToEssentials" />
 
   <command id="cmd_zenCtxDeleteWorkspace" />
   <command id="cmd_zenUnloadWorkspace" />

--- a/src/zen/common/zen-sets.js
+++ b/src/zen/common/zen-sets.js
@@ -87,6 +87,19 @@ document.addEventListener(
           case "cmd_contextZenRemoveFromEssentials":
             gZenPinnedTabManager.removeEssentials();
             break;
+          case "cmd_zenAddToEssentials": {
+            const currentTab = gZenGlanceManager.getTabOrGlanceParent(
+              gBrowser.selectedTab
+            );
+            if (
+              currentTab &&
+              !currentTab.hasAttribute("zen-empty-tab") &&
+              gZenPinnedTabManager.canEssentialBeAdded(currentTab)
+            ) {
+              gZenPinnedTabManager.addToEssentials(currentTab);
+            }
+            break;
+          }
           case "cmd_zenCtxDeleteWorkspace":
             gZenWorkspaces.contextDeleteWorkspace(event);
             break;

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -848,7 +848,7 @@ class nsZenKeyboardShortcutsLoader {
 }
 
 class nsZenKeyboardShortcutsVersioner {
-  static LATEST_KBS_VERSION = 19;
+  static LATEST_KBS_VERSION = 20;
 
   constructor() {}
 
@@ -1254,6 +1254,27 @@ class nsZenKeyboardShortcutsVersioner {
           break;
         }
       }
+    }
+
+    if (version < 20) {
+      // Migrate from version 19 to 20.
+      // Add shortcut to add the current tab to Essentials:
+      // Default Accel+Alt+Shift+E
+      data.push(
+        new KeyShortcut(
+          "zen-add-to-essentials",
+          "E",
+          "",
+          ZEN_OTHER_SHORTCUTS_GROUP,
+          nsKeyShortcutModifiers.fromObject({
+            accel: true,
+            alt: true,
+            shift: true,
+          }),
+          "cmd_zenAddToEssentials",
+          "zen-add-to-essentials-shortcut"
+        )
+      );
     }
 
     return data;

--- a/src/zen/tests/pinned/browser.toml
+++ b/src/zen/tests/pinned/browser.toml
@@ -5,6 +5,8 @@
 [DEFAULT]
 prefs = ["zen.workspaces.separate-essentials=false"]
 
+["browser_essential_shortcut.js"]
+
 ["browser_issue_8726.js"]
 
 ["browser_pinned_changed.js"]

--- a/src/zen/tests/pinned/browser_essential_shortcut.js
+++ b/src/zen/tests/pinned/browser_essential_shortcut.js
@@ -1,0 +1,104 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_Essential_Shortcut() {
+  ok(
+    gZenKeyboardShortcutsManager._currentShortcutList?.length,
+    "The keyboard shortcut registry should be loaded"
+  );
+
+  const shortcut = gZenKeyboardShortcutsManager.getShortcutFromCommand(
+    "cmd_zenAddToEssentials"
+  );
+  ok(shortcut, "A shortcut should be registered for cmd_zenAddToEssentials");
+  Assert.equal(shortcut.getKeyName(), "e", "The default key should be E");
+  const modifiers = shortcut.getModifiers();
+  ok(
+    modifiers.accel && modifiers.alt && modifiers.shift,
+    "The default modifiers should be accel+alt+shift"
+  );
+
+  // Accel+E alone is "key_findSelection" and Accel+Alt+E is "key_netmonitor",
+  //  which is why the default carries the extra shift. The registry here has
+  //  Firefox's own keyset merged in, so this catches a collision with any of
+  //  the bindings, not just the ones Zen declares in this file.
+  const conflict = gZenKeyboardShortcutsManager.checkForConflicts(
+    shortcut.getKeyName(),
+    modifiers,
+    shortcut.getID()
+  );
+  ok(
+    !conflict.hasConflicts,
+    `Default binding is free, conflicts with: ${conflict.conflictShortcut?.getID()}`
+  );
+
+  await BrowserTestUtils.openNewForegroundTab(
+    window.gBrowser,
+    "https://example.com/",
+    true
+  );
+
+  const newTab = gBrowser.selectedTab;
+  gBrowser.pinTab(newTab);
+
+  ok(newTab.pinned, "The tab should be pinned after calling gBrowser.pinTab()");
+
+  const addedToEssentials = BrowserTestUtils.waitForEvent(
+    newTab,
+    "TabAddedToEssentials"
+  );
+  EventUtils.synthesizeKey("e", {
+    accelKey: true,
+    altKey: true,
+    shiftKey: true,
+  });
+  await addedToEssentials;
+
+  ok(
+    newTab.hasAttribute("zen-essential") &&
+      newTab.parentNode.getAttribute("container") == "0",
+    "The selected tab should be marked as essential."
+  );
+
+  gZenPinnedTabManager.removeEssentials(newTab);
+  await BrowserTestUtils.removeTab(newTab);
+});
+
+add_task(async function test_Essential_Shortcut_Cannot_Be_Added() {
+  // A maximum of zero essentials makes canEssentialBeAdded() always fail, the
+  // same gate the tab context menu and the urlbar action use.
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.tabs.essentials.max", 0]],
+  });
+
+  await BrowserTestUtils.openNewForegroundTab(
+    window.gBrowser,
+    "https://example.com/",
+    true
+  );
+
+  const newTab = gBrowser.selectedTab;
+  gBrowser.pinTab(newTab);
+
+  ok(
+    !gZenPinnedTabManager.canEssentialBeAdded(newTab),
+    "The tab should not be allowed to become an essential"
+  );
+
+  EventUtils.synthesizeKey("e", {
+    accelKey: true,
+    altKey: true,
+    shiftKey: true,
+  });
+  await TestUtils.waitForTick();
+
+  ok(
+    !newTab.hasAttribute("zen-essential"),
+    "The tab should stay non-essential when it cannot be added"
+  );
+
+  await BrowserTestUtils.removeTab(newTab);
+  await SpecialPowers.popPrefEnv();
+});


### PR DESCRIPTION
Adds a keyboard shortcut for **Add to Essentials**. Discussion: #14784

The action already exists in the tab context menu and the command palette, so this
registers a shortcut for it rather than adding new essentials logic.

### Default binding: `accel+alt+shift+E`

| Combo | Status |
|---|---|
| `accel+E` | Taken, `key_findSelection` |
| `accel+alt+E` | Taken, `key_netmonitor` |
| `accel+shift+E` | Unsafe. `DevToolsStartup` registers devtools with `accel,alt` on Darwin and `accel,shift` elsewhere, so this is Network Monitor on Windows and Linux. The same flip hits `accel+shift+K`, `+I`, `+Z` and `+M`. |
| `accel+alt+shift+E` | **Free on every platform.** Only `C`, `I`, `S`, `]` and `}` are bound under `accel+alt+shift`. |

Registered in `ZEN_OTHER_SHORTCUTS_GROUP`, so it appears in Settings under Other and
stays user-rebindable.

### Notes for review

- New command rather than reusing `cmd_contextZenAddToEssentials`: with no argument,
  `addToEssentials()` falls back to `TabContextMenu.contextTab`, which is null until the
  context menu has been opened once and stale afterwards.
- Guarded on `canEssentialBeAdded`, so the shortcut refuses exactly when the context menu
  greys out and the palette action hides.
- `LATEST_KBS_VERSION` 19 to 20 with a `version < 20` migration, per the "add new default
  shortcuts inside the migration function" comment in `zenGetDefaultShortcuts()`, so
  existing profiles pick up the binding without a shortcut reset.

### Tests

`src/zen/tests/pinned/browser_essential_shortcut.js`, two tasks: the happy path, and the
`canEssentialBeAdded` no-op staged by setting `zen.tabs.essentials.max` to 0. The first
task also asserts no collision via `checkForConflicts`, which walks the merged registry
including Firefox's own keyset.

I could not run the suite locally - a build needs 40-60GB and I do not have the disk for
it - so these are unexecuted and rely on CI. Flagging that rather than implying otherwise.

