### PR TITLE
gh-14300: Fix URL in addressbar not restored

### DIFF
--- a/src/browser/components/urlbar/UrlbarController-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarController-sys-mjs.patch
@@ -19,3 +19,12 @@ index a05894d593e4149097c473822a38f87b2220625f..1660106c2a6548920fdffd2656e5a1f1
          }
          break;
        }
+
+@@ -362,6 +362,7 @@
+    switch (event.keyCode) {
+      case KeyEvent.DOM_VK_ESCAPE:
+        if (executeAction) {
+          if (this.view.isOpen) {
+            this.view.close();
++           this.input.handleRevert();
+          } else if (


### PR DESCRIPTION
Presently, when the URL bar is opened with ⌘L / Ctrl + L, closing it is handled by Firefox. Pressing Escape closes the URL bar view, but does not revert the address bar to the current URI or its blank state.

This behavior makes sense in Firefox, because closing the view only closes the search suggestions and the address bar remains focused. This change in turn makes behavior visually consistent with opening the URL bar through a new tab and with Arc.

Fixes: #14300