### PR TITLE
Allow custom images as space icons

### DIFF
--- a/locales/en-US/browser/browser/zen-general.ftl
+++ b/locales/en-US/browser/browser/zen-general.ftl
@@ -87,6 +87,16 @@ zen-icons-picker-emoji =
   .label = Emojis
 zen-icons-picker-svg =
   .label = Icons
+zen-icons-picker-custom =
+  .label = Custom
+zen-icons-picker-custom-choose =
+  .label = Choose an image…
+zen-icons-picker-custom-hint = SVG, PNG, JPEG, GIF, WebP and other image files. Large images are resized.
+# Title of the file dialog used to pick a custom icon.
+zen-icons-picker-custom-title = Choose an image
+# $limit (Number) - The maximum accepted file size, in megabytes.
+zen-icons-picker-custom-too-large = That image is too big. Choose a file smaller than { $limit } MB.
+zen-icons-picker-custom-failed = That file could not be used as an icon.
 zen-emojis-picker-search =
   .placeholder = Search emojis
 

--- a/src/browser/base/content/zen-panels/emojis-picker.inc
+++ b/src/browser/base/content/zen-panels/emojis-picker.inc
@@ -8,16 +8,22 @@
     <hbox id="PanelUI-zen-emojis-buttons-wrapper">
       <toolbarbutton id="PanelUI-zen-emojis-picker-change-emojis" class="selected" data-l10n-id="zen-icons-picker-emoji" />
       <toolbarbutton id="PanelUI-zen-emojis-picker-change-svg" data-l10n-id="zen-icons-picker-svg" />
+      <toolbarbutton id="PanelUI-zen-emojis-picker-change-custom" data-l10n-id="zen-icons-picker-custom" />
     </hbox>
     <toolbarbutton id="PanelUI-zen-emojis-picker-none" class="toolbarbutton-1" />
   </hbox>
   <hbox id="PanelUI-zen-emojis-picker-pages">
-    <vbox emojis="true">
+    <vbox page="emojis">
       <hbox id="PanelUI-zen-emojis-picker-header">
         <html:input type="search" id="PanelUI-zen-emojis-picker-search" data-l10n-id="zen-emojis-picker-search" />
       </hbox>
       <hbox id="PanelUI-zen-emojis-picker-list" />
     </vbox>
-    <hbox svgs="true" id="PanelUI-zen-emojis-picker-svgs" />
+    <hbox page="svg" id="PanelUI-zen-emojis-picker-svgs" />
+    <vbox page="custom" id="PanelUI-zen-emojis-picker-custom">
+      <html:img id="PanelUI-zen-emojis-picker-custom-preview" hidden="true" alt="" />
+      <button id="PanelUI-zen-emojis-picker-custom-choose" class="footer-button" data-l10n-id="zen-icons-picker-custom-choose" />
+      <description id="PanelUI-zen-emojis-picker-custom-hint" data-l10n-id="zen-icons-picker-custom-hint" />
+    </vbox>
   </hbox>
 </panel>

--- a/src/browser/themes/shared/zen-icons/icons.css
+++ b/src/browser/themes/shared/zen-icons/icons.css
@@ -920,6 +920,7 @@
 .zen-workspace-context-icon img {
   -moz-context-properties: fill;
   fill: currentColor;
+  object-fit: contain;
 }
 
 #zen-site-data-boost {

--- a/src/zen/common/emojis/ZenEmojiPicker.mjs
+++ b/src/zen/common/emojis/ZenEmojiPicker.mjs
@@ -30,6 +30,16 @@ const SVG_ICONS = [
   "water.svg", "weight.svg",
 ];
 
+// Custom icons are stored inline as data URLs on the object that owns them
+// (e.g. a space), which is persisted to the session store, so they have to stay
+// small. Raster images are re-encoded down to this size; 192px still covers a
+// 32px icon on a 4x display while keeping the encoded result at a few KB.
+const CUSTOM_ICON_MAX_DIMENSION = 192;
+
+// Refused before we try to decode, so a mistakenly picked huge file can't stall
+// the browser.
+const CUSTOM_ICON_MAX_FILE_SIZE = 10 * 1024 * 1024;
+
 class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
   #panel;
 
