### PR TITLE
no-bug: Add keyboard shortcut for moving a tab into a folder

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -360,3 +360,4 @@ zen-close-all-unpinned-tabs-shortcut = Close All Unpinned Tabs
 zen-new-unsynced-window-shortcut = New Blank Window
 zen-duplicate-tab-shortcut = Duplicate Tab
 zen-key-find-selection = Find Selection
+zen-move-tab-to-folder-shortcut = Move Tab to Folder

--- a/src/browser/base/content/zen-commands.inc.xhtml
+++ b/src/browser/base/content/zen-commands.inc.xhtml
@@ -61,6 +61,7 @@
   <command id="cmd_zenGlanceSplit" />
 
   <command id="cmd_zenOpenFolderCreation" />
+  <command id="cmd_zenMoveTabToFolder" />
 
   <command id="cmd_zenTogglePinTab" />
   <command id="cmd_zenCloseUnpinnedTabs" />

--- a/src/zen/common/zen-sets.js
+++ b/src/zen/common/zen-sets.js
@@ -114,6 +114,9 @@ document.addEventListener(
               renameFolder: true,
             });
             break;
+          case "cmd_zenMoveTabToFolder":
+            gZenFolders.moveSelectedTabsToFolder();
+            break;
           case "cmd_zenTogglePinTab": {
             const currentTab = gZenGlanceManager.getTabOrGlanceParent(
               gBrowser.selectedTab

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -48,6 +48,10 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
 
   #lastFolderContextMenu = null;
 
+  // Maps a workspace ID to the ID of the folder last used in it. Used by
+  //  "cmd_zenMoveTabToFolder" to know where to move tabs to.
+  #lastUsedFolderIds = new Map();
+
   #foldersEnabled = false;
 
   #animationCount = 0;
@@ -250,19 +254,7 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
       let tabs = TabContextMenu.contextTab?.multiselected
         ? gBrowser.selectedTabs
         : [TabContextMenu.contextTab];
-      let groups = gBrowser.tabGroups.filter(group => {
-        const isZenFolder = group?.isZenFolder;
-        const isLiveFolder = group?.isLiveFolder;
-        const spaceId = group?.getAttribute("zen-workspace-id");
-        if (
-          !isZenFolder ||
-          isLiveFolder ||
-          spaceId !== gZenWorkspaces.activeWorkspace
-        ) {
-          return false;
-        }
-        return !tabs.some(tab => tab.group === group);
-      });
+      let groups = this.getTargetFoldersForTabs(tabs);
       separator.hidden = groups.length === 0;
       for (const group of groups) {
         const icon = group.iconURL;
@@ -300,6 +292,81 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
         : [TabContextMenu.contextTab];
       group.addTabs(tabs);
     });
+  }
+
+  /**
+   * Get the folders of the active space the given tabs can be moved into.
+   *
+   * @param {MozTabbrowserTab[]} tabs The tabs about to be moved.
+   * @returns {ZenFolder[]} The eligible folders, in sidebar order.
+   */
+  getTargetFoldersForTabs(tabs) {
+    return gBrowser.tabGroups.filter(group => {
+      const isZenFolder = group?.isZenFolder;
+      const isLiveFolder = group?.isLiveFolder;
+      const spaceId = group?.getAttribute("zen-workspace-id");
+      if (
+        !isZenFolder ||
+        isLiveFolder ||
+        spaceId !== gZenWorkspaces.activeWorkspace
+      ) {
+        return false;
+      }
+      return !tabs.some(tab => tab.group === group);
+    });
+  }
+
+  /**
+   * Move tabs into a folder. Folders live in the pinned area and `addTabs`
+   * leaves the pinned state of a tab untouched, so the tabs are pinned first,
+   * exactly like `createFolder` does before handing them to `addTabs`.
+   *
+   * @param {ZenFolder} folder The folder to move the tabs into.
+   * @param {MozTabbrowserTab[]} tabs The tabs to move.
+   */
+  moveTabsToFolder(folder, tabs) {
+    const items = tabs.map(tab => {
+      gBrowser.pinTab(tab);
+      return tab?.group?.hasAttribute("split-view-group") ? tab.group : tab;
+    });
+    folder.addTabs(items);
+    this.#lastUsedFolderIds.set(
+      folder.getAttribute("zen-workspace-id"),
+      folder.id
+    );
+  }
+
+  /**
+   * Move the selected tabs into the folder last used in the active space,
+   * falling back to the first folder of the space. Does nothing when there is
+   * no folder to move them into.
+   */
+  moveSelectedTabsToFolder() {
+    if (!this.#foldersEnabled) {
+      return;
+    }
+    const tabs = gBrowser.selectedTabs
+      .map(tab => gZenGlanceManager.getTabOrGlanceParent(tab))
+      .filter(tab => tab && !tab.hasAttribute("zen-empty-tab"));
+    if (!tabs.length) {
+      return;
+    }
+    const folders = this.getTargetFoldersForTabs(tabs);
+    if (!folders.length) {
+      return;
+    }
+    const lastUsedId = this.#lastUsedFolderIds.get(
+      gZenWorkspaces.activeWorkspace
+    );
+    const folder = folders.find(f => f.id === lastUsedId) ?? folders[0];
+    // Expand the folder and its parents, otherwise a keyboard-only move
+    //  gives no feedback at all.
+    let currentFolder = folder;
+    do {
+      currentFolder.collapsed = false;
+      currentFolder = currentFolder.group;
+    } while (currentFolder);
+    this.moveTabsToFolder(folder, tabs);
   }
 
   handleEvent(aEvent) {
@@ -383,6 +450,11 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     if (!group?.isZenFolder) {
       return;
     }
+
+    this.#lastUsedFolderIds.set(
+      group.getAttribute("zen-workspace-id"),
+      group.id
+    );
 
     const collapsedRoot = group.rootMostCollapsedFolder;
     if (!collapsedRoot) {

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -848,7 +848,7 @@ class nsZenKeyboardShortcutsLoader {
 }
 
 class nsZenKeyboardShortcutsVersioner {
-  static LATEST_KBS_VERSION = 19;
+  static LATEST_KBS_VERSION = 21;
 
   constructor() {}
 
@@ -1254,6 +1254,27 @@ class nsZenKeyboardShortcutsVersioner {
           break;
         }
       }
+    }
+
+    if (version < 21) {
+      // Migrate from version 20 to 21.
+      // Add shortcut to move the current tab into a folder: Default
+      //  Accel+Alt+Shift+F. Accel+Alt+F is taken by "key_search2".
+      data.push(
+        new KeyShortcut(
+          "zen-move-tab-to-folder",
+          "F",
+          "",
+          ZEN_OTHER_SHORTCUTS_GROUP,
+          nsKeyShortcutModifiers.fromObject({
+            accel: true,
+            alt: true,
+            shift: true,
+          }),
+          "cmd_zenMoveTabToFolder",
+          "zen-move-tab-to-folder-shortcut"
+        )
+      );
     }
 
     return data;

