### PR TITLE
Add an opt-in active tab favicon to the collapsed sidebar URL bar

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -188,6 +188,7 @@ zen-urlbar-behavior-floating-on-type =
     .label = Floating only when typing
 zen-urlbar-behavior-float =
     .label = Always floating
+zen-urlbar-show-favicon-when-sidebar-collapsed = Show the active tab favicon when the sidebar is collapsed
 
 pane-zen-CKS-title = Keyboard Shortcuts
 category-zen-CKS =

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1190,6 +1190,11 @@ Preferences.addAll([
     default: "float",
   },
   {
+    id: "zen.urlbar.show-favicon-when-sidebar-collapsed",
+    type: "bool",
+    default: false,
+  },
+  {
     id: "zen.workspaces.separate-essentials",
     type: "bool",
     default: false,

--- a/src/browser/components/preferences/zenLooksAndFeel.inc.xhtml
+++ b/src/browser/components/preferences/zenLooksAndFeel.inc.xhtml
@@ -113,6 +113,8 @@
                   </menupopup>
             </menulist>
         </hbox>
+      <checkbox preference="zen.urlbar.show-favicon-when-sidebar-collapsed"
+                data-l10n-id="zen-urlbar-show-favicon-when-sidebar-collapsed"/>
 </groupbox>
 
 </html:template>

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -73,6 +73,7 @@ window.gZenUIManager = {
     this._debloatContextMenus();
     this._addNewCustomizableButtonsIfNeeded();
     this._initOmnibox();
+    this._initCollapsedUrlbarFavicon();
     this._initBookmarkCollapseListener();
 
     gURLBar._setPlaceholder(null);
@@ -197,6 +198,47 @@ window.gZenUIManager = {
     registerZenUrlbarProviders();
     window.gZenSiteDataPanel = new ZenSiteDataPanel(window);
     gURLBar._zenTrimURL = this.urlbarTrim.bind(this);
+  },
+
+  _initCollapsedUrlbarFavicon() {
+    const inputContainer = gURLBar.querySelector(".urlbar-input-container");
+    if (!inputContainer) {
+      return;
+    }
+
+    const favicon = document.createElement("img");
+    favicon.id = "zen-urlbar-tab-favicon";
+    favicon.alt = "";
+    favicon.setAttribute("aria-hidden", "true");
+    inputContainer.prepend(favicon);
+    this._collapsedUrlbarFavicon = favicon;
+
+    this.updateCollapsedUrlbarFavicon();
+    window.addEventListener("TabSelect", () => {
+      this.updateCollapsedUrlbarFavicon();
+    });
+    gBrowser.tabContainer.addEventListener("TabAttrModified", event => {
+      if (event.target === gBrowser.selectedTab) {
+        this.updateCollapsedUrlbarFavicon();
+      }
+    });
+  },
+
+  updateCollapsedUrlbarFavicon() {
+    const favicon = this._collapsedUrlbarFavicon;
+    if (!favicon) {
+      return;
+    }
+
+    const tabIcon = gBrowser.selectedTab?.querySelector(".tab-icon-image");
+    const faviconURL = tabIcon?.getAttribute("src");
+
+    gURLBar.toggleAttribute("zen-has-tab-favicon", Boolean(faviconURL));
+    if (faviconURL) {
+      favicon.setAttribute("src", faviconURL);
+    } else {
+      favicon.removeAttribute("src");
+    }
   },
 
   _debloatContextMenus() {

--- a/src/zen/common/styles/zen-omnibox.css
+++ b/src/zen/common/styles/zen-omnibox.css
@@ -129,6 +129,30 @@
   font-weight: 500;
 }
 
+#zen-urlbar-tab-favicon {
+  display: none;
+  height: 16px;
+  pointer-events: none;
+  width: 16px;
+}
+
+@media -moz-pref("zen.urlbar.show-favicon-when-sidebar-collapsed") {
+  :root[zen-single-toolbar="true"]:not([zen-sidebar-expanded="true"])
+    #urlbar[zen-has-tab-favicon]:not([focused]):not([breakout-extend]) {
+    & .urlbar-input-container {
+      justify-content: center;
+    }
+
+    & :is(.urlbar-input-box, #identity-box, #page-action-buttons) {
+      opacity: 0;
+    }
+
+    & #zen-urlbar-tab-favicon {
+      display: block;
+    }
+  }
+}
+
 :root[zen-single-toolbar="true"] #urlbar:not([breakout-extend]) {
   & #urlbar-input {
     cursor: default;

