### PR TITLE
gh-14847: Add draft filtering to GitHub Live Folders

### DIFF
--- a/locales/en-US/browser/browser/zen-live-folders.ftl
+++ b/locales/en-US/browser/browser/zen-live-folders.ftl
@@ -20,6 +20,9 @@ zen-live-folder-github-option-assigned-self =
 zen-live-folder-github-option-review-requested =
     .label = Review Requests
 
+zen-live-folder-github-option-include-drafts =
+    .label = Include Draft Pull Requests
+
 zen-live-folder-type-rss =
     .label = RSS Feed
 

--- a/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
@@ -253,6 +253,13 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
       "sort:updated-desc",
     ];
 
+    if (
+      this.state.type === "pull-requests" &&
+      !(this.state.options.includeDrafts ?? true)
+    ) {
+      baseQuery.push("draft:false");
+    }
+
     const options = [
       {
         value: "author:@me",
@@ -334,6 +341,12 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
         l10nId: "zen-live-folder-github-option-review-requested",
         key: "reviewRequested",
         checked: this.state.options.reviewRequested ?? false,
+        hidden: this.state.type === "issues",
+      },
+      {
+        l10nId: "zen-live-folder-github-option-include-drafts",
+        key: "includeDrafts",
+        checked: this.state.options.includeDrafts ?? true,
         hidden: this.state.type === "issues",
       },
       { type: "separator" },

--- a/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
@@ -347,7 +347,7 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
         l10nId: "zen-live-folder-github-option-include-drafts",
         key: "includeDrafts",
         checked: this.state.options.includeDrafts ?? true,
-        hidden: this.state.type === "issues",
+        hidden: this.state.type !== "pull-requests",
       },
       { type: "separator" },
       {

--- a/src/zen/tests/live-folders/browser_github_live_folder.js
+++ b/src/zen/tests/live-folders/browser_github_live_folder.js
@@ -76,6 +76,10 @@ add_task(async function test_fetch_items_url_construction() {
     !query.includes("review-requested:@me"),
     "Should NOT include review-requested"
   );
+  Assert.ok(
+    !query.includes("draft:false"),
+    "Should include draft pull requests by default"
+  );
 
   sandbox.restore();
 });
@@ -88,6 +92,7 @@ add_task(async function test_fetch_items_url_complex_options() {
   let instance = getGithubProviderForTest(sandbox, {
     authorMe: true,
     assignedMe: true,
+    includeDrafts: false,
     reviewRequested: true,
   });
 
@@ -106,6 +111,10 @@ add_task(async function test_fetch_items_url_complex_options() {
   Assert.ok(
     query.includes("review-requested:@me"),
     "Should include review-requested"
+  );
+  Assert.ok(
+    query.includes("draft:false"),
+    "Should exclude draft pull requests"
   );
 
   Assert.ok(query.includes(" OR "), "Should contain OR operators");


### PR DESCRIPTION
Adds an option to exclude draft pull requests from GitHub Live Folders.

This is useful for repositories with a fixed review team enforced by branch protection rules. Team members are always requested for review, causing unfinished draft PRs to appear in their Live Folders.

Checks: syntax, formatting, and diff validation. The full browser test was not run because the local checkout does not include the bootstrapped Firefox engine.