### PR TITLE
fix: declare local network usage on macOS

### DIFF
--- a/src/external-patches/firefox/macos_local_network_usage_description.patch
+++ b/src/external-patches/firefox/macos_local_network_usage_description.patch
@@ -1,0 +1,13 @@
+diff --git a/browser/app/macbuild/Contents/Info.plist.in b/browser/app/macbuild/Contents/Info.plist.in
+index 2795b177f4943d58da987153d3f3b66b81bd16ab..eea4e19e95e9e392a021493a8f57444d62e6fd7b 100644
+--- a/browser/app/macbuild/Contents/Info.plist.in
++++ b/browser/app/macbuild/Contents/Info.plist.in
+@@ -319,4 +319,8 @@
+   <key>NSNetworkVolumesUsageDescription</key>
+   <string>@MAC_APP_NAME@ needs access to network volumes to open and save files at your request.</string>
++
++  <key>NSLocalNetworkUsageDescription</key>
++  <string>@MAC_APP_NAME@ needs access to open websites and services hosted on your local network.</string>
++
+ </dict>
+ </plist>

--- a/src/external-patches/manifest.json
+++ b/src/external-patches/manifest.json
@@ -26,6 +26,10 @@
     "path": "firefox/no_liquid_glass_icon.patch"
   },
   {
+    "type": "local",
+    "path": "firefox/macos_local_network_usage_description.patch"
+  },
+  {
     "type": "patch",
     "url": "https://codeberg.org/librewolf/source/raw/branch/main/patches/firefox-in-ua.patch",
     "dest": "librewolf",


### PR DESCRIPTION
## Summary

- add `NSLocalNetworkUsageDescription` to the macOS application plist through Zen's Firefox patch set
- register the patch in the external-patches manifest

## Problem

Zen users on macOS report that LAN addresses fail while the same addresses work in other browsers, and in some cases Zen does not appear correctly under System Settings > Privacy & Security > Local Network. This is tracked in #13860 and #11201.

The signed Zen 1.21.13b bundle currently has a valid application identifier and unique executable UUIDs, but its main `Info.plist` does not contain `NSLocalNetworkUsageDescription`. Apple recommends that any application which accesses the local network directly or indirectly include this key so macOS can explain and track the permission correctly:

https://developer.apple.com/documentation/BundleResources/Information-Property-List/NSLocalNetworkUsageDescription

Firefox is also tracking the missing metadata upstream in https://bugzilla.mozilla.org/show_bug.cgi?id=1936468. Keeping this as an external Firefox patch lets Zen address the gap until it lands upstream.

## Impact

Signed macOS builds will declare why Zen needs local-network access, allowing macOS to present a meaningful permission prompt for websites and services hosted on the user's LAN. This does not reset already-corrupted or stale macOS permission records.

## Validation

- applied the patch after Zen's existing `no_liquid_glass_icon.patch` against the frozen Firefox 153.0.3 source
- ran the Zen Node 22 patch-import sequence and confirmed the external patch applies
- validated the resulting `Info.plist.in` with `plutil -lint`
- ran `git diff --check`
- applied the final submission patch to a clean Zen checkout
