### PR TITLE
Fix #13427: Skip close-tabs warning for synced windows

### DIFF
--- a/src/browser/base/content/browser-js.patch
+++ b/src/browser/base/content/browser-js.patch
@@ -19,13 +19,19 @@ index 1026474bb1bc026987be01a8c18fa0927cb911bc..60294e0587147d86ace8e6d6985d8c6e
 +  if (!canGoBack) {
 +    canGoBack = gZenCommonActions.shouldCloseTabOnBack();
 +  }
-+  
++
 +  if (backDisabled == canGoBack) {
      if (backDisabled) {
        backCommand.removeAttribute("disabled");
      } else {
-@@ -3719,7 +3725,7 @@ function warnAboutClosingWindow() {
+@@ -3716,9 +3722,13 @@ function warnAboutClosingWindow() {
+     PrivateBrowsingUtils.isWindowPrivate(window) &&
+     !PrivateBrowsingUtils.permanentPrivateBrowsing;
  
++  if (window.gZenWindowSync?.willTabsPersistAfterWindowClose(window)) {
++    return true;
++  }
++
    if (!isPBWindow && !toolbar.visible) {
      return gBrowser.warnAboutClosingTabs(
 -      gBrowser.openTabs.length,
@@ -33,7 +39,7 @@ index 1026474bb1bc026987be01a8c18fa0927cb911bc..60294e0587147d86ace8e6d6985d8c6e
        gBrowser.closingTabsEnum.ALL
      );
    }
-@@ -3759,7 +3765,7 @@ function warnAboutClosingWindow() {
+@@ -3759,7 +3769,7 @@ function warnAboutClosingWindow() {
      return (
        isPBWindow ||
        gBrowser.warnAboutClosingTabs(
@@ -42,7 +48,7 @@ index 1026474bb1bc026987be01a8c18fa0927cb911bc..60294e0587147d86ace8e6d6985d8c6e
          gBrowser.closingTabsEnum.ALL
        )
      );
-@@ -3784,7 +3790,7 @@ function warnAboutClosingWindow() {
+@@ -3784,7 +3794,7 @@ function warnAboutClosingWindow() {
      AppConstants.platform != "macosx" ||
      isPBWindow ||
      gBrowser.warnAboutClosingTabs(
@@ -51,7 +57,7 @@ index 1026474bb1bc026987be01a8c18fa0927cb911bc..60294e0587147d86ace8e6d6985d8c6e
        gBrowser.closingTabsEnum.ALL
      )
    );
-@@ -4744,6 +4750,16 @@ var ConfirmationHint = {
+@@ -4744,6 +4754,16 @@ var ConfirmationHint = {
      }
  
      document.l10n.setAttributes(this._message, messageId, l10nArgs);

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -1214,6 +1214,42 @@ class nsZenWindowSync {
   /* Mark: Public API */
 
   /**
+   * Checks whether every open tab in a window has a live synchronized copy in
+   * another window. When this is true, closing the window only removes that
+   * view of the tabs and must not be presented as closing the tabs themselves.
+   *
+   * @param {Window} aWindow - The window that is about to close.
+   * @returns {boolean} Whether its tabs will remain in another synced window.
+   */
+  willTabsPersistAfterWindowClose(aWindow) {
+    if (
+      !lazy.gWindowSyncEnabled ||
+      aWindow?.gZenWindowSync !== this ||
+      aWindow._zenClosingWindow ||
+      !aWindow.gBrowser
+    ) {
+      return false;
+    }
+
+    const openTabs = Array.from(aWindow.gBrowser.openTabs).filter(
+      tab => !tab.hasAttribute("zen-empty-tab")
+    );
+    return this.#browserWindowsList.some(win => {
+      if (
+        win === aWindow ||
+        win._zenClosingWindow ||
+        win.gZenWindowSync !== this
+      ) {
+        return false;
+      }
+      return openTabs.every(tab => {
+        const syncedTab = tab.id && this.getItemFromWindow(win, tab.id);
+        return syncedTab && !syncedTab.closing;
+      });
+    });
+  }
+
+  /**
    * Sets the initial pinned state for a tab across all windows.
    *
    * @param {object} aTab - The tab to set the pinned state for.

--- a/src/zen/tests/window_sync/browser.toml
+++ b/src/zen/tests/window_sync/browser.toml
@@ -11,3 +11,5 @@ support-files = [
 ["browser_sync_tab_label.js"]
 
 ["browser_sync_tab_open.js"]
+
+["browser_sync_window_close_warning.js"]

--- a/src/zen/tests/window_sync/browser_sync_window_close_warning.js
+++ b/src/zen/tests/window_sync/browser_sync_window_close_warning.js
@@ -1,0 +1,50 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_synced_window_close_does_not_warn_about_tabs() {
+  await withNewTabAndWindow(async (_newTab, win) => {
+    Assert.ok(
+      win.gZenWindowSync.willTabsPersistAfterWindowClose(win),
+      "Every tab in the new window should have a synchronized copy"
+    );
+
+    const originalWarnAboutClosingTabs = win.gBrowser.warnAboutClosingTabs;
+    let warningCalls = 0;
+    win.gBrowser.warnAboutClosingTabs = () => {
+      warningCalls++;
+      return false;
+    };
+
+    try {
+      const windowSync = win.gZenWindowSync;
+      win.gZenWindowSync = null;
+      try {
+        Assert.ok(
+          !win.warnAboutClosingWindow(),
+          "Closing a window outside Window Sync should still respect the warning"
+        );
+        Assert.equal(
+          warningCalls,
+          1,
+          "The close-tabs warning should still be requested for an unsynced window"
+        );
+      } finally {
+        win.gZenWindowSync = windowSync;
+      }
+
+      Assert.ok(
+        win.WindowIsClosing({ ctrlKey: true }),
+        "The real shortcut close pipeline should allow a synchronized window to close"
+      );
+      Assert.equal(
+        warningCalls,
+        1,
+        "The misleading close-tabs warning should not be requested by the synchronized close"
+      );
+    } finally {
+      win.gBrowser.warnAboutClosingTabs = originalWarnAboutClosingTabs;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- skip the close-tabs warning when every open tab has a live synchronized copy in another Zen window
- preserve the warning for unsynchronized windows and windows whose synchronized peer is closing
- add a browser regression test covering the real `WindowIsClosing` shortcut path

Fixes #13427

## Testing

- full local build completed successfully
- all six focused assertions for synchronized-window closing passed
- `git diff --check`

Video of the fix in action, notice no more errant confirmation dialog:

https://github.com/user-attachments/assets/fa195534-aab9-4293-8078-4d0d9ea4a532

