### PR TITLE
gh-12327: Don't implicitly animate window geometry on macOS

### DIFF
--- a/src/widget/cocoa/nsCocoaWindow-mm.patch
+++ b/src/widget/cocoa/nsCocoaWindow-mm.patch
@@ -1,0 +1,32 @@
+diff --git a/widget/cocoa/nsCocoaWindow.mm b/widget/cocoa/nsCocoaWindow.mm
+index f7d150b3a2d549cb1d485778cfbda71ced8bf779..3065905aa4610b7d360326662d7580b9753a2f26 100644
+--- a/widget/cocoa/nsCocoaWindow.mm
++++ b/widget/cocoa/nsCocoaWindow.mm
+@@ -8318,6 +8318,27 @@ - (NSTimeInterval)animationResizeTime:(NSRect)newFrame {
+   return [super animationResizeTime:newFrame];
+ }
+ 
++// Never animate our geometry implicitly.
++//
++// External window managers (Divvy, Hammerspoon, yabai, Rectangle, ...) place
++// us by setting AXPosition and AXSize back to back through the accessibility
++// API. AppKit routes those through the animator proxy, which installs an
++// implicit CABasicAnimation on "frame"; NSAnimationManager then walks the
++// window to its new frame over several hundred milliseconds. The manager's
++// second request is therefore computed against an intermediate frame, so the
++// window lands somewhere else entirely and the user has to trigger the same
++// shortcut two or three times before it snaps into place.
++//
++// Assistive clients expect the frame to be in effect once the request
++// returns, and Gecko never relies on implicit geometry animations itself, so
++// opt out. See https://github.com/zen-browser/desktop/issues/12327.
++- (id)animationForKey:(NSAnimatablePropertyKey)aKey {
++  if ([aKey isEqualToString:@"frame"]) {
++    return nil;
++  }
++  return [super animationForKey:aKey];
++}
++
+ - (NSView*)trackingAreaView {
+   NSView* contentView = self.contentView;
+   return contentView.superview ? contentView.superview : contentView;


### PR DESCRIPTION
Fixes #12327

## The problem

External window managers (Divvy, Hammerspoon, yabai, Rectangle, ...) place windows by setting `AXPosition` and `AXSize` back to back through the accessibility API. With Zen, the window lands somewhere else entirely and you have to trigger the same shortcut two or three times before it snaps into place.

The reporter's instinct was right — it *is* an animation, just not one of ours.

## Root cause

AppKit routes accessibility frame requests through the animator proxy, which installs an implicit `CABasicAnimation` on the window's `frame` property. `NSAnimationManager` then walks the window to its new frame over several hundred milliseconds, driven off the display link:

```
-[BaseWindow setFrame:display:]
-[CABasicAnimation applyForTime:presentationObject:modelObject:]
-[CAAnimation(NSRunningAnimation) apply:object:finished:]
+[NSAnimationManager performAnimations:]
-[NSScreenDisplayLink _fire]
```

The window manager's second request is therefore computed against an intermediate frame, so the result is wrong. Repeating the shortcut converges on the target, which is exactly the reported symptom.

This took a while to pin down because it is none of the obvious paths. Each of these was ruled out experimentally on an instrumented build, not by inspection:

| Hypothesis | Result |
| --- | --- |
| Stale cached origin in `nsCocoaWindow::Resize(DesktopSize)` | `DoResize` is called twice in a whole session, never during a snap |
| `setFrame:display:animate:YES` | Forced `animate:NO` on all 76 calls, the ramp continued |
| `animationResizeTime:` | Never invoked |
| `NSWindowAnimationBehavior` / `macanimationtype="document"` | Forced to `None`, no effect |
| Implicit Core Animation on `frame` | Confirmed by the stack above |

## The fix

Opt out via `-animationForKey:`, the documented `NSAnimatablePropertyContainer` hook.

This is narrower than it may look: `-animationResizeTime:` is untouched, so the zoom button and open/close animations still animate normally. Gecko never relies on implicit geometry animations itself, and assistive clients expect the frame to be in effect once the request returns.

## Verification

Built locally and driven through the accessibility API the same way a window manager does, on a profile with enough load to widen the race (the bug does not reproduce on an idle `about:blank` profile — worth knowing if you try to repro this).

Sweeping the gap between the `AXPosition` and `AXSize` requests:

| Gap | Before | After |
| --- | --- | --- |
| 0–1 ms | 0/4 failures | 0/4 |
| 5 ms | 4/4 | 0/4 |
| 10 ms | 2/4 | 0/4 |
| 20 ms | 4/4 | 0/4 |
| 40 ms | 4/4 | 0/4 |
| 80 ms | 4/4 | 0/4 |
| 160 ms | 4/4 | 0/4 |
| 320 ms | 0/4 | 0/4 |

Window-manager-style test alternating between two cells, 8 snaps: **8/8 failures before, 0/8 after**. Two further full sweeps after the change came back clean (36/36 each).

## Note for maintainers

**This is an upstream Gecko bug, not a Zen-specific one.** Stock Firefox 153 reproduces it on a clean profile with the same harness. Zen hits it far more consistently because its heavier chrome widens the race window, which is presumably why the issue was filed as "cannot be reproduced on Firefox".

Worth forwarding to Bugzilla — happy to file it if that is useful.

Unrelated observation from the same investigation: Zen enforces a minimum window size of 500x523, so window managers requesting smaller cells get clamped. Independent of this bug, just noting it.