@@ -39,6 +49,7 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
   #onSelect = null;
   #hasSelection = false;
   #lastSelectedEmoji = null;
+  #allowCustomImage = false;
 
   #currentPromise = null;
   #currentPromiseResolve = null;
@@ -51,6 +62,21 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     this.#panel.addEventListener("popuphidden", this);
     this.#panel.addEventListener("command", this);
     this.searchInput.addEventListener("input", this);
+  }
+
+  /**
+   * Whether an icon value is meant to be rendered as an image rather than as
+   * text. Covers both the bundled `chrome://` SVGs and the data URLs produced
+   * for custom images and for emojis rasterized via `emojiAsSVG`.
+   *
+   * @param {string} [icon] The stored icon value.
+   * @returns {boolean} True when the icon should be rendered as an image.
+   */
+  isImageIcon(icon) {
+    return (
+      typeof icon === "string" &&
+      (icon.endsWith(".svg") || icon.startsWith("data:image/"))
+    );
   }
 
   handleEvent(event) {
@@ -70,9 +96,17 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
         } else if (
           event.target.id === "PanelUI-zen-emojis-picker-change-emojis"
         ) {
-          this.#changePage(false);
+          this.#changePage("emojis");
         } else if (event.target.id === "PanelUI-zen-emojis-picker-change-svg") {
-          this.#changePage(true);
+          this.#changePage("svg");
+        } else if (
+          event.target.id === "PanelUI-zen-emojis-picker-change-custom"
+        ) {
+          this.#changePage("custom");
+        } else if (
+          event.target.id === "PanelUI-zen-emojis-picker-custom-choose"
+        ) {
+          this.#pickCustomImage();
         }
         break;
       case "input":
@@ -107,11 +141,13 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     return document.getElementById("PanelUI-zen-emojis-picker-search");
   }
 
-  #changePage(toSvg = false, { animate = true } = {}) {
+  get customPreview() {
+    return document.getElementById("PanelUI-zen-emojis-picker-custom-preview");
+  }
+
+  #changePage(page = "emojis", { animate = true } = {}) {
     const pages = document.getElementById("PanelUI-zen-emojis-picker-pages");
-    const itemToScroll = toSvg
-      ? this.svgList
-      : pages.querySelector('[emojis="true"]');
+    const itemToScroll = pages.querySelector(`[page="${page}"]`);
     if (animate) {
       itemToScroll.scrollIntoView({
         behavior: "smooth",
@@ -119,16 +155,16 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
         inline: "start",
       });
     } else {
-      pages.scrollLeft = toSvg ? itemToScroll.offsetLeft : 0;
+      pages.scrollLeft = itemToScroll.offsetLeft;
     }
-    const button = document.getElementById(
-      `PanelUI-zen-emojis-picker-change-${toSvg ? "svg" : "emojis"}`
-    );
-    const otherButton = document.getElementById(
-      `PanelUI-zen-emojis-picker-change-${toSvg ? "emojis" : "svg"}`
-    );
-    button.classList.add("selected");
-    otherButton.classList.remove("selected");
+    for (const button of document.getElementById(
+      "PanelUI-zen-emojis-buttons-wrapper"
+    ).children) {
+      button.classList.toggle(
+        "selected",
+        button.id === `PanelUI-zen-emojis-picker-change-${page}`
+      );
+    }
   }
 
   #clearEmojis() {
@@ -211,7 +247,7 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     if (allowEmojis) {
       this.searchInput.focus({ preventScroll: true });
     }
-    this.#changePage(false, { animate: false });
+    this.#changePage(allowEmojis ? "emojis" : "svg", { animate: false });
   }
 
   #onPopupHidden(event) {
