### PR TITLE
no-bug: Add --workspace flag to open a URL in a named space

### DIFF
--- a/src/zen/spaces/ZenWorkspaceCommandLine.sys.mjs
+++ b/src/zen/spaces/ZenWorkspaceCommandLine.sys.mjs
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  BrowserWindowTracker: "resource:///modules/BrowserWindowTracker.sys.mjs",
+});
+
+const WORKSPACE_FLAG = "workspace";
+const NEW_TAB_FLAG = "new-tab";
+
+/**
+ * Command line handler for `--workspace <name>`.
+ *
+ * Firefox's own handler sends `--new-tab` to whichever space happens to be
+ * active. This handler is registered under the "command-line-handler" category
+ * as "b-zen-workspace" so that it is asked first (handlers run in alphabetical
+ * order of their category entry name, and Firefox registers itself as
+ * "m-browser"). When `--workspace` is present it consumes `--new-tab` as well
+ * and opens the URL in the named space instead. When it is absent, the flags
+ * are left untouched and Firefox behaves exactly as before.
+ *
+ * The tab is always opened in the *background* of the target space: the flag
+ * exists so a script can lay out several spaces in one go, and switching space
+ * per tab would both flicker and leave the user somewhere they did not ask to
+ * be. Nothing about the active space changes.
+ *
+ * An unknown space name is never silently downgraded to the active space; it
+ * reports an error and opens nothing.
+ */
+export class ZenWorkspaceCommandLineHandler {
+  QueryInterface = ChromeUtils.generateQI(["nsICommandLineHandler"]);
+
+  /* nsICommandLineHandler */
+  handle(cmdLine) {
+    const workspaceName = this.#takeFlagWithParam(cmdLine, WORKSPACE_FLAG);
+    if (!workspaceName) {
+      if (workspaceName === "") {
+        this.reportError(
+          `--${WORKSPACE_FLAG} needs the name of a space, for example ` +
+            `--${WORKSPACE_FLAG} "Work" --${NEW_TAB_FLAG} https://example.com`
+        );
+      }
+      return;
+    }
+
+    const uriString = this.#takeFlagWithParam(cmdLine, NEW_TAB_FLAG);
+    if (!uriString) {
+      // Nothing was consumed that the default handler needed, so leave
+      // preventDefault alone and let startup carry on as usual.
+      this.reportError(
+        `--${WORKSPACE_FLAG} "${workspaceName}" was given without ` +
+          `--${NEW_TAB_FLAG} <url>, so there is nothing to open`
+      );
+      return;
+    }
+
+    // From here on `--new-tab` has been taken away from the default handler, so
+    // every exit has to stop default handling as well. Otherwise a second
+    // instance would fall back to opening a window we were not asked for. This
+    // is unconditional for the same reason Firefox's own `--new-tab` branch
+    // does it unconditionally: the flag has been claimed either way.
+    cmdLine.preventDefault = true;
+
+    let uri;
+    try {
+      uri = cmdLine.resolveURI(uriString);
+    } catch (e) {
+      this.reportError(`Could not resolve "${uriString}": ${e}`);
+      return;
+    }
+
+    // Same guard Firefox applies to externally supplied URIs.
+    if (uri.schemeIs("chrome") || uri.schemeIs("moz-extension")) {
+      this.reportError(
+        `Refusing to open a ${uri.scheme}: URI from the command line`
+      );
+      return;
+    }
+
+    const win = this.getTargetWindow();
+    if (!win?.gZenWorkspaces?.workspaceEnabled) {
+      this.reportError(
+        `--${WORKSPACE_FLAG} needs a running window with spaces enabled; ` +
+          `start Zen first, then run the command again`
+      );
+      return;
+    }
+
+    const spaces = win.gZenWorkspaces.getWorkspaces();
+    // Space names are not unique. The first match wins, which keeps the flag
+    // predictable rather than making the caller guess between duplicates.
+    const workspace = spaces.find(space => space.name === workspaceName);
+    if (!workspace) {
+      const known = spaces.map(space => `"${space.name}"`).join(", ");
+      this.reportError(
+        `No space named "${workspaceName}". Known spaces: ${known || "(none)"}`
+      );
+      return;
+    }
+
+    this.#openInWorkspace(win, workspace, uri);
+  }
+
+  /* nsICommandLineHandler */
+  get helpInfo() {
+    return (
+      "  --workspace <name> Open the URL given with --new-tab in the\n" +
+      "                     background of the space named <name>, without\n" +
+      "                     switching to it. If two spaces share a name,\n" +
+      "                     the first one is used.\n"
+    );
+  }
+
+  /**
+   * The window the tab should be added to. Split out so tests can point the
+   * handler at a window of their own.
+   *
+   * @returns {Window|null} The most recently used browser window
+   */
+  getTargetWindow() {
+    return lazy.BrowserWindowTracker.getTopWindow();
+  }
+
+  /**
+   * Reports a command line problem. Split out both so that failures are always
+   * loud in one place, and so tests can observe them.
+   *
+   * @param {string} message - What went wrong
+   */
+  reportError(message) {
+    console.error(`[ZenWorkspaceCommandLine]: ${message}`);
+  }
+
+  /**
+   * Reads and consumes a flag, treating "flag given without a value" as an
+   * empty string rather than letting the exception escape.
+   *
+   * @param {nsICommandLine} cmdLine - The command line being handled
+   * @param {string} flag - The flag name, without dashes
+   * @returns {string|null} The value, "" when it had none, null when absent
+   * @private
+   */
+  #takeFlagWithParam(cmdLine, flag) {
+    try {
+      return cmdLine.handleFlagWithParam(flag, false);
+    } catch (e) {
+      if (e.result != Cr.NS_ERROR_INVALID_ARG) {
+        throw e;
+      }
+      // The flag is still on the command line; take it so nothing else sees it.
+      cmdLine.handleFlag(flag, false);
+      return "";
+    }
+  }
+
+  /**
+   * Opens the URI as a background tab belonging to the given space.
+   *
+   * @param {Window} win - The browser window to add the tab to
+   * @param {object} workspace - The target space
+   * @param {nsIURI} uri - The URI to open
+   * @private
+   */
+  #openInWorkspace(win, workspace, uri) {
+    try {
+      const tab = win.gBrowser.addTab(uri.spec, {
+        inBackground: true,
+        // The destination is explicit, so routing rules must not redirect it.
+        skipRoute: true,
+        // Without this the tab would inherit the *active* space's container.
+        userContextId: workspace.containerTabId ?? 0,
+        // The command line is as trusted as the user running the browser, which
+        // is the same principal Firefox uses for its own --new-tab handling.
+        triggeringPrincipal:
+          Services.scriptSecurityManager.getSystemPrincipal(),
+      });
+      win.gZenWorkspaces.moveTabToWorkspace(tab, workspace.uuid);
+      win.gZenWorkspaces.lastSelectedWorkspaceTabs[workspace.uuid] = tab;
+    } catch (e) {
+      this.reportError(
+        `Could not open ${uri.spec} in space "${workspace.name}": ${e}`
+      );
+    }
+  }
+}

