### PR TITLE
gh-14921: Fix shifted digit and symbol shortcuts

### DIFF
--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -306,28 +306,28 @@ export class nsKeyShortcutModifiers {
 }
 
 class KeyShortcut {
-  static SHIFTED_SYMBOLS = {
-    1: "!",
-    2: "@",
-    3: "#",
-    4: "$",
-    5: "%",
-    6: "^",
-    7: "&",
-    8: "*",
-    9: "(",
-    0: ")",
-    "`": "~",
-    "-": "_",
-    "=": "+",
-    "[": "{",
-    "]": "}",
-    "\\": "|",
-    ";": ":",
-    "'": '"',
-    ",": "<",
-    ".": ">",
-    "/": "?",
+  static SHIFTED_KEYCODES = {
+    1: "VK_1",
+    2: "VK_2",
+    3: "VK_3",
+    4: "VK_4",
+    5: "VK_5",
+    6: "VK_6",
+    7: "VK_7",
+    8: "VK_8",
+    9: "VK_9",
+    0: "VK_0",
+    "`": "VK_BACK_QUOTE",
+    "-": "VK_HYPHEN_MINUS",
+    "=": "VK_EQUALS",
+    "[": "VK_OPEN_BRACKET",
+    "]": "VK_CLOSE_BRACKET",
+    "\\": "VK_BACK_SLASH",
+    ";": "VK_SEMICOLON",
+    "'": "VK_QUOTE",
+    ",": "VK_COMMA",
+    ".": "VK_PERIOD",
+    "/": "VK_SLASH",
   };
   #id = "";
   #key = "";
@@ -455,34 +455,25 @@ class KeyShortcut {
   replaceWithChild(key) {
     key.id = this.#id;
 
-    // When shift is pressed and the char changes when shifted (like 1 -> !),
-    // the XUL matches the shifted character so we need to emit the shifted character
-    // and drop the shift modifier so XUL can match
-    // This problem is also windows specific
-    let keyName = this.#key;
-    let modifiers = this.#modifiers;
-
-    if (AppConstants.platform == "win") {
-      const shiftedKey = KeyShortcut.SHIFTED_SYMBOLS[keyName];
-      if (shiftedKey && modifiers.shift) {
-        keyName = shiftedKey;
-        modifiers = new nsKeyShortcutModifiers(
-          modifiers.control,
-          modifiers.alt,
-          false, // -> for shift key
-          modifiers.meta,
-          modifiers.accel
-        );
-      }
-    }
+    // Character shortcuts are matched against layout-dependent text. Use the
+    // physical keycode when Shift changes that text so bindings captured from
+    // event.code keep their Shift modifier and work across keyboard layouts.
+    const shiftedKeycode =
+      this.#modifiers.shift && KeyShortcut.SHIFTED_KEYCODES[this.#key];
 
     if (this.#keycode) {
       key.setAttribute("keycode", this.#keycode);
       key.removeAttribute("key");
-    } else if (keyName) {
+    } else if (shiftedKeycode) {
+      key.setAttribute("keycode", shiftedKeycode);
+      key.removeAttribute("key");
+      // Printable keypress events expose a zero keyCode, so physical keycode
+      // shortcuts need to be matched while their keyCode is still available.
+      key.setAttribute("event", "keydown");
+    } else if (this.#key) {
       // note to "mr. macos": Better use setAttribute, because without it, there's a
       //  risk of malforming the XUL element.
-      key.setAttribute("key", keyName);
+      key.setAttribute("key", this.#key);
       key.removeAttribute("keycode");
     } else {
       key.removeAttribute("key");
@@ -497,7 +488,7 @@ class KeyShortcut {
     if (this.#l10nId) {
       // key.setAttribute('data-l10n-id', this.#l10nId);
     }
-    key.setAttribute("modifiers", modifiers.toString());
+    key.setAttribute("modifiers", this.#modifiers.toString());
     if (this.#action) {
       key.setAttribute("command", this.#action);
     }

--- a/src/zen/tests/keyboard_shortcuts/browser.toml
+++ b/src/zen/tests/keyboard_shortcuts/browser.toml
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+["browser_shifted_shortcuts.js"]

--- a/src/zen/tests/keyboard_shortcuts/browser_shifted_shortcuts.js
+++ b/src/zen/tests/keyboard_shortcuts/browser_shifted_shortcuts.js
@@ -1,0 +1,76 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const SHORTCUT_ID = "zen-workspace-switch-1";
+const COMMAND_ID = "cmd_zenWorkspaceSwitch1";
+
+add_task(async function test_shifted_shortcuts_use_physical_keycodes() {
+  const manager = window.gZenKeyboardShortcutsManager;
+  const shortcut = manager.getShortcutFromCommand(COMMAND_ID);
+
+  Assert.ok(shortcut, "Workspace shortcut should be available");
+
+  const originalKey = shortcut.getKeyName();
+  const originalModifiers = shortcut.getModifiers();
+
+  registerCleanupFunction(async () => {
+    if (originalKey) {
+      await manager.setShortcut(SHORTCUT_ID, originalKey, originalModifiers);
+    } else {
+      await manager.setShortcut(SHORTCUT_ID, null, null);
+    }
+  });
+
+  const modifiers = originalModifiers.constructor.fromObject({
+    accel: true,
+    shift: true,
+  });
+
+  for (const [keyName, keycode] of [
+    ["1", "VK_1"],
+    ["=", "VK_EQUALS"],
+  ]) {
+    await manager.setShortcut(SHORTCUT_ID, keyName, modifiers);
+
+    const key = document.getElementById(SHORTCUT_ID);
+    Assert.equal(
+      key.getAttribute("keycode"),
+      keycode,
+      `${keyName} should use its physical keycode`
+    );
+    Assert.ok(!key.hasAttribute("key"), "Character key should be removed");
+    Assert.equal(
+      key.getAttribute("modifiers"),
+      "accel,shift",
+      "Shift should remain part of the shortcut"
+    );
+    Assert.equal(
+      key.getAttribute("event"),
+      "keydown",
+      "Physical keycodes should be matched before printable keypress"
+    );
+  }
+
+  await manager.setShortcut(SHORTCUT_ID, "1", modifiers);
+
+  const command = document.getElementById(COMMAND_ID);
+  let commandFired = false;
+  command.addEventListener(
+    "command",
+    event => {
+      commandFired = true;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    },
+    { capture: true, once: true }
+  );
+
+  EventUtils.synthesizeKey("1", { accelKey: true, shiftKey: true }, window);
+  await TestUtils.waitForCondition(
+    () => commandFired,
+    "Shifted digit shortcut should trigger its command"
+  );
+  Assert.ok(commandFired, "Shifted digit shortcut should trigger its command");
+});

--- a/src/zen/tests/moz.build
+++ b/src/zen/tests/moz.build
@@ -8,6 +8,7 @@ BROWSER_CHROME_MANIFESTS += [
     "container_essentials/browser.toml",
     "folders/browser.toml",
     "glance/browser.toml",
+    "keyboard_shortcuts/browser.toml",
     "live-folders/browser.toml",
     "media/browser.toml",
     "pinned/browser.toml",


### PR DESCRIPTION
## Summary

- use physical XUL keycodes for shifted digits and symbols instead of translating them to layout-dependent characters
- preserve the Shift modifier and match these keycode shortcuts on `keydown`, while printable events still expose their physical keycode
- add browser-chrome coverage for the generated attributes and actual command dispatch

## Testing

- `cd engine && ./mach lint zen/kbs/ZenKeyboardShortcuts.mjs`
- `cd engine && node_modules/.bin/eslint --no-ignore zen/tests/keyboard_shortcuts/browser_shifted_shortcuts.js`
- `python3 scripts/run_tests.py keyboard_shortcuts/browser_shifted_shortcuts.js --headless --force` (10/10 subtests passed)
- full debug browser build
- built-browser Linux/X11 UI test with a clean profile and two workspaces: bound `Switch to Workspace 1` to `Ctrl+Shift+1` in Settings and confirmed it switched from workspace 2 to workspace 1; bound `Switch to Workspace 2` to `Alt+Shift+=` and confirmed it switched back to workspace 2

The built-browser UI check used a virtual X11 display. I have not tested a physical keyboard on Windows.

Closes #14921