@@ -224,6 +260,8 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     emojiList.innerHTML = "";
 
     this.svgList.innerHTML = "";
+    this.customPreview.removeAttribute("src");
+    this.customPreview.hidden = true;
 
     if (!this.#hasSelection) {
       this.#currentPromiseReject?.(
@@ -240,14 +278,141 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     this.#closeOnSelect = true;
     this.#hasSelection = false;
     this.#lastSelectedEmoji = null;
+    this.#allowCustomImage = false;
 
     this.#anchor.removeAttribute("zen-emoji-open");
     this.#anchor.parentElement.removeAttribute("zen-emoji-open");
     this.#anchor = null;
   }
 
+  /**
+   * Prompts for an image file and turns it into a data URL usable as an icon.
+   * Kept inline (rather than copied into the profile) so that an icon travels
+   * with the object that owns it, including across synced devices.
+   */
+  async #pickCustomImage() {
+    if (!this.#allowCustomImage) {
+      return;
+    }
+
+    // A modal file dialog takes focus and dismisses the panel on some
+    // platforms, so hold on to the callbacks and report the result directly
+    // instead of going back through #selectEmoji, whose state may already have
+    // been torn down by then.
+    const onSelect = this.#onSelect;
+    const resolveSelection = this.#currentPromiseResolve;
+    const closeOnSelect = this.#closeOnSelect;
+
+    // Keeps #onPopupHidden from rejecting the pending promise if the panel goes
+    // away while the dialog is up.
+    this.#hasSelection = true;
+
+    const path = await this.#promptForImageFile();
+    if (!path) {
+      return;
+    }
+
+    let icon;
+    try {
+      icon = await this.#encodeCustomImage(path);
+    } catch (error) {
+      console.error("Failed to import a custom icon:", error);
+      gZenUIManager.showToast("zen-icons-picker-custom-failed");
+      return;
+    }
+    if (!icon) {
+      return;
+    }
+
+    if (this.#panel.state === "open") {
+      this.customPreview.src = icon;
+      this.customPreview.hidden = false;
+    }
+    this.#lastSelectedEmoji = icon;
+    this.#setAllowNone(true);
+    onSelect?.(icon);
+    resolveSelection?.(icon);
+    if (closeOnSelect) {
+      this.#panel.hidePopup();
+    }
+  }
+
+  /**
+   * @returns {Promise<string|null>} Path of the picked file, or null if the
+   *   dialog was dismissed.
+   */
+  async #promptForImageFile() {
+    const filePicker = Cc["@mozilla.org/filepicker;1"].createInstance(
+      Ci.nsIFilePicker
+    );
+    filePicker.init(
+      window.browsingContext,
+      await document.l10n.formatValue("zen-icons-picker-custom-title"),
+      Ci.nsIFilePicker.modeOpen
+    );
+    filePicker.appendFilters(Ci.nsIFilePicker.filterImages);
+
+    const result = await new Promise(resolve => filePicker.open(resolve));
+    if (result !== Ci.nsIFilePicker.returnOK || !filePicker.file) {
+      return null;
+    }
+    return filePicker.file.path;
+  }
+
+  /**
+   * @param {string} path Absolute path of the image the user picked.
+   * @returns {Promise<string|null>} A data URL, or null if the file was rejected.
+   */
+  async #encodeCustomImage(path) {
+    const { size } = await IOUtils.stat(path);
+    if (size > CUSTOM_ICON_MAX_FILE_SIZE) {
+      gZenUIManager.showToast("zen-icons-picker-custom-too-large", {
+        l10nArgs: { limit: CUSTOM_ICON_MAX_FILE_SIZE / (1024 * 1024) },
+      });
+      return null;
+    }
+
+    const bytes = await IOUtils.read(path);
+
+    // SVGs are kept as-is so they stay sharp at any size. Rendering happens in
+    // an <img>, which does not run scripts or load external references, so an
+    // untrusted document is inert here.
+    if (path.toLowerCase().endsWith(".svg")) {
+      return this.#blobToDataURL(new Blob([bytes], { type: "image/svg+xml" }));
+    }
+
+    // Throws for anything that is not a decodable image, which is also how we
+    // reject files that merely have an image extension.
+    const bitmap = await createImageBitmap(new Blob([bytes]));
+    const scale = Math.min(
+      1,
+      CUSTOM_ICON_MAX_DIMENSION / Math.max(bitmap.width, bitmap.height)
+    );
+    const width = Math.max(1, Math.round(bitmap.width * scale));
+    const height = Math.max(1, Math.round(bitmap.height * scale));
+
+    const canvas = new OffscreenCanvas(width, height);
+    canvas.getContext("2d").drawImage(bitmap, 0, 0, width, height);
+    bitmap.close();
+
+    // WebP keeps transparency and stays far smaller than PNG for photos. If the
+    // encoder does not support it, it falls back to PNG on its own.
+    return this.#blobToDataURL(
+      await canvas.convertToBlob({ type: "image/webp", quality: 0.9 })
+    );
+  }
+
+  #blobToDataURL(blob) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(blob);
+    });
+  }
+
   #selectEmoji(emoji) {