--- a/src/zen/spaces/components.conf
+++ b/src/zen/spaces/components.conf
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Classes = [
+    {
+        'cid': '{33d311b5-4f34-45e4-81bf-070ee8ea74e0}',
+        'contract_ids': ['@mozilla.org/zen/workspace-command-line;1'],
+        'esModule': 'resource:///modules/zen/ZenWorkspaceCommandLine.sys.mjs',
+        'constructor': 'ZenWorkspaceCommandLineHandler',
+        # Firefox registers its own handler as "m-browser". "b-" sorts first, so
+        # this handler gets to claim "--new-tab" before the default one does.
+        'categories': {'command-line-handler': 'b-zen-workspace'},
+        'processes': ProcessSelector.MAIN_PROCESS_ONLY,
+    },
+]

--- a/src/zen/spaces/moz.build
+++ b/src/zen/spaces/moz.build
@@ -9,4 +9,9 @@ EXTRA_JS_MODULES.zen += [
   "ZenSpaceIcons.mjs",
   "ZenSpaceManager.mjs",
   "ZenSpacesSwipe.mjs",
+  "ZenWorkspaceCommandLine.sys.mjs",
+]
+
+XPCOM_MANIFESTS += [
+  "components.conf",
 ]

--- a/src/zen/tests/spaces/browser.toml
+++ b/src/zen/tests/spaces/browser.toml
@@ -31,3 +31,5 @@ support-files = [
 ["browser_unload_all_other_spaces.js"]
 
 ["browser_workspace_bookmarks.js"]
+
+["browser_workspace_command_line.js"]

--- a/src/zen/tests/spaces/browser_workspace_command_line.js
+++ b/src/zen/tests/spaces/browser_workspace_command_line.js
@@ -1,0 +1,275 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { ZenWorkspaceCommandLineHandler } = ChromeUtils.importESModule(
+  "resource:///modules/zen/ZenWorkspaceCommandLine.sys.mjs"
+);
+
+const TEST_URL = "https://example.com/";
+const TARGET_SPACE_NAME = "CLI Target Space";
+
+/**
+ * Minimal stand-in for nsICommandLine. Flags are consumed on first read, the
+ * same way the real implementation behaves, so a handler that reads a flag
+ * twice would be caught here.
+ *
+ * @param {object} flags - Map of flag name to value, e.g. { workspace: "Work" }
+ * @returns {object} A fake command line
+ */
+function makeFakeCommandLine(flags = {}) {
+  const remaining = { ...flags };
+  return {
+    preventDefault: false,
+    handleFlagWithParam(flag) {
+      if (!(flag in remaining)) {
+        return null;
+      }
+      const value = remaining[flag];
+      delete remaining[flag];
+      return value;
+    },
+    handleFlag(flag) {
+      const present = flag in remaining;
+      delete remaining[flag];
+      return present;
+    },
+    resolveURI(spec) {
+      return Services.io.newURI(spec);
+    },
+  };
+}
+
+/**
+ * A window that records what the handler asks of it, so the error paths can be
+ * checked without touching the real tab strip.
+ *
+ * @param {object[]} spaces - The spaces the fake window knows about
+ * @returns {object} A fake browser window
+ */
+function makeFakeWindow(spaces = []) {
+  return {
+    gBrowser: {
+      addTabCalls: [],
+      addTab(uriString, options) {
+        this.addTabCalls.push({ uriString, options });
+        return {};
+      },
+    },
+    gZenWorkspaces: {
+      workspaceEnabled: true,
+      moveCalls: [],
+      lastSelectedWorkspaceTabs: {},
+      getWorkspaces() {
+        return spaces;
+      },
+      moveTabToWorkspace(tab, uuid) {
+        this.moveCalls.push({ tab, uuid });
+      },
+    },
+  };
+}
+
+/**
+ * Builds a handler pointed at the given window, recording every reported
+ * error instead of writing it to the console.
+ *
+ * @param {object|null} win - The window the handler should target
+ * @returns {object} { handler, errors }
+ */
+function makeHandler(win) {
+  const handler = new ZenWorkspaceCommandLineHandler();
+  const errors = [];
+  handler.getTargetWindow = () => win;
+  handler.reportError = message => {
+    errors.push(message);
+  };
+  return { handler, errors };
+}
+
+add_task(async function test_opens_tab_in_named_non_active_space() {
+  const originalUuid = gZenWorkspaces.activeWorkspace;
+  const target = await gZenWorkspaces.createAndSaveWorkspace(TARGET_SPACE_NAME);
+
+  // createAndSaveWorkspace() switches to the space it just made, so go back:
+  // the point of the flag is to target a space that is *not* active.
+  await gZenWorkspaces.changeWorkspaceWithID(originalUuid);
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    originalUuid,
+    "The target space is not the active one"
+  );
+
+  const { handler, errors } = makeHandler(window);
+  const cmdLine = makeFakeCommandLine({
+    workspace: TARGET_SPACE_NAME,
+    "new-tab": TEST_URL,
+  });
+
+  const tabsBefore = new Set(gBrowser.tabs);
+  handler.handle(cmdLine);
+  const newTabs = Array.from(gBrowser.tabs).filter(t => !tabsBefore.has(t));
+
+  Assert.deepEqual(errors, [], "No error was reported");
+  Assert.strictEqual(newTabs.length, 1, "Exactly one tab was opened");
+  Assert.strictEqual(
+    newTabs[0].getAttribute("zen-workspace-id"),
+    target.uuid,
+    "The tab belongs to the space named on the command line"
+  );
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    originalUuid,
+    "The active space did not change"
+  );
+  Assert.notStrictEqual(
+    gBrowser.selectedTab,
+    newTabs[0],
+    "The tab opened in the background"
+  );
+  Assert.ok(
+    cmdLine.preventDefault,
+    "Default command line handling was stopped"
+  );
+
+  BrowserTestUtils.removeTab(newTabs[0]);
+  await gZenWorkspaces.removeWorkspace(target.uuid);
+});
+
+add_task(function test_unknown_space_name_fails_loudly() {
+  const win = makeFakeWindow([
+    { uuid: "uuid-1", name: "Work", containerTabId: 0 },
+  ]);
+  const { handler, errors } = makeHandler(win);
+  const cmdLine = makeFakeCommandLine({
+    workspace: "Nope",
+    "new-tab": TEST_URL,
+  });
+
+  handler.handle(cmdLine);
+
+  Assert.strictEqual(errors.length, 1, "Exactly one error was reported");
+  Assert.ok(
+    errors[0].includes("Nope"),
+    `The error names the space that was asked for: ${errors[0]}`
+  );
+  Assert.ok(
+    errors[0].includes("Work"),
+    `The error lists the spaces that do exist: ${errors[0]}`
+  );
+  Assert.deepEqual(
+    win.gBrowser.addTabCalls,
+    [],
+    "No tab was opened, so the URL did not silently land in the active space"
+  );
+  Assert.deepEqual(win.gZenWorkspaces.moveCalls, [], "No tab was moved");
+});
+
+add_task(function test_duplicate_names_use_the_first_match() {
+  const win = makeFakeWindow([
+    { uuid: "uuid-1", name: "Twin", containerTabId: 3 },
+    { uuid: "uuid-2", name: "Twin", containerTabId: 4 },
+  ]);
+  const { handler, errors } = makeHandler(win);
+
+  handler.handle(
+    makeFakeCommandLine({ workspace: "Twin", "new-tab": TEST_URL })
+  );
+
+  Assert.deepEqual(errors, [], "A duplicated name is not an error");
+  Assert.strictEqual(win.gBrowser.addTabCalls.length, 1, "One tab was opened");
+  Assert.strictEqual(
+    win.gBrowser.addTabCalls[0].options.userContextId,
+    3,
+    "The tab uses the container of the first matching space"
+  );
+  Assert.strictEqual(
+    win.gZenWorkspaces.moveCalls[0].uuid,
+    "uuid-1",
+    "The tab went to the first space with that name"
+  );
+});
+
+add_task(function test_workspace_without_new_tab_fails_loudly() {
+  const win = makeFakeWindow([
+    { uuid: "uuid-1", name: "Work", containerTabId: 0 },
+  ]);
+  const { handler, errors } = makeHandler(win);
+  const cmdLine = makeFakeCommandLine({ workspace: "Work" });
+
+  handler.handle(cmdLine);
+
+  Assert.strictEqual(errors.length, 1, "Exactly one error was reported");
+  Assert.ok(
+    errors[0].includes("--new-tab"),
+    `The error says which flag is missing: ${errors[0]}`
+  );
+  Assert.deepEqual(win.gBrowser.addTabCalls, [], "No tab was opened");
+  Assert.ok(
+    !cmdLine.preventDefault,
+    "Startup is left alone when there was nothing to open"
+  );
+});
+
+// The handler is registered ahead of Firefox's own, so it runs on every launch.
+// Without --workspace it has to be completely inert: no flag consumed, no
+// preventDefault, nothing asked of the window.
+add_task(function test_without_workspace_flag_nothing_is_touched() {
+  const win = makeFakeWindow([
+    { uuid: "uuid-1", name: "Work", containerTabId: 0 },
+  ]);
+  const { handler, errors } = makeHandler(win);
+  const cmdLine = makeFakeCommandLine({
+    "new-tab": TEST_URL,
+    "new-window": TEST_URL,
+    "private-window": TEST_URL,
+    url: TEST_URL,
+  });
+
+  handler.handle(cmdLine);
+
+  Assert.deepEqual(errors, [], "Nothing was reported");
+  Assert.ok(!cmdLine.preventDefault, "Default handling was left alone");
+  Assert.deepEqual(win.gBrowser.addTabCalls, [], "No tab was opened");
+  Assert.strictEqual(
+    cmdLine.handleFlagWithParam("new-tab"),
+    TEST_URL,
+    "--new-tab is still there for the default handler"
+  );
+  Assert.strictEqual(
+    cmdLine.handleFlagWithParam("new-window"),
+    TEST_URL,
+    "--new-window is untouched"
+  );
+  Assert.strictEqual(
+    cmdLine.handleFlagWithParam("private-window"),
+    TEST_URL,
+    "--private-window is untouched"
+  );
+  Assert.strictEqual(
+    cmdLine.handleFlagWithParam("url"),
+    TEST_URL,
+    "-url is untouched"
+  );
+});
+
+add_task(function test_no_arguments_at_all_is_inert() {
+  const { handler, errors } = makeHandler(makeFakeWindow());
+  const cmdLine = makeFakeCommandLine();
+
+  handler.handle(cmdLine);
+
+  Assert.deepEqual(errors, [], "A bare launch reports nothing");
+  Assert.ok(!cmdLine.preventDefault, "A bare launch is not interfered with");
+});
+
+add_task(function test_no_browser_window_fails_loudly() {
+  const { handler, errors } = makeHandler(null);
+
+  handler.handle(
+    makeFakeCommandLine({ workspace: "Work", "new-tab": TEST_URL })
+  );
+
+  Assert.strictEqual(errors.length, 1, "Exactly one error was reported");
+});


