### PR TITLE
Add configurable next/previous tab shortcuts

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -365,4 +365,6 @@ zen-devtools-toggle-accessibility-shortcut = Toggle Accessibility
 zen-close-all-unpinned-tabs-shortcut = Close All Unpinned Tabs
 zen-new-unsynced-window-shortcut = New Blank Window
 zen-duplicate-tab-shortcut = Duplicate Tab
+zen-next-tab-shortcut = Next Tab
+zen-previous-tab-shortcut = Previous Tab
 zen-key-find-selection = Find Selection

--- a/src/browser/base/content/zen-commands.inc.xhtml
+++ b/src/browser/base/content/zen-commands.inc.xhtml
@@ -70,4 +70,7 @@
   <command id="cmd_zenNewLiveFolder" />
 
   <command id="cmd_zenDuplicateTab" />
+
+  <command id="cmd_zenNextTab" />
+  <command id="cmd_zenPreviousTab" />
 </commandset>

--- a/src/toolkit/modules/ShortcutUtils-sys-mjs.patch
+++ b/src/toolkit/modules/ShortcutUtils-sys-mjs.patch
@@ -2,17 +2,17 @@ diff --git a/toolkit/modules/ShortcutUtils.sys.mjs b/toolkit/modules/ShortcutUti
 index 0a2a5ac202fe7fbdd1540254db847d59c3fe2a88..fca3cd0719e51ffa745e8dac050dcefc7bc70f93 100644
 --- a/toolkit/modules/ShortcutUtils.sys.mjs
 +++ b/toolkit/modules/ShortcutUtils.sys.mjs
-@@ -414,13 +414,11 @@ export var ShortcutUtils = {
+@@ -414,13 +414,2 @@ export var ShortcutUtils = {
          }
          break;
-       case event.DOM_VK_UP: // fall through
+-      case event.DOM_VK_UP: // fall through
 -      case event.DOM_VK_LEFT:
-         if (metaAltAccel) {
-           return ShortcutUtils.PREVIOUS_TAB;
-         }
-         break;
-       case event.DOM_VK_DOWN: // fall through
+-        if (metaAltAccel) {
+-          return ShortcutUtils.PREVIOUS_TAB;
+-        }
+-        break;
+-      case event.DOM_VK_DOWN: // fall through
 -      case event.DOM_VK_RIGHT:
-         if (metaAltAccel) {
-           return ShortcutUtils.NEXT_TAB;
-         }
+-        if (metaAltAccel) {
+-          return ShortcutUtils.NEXT_TAB;
+-        }

--- a/src/zen/common/zen-sets.js
+++ b/src/zen/common/zen-sets.js
@@ -160,6 +160,12 @@ document.addEventListener(
             }
             break;
           }
+          case "cmd_zenNextTab":
+            gBrowser.tabContainer.advanceSelectedTab(1, true);
+            break;
+          case "cmd_zenPreviousTab":
+            gBrowser.tabContainer.advanceSelectedTab(-1, true);
+            break;
           default:
             gZenGlanceManager.handleMainCommandSet(event);
             if (event.target.id.startsWith("cmd_zenWorkspaceSwitch")) {

--- a/src/zen/kbs/ZenKeyboardShortcuts.mjs
+++ b/src/zen/kbs/ZenKeyboardShortcuts.mjs
@@ -58,6 +58,8 @@ const defaultKeyboardGroups = {
     "zen-close-all-unpinned-tabs-shortcut",
     "zen-close-tab-shortcut",
     "zen-close-shortcut",
+    "zen-next-tab-shortcut",
+    "zen-previous-tab-shortcut",
     "id:key_selectTab1",
     "id:key_selectTab2",
     "id:key_selectTab3",
@@ -894,7 +896,7 @@ class nsZenKeyboardShortcutsLoader {
 }
 
 class nsZenKeyboardShortcutsVersioner {
-  static LATEST_KBS_VERSION = 20;
+  static LATEST_KBS_VERSION = 21;
 
   constructor() {}
 
@@ -1318,6 +1320,34 @@ class nsZenKeyboardShortcutsVersioner {
           shortcut.setDisabled(true);
         }
       }
+    }
+
+    if (version < 21) {
+      // Migrate from version 20 to 21.
+      // Add configurable Next Tab and Previous Tab shortcuts.
+      // Default: Accel+Alt+Down/Up (Cmd+Option on macOS, Ctrl+Alt on others).
+      data.push(
+        new KeyShortcut(
+          "zen-next-tab",
+          "",
+          "VK_DOWN",
+          "windowAndTabManagement",
+          nsKeyShortcutModifiers.fromObject({ alt: true, accel: true }),
+          "cmd_zenNextTab",
+          "zen-next-tab-shortcut"
+        )
+      );
+      data.push(
+        new KeyShortcut(
+          "zen-previous-tab",
+          "",
+          "VK_UP",
+          "windowAndTabManagement",
+          nsKeyShortcutModifiers.fromObject({ alt: true, accel: true }),
+          "cmd_zenPreviousTab",
+          "zen-previous-tab-shortcut"
+        )
+      );
     }
 
     return data;


### PR DESCRIPTION
Adds "Next Tab" and "Previous Tab" as configurable keyboard shortcuts in the Keyboard Shortcuts settings.

These were previously hardcoded in Firefox's `ShortcutUtils` system (`⌘`+`⌥`+`↓`/`↑` on macOS, `Ctrl`+`Alt`+`↓`/`↑` on other platforms). This change moves them into Zen's configurable shortcut system so users can rebind them.

### Changes
- Added `cmd_zenNextTab` and `cmd_zenPreviousTab` commands
- Added migration v21 with default bindings (Accel+Alt+Down/Up)
- Registered shortcuts under "Window & Tab Management" group
- Extended `ShortcutUtils` patch to remove hardcoded handler, preventing double-firing
- Added l10n strings for the settings UI