### PR TITLE
fix(tabs): keep collapsed sidebar centered when Windows always shows scrollbars

### DIFF
--- a/src/zen/tabs/zen-tabs/vertical-tabs.css
+++ b/src/zen/tabs/zen-tabs/vertical-tabs.css
@@ -479,11 +479,16 @@
   }
 
   /* Windows "Always show scrollbars" reserves layout space for the
-     scrollbar, shifting the collapsed tab list left and clipping the
-     new-tab button (issue #12402). Hide it in the collapsed sidebar
-     where tabs are icon-only; wheel scrolling still works. */
-  :root:not([zen-sidebar-expanded="true"]) & {
-    scrollbar-width: none;
+     scrollbar, shifting the collapsed icon-only tab list left and
+     clipping the new-tab button (issue #12402). The collapsed sidebar
+     is only ~60px wide; hide the classic scrollbar there so tabs stay
+     centered. Wheel scrolling still works, and the expanded sidebar
+     keeps its scrollbar. Limited to Windows: macOS/Linux use overlay
+     scrollbars that never reserve space. */
+  @media (-moz-platform: windows) {
+    :root:not([zen-sidebar-expanded="true"]) & {
+      scrollbar-width: none;
+    }
   }
 }
 

--- a/src/zen/tabs/zen-tabs/vertical-tabs.css
+++ b/src/zen/tabs/zen-tabs/vertical-tabs.css
@@ -477,6 +477,14 @@
     margin-left: calc(-1 * var(--zen-toolbox-padding));
     width: calc(100% + var(--zen-toolbox-padding) * 2);
   }
+
+  /* Windows "Always show scrollbars" reserves layout space for the
+     scrollbar, shifting the collapsed tab list left and clipping the
+     new-tab button (issue #12402). Hide it in the collapsed sidebar
+     where tabs are icon-only; wheel scrolling still works. */
+  :root:not([zen-sidebar-expanded="true"]) & {
+    scrollbar-width: none;
+  }
 }
 
 #pinned-tabs-container {

--- a/src/zen/tabs/zen-tabs/vertical-tabs.css
+++ b/src/zen/tabs/zen-tabs/vertical-tabs.css
@@ -478,16 +478,24 @@
     width: calc(100% + var(--zen-toolbox-padding) * 2);
   }
 
-  /* Windows "Always show scrollbars" reserves layout space for the
-     scrollbar, shifting the collapsed icon-only tab list left and
-     clipping the new-tab button (issue #12402). The collapsed sidebar
-     is only ~60px wide; hide the classic scrollbar there so tabs stay
-     centered. Wheel scrolling still works, and the expanded sidebar
-     keeps its scrollbar. Limited to Windows: macOS/Linux use overlay
-     scrollbars that never reserve space. */
-  @media (-moz-platform: windows) {
-    :root:not([zen-sidebar-expanded="true"]) & {
-      scrollbar-width: none;
+  /* Keep classic scrollbars usable without shifting collapsed controls.
+     A scrollbar on one edge is paired with an equal gutter on the opposite
+     edge, so the content remains centered in the full sidebar (issue #12402).
+     Overlay scrollbars do not create a gutter. */
+  :root:not([zen-sidebar-expanded="true"]) &:has(#tabbrowser-tabs[overflow]) {
+    scrollbar-gutter: stable both-edges;
+
+    /* Both gutters reduce the available inline size. Collapsed controls are
+       icon-only, so let them shrink to the available space instead of being
+       clipped by their 48px default minimum. */
+    & #tabbrowser-tabs .tabbrowser-tab,
+    & #tabbrowser-tabs .tabbrowser-tab .tab-background,
+    & #vertical-tabs-newtab-button,
+    & zen-folder,
+    & tab-group[split-view-group],
+    & tab-group[split-view-group] > .tab-group-container {
+      min-width: 0 !important;
+      width: 100% !important;
     }
   }
 }


### PR DESCRIPTION
Closes #12402

## Problem
With Windows *Always show scrollbars* enabled, the collapsed sidebar tab list shifts left and the new-tab button is clipped when the active workspace overflows. The tab strip is only about 60px wide, so the classic scrollbar consumes a large part of its inline space.

## Fix
Use the platform-standard `scrollbar-gutter: stable both-edges` only when the collapsed tab strip has the existing `[overflow]` state:

- The native scrollbar remains visible and draggable.
- The opposite gutter keeps the icon-only content centered in the full sidebar.
- Collapsed tabs, folders, split-view groups, and the new-tab button can shrink to the available content width instead of overflowing and being clipped.
- When the tab strip does not overflow, the existing layout is unchanged.
- Overlay scrollbars do not consume a gutter, so macOS/Linux overlay behavior is not artificially widened.

The existing `#tabbrowser-tabs[overflow]` state is maintained by `ZenSpaceManager.updateOverflowingTabs()` from the active workspace scrollbox, so this does not add a new observer or scrollbar-width calculation.

## Verification
- Static CSS brace balance: passed.
- `git diff --check`: passed.
- Browser geometry smoke test with a 60px container, classic 17px scrollbar, and `stable both-edges`: content and controls remain centered while the scrollbar remains present.
- ⚠️ Still needs Windows Zen verification with *Always show scrollbars* enabled, including regular tabs, folders, split-view tabs, tab scrolling/dragging, and the no-overflow state.