### PR DESCRIPTION
Adds `--workspace <name>` so a URL can be opened into a named space from the command line.
Discussion: #14786

```
zen --workspace "Work" --new-tab https://example.com
```

`--new-tab` currently always targets whichever space happens to be active, so there is no
way to place a tab in a specific space from a script.

### Behaviour

- Opens in the **background** of the target space, without switching to it. `#openInWorkspace`
  never calls `changeWorkspace`; it only sets `lastSelectedWorkspaceTabs[uuid]`, which decides
  the focused tab if and when the user switches there themselves. Switching would drag the
  user through one awaited animation per tab and serialise a batch.
- Unknown name reports an error, lists the known spaces, and opens nothing. It never falls
  back to the active space.
- Duplicate names: first match wins, stated in `helpInfo`.
- No running window with spaces enabled reports an error and creates no tab. One expression
  covers no window, no `gZenWorkspaces`, and spaces disabled (private windows, popups).

### Notes for review

- Implemented as an `nsICommandLineHandler` via `components.conf`, not a Firefox source patch.
- It registers as `b-zen-workspace` so it is asked before Firefox's `m-browser` and can claim
  `--new-tab`. This is the one design decision I would most like a second opinion on. When
  `--workspace` is absent it consumes nothing and returns before touching `preventDefault`, so
  `--new-window`, `-url`, `-private-window`, bare URLs and no-args are untouched - there is a
  test pinning exactly that. If handler ordering ever changed, the failure mode is the
  `--workspace`-without-`--new-tab` branch: a loud error and no tab, never a tab misfiled into
  the wrong space.
- The alternative was a self-contained flag carrying the URL, e.g. `--zen-open-in-space
  "Name=URL"`, which needs no interception. Rejected because `=` is legal in both space names
  and URLs, and because it would have to reimplement `--new-tab`'s URI resolution and then stay
  in sync with it. Swapping to that approach is about ten lines if you would rather not depend
  on registration order.
- `userContextId` is passed explicitly. Without it, `getContextIdIfNeeded` hands the tab the
  *active* space's container, so it would land in the right space with the wrong container.

### Tests

`src/zen/tests/spaces/browser_workspace_command_line.js`, seven tasks, including a tab opening
into a named non-active space (asserting `activeWorkspace` is unchanged), the unknown-name and
no-window error paths, duplicate names, and one that passes `--new-tab`, `--new-window`,
`--private-window` and `-url` together and re-reads all four to prove none were consumed.

Unexecuted - a build needs 40-60GB and I do not have the disk, so these rely on CI. Two things
I could not settle by reading: whether handler ordering resolves as the `b-` prefix implies, and
whether `moveTabToWorkspace` always finds a DOM section for the target space in a long-running
window.
