### PR TITLE
gh-11210: Fix non-contiguous tab indices from browser.tabs.query

### DIFF
--- a/src/browser/components/extensions/parent/.eslintrc-mjs.patch
+++ b/src/browser/components/extensions/parent/.eslintrc-mjs.patch
@@ -1,0 +1,12 @@
+diff --git a/browser/components/extensions/parent/.eslintrc.mjs b/browser/components/extensions/parent/.eslintrc.mjs
+index 763fe7b7341488f2875cbee4e15f91706d4add80...e27ca96854c7b8d94498a9821913a23aab309ef7 100644
+--- a/browser/components/extensions/parent/.eslintrc.mjs
++++ b/browser/components/extensions/parent/.eslintrc.mjs
+@@ -22,6 +22,7 @@ export default [
+         tabTracker: true,
+         waitForTabLoaded: true,
+         windowTracker: true,
++        zenGetNativeTabAtLogicalIndex: true,
+ 
+         // NOTE: Unlike ext-browser.js (and ext-toolkit.js, ext-tabs-base.js), the
+         // files mentioned below are not loaded unconditionally. In practice,

--- a/src/browser/components/extensions/parent/ext-browser-js.patch
+++ b/src/browser/components/extensions/parent/ext-browser-js.patch
@@ -1,35 +1,31 @@
 diff --git a/browser/components/extensions/parent/ext-browser.js b/browser/components/extensions/parent/ext-browser.js
-index 91adc6bc3649af47745818e6f9d00cbbdffc35a5..cd83459693067211f030b6354b839a555df2e822 100644
+index 91adc6bc3649af47745818e6f9d00cbbdffc35a5...4ff10dc750e037dbc9c342f616b4132ee6ef2865 100644
 --- a/browser/components/extensions/parent/ext-browser.js
 +++ b/browser/components/extensions/parent/ext-browser.js
-@@ -27,6 +27,59 @@ function isPrivateTab(nativeTab) {
+@@ -27,6 +27,40 @@ function isPrivateTab(nativeTab) {
    return PrivateBrowsingUtils.isBrowserPrivate(nativeTab.linkedBrowser);
  }
  
-+// Zen hides placeholder "empty tabs" (the workspace New Tab button and one
-+// per folder) from extensions, so extension-facing indices are "logical"
-+// indices that exclude them, translated to physical gBrowser.tabs positions
-+// at the boundaries below.
++// Zen hides placeholder "empty tabs" (workspace New Tab button, one per
++// folder) from extensions; _zenLogicalIndex holds the extension-facing index.
 +function zenIsEmptyTab(nativeTab) {
-+  return (
-+    nativeTab && nativeTab.hasAttribute && nativeTab.hasAttribute("zen-empty-tab")
-+  );
++  return nativeTab?.hasAttribute("zen-empty-tab");
 +}
 +
-+// Extension-visible index of nativeTab: count of non-empty tabs before it.
-+function zenLogicalTabIndex(nativeTab) {
-+  let gBrowser = nativeTab.documentGlobal.gBrowser;
++// Recompute _zenLogicalIndex for every tab; skip the closing tab, which is
++// still listed when TabClose fires.
++function zenSyncTabIndices(gBrowser, excludedTab) {
++  // gBrowser.tabs is cached and can be stale at event time.
++  gBrowser.tabContainer._invalidateCachedTabs();
 +  let logical = 0;
-+  let pos = nativeTab._tPos;
-+  for (let i = 0; i < pos; i++) {
-+    if (!zenIsEmptyTab(gBrowser.tabs[i])) {
-+      logical++;
++  for (let tab of gBrowser.tabs) {
++    if (tab === excludedTab) {
++      continue;
 +    }
++    tab._zenLogicalIndex = zenIsEmptyTab(tab) ? -1 : logical++;
 +  }
-+  return logical;
 +}
 +
-+// The nativeTab at the given logical index in gBrowser, or undefined.
 +function zenGetNativeTabAtLogicalIndex(gBrowser, logicalIndex) {
 +  let seen = 0;
 +  for (let tab of gBrowser.tabs) {
@@ -44,20 +40,18 @@ index 91adc6bc3649af47745818e6f9d00cbbdffc35a5..cd83459693067211f030b6354b839a55
 +  return undefined;
 +}
 +
-+// Map a logical index from an extension to a physical tab index for
-+// gBrowser.addTab / moveTabTo. -1 and out-of-range values map to the end.
-+function zenLogicalIndexToTabIndex(gBrowser, logicalIndex) {
-+  if (logicalIndex === -1) {
-+    return gBrowser.tabs.length;
-+  }
-+  let tab = zenGetNativeTabAtLogicalIndex(gBrowser, logicalIndex);
-+  return tab ? tab._tPos : gBrowser.tabs.length;
-+}
-+
  /* eslint-disable mozilla/balanced-listeners */
  extensions.on("uninstalling", (msg, extension) => {
    if (extension.uninstallURL) {
-@@ -362,6 +415,9 @@ class TabTracker extends TabTrackerBase {
+@@ -348,6 +382,7 @@ class TabTracker extends TabTrackerBase {
+ 
+     windowTracker.addListener("TabClose", this);
+     windowTracker.addListener("TabOpen", this);
++    windowTracker.addListener("TabMove", this);
+     windowTracker.addListener("TabSelect", this);
+     windowTracker.addListener("TabMultiSelect", this);
+     windowTracker.addOpenListener(this._handleWindowOpen);
+@@ -362,6 +397,9 @@ class TabTracker extends TabTrackerBase {
    }
  
    getId(nativeTab) {
@@ -67,7 +61,7 @@ index 91adc6bc3649af47745818e6f9d00cbbdffc35a5..cd83459693067211f030b6354b839a55
      let id = this._tabs.get(nativeTab);
      if (id) {
        return id;
-@@ -395,6 +451,9 @@ class TabTracker extends TabTrackerBase {
+@@ -395,6 +433,9 @@ class TabTracker extends TabTrackerBase {
      if (nativeTab.documentGlobal.closed) {
        throw new Error("Cannot attach ID to a tab in a closed window.");
      }
@@ -77,31 +71,56 @@ index 91adc6bc3649af47745818e6f9d00cbbdffc35a5..cd83459693067211f030b6354b839a55
  
      this._tabs.set(nativeTab, id);
      this._tabIds.set(id, nativeTab);
-@@ -846,7 +905,13 @@ class Tab extends TabBase {
+@@ -531,6 +572,7 @@ class TabTracker extends TabTrackerBase {
+ 
+     switch (event.type) {
+       case "TabOpen": {
++        zenSyncTabIndices(nativeTab.documentGlobal.gBrowser);
+         let { adoptedTab } = event.detail;
+         if (adoptedTab) {
+           // This tab is being created to adopt a tab from a different window.
+@@ -564,6 +606,7 @@ class TabTracker extends TabTrackerBase {
+       }
+ 
+       case "TabClose": {
++        zenSyncTabIndices(nativeTab.documentGlobal.gBrowser, nativeTab);
+         let { adoptedBy } = event.detail;
+         if (adoptedBy) {
+           // This tab is being closed because it was adopted by a new window.
+@@ -599,6 +642,10 @@ class TabTracker extends TabTrackerBase {
+           });
+         }
+         break;
++
++      case "TabMove":
++        zenSyncTabIndices(event.target.documentGlobal.gBrowser);
++        break;
+     }
+   }
+ 
+@@ -846,7 +893,11 @@ class Tab extends TabBase {
    }
  
    get index() {
 -    return this.nativeTab._tPos;
-+    // Report the logical index (excluding empty tabs) so query() results
-+    // have contiguous indices 0..N-1.
-+    if (zenIsEmptyTab(this.nativeTab)) {
-+      return -1;
++    let { nativeTab } = this;
++    if (nativeTab._zenLogicalIndex === undefined) {
++      zenSyncTabIndices(nativeTab.documentGlobal.gBrowser);
 +    }
-+    return zenLogicalTabIndex(this.nativeTab);
++    return nativeTab._zenLogicalIndex;
    }
  
    get mutedInfo() {
-@@ -1197,7 +1262,9 @@ class Window extends WindowBase {
+@@ -1197,7 +1248,7 @@ class Window extends WindowBase {
    }
  
    getTabAtIndex(index) {
 -    let nativeTab = this.window.gBrowser.tabs[index];
-+    // Translate the logical index to the physical tab, skipping empty tabs.
 +    let nativeTab = zenGetNativeTabAtLogicalIndex(this.window.gBrowser, index);
      if (nativeTab) {
        return this.extension.tabManager.getWrapper(nativeTab);
      }
-@@ -1262,6 +1329,10 @@ class TabManager extends TabManagerBase {
+@@ -1262,6 +1313,10 @@ class TabManager extends TabManagerBase {
    }
  
    canAccessTab(nativeTab) {

--- a/src/browser/components/extensions/parent/ext-browser-js.patch
+++ b/src/browser/components/extensions/parent/ext-browser-js.patch
@@ -1,29 +1,112 @@
 diff --git a/browser/components/extensions/parent/ext-browser.js b/browser/components/extensions/parent/ext-browser.js
-index 91adc6bc3649af47745818e6f9d00cbbdffc35a5..e221b077dbfbe20c8696732f003bd5809d761a02 100644
+index 91adc6bc3649af47745818e6f9d00cbbdffc35a5..cd83459693067211f030b6354b839a555df2e822 100644
 --- a/browser/components/extensions/parent/ext-browser.js
 +++ b/browser/components/extensions/parent/ext-browser.js
-@@ -362,6 +362,7 @@ class TabTracker extends TabTrackerBase {
+@@ -27,6 +27,59 @@ function isPrivateTab(nativeTab) {
+   return PrivateBrowsingUtils.isBrowserPrivate(nativeTab.linkedBrowser);
+ }
+ 
++// Zen hides placeholder "empty tabs" (the workspace New Tab button and one
++// per folder) from extensions, so extension-facing indices are "logical"
++// indices that exclude them, translated to physical gBrowser.tabs positions
++// at the boundaries below.
++function zenIsEmptyTab(nativeTab) {
++  return (
++    nativeTab && nativeTab.hasAttribute && nativeTab.hasAttribute("zen-empty-tab")
++  );
++}
++
++// Extension-visible index of nativeTab: count of non-empty tabs before it.
++function zenLogicalTabIndex(nativeTab) {
++  let gBrowser = nativeTab.documentGlobal.gBrowser;
++  let logical = 0;
++  let pos = nativeTab._tPos;
++  for (let i = 0; i < pos; i++) {
++    if (!zenIsEmptyTab(gBrowser.tabs[i])) {
++      logical++;
++    }
++  }
++  return logical;
++}
++
++// The nativeTab at the given logical index in gBrowser, or undefined.
++function zenGetNativeTabAtLogicalIndex(gBrowser, logicalIndex) {
++  let seen = 0;
++  for (let tab of gBrowser.tabs) {
++    if (zenIsEmptyTab(tab)) {
++      continue;
++    }
++    if (seen === logicalIndex) {
++      return tab;
++    }
++    seen++;
++  }
++  return undefined;
++}
++
++// Map a logical index from an extension to a physical tab index for
++// gBrowser.addTab / moveTabTo. -1 and out-of-range values map to the end.
++function zenLogicalIndexToTabIndex(gBrowser, logicalIndex) {
++  if (logicalIndex === -1) {
++    return gBrowser.tabs.length;
++  }
++  let tab = zenGetNativeTabAtLogicalIndex(gBrowser, logicalIndex);
++  return tab ? tab._tPos : gBrowser.tabs.length;
++}
++
+ /* eslint-disable mozilla/balanced-listeners */
+ extensions.on("uninstalling", (msg, extension) => {
+   if (extension.uninstallURL) {
+@@ -362,6 +415,9 @@ class TabTracker extends TabTrackerBase {
    }
  
    getId(nativeTab) {
-+    if (nativeTab.hasAttribute("zen-empty-tab")) return -1;
++    if (zenIsEmptyTab(nativeTab)) {
++      return -1;
++    }
      let id = this._tabs.get(nativeTab);
      if (id) {
        return id;
-@@ -395,6 +396,7 @@ class TabTracker extends TabTrackerBase {
+@@ -395,6 +451,9 @@ class TabTracker extends TabTrackerBase {
      if (nativeTab.documentGlobal.closed) {
        throw new Error("Cannot attach ID to a tab in a closed window.");
      }
-+    if (nativeTab.hasAttribute("zen-empty-tab")) return;
++    if (zenIsEmptyTab(nativeTab)) {
++      return;
++    }
  
      this._tabs.set(nativeTab, id);
      this._tabIds.set(id, nativeTab);
-@@ -1262,6 +1264,10 @@ class TabManager extends TabManagerBase {
+@@ -846,7 +905,13 @@ class Tab extends TabBase {
+   }
+ 
+   get index() {
+-    return this.nativeTab._tPos;
++    // Report the logical index (excluding empty tabs) so query() results
++    // have contiguous indices 0..N-1.
++    if (zenIsEmptyTab(this.nativeTab)) {
++      return -1;
++    }
++    return zenLogicalTabIndex(this.nativeTab);
+   }
+ 
+   get mutedInfo() {
+@@ -1197,7 +1262,9 @@ class Window extends WindowBase {
+   }
+ 
+   getTabAtIndex(index) {
+-    let nativeTab = this.window.gBrowser.tabs[index];
++    // Translate the logical index to the physical tab, skipping empty tabs.
++    let nativeTab = zenGetNativeTabAtLogicalIndex(this.window.gBrowser, index);
+     if (nativeTab) {
+       return this.extension.tabManager.getWrapper(nativeTab);
+     }
+@@ -1262,6 +1329,10 @@ class TabManager extends TabManagerBase {
    }
  
    canAccessTab(nativeTab) {
-+    if (nativeTab.hasAttribute("zen-empty-tab")) {
-+      return false
++    if (zenIsEmptyTab(nativeTab)) {
++      return false;
 +    }
 +
      // Check private browsing access at browser window level.

--- a/src/browser/components/extensions/parent/ext-tabs-js.patch
+++ b/src/browser/components/extensions/parent/ext-tabs-js.patch
@@ -1,42 +1,46 @@
 diff --git a/browser/components/extensions/parent/ext-tabs.js b/browser/components/extensions/parent/ext-tabs.js
-index f342748d4b680a5de3a8b7c90df79f7c380b9e1c..5e5b19f52d036808e73b8a3f57258571a24f8de7 100644
+index f342748d4b680a5de3a8b7c90df79f7c380b9e1c...c61b2d2763838563f4acb7c370cfc4fd92c96a7a 100644
 --- a/browser/components/extensions/parent/ext-tabs.js
 +++ b/browser/components/extensions/parent/ext-tabs.js
-@@ -438,6 +438,7 @@ this.tabs = class extends ExtensionAPIPersistent {
+@@ -97,6 +97,11 @@ const allProperties = new Set([
+ ]);
+ const restricted = new Set(["url", "favIconUrl", "title"]);
+ 
++function zenLogicalIndexToTabIndex(gBrowser, logicalIndex) {
++  let tab = zenGetNativeTabAtLogicalIndex(gBrowser, logicalIndex);
++  return tab ? tab._tPos : gBrowser.tabs.length;
++}
++
+ this.tabs = class extends ExtensionAPIPersistent {
+   static onUpdate(id, manifest) {
+     if (!manifest.permissions || !manifest.permissions.includes("tabHide")) {
+@@ -438,6 +443,9 @@ this.tabs = class extends ExtensionAPIPersistent {
          }
  
          let tab = tabManager.getWrapper(updatedTab);
-+        if (!tab) return;
++        if (!tab) {
++          return;
++        }
  
          let changeInfo = {};
          for (let prop of needed) {
-@@ -771,7 +772,13 @@ this.tabs = class extends ExtensionAPIPersistent {
+@@ -771,7 +779,10 @@ this.tabs = class extends ExtensionAPIPersistent {
              }
-
+ 
              if (createProperties.index != null) {
 -              options.tabIndex = createProperties.index;
-+              // index is a logical index; translate it to a physical tabIndex.
 +              options.tabIndex = zenLogicalIndexToTabIndex(
 +                window.gBrowser,
 +                createProperties.index
 +              );
              }
-
-             if (createProperties.pinned != null) {
-@@ -806,6 +813,7 @@ this.tabs = class extends ExtensionAPIPersistent {
-               });
-             }
  
-+            window.gZenCompactModeManager._nextTimeWillBeActive = active;
-             let nativeTab = window.gBrowser.addTab(url, options);
-             tabTracker.addTabReadyBlocker(nativeTab);
-
-@@ -1114,14 +1122,15 @@ this.tabs = class extends ExtensionAPIPersistent {
+             if (createProperties.pinned != null) {
+@@ -1114,14 +1125,12 @@ this.tabs = class extends ExtensionAPIPersistent {
              let insertionPoint;
              let lastInsertion = lastInsertionMap.get(window);
              if (lastInsertion == null) {
 -              insertionPoint = moveProperties.index;
-+              // index is a logical index; map it to a physical tabIndex.
                let maxIndex = gBrowser.tabs.length - (isSameWindow ? 1 : 0);
 -              if (insertionPoint == -1) {
 -                // If the index is -1 it should go to the end of the tabs.
@@ -52,12 +56,11 @@ index f342748d4b680a5de3a8b7c90df79f7c380b9e1c..5e5b19f52d036808e73b8a3f57258571
              } else if (isSameWindow && nativeTab._tPos <= lastInsertion) {
                // lastInsertion is the current index of the last inserted tab.
                // insertionPoint is the desired index of the current tab *after* moving it.
-@@ -1694,7 +1703,9 @@ this.tabs = class extends ExtensionAPIPersistent {
+@@ -1694,7 +1703,7 @@ this.tabs = class extends ExtensionAPIPersistent {
              throw new ExtensionError("No highlighted tab.");
            }
            window.gBrowser.selectedTabs = tabs.map(tabIndex => {
 -            let tab = window.gBrowser.tabs[tabIndex];
-+            // tabIndex is a logical index; resolve the physical tab.
 +            let tab = zenGetNativeTabAtLogicalIndex(window.gBrowser, tabIndex);
              if (!tab || !tabManager.canAccessTab(tab)) {
                throw new ExtensionError("No tab at index: " + tabIndex);

--- a/src/browser/components/extensions/parent/ext-tabs-js.patch
+++ b/src/browser/components/extensions/parent/ext-tabs-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/extensions/parent/ext-tabs.js b/browser/components/extensions/parent/ext-tabs.js
-index f342748d4b680a5de3a8b7c90df79f7c380b9e1c..65091cf370e00a580ae2cb1fad9cde76f10c8bd9 100644
+index f342748d4b680a5de3a8b7c90df79f7c380b9e1c..5e5b19f52d036808e73b8a3f57258571a24f8de7 100644
 --- a/browser/components/extensions/parent/ext-tabs.js
 +++ b/browser/components/extensions/parent/ext-tabs.js
 @@ -438,6 +438,7 @@ this.tabs = class extends ExtensionAPIPersistent {
@@ -10,11 +10,55 @@ index f342748d4b680a5de3a8b7c90df79f7c380b9e1c..65091cf370e00a580ae2cb1fad9cde76
  
          let changeInfo = {};
          for (let prop of needed) {
-@@ -806,6 +807,7 @@ this.tabs = class extends ExtensionAPIPersistent {
+@@ -771,7 +772,13 @@ this.tabs = class extends ExtensionAPIPersistent {
+             }
+
+             if (createProperties.index != null) {
+-              options.tabIndex = createProperties.index;
++              // index is a logical index; translate it to a physical tabIndex.
++              options.tabIndex = zenLogicalIndexToTabIndex(
++                window.gBrowser,
++                createProperties.index
++              );
+             }
+
+             if (createProperties.pinned != null) {
+@@ -806,6 +813,7 @@ this.tabs = class extends ExtensionAPIPersistent {
                });
              }
  
 +            window.gZenCompactModeManager._nextTimeWillBeActive = active;
              let nativeTab = window.gBrowser.addTab(url, options);
              tabTracker.addTabReadyBlocker(nativeTab);
- 
+
+@@ -1114,14 +1122,15 @@ this.tabs = class extends ExtensionAPIPersistent {
+             let insertionPoint;
+             let lastInsertion = lastInsertionMap.get(window);
+             if (lastInsertion == null) {
+-              insertionPoint = moveProperties.index;
++              // index is a logical index; map it to a physical tabIndex.
+               let maxIndex = gBrowser.tabs.length - (isSameWindow ? 1 : 0);
+-              if (insertionPoint == -1) {
+-                // If the index is -1 it should go to the end of the tabs.
+-                insertionPoint = maxIndex;
+-              } else {
+-                insertionPoint = Math.min(insertionPoint, maxIndex);
+-              }
++              insertionPoint = zenLogicalIndexToTabIndex(
++                gBrowser,
++                moveProperties.index
++              );
++              insertionPoint = Math.min(insertionPoint, maxIndex);
+             } else if (isSameWindow && nativeTab._tPos <= lastInsertion) {
+               // lastInsertion is the current index of the last inserted tab.
+               // insertionPoint is the desired index of the current tab *after* moving it.
+@@ -1694,7 +1703,9 @@ this.tabs = class extends ExtensionAPIPersistent {
+             throw new ExtensionError("No highlighted tab.");
+           }
+           window.gBrowser.selectedTabs = tabs.map(tabIndex => {
+-            let tab = window.gBrowser.tabs[tabIndex];
++            // tabIndex is a logical index; resolve the physical tab.
++            let tab = zenGetNativeTabAtLogicalIndex(window.gBrowser, tabIndex);
+             if (!tab || !tabManager.canAccessTab(tab)) {
+               throw new ExtensionError("No tab at index: " + tabIndex);
+             }

--- a/src/zen/tests/tabs/browser.toml
+++ b/src/zen/tests/tabs/browser.toml
@@ -19,4 +19,6 @@ tags = [
 
 ["browser_tabs_empty_checks.js"]
 
+["browser_tabs_ext_query_index.js"]
+
 ["browser_tabs_fetch_checks.js"]

--- a/src/zen/tests/tabs/browser_tabs_ext_query_index.js
+++ b/src/zen/tests/tabs/browser_tabs_ext_query_index.js
@@ -1,0 +1,109 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Regression test: browser.tabs.query() must report contiguous 0..N-1 indices
+// even though Zen hides "empty tab" placeholders (workspace New Tab button,
+// one per folder) that occupy physical positions in the tab strip.
+
+// Asserts query({currentWindow: true}) returns contiguous 0-based indices and
+// that query({index: i}) round-trips. The label is passed via messaging since
+// background scripts cannot close over test-file variables.
+async function assertContiguousIndices(label) {
+  let extension = ExtensionTestUtils.loadExtension({
+    manifest: {
+      permissions: ["tabs"],
+    },
+    background() {
+      browser.test.onMessage.addListener(async msg => {
+        let { label } = msg;
+        try {
+          let tabs = await browser.tabs.query({ currentWindow: true });
+          tabs.sort((a, b) => a.index - b.index);
+
+          for (let i = 0; i < tabs.length; i++) {
+            browser.test.assertEq(
+              tabs[i].index,
+              i,
+              `${label}: tab at position ${i} should have index ${i} (got ${tabs[i].index})`
+            );
+          }
+
+          // Round-trip: query({index: i}) must return exactly the same tab.
+          for (let i = 0; i < tabs.length; i++) {
+            let found = await browser.tabs.query({ index: i });
+            browser.test.assertEq(
+              found.length,
+              1,
+              `${label}: query({index: ${i}}) should return one tab`
+            );
+            browser.test.assertEq(
+              found[0].id,
+              tabs[i].id,
+              `${label}: query({index: ${i}}) should match tab ${i} from full query`
+            );
+          }
+
+          // Out-of-range index returns no tabs.
+          let none = await browser.tabs.query({ index: tabs.length });
+          browser.test.assertEq(
+            none.length,
+            0,
+            `${label}: query({index: tabs.length}) should return no tabs`
+          );
+
+          browser.test.notifyPass("done");
+        } catch (e) {
+          browser.test.fail(`unexpected error: ${e}`);
+          browser.test.notifyFail("done");
+        }
+      });
+    },
+  });
+  await extension.startup();
+  await extension.sendMessage({ label });
+  await extension.awaitFinish("done");
+  await extension.unload();
+}
+
+add_task(async function test_query_indices_contiguous_at_startup() {
+  // Startup has one hidden workspace empty tab plus the initial about:blank.
+  await assertContiguousIndices("startup");
+});
+
+add_task(async function test_query_indices_contiguous_with_real_tabs() {
+  let tab1 = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "about:robots"
+  );
+  let tab2 = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "about:config"
+  );
+  try {
+    await assertContiguousIndices("with tabs");
+  } finally {
+    BrowserTestUtils.removeTab(tab2);
+    BrowserTestUtils.removeTab(tab1);
+  }
+});
+
+add_task(async function test_query_indices_contiguous_with_folder() {
+  // A Zen Folder inserts a hidden empty-tab placeholder that used to gap indices.
+  let tab = BrowserTestUtils.addTab(gBrowser, "about:blank");
+  let folder = await gZenFolders.createFolder([tab], {
+    renameFolder: false,
+    label: "test-folder",
+  });
+  Assert.ok(folder, "Folder created");
+
+  try {
+    await assertContiguousIndices("with folder");
+  } finally {
+    let removed = BrowserTestUtils.waitForEvent(folder, "TabGroupRemoved");
+    folder.delete();
+    await removed;
+  }
+});
+


### PR DESCRIPTION
Fixes https://github.com/zen-browser/desktop/issues/11210

First observed after https://github.com/zen-browser/desktop/commit/43c98b7ddd78ff4c1beedf4348021da1ca63c071

Issue: The folders & "New Tab" were created as tabs but filtered from the `browser.tabs.query` API without adjusting the `tab.index` leading to non contiguous indices.


After this fix:
<img width="621" height="412" alt="image" src="https://github.com/user-attachments/assets/e87a16ab-39ae-44c8-9c81-6a62c88f1d51" />
