### PR TITLE
fix: Allow renaming folders, tabs, and spaces in collapsed sidebar mode

### DIFF
--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -1647,7 +1647,7 @@ window.gZenVerticalTabsManager = {
     }
   },
 
-  renameTabStart(event) {
+  async renameTabStart(event) {
     let target = event.target;
     if (event.target.id === "context_zen-edit-tab-title") {
       target = TabContextMenu.contextTab;
@@ -1658,8 +1658,7 @@ window.gZenVerticalTabsManager = {
       ((!Services.prefs.getBoolPref("zen.tabs.rename-tabs") ||
         (Services.prefs.getBoolPref("browser.tabs.closeTabByDblclick") &&
           event.type === "dblclick")) &&
-        isTab) ||
-      !gZenVerticalTabsManager._prefsSidebarExpanded
+        isTab)
     ) {
       return;
     }
@@ -1678,6 +1677,56 @@ window.gZenVerticalTabsManager = {
       !this._tabEdited ||
       (this._tabEdited.hasAttribute("zen-essential") && isTab)
     ) {
+      this._tabEdited = null;
+      return;
+    }
+
+    if (!gZenVerticalTabsManager._prefsSidebarExpanded) {
+      const content = isTab ? this._tabEdited.label : this._tabEdited.textContent;
+      const inputVal = { value: content || "" };
+      const isWorkspace = !!this._tabEdited.closest(".zen-current-workspace-indicator-name");
+      let l10nKey = "zen-folders-panel-rename-folder";
+      if (isTab) {
+        l10nKey = "tab-context-zen-edit-title";
+      } else if (isWorkspace) {
+        l10nKey = "zen-workspaces-panel-change-name";
+      }
+
+      let title = "Rename";
+      try {
+        const msgs = await document.l10n.formatMessages([{ id: l10nKey }]);
+        const labelAttr = msgs?.[0]?.attributes?.find(a => a.name === "label");
+        if (labelAttr?.value) {
+          title = labelAttr.value.replace(/…|\.\.\./g, "").trim();
+        }
+      } catch (e) { }
+
+      const confirmed = Services.prompt.prompt(
+        window,
+        title,
+        null,
+        inputVal,
+        null,
+        { value: false }
+      );
+      if (confirmed) {
+        const newName = inputVal.value.replace(/\s+/g, " ").trim();
+        const hasChanged = newName !== content && newName;
+        if (!isTab) {
+          await this._tabEdited.onRenameFinished(newName);
+        } else {
+          if (hasChanged || (this._tabEdited.zenStaticLabel && newName)) {
+            this._tabEdited.zenStaticLabel = newName;
+            gBrowser._setTabLabel(this._tabEdited, newName, {
+              _zenChangeLabelFlag: true,
+            });
+            gZenUIManager.showToast("zen-tabs-renamed");
+          } else if (!newName) {
+            delete this._tabEdited.zenStaticLabel;
+            gBrowser.setTabTitle(this._tabEdited);
+          }
+        }
+      }
       this._tabEdited = null;
       return;
     }

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -1592,6 +1592,29 @@ window.gZenVerticalTabsManager = {
     }
   },
 
+  async _applyTabRename(newValue, originalValue) {
+    const newName = newValue.replace(/\s+/g, " ").trim();
+    const hasChanged = newName !== originalValue && newName;
+    const isTab = !!this._tabEdited.closest(".tabbrowser-tab");
+    if (!isTab) {
+      await this._tabEdited.onRenameFinished(newName);
+    } else {
+      // Check if name is blank, reset if so
+      // Always remove, so we can always rename and if it's empty,
+      // it will reset to the original name anyway
+      if (hasChanged || (this._tabEdited.zenStaticLabel && newName)) {
+        this._tabEdited.zenStaticLabel = newName;
+        gBrowser._setTabLabel(this._tabEdited, newName, {
+          _zenChangeLabelFlag: true,
+        });
+        gZenUIManager.showToast("zen-tabs-renamed");
+      } else {
+        delete this._tabEdited.zenStaticLabel;
+        gBrowser.setTabTitle(this._tabEdited);
+      }
+    }
+  },
+
   async renameTabKeydown(event) {
     event.stopPropagation();
     if (event.key === "Enter") {
@@ -1600,28 +1623,11 @@ window.gZenVerticalTabsManager = {
         ? this._tabEdited.querySelector(".tab-label-container-editing")
         : this._tabEdited;
       let input = document.getElementById("tab-label-input");
-      let newName = input.value.replace(/\s+/g, " ").trim();
-      const hasChanged = input.value !== input._originalValue && newName;
-
       document.documentElement.removeAttribute("zen-renaming-tab");
       input.remove();
-      if (!isTab) {
-        await this._tabEdited.onRenameFinished(newName);
-      } else {
-        // Check if name is blank, reset if so
-        // Always remove, so we can always rename and if it's empty,
-        // it will reset to the original name anyway
-        if (hasChanged || (this._tabEdited.zenStaticLabel && newName)) {
-          this._tabEdited.zenStaticLabel = newName;
-          gBrowser._setTabLabel(this._tabEdited, newName, {
-            _zenChangeLabelFlag: true,
-          });
-          gZenUIManager.showToast("zen-tabs-renamed");
-        } else {
-          delete this._tabEdited.zenStaticLabel;
-          gBrowser.setTabTitle(this._tabEdited);
-        }
+      await this._applyTabRename(input.value, input._originalValue);
 
+      if (isTab) {
         gZenUIManager.motion.animate(
           this._tabEdited,
           {
@@ -1647,7 +1653,7 @@ window.gZenVerticalTabsManager = {
     }
   },
 
-  renameTabStart(event) {
+  async renameTabStart(event) {
     let target = event.target;
     if (event.target.id === "context_zen-edit-tab-title") {
       target = TabContextMenu.contextTab;
@@ -1658,8 +1664,7 @@ window.gZenVerticalTabsManager = {
       ((!Services.prefs.getBoolPref("zen.tabs.rename-tabs") ||
         (Services.prefs.getBoolPref("browser.tabs.closeTabByDblclick") &&
           event.type === "dblclick")) &&
-        isTab) ||
-      !gZenVerticalTabsManager._prefsSidebarExpanded
+        isTab)
     ) {
       return;
     }
@@ -1678,6 +1683,39 @@ window.gZenVerticalTabsManager = {
       !this._tabEdited ||
       (this._tabEdited.hasAttribute("zen-essential") && isTab)
     ) {
+      this._tabEdited = null;
+      return;
+    }
+
+    if (!gZenVerticalTabsManager._prefsSidebarExpanded) {
+      const content = isTab ? this._tabEdited.label : this._tabEdited.textContent;
+      const inputVal = { value: content || "" };
+      const isWorkspace = !!this._tabEdited.closest(".zen-current-workspace-indicator-name");
+      let l10nKey = "zen-folders-panel-rename-folder";
+      if (isTab) {
+        l10nKey = "tab-context-zen-edit-title";
+      } else if (isWorkspace) {
+        l10nKey = "zen-workspaces-panel-change-name";
+      }
+
+      let title = "Rename";
+      const msgs = await document.l10n.formatMessages([{ id: l10nKey }]);
+      const labelAttr = msgs?.[0]?.attributes?.find(a => a.name === "label");
+      if (labelAttr?.value) {
+        title = labelAttr.value.replace(/…|\.\.\./g, "").trim();
+      }
+
+      const confirmed = Services.prompt.prompt(
+        window,
+        title,
+        null,
+        inputVal,
+        null,
+        { value: false }
+      );
+      if (confirmed) {
+        await this._applyTabRename(inputVal.value, content);
+      }
       this._tabEdited = null;
       return;
     }

--- a/src/zen/folders/ZenFolder.mjs
+++ b/src/zen/folders/ZenFolder.mjs
@@ -136,9 +136,6 @@ export class nsZenFolder extends MozTabbrowserTabGroup {
   }
 
   rename() {
-    if (!document.documentElement.hasAttribute("zen-sidebar-expanded")) {
-      return;
-    }
     gZenVerticalTabsManager.renameTabStart({
       target: this.labelElement,
       explicit: true,

--- a/src/zen/folders/zen-folders.css
+++ b/src/zen/folders/zen-folders.css
@@ -347,8 +347,3 @@ zen-folder[collapsed] > .tab-group-container {
   display: none !important;
 }
 
-:root:not([zen-sidebar-expanded]) {
-  & #context_zenFolderRename {
-    display: none !important;
-  }
-}

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -1220,15 +1220,9 @@ class nsZenWorkspaces {
     const themePicker = document.getElementById(
       "context_zenChangeWorkspaceTheme"
     );
-    /* We can't show the rename input properly in collapsed state,
-    so hide the workspace edit input */
-    const isCollapsed = !Services.prefs.getBoolPref(
-      "zen.view.sidebar-expanded"
-    );
     workspaceName.hidden =
-      isCollapsed ||
-      (this.#contextMenuData.workspaceId &&
-        this.#contextMenuData.workspaceId !== this.activeWorkspace);
+      this.#contextMenuData.workspaceId &&
+      this.#contextMenuData.workspaceId !== this.activeWorkspace;
     themePicker.hidden =
       this.#contextMenuData.workspaceId &&
       this.#contextMenuData.workspaceId !== this.activeWorkspace;

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -731,8 +731,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
       !isVisible;
     document.getElementById("context_zen-edit-tab-title").hidden =
       isEssential ||
-      !Services.prefs.getBoolPref("zen.tabs.rename-tabs") ||
-      !gZenVerticalTabsManager._prefsSidebarExpanded;
+      !Services.prefs.getBoolPref("zen.tabs.rename-tabs");
   }
 
   // eslint-disable-next-line complexity


### PR DESCRIPTION
Closes #14082 

### Problem

When the sidebar is in **Collapsed Toolbar** mode (compact icon-only view), attempting to rename tab folders, tabs, or spaces/workspaces either hid the context menu item or did nothing.

The root causes were:
1. `nsZenFolder.rename()` had an early-return check (`if (!document.documentElement.hasAttribute("zen-sidebar-expanded")) return;`) which silently bailed out in collapsed mode.
2. `ZenPinnedTabManager` and `ZenSpaceManager` explicitly hid their rename context menu items (`context_zen-edit-tab-title` and `context_zenEditWorkspace`) when the sidebar was not expanded.
3. `ZenUIManager.renameTabStart()` returned early when collapsed because the inline `<input>` editing flow relies on a visible expanded label container.

---

### Solution

When the sidebar is in collapsed mode, `gZenVerticalTabsManager.renameTabStart()` falls back to a native `Services.prompt.prompt()` modal dialog pre-filled with the item's current name.

- The dialog header dynamically extracts the localized string via `document.l10n.formatMessages()` ("Rename Folder", "Change Label", or "Change Name").
- Upon confirmation, the new name is saved using `onRenameFinished()` for folders and spaces, and `gBrowser._setTabLabel()` for tabs.
- When the sidebar is expanded, the existing inline rename flow continues to function unchanged.

---

### Changes

* `src/zen/folders/zen-folders.css`: Removed CSS rule hiding `#context_zenFolderRename` in collapsed mode.
* `src/zen/folders/ZenFolder.mjs`: Allowed `rename()` to execute regardless of sidebar expansion state.
* `src/zen/tabs/ZenPinnedTabManager.mjs`: Un-hid `context_zen-edit-tab-title` in collapsed sidebar mode.
* `src/zen/spaces/ZenSpaceManager.mjs`: Un-hid `context_zenEditWorkspace` in collapsed sidebar mode.
* `src/zen/common/modules/ZenUIManager.mjs`: Centralized prompt modal rename fallback in `renameTabStart()` for collapsed mode with async Fluent L10n title extraction.