-    if (this.#emojiAsSVG && emoji && !emoji.startsWith("chrome://")) {
+    if (this.#emojiAsSVG && emoji && !this.isImageIcon(emoji)) {
       emoji = `data:image/svg+xml;base64,${btoa(
         `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><text y="28" font-size="28" x="0">${unescape(
           encodeURIComponent(emoji)
@@ -272,6 +437,7 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
       emojiAsSVG = false,
       allowNone = true,
       closeOnSelect = true,
+      allowCustomImage = false,
       onSelect = null,
     } = {}
   ) {
@@ -283,6 +449,7 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     this.#onSelect = onSelect;
     this.#hasSelection = false;
     this.#lastSelectedEmoji = null;
+    this.#allowCustomImage = allowCustomImage;
     this.#currentPromise = new Promise((resolve, reject) => {
       this.#currentPromiseResolve = resolve;
       this.#currentPromiseReject = reject;
@@ -294,6 +461,11 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
       this.#panel.setAttribute("only-svg-icons", "true");
     } else {
       this.#panel.removeAttribute("only-svg-icons");
+    }
+    if (this.#allowCustomImage) {
+      this.#panel.setAttribute("allow-custom-image", "true");
+    } else {
+      this.#panel.removeAttribute("allow-custom-image");
     }
     this.#setAllowNone(allowNone);
     this.#panel.openPopup(anchor, "after_start", 0, 0, false, false);

--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -83,8 +83,36 @@
       pointer-events: none;
     }
 
-    & #PanelUI-zen-emojis-picker-pages > vbox[emojis="true"] {
+    & #PanelUI-zen-emojis-picker-pages > [page="emojis"] {
       display: none;
+    }
+  }
+
+  &:not([allow-custom-image="true"]) {
+    & #PanelUI-zen-emojis-picker-change-custom,
+    & #PanelUI-zen-emojis-picker-pages > [page="custom"] {
+      display: none;
+    }
+  }
+
+  #PanelUI-zen-emojis-picker-custom {
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 16px 20px;
+
+    & #PanelUI-zen-emojis-picker-custom-preview {
+      width: 48px;
+      height: 48px;
+      object-fit: contain;
+      border-radius: 6px;
+    }
+
+    & #PanelUI-zen-emojis-picker-custom-hint {
+      margin: 0;
+      font-size: x-small;
+      text-align: center;
+      opacity: 0.6;
     }
   }
 

