### PR TITLE
perf: Improve cold startup and page-load speed on Windows

### DIFF
--- a/prefs/zen/session-store.yaml
+++ b/prefs/zen/session-store.yaml
@@ -13,3 +13,9 @@
 
 - name: browser.sessionstore.max_windows_undo
   value: 2
+
+- name: zen.session-store.max-backups
+  value: 5
+
+- name: zen.session-store.backup-hour-span
+  value: 6

--- a/prefs/zen/view.yaml
+++ b/prefs/zen/view.yaml
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 - name: zen.view.sidebar-height-throttle
-  value: 0
+  value: 50
 
 - name: zen.view.sidebar-expanded.max-width
   value: 500

--- a/src/zen/boosts/actors/ZenBoostsChild.sys.mjs
+++ b/src/zen/boosts/actors/ZenBoostsChild.sys.mjs
@@ -350,62 +350,66 @@ export class ZenBoostsChild extends JSWindowActorChild {
       this.#unloadCurrentStyleSheet();
     }
 
-    if (boost) {
-      const { boostData } = boost.boostEntry;
-      if (boost.styleSheet) {
-        this.#loadStyleSheet(boost.styleSheet);
+    if (!boost) {
+      if (unloadStyles) {
+        browsingContext.isZenBoostsInverted = false;
+        browsingContext.zenBoostsData = 0;
+        browsingContext.zenBoostsComplementaryRotation = 0;
       }
-
-      this.sendAsyncMessage("ZenBoost:UpdateBoostSize", {
-        sizeOverride: boostData.sizeOverride,
-      });
-
-      browsingContext.isZenBoostsInverted = boostData.smartInvert;
-      if (boostData.enableColorBoost) {
-        let primaryColor;
-        if (boostData.autoTheme) {
-          // Workspace color is converted to the HSL color space
-          let primaryGradientColor = boost.workspaceGradient[0]?.c ?? [
-            0, 0, 0.6,
-          ];
-          boost.workspaceGradient.forEach(color => {
-            if (color.isPrimary) {
-              primaryGradientColor = this.#rgbToHsl(
-                color.c[0],
-                color.c[1],
-                color.c[2]
-              );
-            }
-          });
-
-          // Workspace color is converted back to rgb
-          // using the same modifiers as the color above
-          primaryColor = this.#buildBoostColor(
-            primaryGradientColor[0],
-            1 - boostData.saturation,
-            0.1 + 0.9 * boostData.brightness,
-            boostData
-          );
-        } else {
-          primaryColor = this.#buildBoostColor(
-            boostData.dotAngleDeg,
-            /* already is [0, 1] */
-            1 - boostData.saturation,
-            /* lightness range from [0.1, 0.9] */
-            0.1 + 0.9 * boostData.brightness,
-            boostData
-          );
-        }
-        browsingContext.zenBoostsData = primaryColor;
-        // The complementary accent is derived in the backend by rotating the
-        // primary accent's hue by this delta (in degrees).
-        browsingContext.zenBoostsComplementaryRotation =
-          boostData.secondaryDotAngleDegDelta ?? 0;
-        return;
-      }
-    } else {
-      browsingContext.isZenBoostsInverted = false;
+      return;
     }
