### PR TITLE
gh-15402: Add `archived:false` to github live folder queries

### DIFF
--- a/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
@@ -250,6 +250,7 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
     const baseQuery = [
       this.state.type === "pull-requests" ? "is:pr" : "is:issue",
       "is:open",
+      "archived:false",
       "sort:updated-desc",
     ];
 

--- a/src/zen/tests/live-folders/browser_github_live_folder.js
+++ b/src/zen/tests/live-folders/browser_github_live_folder.js
@@ -70,6 +70,7 @@ add_task(async function test_fetch_items_url_construction() {
   const query = searchParams.get("q");
   Assert.ok(query.includes("is:open"), "Should include state:open");
   Assert.ok(query.includes("is:pr"), "Should include is:PR");
+  Assert.ok(query.includes("archived:false"), "Should include archived:false");
   Assert.ok(query.includes("author:@me"), "Should include author:@me");
   Assert.ok(!query.includes("assignee:@me"), "Should NOT include assignee:@me");
   Assert.ok(


### PR DESCRIPTION
Adds `archived:false` to GitHub live folder queries so issues and pull requests from archived repositories no longer appear. 

Includes test coverage for the updated filters.