### PR TITLE
gh-14922: Collapse toolbar after modal prompts

### DIFF
--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -24,6 +24,9 @@ window.gZenUIManager = {
 
     document.addEventListener("popupshowing", this.onPopupShowing.bind(this));
     document.addEventListener("popuphidden", this.onPopupHidden.bind(this));
+    window.addEventListener("DOMModalDialogClosed", () =>
+      this._clearDeferredPopupTrackingAttribute()
+    );
 
     document.addEventListener(
       "mousedown",
@@ -333,6 +336,15 @@ window.gZenUIManager = {
     this._popupTrackingElements.remove(element);
   },
 
+  _clearDeferredPopupTrackingAttribute() {
+    const removeAttribute = this.__removeHasPopupAttribute;
+    if (!removeAttribute) {
+      return;
+    }
+    document.removeEventListener("mousemove", removeAttribute);
+    removeAttribute();
+  },
+
   // On macOS, the app menu panel is displayed as a native NSPopover which
   // silently clips content beyond the screen without informing Firefox's
   // layout engine. This makes bottom menu items unreachable by scrolling.
@@ -378,7 +390,7 @@ window.gZenUIManager = {
       ) {
         continue;
       }
-      document.removeEventListener("mousemove", this.__removeHasPopupAttribute);
+      this._clearDeferredPopupTrackingAttribute();
       gZenCompactModeManager._setElementExpandAttribute(
         el,
         true,
@@ -402,15 +414,18 @@ window.gZenUIManager = {
         "has-popup-menu"
       );
     } else {
-      this.__removeHasPopupAttribute = () =>
+      const removeAttribute = () => {
+        if (this.__removeHasPopupAttribute === removeAttribute) {
+          this.__removeHasPopupAttribute = null;
+        }
         gZenCompactModeManager._setElementExpandAttribute(
           element,
           false,
           "has-popup-menu"
         );
-      document.addEventListener("mousemove", this.__removeHasPopupAttribute, {
-        once: true,
-      });
+      };
+      this.__removeHasPopupAttribute = removeAttribute;
+      document.addEventListener("mousemove", removeAttribute, { once: true });
     }
     this.__currentPopup = null;
     this.__currentPopupTrackElement = null;

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -129,6 +129,12 @@ window.gZenCompactModeManager = {
       this._clearAllHoverStates()
     );
 
+    // Modal prompts can interrupt mouseleave delivery and leave a stale hover
+    // state behind after the prompt closes.
+    window.addEventListener("DOMModalDialogClosed", () =>
+      this._clearAllHoverStates()
+    );
+
     // Hide any element kept open by the outside mouse tracking as soon as the
     // window loses focus
     window.addEventListener("deactivate", () => this._collapseTrackedElement());

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -129,12 +129,6 @@ window.gZenCompactModeManager = {
       this._clearAllHoverStates()
     );
 
-    // Modal prompts can interrupt mouseleave delivery and leave a stale hover
-    // state behind after the prompt closes.
-    window.addEventListener("DOMModalDialogClosed", () =>
-      this._clearAllHoverStates()
-    );
-
     // Hide any element kept open by the outside mouse tracking as soon as the
     // window loses focus
     window.addEventListener("deactivate", () => this._collapseTrackedElement());

--- a/src/zen/tests/compact_mode/browser.toml
+++ b/src/zen/tests/compact_mode/browser.toml
@@ -4,4 +4,6 @@
 
 [DEFAULT]
 
+["browser_compact_mode_dialog.js"]
+
 ["browser_compact_mode_width.js"]

--- a/src/zen/tests/compact_mode/browser_compact_mode_dialog.js
+++ b/src/zen/tests/compact_mode/browser_compact_mode_dialog.js
@@ -5,9 +5,12 @@
 
 add_task(async function test_toolbar_collapses_after_modal_dialog_closes() {
   const toolbar = document.getElementById("zen-appcontent-navbar-wrapper");
-  const browser = gBrowser.selectedBrowser;
 
-  EventUtils.synthesizeMouseAtCenter(browser, { type: "mousemove" }, window);
+  EventUtils.synthesizeMouseAtCenter(
+    gBrowser.selectedBrowser,
+    { type: "mousemove" },
+    window
+  );
   await TestUtils.waitForCondition(
     () => !toolbar.matches(":hover"),
     "The pointer should be outside the toolbar"
@@ -19,8 +22,27 @@ add_task(async function test_toolbar_collapses_after_modal_dialog_closes() {
     "The toolbar starts with a stale hover state"
   );
 
-  // Firefox dispatches this event after beforeunload and other modal prompts.
-  window.dispatchEvent(new CustomEvent("DOMModalDialogClosed"));
+  const dialogClosed = BrowserTestUtils.waitForEvent(
+    window,
+    "DOMModalDialogClosed"
+  );
+  const dialogOpened = BrowserTestUtils.promiseAlertDialogOpen();
+  setTimeout(() => Services.prompt.alert(window, "Test", "Test"), 0);
+
+  let dialogWindow = await dialogOpened;
+  let dialogContainer =
+    dialogWindow.docShell.chromeEventHandler.closest("dialog");
+  const dialogRemoved = BrowserTestUtils.waitForMutationCondition(
+    dialogContainer,
+    { childList: true, attributes: true },
+    () => !dialogContainer.hasChildNodes() && !dialogContainer.open
+  );
+
+  dialogWindow.document.querySelector("dialog").acceptDialog();
+  await dialogClosed;
+  await dialogRemoved;
+  dialogWindow = null;
+  dialogContainer = null;
 
   Assert.ok(
     !toolbar.hasAttribute("zen-has-hover"),

--- a/src/zen/tests/compact_mode/browser_compact_mode_dialog.js
+++ b/src/zen/tests/compact_mode/browser_compact_mode_dialog.js
@@ -3,49 +3,82 @@
 
 "use strict";
 
-add_task(async function test_toolbar_collapses_after_modal_dialog_closes() {
+add_task(async function test_popup_tracking_clears_after_close_warning() {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["browser.tabs.warnOnClose", true],
+      ["browser.warnOnQuit", true],
+    ],
+  });
+  const tab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "about:blank"
+  );
   const toolbar = document.getElementById("zen-appcontent-navbar-wrapper");
-
-  EventUtils.synthesizeMouseAtCenter(
-    gBrowser.selectedBrowser,
-    { type: "mousemove" },
-    window
-  );
-  await TestUtils.waitForCondition(
-    () => !toolbar.matches(":hover"),
-    "The pointer should be outside the toolbar"
-  );
-
-  gZenCompactModeManager._setElementExpandAttribute(toolbar, true);
+  const popupAnchor = document.getElementById("PanelUI-menu-button");
+  const popup = document.createXULElement("menupopup");
+  let trackedToolbar;
   Assert.ok(
-    toolbar.hasAttribute("zen-has-hover"),
-    "The toolbar starts with a stale hover state"
+    toolbar.contains(popupAnchor),
+    "The popup anchor should be inside a tracked toolbar"
   );
+  registerCleanupFunction(() => {
+    if (gZenUIManager.__removeHasPopupAttribute) {
+      document.removeEventListener(
+        "mousemove",
+        gZenUIManager.__removeHasPopupAttribute
+      );
+      gZenUIManager.__removeHasPopupAttribute();
+      gZenUIManager.__removeHasPopupAttribute = null;
+    }
+    gZenUIManager.__currentPopup = null;
+    gZenUIManager.__currentPopupTrackElement = null;
+    if (tab.isConnected) {
+      BrowserTestUtils.removeTab(tab);
+    }
+    trackedToolbar?.removeAttribute("has-popup-menu");
+  });
 
-  const dialogClosed = BrowserTestUtils.waitForEvent(
-    window,
-    "DOMModalDialogClosed"
-  );
-  const dialogOpened = BrowserTestUtils.promiseAlertDialogOpen();
-  setTimeout(() => Services.prompt.alert(window, "Test", "Test"), 0);
+  const dialogClosed = BrowserTestUtils.promiseAlertDialog("", undefined, {
+    callback(dialogWindow) {
+      gZenUIManager.onPopupShowing({
+        explicitOriginalTarget: popupAnchor,
+        target: popup,
+      });
+      trackedToolbar = gZenUIManager.__currentPopupTrackElement;
+      Assert.ok(
+        trackedToolbar?.hasAttribute("has-popup-menu"),
+        "Opening a toolbar popup should set the tracking attribute"
+      );
 
-  let dialogWindow = await dialogOpened;
-  let dialogContainer =
-    dialogWindow.docShell.chromeEventHandler.closest("dialog");
-  const dialogRemoved = BrowserTestUtils.waitForMutationCondition(
-    dialogContainer,
-    { childList: true, attributes: true },
-    () => !dialogContainer.hasChildNodes() && !dialogContainer.open
-  );
-
-  dialogWindow.document.querySelector("dialog").acceptDialog();
+      const mainWindow = document.getElementById("main-window");
+      const matches = mainWindow.matches;
+      Object.defineProperty(mainWindow, "matches", {
+        configurable: true,
+        value(selector) {
+          return selector === ":hover"
+            ? false
+            : matches.call(mainWindow, selector);
+        },
+      });
+      try {
+        gZenUIManager.onPopupHidden({ target: popup });
+      } finally {
+        delete mainWindow.matches;
+      }
+      Assert.ok(
+        trackedToolbar.hasAttribute("has-popup-menu"),
+        "Popup cleanup should be deferred while the modal owns hover"
+      );
+      dialogWindow.document.querySelector("dialog").getButton("cancel").click();
+    },
+  });
+  BrowserCommands.tryToCloseWindow();
   await dialogClosed;
-  await dialogRemoved;
-  dialogWindow = null;
-  dialogContainer = null;
 
   Assert.ok(
-    !toolbar.hasAttribute("zen-has-hover"),
-    "Closing a modal dialog clears the stale toolbar hover state"
+    !trackedToolbar.hasAttribute("has-popup-menu"),
+    "Closing the warning clears the stale toolbar popup state"
   );
+  BrowserTestUtils.removeTab(tab);
 });

--- a/src/zen/tests/compact_mode/browser_compact_mode_dialog.js
+++ b/src/zen/tests/compact_mode/browser_compact_mode_dialog.js
@@ -1,0 +1,29 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_toolbar_collapses_after_modal_dialog_closes() {
+  const toolbar = document.getElementById("zen-appcontent-navbar-wrapper");
+  const browser = gBrowser.selectedBrowser;
+
+  EventUtils.synthesizeMouseAtCenter(browser, { type: "mousemove" }, window);
+  await TestUtils.waitForCondition(
+    () => !toolbar.matches(":hover"),
+    "The pointer should be outside the toolbar"
+  );
+
+  gZenCompactModeManager._setElementExpandAttribute(toolbar, true);
+  Assert.ok(
+    toolbar.hasAttribute("zen-has-hover"),
+    "The toolbar starts with a stale hover state"
+  );
+
+  // Firefox dispatches this event after beforeunload and other modal prompts.
+  window.dispatchEvent(new CustomEvent("DOMModalDialogClosed"));
+
+  Assert.ok(
+    !toolbar.hasAttribute("zen-has-hover"),
+    "Closing a modal dialog clears the stale toolbar hover state"
+  );
+});


### PR DESCRIPTION
## Summary

- clear stale compact-mode hover state when modal prompts close
- preserve genuinely hovered toolbars through the existing hover check
- add browser regression coverage for the modal-close event

Fixes #14922

## Testing

- `cd engine && ./mach build faster`
- `python3 scripts/run_tests.py compact_mode/browser_compact_mode_dialog.js --headless --force` (2/2 subtests passed)
- `cd engine && ./mach lint --warnings=soft zen/compact-mode/ZenCompactMode.mjs zen/tests/compact_mode/browser_compact_mode_dialog.js`
