### PR TITLE
gh-14872: Fix mobile bookmarks item alignment in the bookmarks menu

### DIFF
--- a/src/zen/common/styles/zen-panels/bookmarks.css
+++ b/src/zen/common/styles/zen-panels/bookmarks.css
@@ -68,3 +68,8 @@ hbox.editBMPanel_folderRow {
 #PersonalToolbar {
   background: transparent;
 }
+
+/* Also a .subviewbutton unlike its siblings, so it gets arrowpanel padding */
+menupopup > #BMB_mobileBookmarks {
+  padding: var(--menuitem-padding);
+}


### PR DESCRIPTION
fixes #14872

upstream markup gives the mobile bookmarks menu an extra subviewbutton class that its siblings in the bookmarks popup do not have, so it picks up the arrowpanel padding of 8px instead of the 6px that every other row in that popup gets. the result is a row that sits slightly inset on both edges compared to the rest of the menu.

this scopes a rule to that item so it uses the same menuitem padding variable as the rest of the popup. the id selector wins on specificity, so no important flag is needed.