--- a/src/zen/tests/folders/browser.toml
+++ b/src/zen/tests/folders/browser.toml
@@ -24,6 +24,8 @@ support-files = [
 
 ["browser_folder_max_subfolders.js"]
 
+["browser_folder_move_shortcut.js"]
+
 ["browser_folder_multiselected.js"]
 
 ["browser_folder_owner_tabs.js"]

--- a/src/zen/tests/folders/browser_folder_move_shortcut.js
+++ b/src/zen/tests/folders/browser_folder_move_shortcut.js
@@ -1,0 +1,184 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+function moveTabToFolder() {
+  document.getElementById("cmd_zenMoveTabToFolder").doCommand();
+}
+
+add_task(async function test_Move_Tab_To_Folder_Shortcut_Registered() {
+  ok(
+    gZenKeyboardShortcutsManager._currentShortcutList?.length,
+    "The keyboard shortcut registry is loaded"
+  );
+
+  const shortcut = gZenKeyboardShortcutsManager.getShortcutFromCommand(
+    "cmd_zenMoveTabToFolder"
+  );
+  ok(shortcut, "The move to folder shortcut is registered");
+  Assert.equal(
+    shortcut.getKeyName().toUpperCase(),
+    "F",
+    "Shortcut is bound to the F key"
+  );
+
+  const modifiers = shortcut.getModifiers();
+  ok(modifiers.accel, "Shortcut uses accel");
+  ok(modifiers.alt, "Shortcut uses alt");
+  ok(modifiers.shift, "Shortcut uses shift");
+
+  // Accel+Alt+F on its own is "key_search2". The registry here has Firefox's
+  //  own keyset merged into it, so this catches a collision with any of the
+  //  141 bindings, not just the ones Zen declares.
+  const conflict = gZenKeyboardShortcutsManager.checkForConflicts(
+    shortcut.getKeyName(),
+    modifiers,
+    shortcut.getID()
+  );
+  ok(
+    !conflict.hasConflicts,
+    `Default binding is free, conflicts with: ${conflict.conflictShortcut?.getID()}`
+  );
+});
+
+// Note: This task runs first of the move tasks on purpose, so that the space
+// is still guaranteed to be free of folders.
+add_task(async function test_Move_Tab_To_Folder_Without_Folders() {
+  const selectedTab = gBrowser.selectedTab;
+  const tab = BrowserTestUtils.addTab(gBrowser, "about:blank");
+  gBrowser.selectedTab = tab;
+
+  Assert.equal(
+    gZenFolders.getTargetFoldersForTabs([tab]).length,
+    0,
+    "The space has no folder to move the tab into"
+  );
+
+  moveTabToFolder();
+
+  ok(!tab.group, "Tab is not grouped when the space has no folders");
+  ok(!tab.pinned, "Tab is not pinned when the space has no folders");
+
+  gBrowser.selectedTab = selectedTab;
+  BrowserTestUtils.removeTab(tab);
+});
+
+add_task(async function test_Move_Tab_To_First_Folder_By_Default() {
+  const selectedTab = gBrowser.selectedTab;
+  const folderA = await gZenFolders.createFolder([], {
+    renameFolder: false,
+    label: "a",
+  });
+  const folderB = await gZenFolders.createFolder([], {
+    renameFolder: false,
+    label: "b",
+  });
+
+  // No tab has been moved into or selected inside either folder yet, so there
+  //  is no last used folder and the first one of the space is used instead.
+  const firstInSidebar =
+    folderA.compareDocumentPosition(folderB) & Node.DOCUMENT_POSITION_FOLLOWING
+      ? folderA
+      : folderB;
+
+  const tab = BrowserTestUtils.addTab(gBrowser, "about:blank");
+  gBrowser.selectedTab = tab;
+
+  const groupedEvent = BrowserTestUtils.waitForEvent(window, "TabGrouped");
+  moveTabToFolder();
+  await groupedEvent;
+
+  Assert.equal(
+    tab.group,
+    firstInSidebar,
+    `Tab is moved into "${firstInSidebar.label}", the first folder of the space`
+  );
+
+  gBrowser.selectedTab = selectedTab;
+  BrowserTestUtils.removeTab(tab);
+  await removeFolder(folderA);
+  await removeFolder(folderB);
+});
+
+add_task(async function test_Move_Tab_To_Folder() {
+  const selectedTab = gBrowser.selectedTab;
+  const folder = await gZenFolders.createFolder([], {
+    renameFolder: false,
+    label: "target",
+    collapsed: true,
+  });
+
+  // The collapsed state is only applied a tick after the folder is created.
+  /* eslint-disable-next-line mozilla/no-arbitrary-setTimeout */
+  await new Promise(resolve => setTimeout(resolve, 100));
+  ok(folder.collapsed, "Folder starts out collapsed");
+
+  const tab = BrowserTestUtils.addTab(gBrowser, "about:blank");
+  gBrowser.selectedTab = tab;
+
+  const groupedEvent = BrowserTestUtils.waitForEvent(window, "TabGrouped");
+  moveTabToFolder();
+  await groupedEvent;
+
+  Assert.equal(tab.group, folder, "Tab is moved into the folder");
+  ok(tab.pinned, "Tab is pinned once it lives inside the folder");
+  ok(!folder.collapsed, "Folder is expanded so the moved tab is visible");
+
+  gBrowser.selectedTab = selectedTab;
+  BrowserTestUtils.removeTab(tab);
+  await removeFolder(folder);
+});
+
+add_task(async function test_Move_Tab_To_Last_Used_Folder() {
+  const selectedTab = gBrowser.selectedTab;
+  const firstFolder = await gZenFolders.createFolder([], {
+    renameFolder: false,
+    label: "first",
+  });
+  const secondFolder = await gZenFolders.createFolder([], {
+    renameFolder: false,
+    label: "second",
+  });
+
+  const tabInFirst = BrowserTestUtils.addTab(gBrowser, "about:blank");
+  gZenFolders.moveTabsToFolder(firstFolder, [tabInFirst]);
+  const tabInSecond = BrowserTestUtils.addTab(gBrowser, "about:blank");
+  gZenFolders.moveTabsToFolder(secondFolder, [tabInSecond]);
+
+  // Both folders are targeted in turn, so that the assertions hold no matter
+  //  which of the two comes first in the sidebar.
+  const movedTabs = [];
+  for (const [folder, tabInFolder] of [
+    [secondFolder, tabInSecond],
+    [firstFolder, tabInFirst],
+  ]) {
+    // Selecting a tab inside a folder makes it the last used one.
+    let selectEvent = BrowserTestUtils.waitForEvent(window, "TabSelect");
+    gBrowser.selectedTab = tabInFolder;
+    await selectEvent;
+
+    const tab = BrowserTestUtils.addTab(gBrowser, "about:blank");
+    movedTabs.push(tab);
+    selectEvent = BrowserTestUtils.waitForEvent(window, "TabSelect");
+    gBrowser.selectedTab = tab;
+    await selectEvent;
+
+    const groupedEvent = BrowserTestUtils.waitForEvent(window, "TabGrouped");
+    moveTabToFolder();
+    await groupedEvent;
+
+    Assert.equal(
+      tab.group,
+      folder,
+      `Tab is moved into "${folder.label}", the last used folder`
+    );
+  }
+
+  gBrowser.selectedTab = selectedTab;
+  for (const tab of movedTabs) {
+    BrowserTestUtils.removeTab(tab);
+  }
+  await removeFolder(firstFolder);
+  await removeFolder(secondFolder);
+});


### PR DESCRIPTION
Adds a keyboard shortcut to move the selected tab into a sidebar folder.
Discussion: #14785

There are currently no folder commands in the shortcut registry, so a folder can only be
filled by dragging tabs in. The **Move to Folder** context submenu cannot be driven from a
command either, since its `popupshowing` reads `TabContextMenu.contextTab`.

> **Depends on #14787.** That PR takes `LATEST_KBS_VERSION` 19 to 20; this one takes it to
> 21. If this merges first, existing profiles jump 19 to 21 and #14787's `version < 20`
> block never runs for them, so its shortcut would silently never appear. Fresh profiles
> run every block, so manual testing would not catch it. Happy to rebase to whatever
> order suits you.

### Default binding: `accel+alt+shift+F`

| Combo | Status |
|---|---|
| `accel+alt+F` | Taken, `key_search2` / `Tools:Search` |
| `accel+shift+F` | Taken, `key_enterFullScreen_old` |
| `accel+alt+shift+F` | **Free on every platform.** Only `C`, `I`, `S`, `]` and `}` are bound under `accel+alt+shift`. |

Three modifiers also sidesteps the devtools platform flip: the bindings that swap
`accel,alt` on Darwin for `accel,shift` elsewhere are all two-modifier, and the one genuine
three-modifier devtools key (`key_browserToolbox`, `accel+alt+shift+I`) uses the same combo
everywhere.

### Targeting

Most recently used folder in the active space, falling back to the first folder in sidebar
order, no-op when the space has none. "Nearest folder" was rejected because a loose tab
sits below every folder, so it always resolves to the bottom-most one. The target folder
and its ancestors are expanded before the move, otherwise a keyboard-only action gives no
feedback.

### Notes for review

- `getTargetFoldersForTabs` is extracted from the context submenu's existing filter rather
  than duplicated. That extraction is the only change to existing code; the context-menu
  call site still calls `group.addTabs(tabs)` and behaves exactly as before.
- `moveTabsToFolder` pins first, mirroring `createFolder`, since folders live in the pinned
  area and `addTabs` leaves pinned state untouched.
- Separately, I think **Move to Folder** has a pre-existing bug: it is offered for unpinned
  tabs with no gating and leaves them unpinned inside the folder. Not touched here. Happy to
  file it and fix it in its own PR if useful.

### Tests

`src/zen/tests/folders/browser_folder_move_shortcut.js`, five tasks: registration plus a
`checkForConflicts` assertion, no-folders no-op, multi-folder fallback with an empty MRU
map, happy path, and last-used targeting in both directions.

Unexecuted - a build needs 40-60GB and I do not have the disk, so these rely on CI.