--- a/src/zen/space-routing/ZenSpaceRoutingDialog.mjs
+++ b/src/zen/space-routing/ZenSpaceRoutingDialog.mjs
@@ -387,7 +387,7 @@ export class nsZenSpaceRoutingDialog {
       menuItem.setAttribute("value", id || text);
 
       if (iconPath) {
-        if (iconPath.startsWith("chrome://")) {
+        if (this.openerWindow.gZenEmojiPicker.isImageIcon(iconPath)) {
           menuItem.setAttribute("class", "menuitem-iconic");
           menuItem.setAttribute("image", iconPath);
         } else {

--- a/src/zen/spaces/ZenSpaceCreation.mjs
+++ b/src/zen/spaces/ZenSpaceCreation.mjs
@@ -274,16 +274,16 @@ class nsZenWorkspaceCreation extends MozXULElement {
   onIconCommand(event) {
     gZenEmojiPicker.open(event.target, {
       closeOnSelect: false,
+      allowCustomImage: true,
       onSelect: async icon => {
-        const isSvg = icon && icon.endsWith(".svg");
-        if (isSvg) {
+        if (gZenEmojiPicker.isImageIcon(icon)) {
           this.inputIcon.label = "";
           this.inputIcon.image = icon;
-          this.inputIcon.setAttribute("has-svg-icon", "true");
+          this.inputIcon.setAttribute("has-image-icon", "true");
         } else {
           this.inputIcon.image = "";
           this.inputIcon.label = icon || "";
-          this.inputIcon.removeAttribute("has-svg-icon");
+          this.inputIcon.removeAttribute("has-image-icon");
         }
       },
     });

--- a/src/zen/spaces/ZenSpaceIcons.mjs
+++ b/src/zen/spaces/ZenSpaceIcons.mjs
@@ -111,9 +111,9 @@ class nsZenWorkspaceIcons extends MozXULElement {
     button.setAttribute("context", "zenWorkspaceMoreActions");
     const icon = document.createXULElement("label");
     icon.setAttribute("class", "zen-workspace-icon");
-    const isSvgIcon = workspace.icon && workspace.icon.endsWith(".svg");
+    const isImageIcon = gZenEmojiPicker.isImageIcon(workspace.icon);
     if (gZenWorkspaces.workspaceHasIcon(workspace)) {
-      if (isSvgIcon) {
+      if (isImageIcon) {
         const image = document.createElement("img");
         image.src = workspace.icon;
         image.classList.add("zen-workspace-icon");
@@ -124,7 +124,7 @@ class nsZenWorkspaceIcons extends MozXULElement {
     } else {
       icon.setAttribute("no-icon", true);
     }
-    if (!isSvgIcon) {
+    if (!isImageIcon) {
       button.appendChild(icon);
     }
     button.addEventListener("command", this);

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -1027,6 +1027,7 @@ class nsZenWorkspaces {
     gZenEmojiPicker.open(anchor, {
       closeOnSelect: false,
       allowNone: !hasNoIcon,
+      allowCustomImage: true,
       onSelect: async icon => {
         const workspace = this.getWorkspaceFromId(workspaceId);
         if (!workspace) {
@@ -1179,12 +1180,12 @@ class nsZenWorkspaces {
       item.setAttribute(disableCurrent ? "disabled" : "checked", true);
     }
     let name = workspace.name;
-    const iconIsSvg = workspace.icon && workspace.icon.endsWith(".svg");
-    if (workspace.icon && workspace.icon !== "" && !iconIsSvg) {
+    const iconIsImage = gZenEmojiPicker.isImageIcon(workspace.icon);
+    if (workspace.icon && workspace.icon !== "" && !iconIsImage) {
       name = `${workspace.icon}  ${name}`;
     }
     item.setAttribute("label", name);
-    if (iconIsSvg) {
+    if (iconIsImage) {
       item.setAttribute("image", workspace.icon);
       item.classList.add("zen-workspace-context-icon");
     }
@@ -1997,7 +1998,7 @@ class nsZenWorkspaces {
     }
     const icon = this.getWorkspaceIcon(currentWorkspace);
     indicatorIcon.innerHTML = "";
-    if (icon?.endsWith(".svg")) {
+    if (gZenEmojiPicker.isImageIcon(icon)) {
       const img = document.createElement("img");
       img.src = icon;
       indicatorIcon.appendChild(img);

--- a/src/zen/spaces/create-workspace-form.css
+++ b/src/zen/spaces/create-workspace-form.css
@@ -75,11 +75,12 @@ zen-workspace-creation {
             position: absolute;
             width: var(--size-item-small);
             height: var(--size-item-small);
+            object-fit: contain;
             -moz-context-properties: fill-opacity, fill;
             fill: currentColor;
           }
 
-          &:not([has-svg-icon="true"]) image {
+          &:not([has-image-icon="true"]) image {
             display: none;
           }
 
@@ -89,7 +90,7 @@ zen-workspace-creation {
             justify-content: center;
           }
 
-          &[has-svg-icon="true"] label {
+          &[has-image-icon="true"] label {
             display: none;
           }
 

--- a/src/zen/spaces/zen-workspaces.css
+++ b/src/zen/spaces/zen-workspaces.css
@@ -52,8 +52,11 @@
         font-size: 14px;
       }
 
+      /* Custom icons can be any aspect ratio, so constrain both axes. */
       &:is(img) {
         width: 14px;
+        height: 14px;
+        object-fit: contain;
       }
 
       &[no-icon='true'] {
@@ -225,6 +228,9 @@
 
     & img {
       transform: translateY(-1px);
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
     }
 
     &[zen-emoji-open='true']::before {

--- a/src/zen/tests/spaces/browser.toml
+++ b/src/zen/tests/spaces/browser.toml
@@ -10,6 +10,8 @@ support-files = [
 
 ["browser_basic_workspaces.js"]
 
+["browser_custom_space_icon.js"]
+
 ["browser_double_click_newtab.js"]
 
 ["browser_issue_10455.js"]

--- a/src/zen/tests/spaces/browser_custom_space_icon.js
+++ b/src/zen/tests/spaces/browser_custom_space_icon.js
@@ -1,0 +1,121 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// A 1x1 transparent PNG, standing in for whatever the user imported.
+const CUSTOM_ICON =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+const BUNDLED_ICON = "chrome://browser/skin/zen-icons/selectable/star.svg";
+
+function getIndicator(workspace) {
+  return gZenWorkspaces.workspaceElement(workspace.uuid).indicator;
+}
+
+function getIndicatorIcon(workspace) {
+  return getIndicator(workspace).querySelector(
+    ".zen-current-workspace-indicator-icon"
+  );
+}
+
+add_task(async function test_isImageIcon_classification() {
+  Assert.ok(
+    gZenEmojiPicker.isImageIcon(CUSTOM_ICON),
+    "A custom image data URL is an image icon."
+  );
+  Assert.ok(
+    gZenEmojiPicker.isImageIcon(BUNDLED_ICON),
+    "A bundled SVG is an image icon."
+  );
+  Assert.ok(
+    !gZenEmojiPicker.isImageIcon("🦊"),
+    "An emoji is not an image icon."
+  );
+  Assert.ok(!gZenEmojiPicker.isImageIcon(""), "An empty icon is not an image.");
+  Assert.ok(
+    !gZenEmojiPicker.isImageIcon(undefined),
+    "A missing icon is not an image."
+  );
+});
+
+add_task(async function test_custom_icon_renders_as_image() {
+  const workspace = gZenWorkspaces.getActiveWorkspace();
+  const previousIcon = workspace.icon;
+
+  workspace.icon = CUSTOM_ICON;
+  gZenWorkspaces.updateWorkspaceIndicator(workspace, getIndicator(workspace));
+
+  const indicatorIcon = getIndicatorIcon(workspace);
+  const image = indicatorIcon.querySelector("img");
+  Assert.ok(image, "The custom image is rendered as an image element.");
+  Assert.strictEqual(image.src, CUSTOM_ICON, "The image points at the icon.");
+  Assert.strictEqual(
+    indicatorIcon.textContent,
+    "",
+    "No text is left behind next to the image."
+  );
+  Assert.ok(
+    !indicatorIcon.hasAttribute("no-icon"),
+    "The indicator is not marked as icon-less."
+  );
+
+  workspace.icon = previousIcon;
+  gZenWorkspaces.updateWorkspaceIndicator(workspace, getIndicator(workspace));
+});
+
+add_task(async function test_emoji_icon_still_renders_as_text() {
+  const workspace = gZenWorkspaces.getActiveWorkspace();
+  const previousIcon = workspace.icon;
+
+  workspace.icon = "🦊";
+  gZenWorkspaces.updateWorkspaceIndicator(workspace, getIndicator(workspace));
+
+  const indicatorIcon = getIndicatorIcon(workspace);
+  Assert.strictEqual(
+    indicatorIcon.textContent,
+    "🦊",
+    "The indicator still renders emojis as text."
+  );
+  Assert.strictEqual(
+    indicatorIcon.querySelector("img"),
+    null,
+    "An emoji does not produce an image element."
+  );
+
+  workspace.icon = previousIcon;
+  gZenWorkspaces.updateWorkspaceIndicator(workspace, getIndicator(workspace));
+});
+
+add_task(async function test_custom_icon_in_the_spaces_strip() {
+  const workspace = gZenWorkspaces.getActiveWorkspace();
+  const previousIcon = workspace.icon;
+
+  // Two spaces are needed for the icon strip to be shown at all.
+  await gZenWorkspaces.createAndSaveWorkspace("Custom Icon Space");
+  const created = gZenWorkspaces
+    .getWorkspaces()
+    .find(space => space.name === "Custom Icon Space");
+
+  created.icon = CUSTOM_ICON;
+  await gZenWorkspaces.saveWorkspace(created);
+
+  const icons = document.querySelector("zen-workspace-icons");
+  const selector = `toolbarbutton[zen-workspace-id="${created.uuid}"]`;
+  await BrowserTestUtils.waitForCondition(
+    () => icons.querySelector(`${selector} img.zen-workspace-icon`),
+    "The new space shows up in the icon strip with its custom image."
+  );
+
+  const button = icons.querySelector(selector);
+  const image = button.querySelector("img.zen-workspace-icon");
+  Assert.strictEqual(image.src, CUSTOM_ICON, "The image points at the icon.");
+  Assert.strictEqual(
+    button.querySelector("label.zen-workspace-icon"),
+    null,
+    "No text label is added alongside the image."
+  );
+
+  await gZenWorkspaces.removeWorkspace(created.uuid);
+  workspace.icon = previousIcon;
+});

--- a/src/zen/urlbar/ZenUBActionsProvider.sys.mjs
+++ b/src/zen/urlbar/ZenUBActionsProvider.sys.mjs
@@ -441,10 +441,14 @@ export class ZenUrlbarProviderGlobalActions extends UrlbarProvider {
    * @returns {object} An object describing the view update.
    */
   getViewUpdate(result) {
-    const prettyIconIsSvg =
+    // Space icons can be an emoji, a bundled icon or a user-supplied image
+    // stored as a data URL. Keep this in sync with nsZenEmojiPicker.isImageIcon;
+    // this module cannot reach the window-scoped picker.
+    const prettyIconIsImage =
       result.payload.prettyIcon &&
       (result.payload.prettyIcon.endsWith(".svg") ||
-        result.payload.prettyIcon.endsWith(".png"));
+        result.payload.prettyIcon.endsWith(".png") ||
+        result.payload.prettyIcon.startsWith("data:image/"));
     return {
       icon: {
         attributes: {
@@ -467,7 +471,7 @@ export class ZenUrlbarProviderGlobalActions extends UrlbarProvider {
       prettyNameTitle: {
         /* eslint-disable-next-line no-nested-ternary */
         textContent: result.payload.prettyName
-          ? prettyIconIsSvg || !result.payload.prettyIcon
+          ? prettyIconIsImage || !result.payload.prettyIcon
             ? result.payload.prettyName
             : `${result.payload.prettyIcon}  ${result.payload.prettyName}`
           : "",
@@ -476,7 +480,7 @@ export class ZenUrlbarProviderGlobalActions extends UrlbarProvider {
       prettyNameIcon: {
         attributes: {
           src: result.payload.prettyIcon || "",
-          hidden: !prettyIconIsSvg || !result.payload.prettyIcon,
+          hidden: !prettyIconIsImage || !result.payload.prettyIcon,
         },
       },
     };


### PR DESCRIPTION
## What

The icon picker only offered bundled emojis and SVGs. This adds a **Custom** page to the picker that opens a file dialog and accepts any image Gecko can decode — SVG, PNG, JPEG, GIF, WebP, AVIF and so on — so a space can use an image the user supplies.

It is opt-in per call site (`allowCustomImage`), and enabled for the two places a space icon is chosen: the space creation form and *Change icon* on an existing space. Folders and pinned tabs keep their current picker behaviour untouched.

## How the icon is stored

The picked file is encoded inline as a `data:` URL. That is the representation the picker already produces for emojis rasterized via `emojiAsSVG`, and the one `gBrowser.setIcon` already persists for pinned tabs, so nothing new had to be taught to the session store or to sync — the icon survives a restart and travels with the space to other devices.

To keep that viable:

- SVGs are stored as-is, so they stay sharp at any size.
- Raster images are decoded, scaled to fit 192px on the long edge and re-encoded (WebP, falling back to PNG where the encoder does not support it). 192px still covers a 32px icon on a 4x display, and keeps the encoded result at a few KB rather than a few MB.
- Files over 10 MB are refused before we attempt to decode them, and anything that fails to decode reports a toast instead of silently doing nothing.

User-supplied SVGs are only ever rendered through `<img>`/XUL image, which does not run scripts or load external references, so an untrusted document is inert.

## Drive-by fixes

Whether an icon should render as an image was decided by `icon.endsWith(".svg")` in four separate places. A data URL fails that test, which would have rendered the base64 blob as the space's text label. Those are now a single `nsZenEmojiPicker.isImageIcon()`.

Two more copies of the same idea existed outside the spaces code and had the same defect:

- `ZenUBActionsProvider` — space icons appear in urlbar actions.
- `ZenSpaceRoutingDialog` — it tested `startsWith("chrome://")`.

It cannot reach the window-scoped picker from a `.sys.mjs`, so the urlbar one keeps a local copy of the rule with a comment pointing back at the canonical version.

Finally, the icon CSS only constrained the width of icon images, which was fine for square bundled SVGs but not for arbitrary photos; both axes are now constrained with `object-fit: contain`.

## Tests

`src/zen/tests/spaces/browser_custom_space_icon.js` covers the classification helper and asserts that a data-URL icon renders as an image — in both the space indicator and the spaces strip — while an emoji still renders as text.

## What I could not verify

I do not have a built `engine/` here, so this has **not** been run: no `npm run lint`, no `npm run test`, and no manual pass through the UI. The JS/CSS is Prettier-clean against the repo's settings, but the new panel markup, the file dialog flow and the appearance of the custom page all deserve a look on a real build before this lands. In particular, the file dialog is modal and dismisses the panel on some platforms — the code deliberately captures the selection callbacks up front so the result is still delivered when that happens, but that path is exactly what I could not exercise.

One consequence worth a maintainer's opinion: because icons are inlined, a space with a custom icon adds tens of KB to the session store and to the sync payload. Storing the file in the profile instead would avoid that, but would not sync and would need its own lifecycle management. Happy to switch if you would rather have it the other way.

No tracking issue — the repo routes feature requests to Discussions, so I did not open one; please attach the right `gh-` number on merge.