--- a/src/zen/tests/urlbar/browser.toml
+++ b/src/zen/tests/urlbar/browser.toml
@@ -11,4 +11,6 @@ support-files = [
 
 ["browser_floating_urlbar.js"]
 
+["browser_collapsed_urlbar_favicon.js"]
+
 ["browser_issue_7385.js"]

--- a/src/zen/tests/urlbar/browser_collapsed_urlbar_favicon.js
+++ b/src/zen/tests/urlbar/browser_collapsed_urlbar_favicon.js
@@ -1,0 +1,35 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_CollapsedUrlbarFaviconTracksSelectedTab() {
+  const tabIcon = gBrowser.selectedTab.querySelector(".tab-icon-image");
+  const faviconURL =
+    "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>";
+  Assert.ok(tabIcon, "Selected tab has a favicon element");
+
+  const originalSource = tabIcon.getAttribute("src");
+  try {
+    tabIcon.setAttribute("src", faviconURL);
+    gZenUIManager.updateCollapsedUrlbarFavicon();
+
+    const favicon = document.getElementById("zen-urlbar-tab-favicon");
+    Assert.equal(
+      favicon.getAttribute("src"),
+      faviconURL,
+      "URL bar uses the selected tab favicon"
+    );
+    ok(
+      gURLBar.hasAttribute("zen-has-tab-favicon"),
+      "URL bar marks the favicon as available"
+    );
+  } finally {
+    if (originalSource) {
+      tabIcon.setAttribute("src", originalSource);
+    } else {
+      tabIcon.removeAttribute("src");
+    }
+    gZenUIManager.updateCollapsedUrlbarFavicon();
+  }
+});


### PR DESCRIPTION
# Add an opt-in active-tab favicon to the collapsed sidebar URL bar

## What this changes

- Adds a small native image element inside Zen's URL bar.
- Synchronizes that image with the selected tab's existing favicon.
- Adds a **Show the active tab favicon when the sidebar is collapsed** setting, disabled by default.
- Shows only the favicon while Zen's own sidebar is collapsed and the URL bar is not focused.
- Restores the complete URL bar when the sidebar expands or the user focuses it.

## Why

The collapsed sidebar has limited horizontal space. Showing the selected tab's favicon gives an immediate page cue without rendering a truncated URL. This uses the same icon Zen already renders for the selected tab; it does not fetch, invent, or hard-code site icons.

## Implementation notes

- `ZenUIManager` creates one URL-bar favicon element and refreshes it on tab selection and active-tab attribute updates.
- CSS gates the compact presentation behind a preference and Zen's native collapsed-sidebar state.
- The input remains clickable, so clicking it focuses the URL bar and reveals its normal controls.
- The preference is exposed in the URL Bar section of Zen's Looks and Feel settings.

## Test coverage

- Adds a browser-chrome test that verifies the URL bar copies the selected tab icon source and marks the favicon as available.

## Manual review checklist

1. Enable the new setting in `about:preferences` → **Zen Looks and Feel**.
2. Use Zen's normal collapsed sidebar (not a third-party CSS hover mod).
3. Switch between two tabs with visibly different favicons.
4. Confirm the top URL area shows the active tab's favicon only.
5. Click the favicon area and confirm the complete URL bar appears.
6. Expand the sidebar and confirm the complete URL bar remains visible.

## Scope

This deliberately does not recreate macOS window controls or implement an extension-button shortcut. Those are native/customizable browser controls and are outside the safe scope of a URL-bar presentation feature.