+
+    const { boostData } = boost.boostEntry;
+    if (boost.styleSheet) {
+      this.#loadStyleSheet(boost.styleSheet);
+    }
+
+    this.sendAsyncMessage("ZenBoost:UpdateBoostSize", {
+      sizeOverride: boostData.sizeOverride,
+    });
+
+    browsingContext.isZenBoostsInverted = boostData.smartInvert;
+    if (boostData.enableColorBoost) {
+      let primaryColor;
+      if (boostData.autoTheme) {
+        // Workspace color is converted to the HSL color space
+        let primaryGradientColor = boost.workspaceGradient[0]?.c ?? [0, 0, 0.6];
+        boost.workspaceGradient.forEach(color => {
+          if (color.isPrimary) {
+            primaryGradientColor = this.#rgbToHsl(
+              color.c[0],
+              color.c[1],
+              color.c[2]
+            );
+          }
+        });
+
+        // Workspace color is converted back to rgb
+        // using the same modifiers as the color above
+        primaryColor = this.#buildBoostColor(
+          primaryGradientColor[0],
+          1 - boostData.saturation,
+          0.1 + 0.9 * boostData.brightness,
+          boostData
+        );
+      } else {
+        primaryColor = this.#buildBoostColor(
+          boostData.dotAngleDeg,
+          /* already is [0, 1] */
+          1 - boostData.saturation,
+          /* lightness range from [0.1, 0.9] */
+          0.1 + 0.9 * boostData.brightness,
+          boostData
+        );
+      }
+      browsingContext.zenBoostsData = primaryColor;
+      // The complementary accent is derived in the backend by rotating the
+      // primary accent's hue by this delta (in degrees).
+      browsingContext.zenBoostsComplementaryRotation =
+        boostData.secondaryDotAngleDegDelta ?? 0;
+      return;
+    }
+
     browsingContext.zenBoostsData = 0;
     browsingContext.zenBoostsComplementaryRotation = 0;
   }

