### PR TITLE
Fix space routing containers for new tabs

### DIFF
--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -297,7 +297,7 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
        } = {}
      ) {
        // all callers of addTab that pass a params object need to pass
-@@ -3330,10 +3423,25 @@
+@@ -3330,10 +3423,33 @@
          );
        }
  
@@ -308,7 +308,15 @@ index c42b1a1a8df6b38886c17f71ea88e5aaa7eebc80..c741404ed973ee3ac246fe246c0f645e
 +
 +      let hasZenDefaultUserContextId = false;
 +      let zenForcedWorkspaceId = undefined;
-+      if (beforeRouteResult.isRouteFound && (typeof userContextId === "undefined" || fromExternal)) {
++      const userContextWasInherited =
++        typeof userContextId !== "undefined" &&
++        userContextId === triggeringPrincipal?.originAttributes?.userContextId;
++      if (
++        beforeRouteResult.isRouteFound &&
++        (typeof userContextId === "undefined" ||
++          userContextWasInherited ||
++          fromExternal)
++      ) {
 +        userContextId = beforeRouteResult.userContextId;
 +        hasZenDefaultUserContextId = true;
 +      } else if (typeof gZenWorkspaces !== "undefined" && !_forZenEmptyTab) {

--- a/src/zen/common/sys/ui/ZenSpaceRoutingNavigation.sys.mjs
+++ b/src/zen/common/sys/ui/ZenSpaceRoutingNavigation.sys.mjs
@@ -14,6 +14,8 @@ import { ZenUIComponent } from "resource:///modules/zen/ui/ZenUIComponent.sys.mj
  * into the matching space.
  */
 export class ZenSpaceRoutingNavigation extends ZenUIComponent {
+  #initialBrowsersBeingReplaced = new WeakSet();
+
   init() {
     this.listenBrowserTabsProgress();
   }
@@ -84,30 +86,48 @@ export class ZenSpaceRoutingNavigation extends ZenUIComponent {
     }
 
     // A brand-new tab whose very first real navigation this is (a
-    // target="_blank" link, window.open(), or a freshly opened tab) is still
-    // showing its initial about:blank document. There is nothing to preserve,
-    // so rather than cancelling the load and spawning a duplicate tab - which
-    // would leave this one behind empty - just move this very tab into the
-    // destination space and let the in-flight load finish in place.
+    // target="_blank" link or window.open()) was created before its target URL
+    // was known, so addTab() could not apply the route's container. Container
+    // origin attributes cannot be changed on an existing browser. Stop this
+    // load and replace the initial tab with one created through the routed
+    // addTab() path, then remove the now-unused blank tab.
     const isInitialDocument =
       aBrowser.browsingContext?.currentWindowGlobal?.isInitialDocument ?? false;
     if (isInitialDocument) {
+      if (this.#initialBrowsersBeingReplaced.has(aBrowser)) {
+        return;
+      }
+      this.#initialBrowsersBeingReplaced.add(aBrowser);
       const wasSelected = tab.selected;
+      const ownerTab = tab.owner;
+      const principal =
+        aBrowser.contentPrincipal ||
+        Services.scriptSecurityManager.createNullPrincipal({});
+      try {
+        aBrowser.stop();
+      } catch (e) {
+        this.#initialBrowsersBeingReplaced.delete(aBrowser);
+        return;
+      }
       // Defer so we don't mutate the tab strip from inside a progress notification.
       win.setTimeout(() => {
         if (!tab.isConnected) {
           return;
         }
-        gBrowser.selectedTab = tab.owner;
-        win.gZenWorkspaces.moveTabToWorkspace(tab, targetWorkspaceId);
-        if (wasSelected) {
-          const targetWorkspace =
-            win.gZenWorkspaces.getWorkspaceFromId(targetWorkspaceId);
-          if (targetWorkspace) {
-            win.gZenWorkspaces.lastSelectedWorkspaceTabs[targetWorkspaceId] =
-              tab;
-            win.gZenWorkspaces.changeWorkspace(targetWorkspace);
-          }
+        let routedTab;
+        try {
+          routedTab = gBrowser.addTab(uri.spec, {
+            triggeringPrincipal: principal,
+            ownerTab: ownerTab?.isConnected ? ownerTab : null,
+            inBackground: !wasSelected,
+          });
+        } catch (e) {
+          console.error("[ZenSpaceRouting]: Failed to replace routed tab", e);
+        }
+        if (routedTab) {
+          gBrowser.removeTab(tab, { animate: false });
+        } else {
+          this.#initialBrowsersBeingReplaced.delete(aBrowser);
         }
       }, 0);
       return;

--- a/src/zen/tests/space_routing/browser.toml
+++ b/src/zen/tests/space_routing/browser.toml
@@ -4,6 +4,8 @@
 
 [DEFAULT]
 support-files = [
+  "file_space_routing_opener.html",
+  "file_space_routing_target.html",
   "head.js",
 ]
 
@@ -12,6 +14,8 @@ support-files = [
 ["browser_space_routing_dialog.js"]
 
 ["browser_space_routing_fuzz.js"]
+
+["browser_space_routing_initial_tab_container.js"]
 
 ["browser_space_routing_on_add_tab.js"]
 

--- a/src/zen/tests/space_routing/browser_space_routing_initial_tab_container.js
+++ b/src/zen/tests/space_routing/browser_space_routing_initial_tab_container.js
@@ -1,0 +1,180 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { ZenSpaceRoutingNavigation } = ChromeUtils.importESModule(
+  "resource:///modules/zen/ui/ZenSpaceRoutingNavigation.sys.mjs"
+);
+
+const TEST_ROOT = getRootDirectory(gTestPath).replace(
+  "chrome://mochitests/content",
+  "https://example.com"
+);
+const OPENER_URL = `${TEST_ROOT}file_space_routing_opener.html`;
+const TARGET_URL = `${TEST_ROOT}file_space_routing_target.html`;
+
+add_setup(async function () {
+  clearAllRoutes();
+  registerCleanupFunction(() => clearAllRoutes());
+});
+
+add_task(async function test_inherited_container_is_replaced_by_route() {
+  await gZenWorkspaces.promiseInitialized;
+
+  const originalWorkspace = gZenWorkspaces.getActiveWorkspaceFromCache();
+  const originalTabs = new Set(gBrowser.tabs);
+  const targetWorkspace = await gZenWorkspaces.createAndSaveWorkspace(
+    "Space Routing Container Test",
+    undefined,
+    false,
+    1
+  );
+  const sourceWorkspace = await gZenWorkspaces.createAndSaveWorkspace(
+    "Space Routing Source Container Test",
+    undefined,
+    false,
+    2
+  );
+
+  let openerTab;
+  let targetTab;
+  let explicitContainerTab;
+  let initialTab;
+  let replacementTab;
+  let replacementCount = 0;
+  try {
+    await gZenWorkspaces.changeWorkspace(sourceWorkspace);
+    addRoute({
+      reference: TARGET_URL,
+      matchType: "equal-to",
+      openIn: targetWorkspace.uuid,
+    });
+
+    openerTab = BrowserTestUtils.addTab(gBrowser, OPENER_URL, {
+      inBackground: true,
+    });
+    await BrowserTestUtils.browserLoaded(openerTab.linkedBrowser);
+    // Link-opening code passes the source principal and its inherited container
+    // to addTab. The route must replace that inherited value before the browser
+    // and its origin attributes are created.
+    targetTab = BrowserTestUtils.addTab(gBrowser, TARGET_URL, {
+      triggeringPrincipal: openerTab.linkedBrowser.contentPrincipal,
+      userContextId: openerTab.userContextId,
+    });
+
+    Assert.equal(
+      targetTab.getAttribute("zen-workspace-id"),
+      targetWorkspace.uuid,
+      "The target tab belongs to the routed workspace"
+    );
+    Assert.equal(
+      targetTab.linkedBrowser.browsingContext.originAttributes.userContextId,
+      targetWorkspace.containerTabId,
+      "The target browser was created with the routed container origin attributes"
+    );
+
+    explicitContainerTab = BrowserTestUtils.addTab(gBrowser, TARGET_URL, {
+      triggeringPrincipal: openerTab.linkedBrowser.contentPrincipal,
+      userContextId: 3,
+    });
+    Assert.equal(
+      explicitContainerTab.getAttribute("zen-workspace-id"),
+      targetWorkspace.uuid,
+      "An explicitly containerized tab is still routed to the target workspace"
+    );
+    Assert.equal(
+      explicitContainerTab.userContextId,
+      3,
+      "An explicitly selected container is preserved"
+    );
+
+    initialTab = BrowserTestUtils.addTab(gBrowser, "about:blank", {
+      triggeringPrincipal: openerTab.linkedBrowser.contentPrincipal,
+      userContextId: openerTab.userContextId,
+      skipRoute: true,
+    });
+    initialTab.setAttribute("zen-workspace-id", sourceWorkspace.uuid);
+
+    const fakeWindow = {
+      addEventListener() {},
+      setTimeout: window.setTimeout.bind(window),
+      gZenSpaceRoutingManager,
+      gZenWorkspaces,
+      gBrowser: {
+        addTabsProgressListener() {},
+        getTabForBrowser: browser => gBrowser.getTabForBrowser(browser),
+        addTab: (...args) => {
+          replacementCount++;
+          replacementTab = gBrowser.addTab(...args);
+          return replacementTab;
+        },
+        removeTab: (...args) => gBrowser.removeTab(...args),
+      },
+    };
+    const navigation = new ZenSpaceRoutingNavigation(fakeWindow);
+    const progress = { isTopLevel: true };
+    const request = {
+      QueryInterface() {
+        return { URI: Services.io.newURI(TARGET_URL) };
+      },
+    };
+    const stateFlags =
+      Ci.nsIWebProgressListener.STATE_START |
+      Ci.nsIWebProgressListener.STATE_IS_DOCUMENT;
+    navigation.onStateChange(
+      initialTab.linkedBrowser,
+      progress,
+      request,
+      stateFlags
+    );
+    navigation.onStateChange(
+      initialTab.linkedBrowser,
+      progress,
+      request,
+      stateFlags
+    );
+
+    await TestUtils.waitForCondition(
+      () => replacementTab && !initialTab.isConnected,
+      "The incorrectly containerized initial tab is replaced"
+    );
+    Assert.equal(
+      replacementCount,
+      1,
+      "Repeated progress notifications only replace the tab once"
+    );
+    Assert.equal(
+      replacementTab.getAttribute("zen-workspace-id"),
+      targetWorkspace.uuid,
+      "The replacement tab belongs to the routed workspace"
+    );
+    Assert.equal(
+      replacementTab.linkedBrowser.browsingContext.originAttributes
+        .userContextId,
+      targetWorkspace.containerTabId,
+      "The replacement browser has the routed container origin attributes"
+    );
+  } finally {
+    if (replacementTab?.isConnected) {
+      BrowserTestUtils.removeTab(replacementTab);
+    }
+    if (initialTab?.isConnected) {
+      BrowserTestUtils.removeTab(initialTab);
+    }
+    if (targetTab?.isConnected) {
+      BrowserTestUtils.removeTab(targetTab);
+    }
+    if (explicitContainerTab?.isConnected) {
+      BrowserTestUtils.removeTab(explicitContainerTab);
+    }
+    for (const tab of [...gBrowser.tabs]) {
+      if (!originalTabs.has(tab)) {
+        BrowserTestUtils.removeTab(tab);
+      }
+    }
+    await gZenWorkspaces.changeWorkspace(originalWorkspace);
+    await gZenWorkspaces.removeWorkspace(sourceWorkspace.uuid);
+    await gZenWorkspaces.removeWorkspace(targetWorkspace.uuid);
+  }
+});

--- a/src/zen/tests/space_routing/file_space_routing_opener.html
+++ b/src/zen/tests/space_routing/file_space_routing_opener.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>Space Routing opener</title>
+<a id="routed-link" href="file_space_routing_target.html">
+  Open routed target
+</a>

--- a/src/zen/tests/space_routing/file_space_routing_target.html
+++ b/src/zen/tests/space_routing/file_space_routing_target.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>Space Routing target</title>


### PR DESCRIPTION
## Summary

- apply a routed space's container when a new tab inherited its opener's container
- recreate initially blank tabs through the routed `addTab` path so their immutable origin attributes use the destination container
- preserve explicitly selected containers and guard against duplicate replacement tabs

## Testing

- `./mach lint zen/common/sys/ui/ZenSpaceRoutingNavigation.sys.mjs zen/tests/space_routing/browser_space_routing_initial_tab_container.js`
- `MOZ_HEADLESS=1 ./mach test --force zen/tests/space_routing/browser_space_routing_initial_tab_container.js` (7/7 assertions passed)
- manually verified routed links retain the authenticated destination-container session