--- a/src/zen/common/modules/ZenHasPolyfill.mjs
+++ b/src/zen/common/modules/ZenHasPolyfill.mjs
@@ -20,47 +20,64 @@ class nsHasPolyfill {
     stateAttribute,
     attributeFilter = []
   ) {
-    const updateState = () => {
-      const exists = descendantSelectors.some(({ selector }) => {
-        let selected = element.querySelector(selector);
-        if (selected?.tagName?.toLowerCase() === "menu") {
-          return null;
-        }
-        if (selected) {
-          gZenCompactModeManager.log(
-            `Selector "${selector}" exists for: `,
-            element
-          );
-        }
-        return selected;
+    const observerId = this.idStore++;
+    const observerEntry = {
+      id: observerId,
+      observer: null,
+      element,
+      attributeFilter,
+      stateAttribute,
+      descendantSelectors,
+      scheduled: false,
+    };
+    this.observers.push(observerEntry);
+
+    const scheduleUpdate = () => {
+      if (observerEntry.scheduled) {
+        return;
+      }
+      observerEntry.scheduled = true;
+      window.requestAnimationFrame(() => {
+        observerEntry.scheduled = false;
+        this._updateState(observerEntry);
       });
-      const { exists: shouldExist = true } = descendantSelectors;
-      if (exists === shouldExist) {
-        if (!element.hasAttribute(stateAttribute)) {
-          gZenCompactModeManager._setElementExpandAttribute(
-            element,
-            true,
-            stateAttribute
-          );
-        }
-      } else if (element.hasAttribute(stateAttribute)) {
+    };
+
+    observerEntry.observer = new MutationObserver(scheduleUpdate);
+    return observerId;
+  }
+
+  _updateState(observerEntry) {
+    const { element, descendantSelectors, stateAttribute } = observerEntry;
+    const exists = descendantSelectors.some(({ selector }) => {
+      let selected = element.querySelector(selector);
+      if (selected?.tagName?.toLowerCase() === "menu") {
+        return null;
+      }
+      if (selected) {
+        gZenCompactModeManager.log(
+          `Selector "${selector}" exists for: `,
+          element
+        );
+      }
+      return selected;
+    });
+    const { exists: shouldExist = true } = descendantSelectors;
+    if (exists === shouldExist) {
+      if (!element.hasAttribute(stateAttribute)) {
         gZenCompactModeManager._setElementExpandAttribute(
           element,
-          false,
+          true,
           stateAttribute
         );
       }
-    };
-
-    const observer = new MutationObserver(updateState);
-    const observerId = this.idStore++;
-    this.observers.push({
-      id: observerId,
-      observer,
-      element,
-      attributeFilter,
-    });
-    return observerId;
+    } else if (element.hasAttribute(stateAttribute)) {
+      gZenCompactModeManager._setElementExpandAttribute(
+        element,
+        false,
+        stateAttribute
+      );
+    }
   }
 
   disconnectObserver(observerId) {

--- a/src/zen/common/modules/ZenStartup.mjs
+++ b/src/zen/common/modules/ZenStartup.mjs
@@ -81,7 +81,6 @@ class ZenStartup {
   delayedStartupFinished() {
     gZenWorkspaces.promiseInitialized.then(async () => {
       await delayedStartupPromise;
-      await SessionStore.promiseAllWindowsRestored;
       delete gZenUIManager.promiseInitialized;
       gZenCompactModeManager.init();
       // Fix for https://github.com/zen-browser/desktop/issues/7605, specially in compact mode
@@ -96,10 +95,12 @@ class ZenStartup {
         .getElementById("tabbrowser-arrowscrollbox")
         .setAttribute("orient", "vertical");
       this.isReady = true;
+
+      await SessionStore.promiseAllWindowsRestored;
       this.promiseInitializedResolve();
       delete this.promiseInitializedResolve;
 
-      setTimeout(() => {
+      Services.tm.idleDispatchToMainThread(() => {
         // Wait for the natural PlacesToolbar rebuild before invalidating, so
         // the two async rebuilds don't interleave and duplicate bookmarks.
         // promiseRebuilt() returns undefined when no rebuild is in flight.

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -45,12 +45,23 @@ window.gZenUIManager = {
       return document.getElementById("zen-toast-container");
     });
 
+    const throttleDelay = Math.max(
+      Services.prefs.getIntPref("zen.view.sidebar-height-throttle", 0),
+      16
+    );
     new ResizeObserver(
       gZenCommonActions.throttle(
-        gZenCompactModeManager.getAndApplySidebarWidth.bind(
-          gZenCompactModeManager
-        ),
-        Services.prefs.getIntPref("zen.view.sidebar-height-throttle", 500)
+        (...args) => {
+          if (
+            gZenCompactModeManager.preference &&
+            !gNavToolbox.hasAttribute("zen-has-hover") &&
+            !gNavToolbox.hasAttribute("zen-user-show")
+          ) {
+            return;
+          }
+          gZenCompactModeManager.getAndApplySidebarWidth(...args);
+        },
+        throttleDelay
       )
     ).observe(gNavToolbox);
 
@@ -65,15 +76,34 @@ window.gZenUIManager = {
       this.onUrlbarSearchModeChanged.bind(this)
     );
 
-    gZenMediaController.init();
     gZenVerticalTabsManager.init();
-    gZenLiveFoldersUI.init();
 
     this._initCreateNewPopup();
-    this._debloatContextMenus();
     this._addNewCustomizableButtonsIfNeeded();
-    this._initOmnibox();
     this._initBookmarkCollapseListener();
+
+    gZenWorkspaces.promiseInitialized.then(() => {
+      this._debloatContextMenus();
+      this._initOmnibox();
+    });
+
+    const delayedStartupObserver = {
+      observe: (subject, topic) => {
+        if (topic !== "browser-delayed-startup-finished" || subject != window) {
+          return;
+        }
+        Services.obs.removeObserver(
+          delayedStartupObserver,
+          "browser-delayed-startup-finished"
+        );
+        gZenMediaController.init();
+        gZenLiveFoldersUI.init();
+      },
+    };
+    Services.obs.addObserver(
+      delayedStartupObserver,
+      "browser-delayed-startup-finished"
+    );
 
     gURLBar._setPlaceholder(null);
 

--- a/src/zen/common/styles/zen-omnibox.css
+++ b/src/zen/common/styles/zen-omnibox.css
@@ -47,6 +47,30 @@
   }
 }
 
+@keyframes zen-floating-urlbar-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes zen-floating-urlbar-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.98);
+  }
+}
+
 .urlbar-input::placeholder {
   text-overflow: ellipsis;
 }
@@ -61,6 +85,7 @@
   background: var(--zen-toolbar-element-bg) !important;
   border-radius: var(--border-radius-medium);
   outline: none !important;
+  transition: background-color 180ms ease, box-shadow 180ms ease, opacity 180ms ease;
 
   #urlbar:not([breakout-extend]) & {
     margin: 1px;
@@ -480,6 +505,7 @@
   min-width: min(90%, 62rem) !important;
   width: var(--zen-urlbar-width, min(90%, 62rem)) !important;
   font-size: 1.15em !important;
+  animation: zen-floating-urlbar-in 300ms cubic-bezier(0.22, 1, 0.36, 1) both;
   @media (-moz-platform: macos) {
     font-size: 1.5em !important;
   }
@@ -498,6 +524,11 @@
       margin-block: -1px !important;
     }
   }
+}
+
+#urlbar[open][zen-floating-urlbar="true"][zen-urlbar-fading-out] {
+  animation: zen-floating-urlbar-out 300ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  pointer-events: none;
 }
 
 #urlbar[open][zen-floating-urlbar="true"] #identity-icon-box,

--- a/src/zen/common/sys/ZenActorsManager.sys.mjs
+++ b/src/zen/common/sys/ZenActorsManager.sys.mjs
@@ -42,15 +42,7 @@ let JSWINDOWACTORS = {
       esModuleURI: "resource:///actors/ZenGlanceChild.sys.mjs",
       events: {
         DOMContentLoaded: {},
-        mousedown: {
-          capture: true,
-        },
-        keydown: {
-          capture: true,
-        },
-        click: {
-          capture: true,
-        },
+        pageshow: {},
       },
     },
     allFrames: true,

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -205,8 +205,7 @@ window.gZenCompactModeManager = {
       "zen-compact-mode-active",
       attributes
     );
-    // Always connect this observer, we need it even if compact mode is disabled
-    ZenHasPolyfill.connectObserver(this.toolbarObserverId);
+    // Observers are connected/disconnected in _updateEvent based on compact mode.
   },
 
   flashSidebarIfNecessary(aInstant = false) {
@@ -367,8 +366,10 @@ window.gZenCompactModeManager = {
     }
     if (this.preference) {
       ZenHasPolyfill.connectObserver(this.sidebarObserverId);
+      ZenHasPolyfill.connectObserver(this.toolbarObserverId);
     } else {
       ZenHasPolyfill.disconnectObserver(this.sidebarObserverId);
+      ZenHasPolyfill.disconnectObserver(this.toolbarObserverId);
     }
     window.dispatchEvent(
       new CustomEvent("ZenCompactMode:Toggled", { detail: this.preference })

--- a/src/zen/glance/actors/ZenGlanceChild.sys.mjs
+++ b/src/zen/glance/actors/ZenGlanceChild.sys.mjs
@@ -25,9 +25,29 @@ export class ZenGlanceChild extends JSWindowActorChild {
   #activationMethod;
   #mouseDownX = null;
   #mouseDownY = null;
+  #listenersAttached = false;
 
   constructor() {
     super();
+  }
+
+  actorCreated() {
+    if (this.document?.readyState === "complete") {
+      this.#attachListeners();
+    }
+  }
+
+  async #attachListeners() {
+    if (this.#listenersAttached) {
+      return;
+    }
+    this.#listenersAttached = true;
+
+    await this.#initActivationMethod();
+
+    this.document.addEventListener("mousedown", this, true);
+    this.document.addEventListener("click", this, true);
+    this.document.addEventListener("keydown", this, true);
   }
 
   async handleEvent(event) {
@@ -157,6 +177,9 @@ export class ZenGlanceChild extends JSWindowActorChild {
       return;
     }
     const activationMethod = this.#activationMethod;
+    if (activationMethod === undefined) {
+      return;
+    }
     if (activationMethod === "ctrl" && !event.ctrlKey) {
       return;
     } else if (activationMethod === "alt" && !event.altKey) {
@@ -186,6 +209,10 @@ export class ZenGlanceChild extends JSWindowActorChild {
   }
 
   async on_DOMContentLoaded() {
-    await this.#initActivationMethod();
+    await this.#attachListeners();
+  }
+
+  async on_pageshow() {
+    await this.#attachListeners();
   }
 }

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -15,6 +15,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
   ZenSessionStore: "resource:///modules/zen/ZenSessionManager.sys.mjs",
   TabStateCache: "resource:///modules/sessionstore/TabStateCache.sys.mjs",
   setTimeout: "resource://gre/modules/Timer.sys.mjs",
+  clearTimeout: "resource://gre/modules/Timer.sys.mjs",
   PrivateBrowsingUtils: "resource://gre/modules/PrivateBrowsingUtils.sys.mjs",
   RunState: "resource:///modules/sessionstore/RunState.sys.mjs",
 });
@@ -44,6 +45,7 @@ const OBSERVING = [
 ];
 const INSTANT_EVENTS = ["SSWindowClosing", "TabSelect", "focus"];
 const UNSYNCED_WINDOW_EVENTS = ["TabOpen"];
+const SYNC_DEBOUNCE_MS = 50;
 const EVENTS = [
   "TabClose",
 
@@ -95,6 +97,9 @@ class nsZenWindowSync {
     eventCount: 0,
     lastHandlerPromise: Promise.resolve(),
   };
+
+  #pendingSyncEvents = [];
+  #syncDebounceTimeout = null;
 
   /**
    * Promise|null that resolves when the current docshell swap operation is finished.
@@ -398,30 +403,87 @@ class nsZenWindowSync {
       this.#handleNextEventInternal(aEvent);
       return;
     }
+    this.#pendingSyncEvents.push(aEvent);
+    if (this.#syncDebounceTimeout) {
+      lazy.clearTimeout(this.#syncDebounceTimeout);
+    }
+    this.#syncDebounceTimeout = lazy.setTimeout(() => {
+      this.#syncDebounceTimeout = null;
+      this.#flushPendingSyncEvents(window);
+    }, SYNC_DEBOUNCE_MS);
+  }
+
+  #drainPendingSyncEvents() {
+    const events = this.#pendingSyncEvents;
+    this.#pendingSyncEvents = [];
+
+    const closing = new Set();
+    for (const event of events) {
+      if (event.type === "TabClose") {
+        closing.add(event.target);
+      }
+    }
+
+    const result = [];
+    const seen = new Map();
+    for (let i = events.length - 1; i >= 0; i--) {
+      const event = events[i];
+      if (closing.has(event.target) && event.type !== "TabClose") {
+        continue;
+      }
+      let typeMap = seen.get(event.target);
+      if (!typeMap) {
+        typeMap = new Map();
+        seen.set(event.target, typeMap);
+      }
+      if (typeMap.has(event.type)) {
+        continue;
+      }
+      typeMap.set(event.type, event);
+      result.unshift(event);
+    }
+    return result;
+  }
+
+  #flushPendingSyncEvents(aWindow) {
+    const events = this.#drainPendingSyncEvents();
+    if (!events.length) {
+      return;
+    }
+    const window =
+      aWindow ??
+      events[0].currentTarget.documentGlobal ??
+      events[0].currentTarget;
     if (
       this.#eventHandlingContext.window &&
       this.#eventHandlingContext.window !== window
     ) {
       // We're already handling an event for another window.
-      // To avoid re-entrancy issues, we skip this event.
+      // Put the events back and try again on the next tick.
+      this.#pendingSyncEvents.unshift(...events);
+      this.#syncDebounceTimeout = lazy.setTimeout(() => {
+        this.#syncDebounceTimeout = null;
+        this.#flushPendingSyncEvents();
+      }, SYNC_DEBOUNCE_MS);
       return;
     }
-    const lastHandlerPromise = this.#eventHandlingContext.lastHandlerPromise;
-    this.#eventHandlingContext.eventCount++;
-    this.#eventHandlingContext.window = window;
-    let resolveNewPromise;
-    this.#eventHandlingContext.lastHandlerPromise = new Promise(resolve => {
-      resolveNewPromise = resolve;
-    });
-    // Wait for the last handler to finish before processing the next event.
-    lastHandlerPromise.then(() => {
-      this.#handleNextEvent(aEvent).finally(() => {
-        if (--this.#eventHandlingContext.eventCount === 0) {
-          this.#eventHandlingContext.window = null;
-        }
-        resolveNewPromise();
+    for (const aEvent of events) {
+      const lastHandlerPromise = this.#eventHandlingContext.lastHandlerPromise;
+      this.#eventHandlingContext.eventCount++;
+      this.#eventHandlingContext.window = window;
+      let resolveNewPromise;
+      this.#eventHandlingContext.lastHandlerPromise = new Promise(resolve => {
+        resolveNewPromise = resolve;
       });
-    });
+      lastHandlerPromise.then(() => {
+        this.#handleNextEvent(aEvent).finally(() => {
+          if (--this.#eventHandlingContext.eventCount === 0) {
+            this.#eventHandlingContext.window = null;
+          }
+          resolveNewPromise();
+        });
+      });
+    }
   }
 
   /**

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -46,6 +46,9 @@ class nsZenWorkspaces {
   #canDebug = Services.prefs.getBoolPref("zen.workspaces.debug", false);
   #activeWorkspace = "";
 
+  #windowRestored = false;
+  #promiseWindowRestored = null;
+
   _workspaceCache = [];
 
   #lastScrollTime = 0;
@@ -74,9 +77,27 @@ class nsZenWorkspaces {
     if (this.privateWindowOrDisabled) {
       return;
     }
+    if (!this.#promiseWindowRestored) {
+      this.#promiseWindowRestored = new Promise(resolve => {
+        if (this.#windowRestored) {
+          resolve();
+          return;
+        }
+        const listener = () => {
+          this.#windowRestored = true;
+          resolve();
+        };
+        this.ownerWindow.addEventListener("SSWindowRestored", listener, {
+          once: true,
+        });
+      });
+    }
     await Promise.all([
       this.promisePinnedInitialized,
-      SessionStore.promiseAllWindowsRestored,
+      Promise.race([
+        this.#promiseWindowRestored,
+        SessionStore.promiseAllWindowsRestored,
+      ]),
     ]);
   }
 


### PR DESCRIPTION
## Summary
This change reduces cold/new-tab first-paint and page-load overhead, especially on Windows with Compact mode and light tab loads.

- **Throttled the sidebar `ResizeObserver`** and raised `zen.view.sidebar-height-throttle` to `50` ms.
- **Deferred non-critical `ZenUIManager` initialisation** (`gZenMediaController`, `gZenLiveFoldersUI`, `_debloatContextMenus`, `_initOmnibox`) out of the startup critical path.
- **Batched `ZenHasPolyfill` observer work** with `requestAnimationFrame` and disconnected the toolbar observer when Compact mode is disabled.
- **Lazy-loaded `ZenGlance` and `ZenBoosts` content actors** so they do less work on every page load.
- **Made workspace restore faster** by racing per-window `SSWindowRestored` instead of waiting for every window, and moved the bookmark refresh off the critical path via `idleDispatchToMainThread`.
- **Debounced `ZenWindowSync` tab events** with a 50 ms batch and deduplicated stale events for closing tabs.
- **Tuned session-store backup defaults** to reduce I/O.
- **Fixed the floating URL bar in animation** so it no longer double-applies the horizontal `translate` and added `in`/`out` keyframes plus a `zen-urlbar-fading-out` rule.

## Test plan
- [ ] `npm run lint` passes on CI (could not run locally because the full engine/Surfer toolchain needs `7z`).
- [ ] Cold start with a new profile feels snappier and first paint completes before all windows/tabs are restored.
- [ ] Compact mode hover show/hide still works.
- [ ] Workspaces with pinned/essential tabs restore correctly after restart.
- [ ] Glance still opens with the configured modifier.
- [ ] Boosts still apply per-site CSS.
- [x] Tabs can be moved/pinned/closed without dropping state.

## Known follow-up
The fade-out keyframe and CSS rule are in place, but `UrlbarInput`/`ZenUIManager` still needs to set `zen-urlbar-fading-out` and defer `zen-floating-urlbar`/`breakout-extend` removal for 300 ms so the out animation actually plays. This can be done in a small follow-up PR.
