### PR TITLE
no-bug: Enable compact sidebar resizing

### DIFF
--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -66,6 +66,8 @@ window.gZenCompactModeManager = {
   _eventListeners: [],
   _removeHoverFrames: {},
 
+  SIDEBAR_HOVER_BUFFER: 100,
+
   // Delay to avoid flickering when hovering over the sidebar
   HOVER_HACK_DELAY: Services.prefs.getIntPref(
     "zen.view.compact.hover-hack-delay",
@@ -90,7 +92,7 @@ window.gZenCompactModeManager = {
 
     this._emptyTabObserver = new MutationObserver(() => {
       if (this.preference && !this.sidebar.hasAttribute("zen-has-empty-tab")) {
-        if (this.sidebar.matches(":hover")) {
+        if (this._isPointerInsideSidebar()) {
           this._unlockSidebarHover();
           this._setElementExpandAttribute(this.sidebar, true);
           return;
@@ -361,7 +363,7 @@ window.gZenCompactModeManager = {
     this._unlockSidebarHover();
     this._sidebarHoverUnlockListener = () => {
       this._unlockSidebarHover();
-      if (this.preference && this.sidebar.matches(":hover")) {
+      if (this.preference && this._isPointerInsideSidebar()) {
         this._setElementExpandAttribute(this.sidebar, true);
       }
     };
@@ -369,6 +371,22 @@ window.gZenCompactModeManager = {
       capture: true,
       once: true,
     });
+  },
+
+  _isPointerInsideSidebar() {
+    const pointerX = {};
+    const pointerY = {};
+    window.windowUtils.getLastOverWindowPointerLocationInCSSPixels(
+      pointerX,
+      pointerY
+    );
+    const rect = document.getElementById("titlebar").getBoundingClientRect();
+    return (
+      pointerX.value >= rect.left &&
+      pointerX.value <= rect.right &&
+      pointerY.value >= rect.top &&
+      pointerY.value <= rect.bottom
+    );
   },
 
   _unlockSidebarHover() {
@@ -410,7 +428,7 @@ window.gZenCompactModeManager = {
       const distance = this.sidebarIsOnRight
         ? rect.left - event.clientX
         : event.clientX - rect.right;
-      if (distance <= lazy.COMPACT_MODE_OUTSIDE_WINDOW_HORIZONTAL_OFFSET) {
+      if (distance <= this.SIDEBAR_HOVER_BUFFER) {
         return;
       }
 

--- a/src/zen/compact-mode/ZenCompactMode.mjs
+++ b/src/zen/compact-mode/ZenCompactMode.mjs
@@ -88,11 +88,37 @@ window.gZenCompactModeManager = {
   init() {
     this.addMouseActions();
 
+    this._emptyTabObserver = new MutationObserver(() => {
+      if (this.preference && !this.sidebar.hasAttribute("zen-has-empty-tab")) {
+        if (this.sidebar.matches(":hover")) {
+          this._unlockSidebarHover();
+          this._setElementExpandAttribute(this.sidebar, true);
+          return;
+        }
+        this._lockSidebarHoverUntilPointerMove();
+        this._setElementExpandAttribute(this.sidebar, false);
+      }
+    });
+    this._emptyTabObserver.observe(this.sidebar, {
+      attributes: true,
+      attributeFilter: ["zen-has-empty-tab"],
+    });
+
     const tabIsRightObserver = this._updateSidebarIsOnRight.bind(this);
     Services.prefs.addObserver(
       "zen.tabs.vertical.right-side",
       tabIsRightObserver
     );
+    const sidebarLayoutPrefs = [
+      "zen.view.sidebar-expanded",
+      "zen.view.use-single-toolbar",
+    ];
+    const sidebarLayoutPrefObserver =
+      this._invalidateSidebarMinWidth.bind(this);
+    for (const pref of sidebarLayoutPrefs) {
+      Services.prefs.addObserver(pref, sidebarLayoutPrefObserver);
+    }
+    window.addEventListener("aftercustomization", sidebarLayoutPrefObserver);
 
     const outsideMouseTrackerExitObserver =
       this._onOutsideMouseTrackerExit.bind(this);
@@ -104,6 +130,16 @@ window.gZenCompactModeManager = {
     window.addEventListener(
       "unload",
       () => {
+        this._emptyTabObserver.disconnect();
+        this._unlockSidebarHover();
+        for (const pref of sidebarLayoutPrefs) {
+          Services.prefs.removeObserver(pref, sidebarLayoutPrefObserver);
+        }
+        window.removeEventListener(
+          "aftercustomization",
+          sidebarLayoutPrefObserver
+        );
+        this._stopSidebarHoverBuffer();
         this._stopTrackingMouseOutsideWindow();
         Services.obs.removeObserver(
           outsideMouseTrackerExitObserver,
@@ -148,7 +184,10 @@ window.gZenCompactModeManager = {
       });
     }
 
-    SessionStore.promiseAllWindowsRestored.then(() => {
+    SessionStore.promiseAllWindowsRestored.then(async () => {
+      if (this._wasInCompactMode) {
+        await this._ensureSidebarMinWidth();
+      }
       this.preference = this._wasInCompactMode;
     });
   },
@@ -188,8 +227,18 @@ window.gZenCompactModeManager = {
       return;
     }
     delete this._isTabBeingDragged;
+    this._stopSidebarHoverBuffer();
     this._stopTrackingMouseOutsideWindow();
     this.sidebar.removeAttribute("zen-user-show");
+    if (value) {
+      this.sidebar.style.setProperty(
+        "--zen-toolbox-min-width",
+        `${this.sidebarMinWidth}px`
+      );
+    } else {
+      this._unlockSidebarHover();
+      this.sidebar.style.removeProperty("--zen-toolbox-min-width");
+    }
     // We use this element in order to make it persis across restarts, by using the XULStore.
     // main-window can't store attributes other than window sizes, so we use this instead
     lazy.mainAppWrapper.setAttribute("zen-compact-mode", value);
@@ -212,6 +261,250 @@ window.gZenCompactModeManager = {
 
   get sidebar() {
     return gNavToolbox;
+  },
+
+  get sidebarMinWidth() {
+    if (Number.isFinite(this._sidebarMinWidth)) {
+      return this._sidebarMinWidth;
+    }
+
+    const inlineMinWidth = Number.parseFloat(
+      this.sidebar.style.getPropertyValue("--zen-toolbox-min-width")
+    );
+    return Number.isFinite(inlineMinWidth)
+      ? inlineMinWidth
+      : this.sidebar.getBoundingClientRect().width;
+  },
+
+  _invalidateSidebarMinWidth() {
+    delete this._sidebarMinWidth;
+  },
+
+  async _ensureSidebarMinWidth() {
+    if (Number.isFinite(this._sidebarMinWidth)) {
+      return this._sidebarMinWidth;
+    }
+    if (this._sidebarMinWidthPromise) {
+      return this._sidebarMinWidthPromise;
+    }
+
+    // The normal-mode minimum is only stable after CustomizableUI has moved
+    // optional top-bar buttons into overflow, so wait for that layout here.
+    this._sidebarMinWidthPromise = (async () => {
+      const win = this.sidebar.documentGlobal;
+      const style = this.sidebar.style;
+      const width = style.width;
+      const sidebarWidth = style.getPropertyValue("--zen-sidebar-width");
+      const actualWidth = style.getPropertyValue("--actual-zen-sidebar-width");
+      const inlineMinWidth = style.getPropertyValue("--zen-toolbox-min-width");
+      const customizationTarget = document.getElementById(
+        "zen-sidebar-top-buttons-customization-target"
+      );
+      const hasStableMinimumLayout = () =>
+        !!customizationTarget.children.length &&
+        [...customizationTarget.children].every(
+          element => element.getAttribute("overflows") === "false"
+        );
+
+      try {
+        style.width = "1px";
+        style.removeProperty("--zen-sidebar-width");
+        style.removeProperty("--actual-zen-sidebar-width");
+        style.removeProperty("--zen-toolbox-min-width");
+
+        if (!hasStableMinimumLayout()) {
+          await new Promise(resolve => {
+            let timeout;
+            const observer = new win.MutationObserver(() => {
+              if (hasStableMinimumLayout()) {
+                observer.disconnect();
+                win.clearTimeout(timeout);
+                resolve();
+              }
+            });
+            timeout = win.setTimeout(() => {
+              observer.disconnect();
+              resolve();
+            }, 1000);
+            observer.observe(customizationTarget, { childList: true });
+            win.dispatchEvent(new win.Event("resize"));
+          });
+        }
+
+        this._sidebarMinWidth = this.sidebar.getBoundingClientRect().width;
+      } finally {
+        style.width = width;
+        for (const [property, value] of [
+          ["--zen-sidebar-width", sidebarWidth],
+          ["--actual-zen-sidebar-width", actualWidth],
+          ["--zen-toolbox-min-width", inlineMinWidth],
+        ]) {
+          if (value) {
+            style.setProperty(property, value);
+          } else {
+            style.removeProperty(property);
+          }
+        }
+        win.dispatchEvent(new win.Event("resize"));
+      }
+      return this._sidebarMinWidth;
+    })();
+
+    try {
+      return await this._sidebarMinWidthPromise;
+    } finally {
+      delete this._sidebarMinWidthPromise;
+    }
+  },
+
+  _lockSidebarHoverUntilPointerMove() {
+    this._unlockSidebarHover();
+    this._sidebarHoverUnlockListener = () => {
+      this._unlockSidebarHover();
+      if (this.preference && this.sidebar.matches(":hover")) {
+        this._setElementExpandAttribute(this.sidebar, true);
+      }
+    };
+    window.addEventListener("mousemove", this._sidebarHoverUnlockListener, {
+      capture: true,
+      once: true,
+    });
+  },
+
+  _unlockSidebarHover() {
+    if (!this._sidebarHoverUnlockListener) {
+      return;
+    }
+    window.removeEventListener(
+      "mousemove",
+      this._sidebarHoverUnlockListener,
+      true
+    );
+    delete this._sidebarHoverUnlockListener;
+  },
+
+  _startSidebarHoverBuffer(waitForReentry = false) {
+    this._stopSidebarHoverBuffer();
+    const rect = document.getElementById("titlebar").getBoundingClientRect();
+    const resizeHandle = document.getElementById(
+      "zen-compact-sidebar-resize-handle"
+    );
+    let waitingForReentry = waitForReentry;
+    this._sidebarHoverBufferListener = event => {
+      const isInside =
+        event.clientX >= rect.left &&
+        event.clientX <= rect.right &&
+        event.clientY >= rect.top &&
+        event.clientY <= rect.bottom;
+      if (isInside) {
+        waitingForReentry = false;
+        return;
+      }
+      if (
+        waitingForReentry ||
+        resizeHandle?.getAttribute("state") === "dragging"
+      ) {
+        return;
+      }
+
+      const distance = this.sidebarIsOnRight
+        ? rect.left - event.clientX
+        : event.clientX - rect.right;
+      if (distance <= lazy.COMPACT_MODE_OUTSIDE_WINDOW_HORIZONTAL_OFFSET) {
+        return;
+      }
+
+      this._stopSidebarHoverBuffer();
+      this._setElementExpandAttribute(this.sidebar, false);
+    };
+    window.addEventListener(
+      "mousemove",
+      this._sidebarHoverBufferListener,
+      true
+    );
+  },
+
+  _stopSidebarHoverBuffer() {
+    if (this._sidebarHoverBufferListener) {
+      window.removeEventListener(
+        "mousemove",
+        this._sidebarHoverBufferListener,
+        true
+      );
+      delete this._sidebarHoverBufferListener;
+    }
+  },
+
+  _applySidebarWidth(width) {
+    const minWidth = this.sidebarMinWidth;
+    const maxWidth = Math.max(
+      minWidth,
+      Services.prefs.getIntPref("zen.view.sidebar-expanded.max-width")
+    );
+    const appliedWidth = Math.max(minWidth, Math.min(maxWidth, width));
+    const cssWidth = `${appliedWidth}px`;
+
+    this.sidebar.style.setProperty("--zen-toolbox-min-width", `${minWidth}px`);
+    this.sidebar.style.setProperty("--zen-sidebar-width", cssWidth);
+    this.sidebar.style.setProperty("--actual-zen-sidebar-width", cssWidth);
+    this.sidebar.style.width = cssWidth;
+    this.sidebar.setAttribute("width", cssWidth);
+    return appliedWidth;
+  },
+
+  addSidebarResizeActions() {
+    const handle = document.createElementNS(
+      "http://www.w3.org/1999/xhtml",
+      "div"
+    );
+    handle.id = "zen-compact-sidebar-resize-handle";
+    document.getElementById("titlebar").append(handle);
+
+    handle.addEventListener("mousedown", event => {
+      if (event.button !== 0) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      handle.setAttribute("state", "dragging");
+
+      const startX = event.clientX;
+      const startWidth = this.sidebar.getBoundingClientRect().width;
+      const direction = this.sidebarIsOnRight ? -1 : 1;
+
+      const onMouseMove = moveEvent => {
+        this._applySidebarWidth(
+          startWidth + direction * (moveEvent.clientX - startX)
+        );
+      };
+
+      const finishResize = finishEvent => {
+        window.removeEventListener("mousemove", onMouseMove, true);
+        window.removeEventListener("mouseup", finishResize, true);
+        window.removeEventListener("blur", finishResize, true);
+        handle.removeAttribute("state");
+
+        this.getAndApplySidebarWidth({});
+
+        const rect = document
+          .getElementById("titlebar")
+          .getBoundingClientRect();
+        if (
+          finishEvent.type === "mouseup" &&
+          (finishEvent.clientX < rect.left ||
+            finishEvent.clientX > rect.right ||
+            finishEvent.clientY < rect.top ||
+            finishEvent.clientY > rect.bottom)
+        ) {
+          this._startSidebarHoverBuffer(true);
+        }
+      };
+
+      window.addEventListener("mousemove", onMouseMove, true);
+      window.addEventListener("mouseup", finishResize, true);
+      window.addEventListener("blur", finishResize, true);
+    });
   },
 
   addHasPolyfillObserver() {
@@ -659,16 +952,21 @@ window.gZenCompactModeManager = {
     }
   },
 
-  toggle(ignoreHover = false) {
+  async toggle(ignoreHover = false) {
     // Only ignore the next hover when we are enabling compact mode
-    this._ignoreNextHover = ignoreHover && !this.preference;
-    return (this.preference = !this.preference);
+    const enableCompactMode = !this.preference;
+    this._ignoreNextHover = ignoreHover && enableCompactMode;
+    if (enableCompactMode) {
+      await this._ensureSidebarMinWidth();
+    }
+    return (this.preference = enableCompactMode);
   },
 
   _updateSidebarIsOnRight() {
     this._sidebarIsOnRight = Services.prefs.getBoolPref(
       "zen.tabs.vertical.right-side"
     );
+    this._invalidateSidebarMinWidth();
   },
 
   toggleSidebar() {
@@ -763,6 +1061,9 @@ window.gZenCompactModeManager = {
       }
     } else {
       if (attr === "zen-has-hover") {
+        if (element === this.sidebar) {
+          this._stopSidebarHoverBuffer();
+        }
         if (element === this._outsideTrackedElement) {
           this._stopTrackingMouseOutsideWindow();
         }
@@ -783,6 +1084,7 @@ window.gZenCompactModeManager = {
   },
 
   addMouseActions() {
+    this.addSidebarResizeActions();
     gURLBar.addEventListener("mouseenter", event => {
       this.log("Mouse entered URL bar:", event.target);
       if (event.target.closest("#urlbar[zen-floating-urlbar]")) {
@@ -805,6 +1107,12 @@ window.gZenCompactModeManager = {
       }
 
       const onEnter = event => {
+        if (target === this.sidebar) {
+          this._stopSidebarHoverBuffer();
+          if (this._sidebarHoverUnlockListener) {
+            return;
+          }
+        }
         setTimeout(() => {
           if (event.type === "mouseenter" && !event.target.matches(":hover")) {
             return;
@@ -821,6 +1129,7 @@ window.gZenCompactModeManager = {
               ) === "true" ||
               this._hasHoveredUrlbar ||
               this._ignoreNextHover ||
+              (target === this.sidebar && this._sidebarHoverUnlockListener) ||
               target.hasAttribute("zen-has-hover")
             ) {
               return;
@@ -873,6 +1182,11 @@ window.gZenCompactModeManager = {
           }
 
           if (this._isTabBeingDragged) {
+            return;
+          }
+
+          if (target === this.sidebar && event.type === "mouseleave") {
+            this._startSidebarHoverBuffer();
             return;
           }
 
@@ -1037,6 +1351,7 @@ window.gZenCompactModeManager = {
   },
 
   _clearAllHoverStates() {
+    this._stopSidebarHoverBuffer();
     this._stopTrackingMouseOutsideWindow();
     // Clear hover attributes from all hoverable elements
     for (let entry of this.hoverableElements) {

--- a/src/zen/compact-mode/sidebar.inc.css
+++ b/src/zen/compact-mode/sidebar.inc.css
@@ -32,8 +32,32 @@
     }
   }
 
-  #zen-sidebar-splitter {
-    display: none !important;
+  #zen-compact-sidebar-resize-handle {
+    display: block;
+    position: absolute;
+    inset-block: 0;
+    inset-inline-end: calc(var(--zen-toolbox-padding) / -2);
+    width: var(--zen-toolbox-padding);
+    z-index: 1;
+    visibility: hidden;
+    pointer-events: none;
+    cursor: ew-resize;
+    background: transparent;
+    transition:
+      background 0.2s ease-in-out,
+      opacity 0.2s ease-in-out;
+    -moz-window-dragging: no-drag;
+
+    :root[zen-right-side='true'] & {
+      inset-inline-start: calc(var(--zen-toolbox-padding) / -2);
+      inset-inline-end: auto;
+    }
+
+    &:hover,
+    &[state='dragging'] {
+      background: var(--zen-primary-color);
+      opacity: 1;
+    }
   }
 
   #zen-sidebar-top-buttons-customization-target {
@@ -119,6 +143,10 @@
   &[zen-right-side='true'] {
     & #navigator-toolbox:not([animate='true']) {
       right: calc(-1 * var(--actual-zen-sidebar-width) + var(--zen-element-separation) / 2 + 1px);
+
+      & #titlebar {
+        align-self: flex-end;
+      }
     }
 
     & .browserSidebarContainer:not([is-zen-split='true']) {
@@ -136,8 +164,16 @@
     }
     position: relative;
     min-width: var(--zen-toolbox-min-width);
-    transition: visibility 0.15s; /* Same as the toolbox */
+    transition:
+      visibility 0.15s,
+      opacity 0.15s; /* Same as the toolbox */
     visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+
+    & #urlbar {
+      visibility: hidden !important;
+    }
 
     :root[zen-sidebar-expanded='true'] & {
       width: calc(var(--zen-sidebar-width) + var(--zen-toolbox-padding));
@@ -149,12 +185,35 @@
   }
 
   #navigator-toolbox:is(
-    [zen-has-hover], [zen-user-show],
-    [zen-has-empty-tab], [flash-popup],
-    [has-popup-menu], [movingtab],
-    [zen-compact-mode-active]
+    [zen-has-hover],
+    [zen-user-show],
+    [zen-has-empty-tab],
+    [flash-popup],
+    [has-popup-menu],
+    [movingtab],
+    [zen-compact-mode-active],
+    :has(
+      #zen-compact-sidebar-resize-handle:is(
+        :hover,
+        [state='dragging']
+      )
+    )
   ),
   &[zen-renaming-tab='true'] #navigator-toolbox {
+    & #titlebar {
+      opacity: 1;
+      pointer-events: auto;
+
+      & #urlbar {
+        visibility: visible !important;
+      }
+    }
+
+    & #zen-compact-sidebar-resize-handle {
+      visibility: visible;
+      pointer-events: auto;
+    }
+
     &:not([animate='true']) {
       --zen-compact-mode-func: linear(
         0 0%,

--- a/src/zen/compact-mode/zen-compact-mode.css
+++ b/src/zen/compact-mode/zen-compact-mode.css
@@ -33,6 +33,10 @@
   }
 }
 
+#zen-compact-sidebar-resize-handle {
+  display: none;
+}
+
 :root[zen-compact-mode='true']:not([customizing]):not([inDOMFullscreen='true']) {
 
 %include ../tabs/zen-tabs/vertical-tabs-topbuttons-fix.css

--- a/src/zen/tests/compact_mode/browser_compact_mode_width.js
+++ b/src/zen/tests/compact_mode/browser_compact_mode_width.js
@@ -55,8 +55,200 @@ async function testSidebarWidth() {
 
   gZenCompactModeManager.addEventListener(onCompactChanged);
 
-  gZenCompactModeManager.preference = true;
+  await gZenCompactModeManager.toggle();
   await promise;
+}
+
+async function setCompactMode(enabled) {
+  if (gZenCompactModeManager.preference === enabled) {
+    return;
+  }
+  const toggled = BrowserTestUtils.waitForEvent(
+    window,
+    "ZenCompactMode:Toggled",
+    false,
+    event => event.detail === enabled
+  );
+  await gZenCompactModeManager.toggle();
+  await toggled;
+}
+
+function dispatchMouseEvent(target, type, clientX, clientY) {
+  target.dispatchEvent(
+    new MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      button: 0,
+      buttons: type === "mouseup" ? 0 : 1,
+      clientX,
+      clientY,
+      screenX: window.mozInnerScreenX + clientX,
+      screenY: window.mozInnerScreenY + clientY,
+    })
+  );
+}
+
+async function testResizeHandlePointer() {
+  await BrowserTestUtils.withNewTab(
+    "data:text/html,<!doctype html><title>Compact mode pointer test</title>",
+    async () => {
+      const originalWidth = gNavToolbox.getBoundingClientRect().width;
+      const handle = document.getElementById(
+        "zen-compact-sidebar-resize-handle"
+      );
+      await setCompactMode(true);
+      const positionProperty = gZenCompactModeManager.sidebarIsOnRight
+        ? "right"
+        : "left";
+      const opened = BrowserTestUtils.waitForEvent(
+        gNavToolbox,
+        "transitionend",
+        false,
+        event => event.propertyName === positionProperty
+      );
+      gNavToolbox.setAttribute("zen-has-hover", "true");
+      await opened;
+      await TestUtils.waitForCondition(
+        () => BrowserTestUtils.isVisible(handle),
+        "The compact sidebar resize handle should be visible"
+      );
+      const titlebarRect = document
+        .getElementById("titlebar")
+        .getBoundingClientRect();
+      const rootRect = document.documentElement.getBoundingClientRect();
+      const outerGap = gZenCompactModeManager.sidebarIsOnRight
+        ? rootRect.right - titlebarRect.right
+        : titlebarRect.left - rootRect.left;
+      const expectedOuterGap =
+        Number.parseFloat(getComputedStyle(gNavToolbox).paddingLeft) / 2;
+      Assert.lessOrEqual(
+        Math.abs(outerGap - expectedOuterGap),
+        1,
+        "The compact sidebar keeps the same outer gap on either side"
+      );
+
+      const minWidth = gZenCompactModeManager.sidebarMinWidth;
+      const maxWidth = Math.max(
+        minWidth,
+        Services.prefs.getIntPref("zen.view.sidebar-expanded.max-width")
+      );
+      const middleWidth = minWidth + (maxWidth - minWidth) / 2;
+      const direction = gZenCompactModeManager.sidebarIsOnRight ? -1 : 1;
+      gZenCompactModeManager._applySidebarWidth(middleWidth);
+
+      let handleRect = handle.getBoundingClientRect();
+      let startX = handleRect.left + handleRect.width / 2;
+      let pointerY = handleRect.top + handleRect.height / 2;
+      const growX = startX + direction * (maxWidth - middleWidth + 50);
+      dispatchMouseEvent(handle, "mousedown", startX, pointerY);
+      Assert.equal(
+        handle.getAttribute("state"),
+        "dragging",
+        "Pointer down starts compact sidebar resizing"
+      );
+      dispatchMouseEvent(
+        document.documentElement,
+        "mousemove",
+        growX,
+        pointerY
+      );
+      dispatchMouseEvent(document.documentElement, "mouseup", growX, pointerY);
+      Assert.equal(
+        Math.round(gNavToolbox.getBoundingClientRect().width),
+        maxWidth,
+        "Pointer dragging is clamped to the maximum width"
+      );
+      Assert.ok(
+        !!gZenCompactModeManager._sidebarHoverBufferListener,
+        "Releasing outside the sidebar starts the hover buffer"
+      );
+
+      dispatchMouseEvent(
+        document.documentElement,
+        "mousemove",
+        growX,
+        pointerY
+      );
+      Assert.ok(
+        gNavToolbox.hasAttribute("zen-has-hover"),
+        "The sidebar stays open until the pointer re-enters it"
+      );
+
+      const sidebarRect = document
+        .getElementById("titlebar")
+        .getBoundingClientRect();
+      const insideX = (sidebarRect.left + sidebarRect.right) / 2;
+      dispatchMouseEvent(
+        document.documentElement,
+        "mousemove",
+        insideX,
+        pointerY
+      );
+
+      const bufferedX = gZenCompactModeManager.sidebarIsOnRight
+        ? sidebarRect.left - 100
+        : sidebarRect.right + 100;
+      dispatchMouseEvent(
+        document.documentElement,
+        "mousemove",
+        bufferedX,
+        pointerY
+      );
+      Assert.ok(
+        gNavToolbox.hasAttribute("zen-has-hover"),
+        "The sidebar stays open inside the outside hover buffer"
+      );
+
+      const outsideOffset = Services.prefs.getIntPref(
+        "zen.view.compact.outside-window-edge-offset.horizontal"
+      );
+      const outsideX = gZenCompactModeManager.sidebarIsOnRight
+        ? sidebarRect.left - outsideOffset - 1
+        : sidebarRect.right + outsideOffset + 1;
+      dispatchMouseEvent(
+        document.documentElement,
+        "mousemove",
+        outsideX,
+        pointerY
+      );
+      Assert.ok(
+        !gNavToolbox.hasAttribute("zen-has-hover"),
+        "The sidebar hides after the pointer leaves the outside hover buffer"
+      );
+
+      gNavToolbox.setAttribute("zen-has-hover", "true");
+      gZenCompactModeManager._applySidebarWidth(maxWidth);
+      handleRect = handle.getBoundingClientRect();
+      startX = handleRect.left + handleRect.width / 2;
+      pointerY = handleRect.top + handleRect.height / 2;
+      const shrinkX = startX - direction * (maxWidth - minWidth + 50);
+      dispatchMouseEvent(handle, "mousedown", startX, pointerY);
+      dispatchMouseEvent(
+        document.documentElement,
+        "mousemove",
+        shrinkX,
+        pointerY
+      );
+      dispatchMouseEvent(
+        document.documentElement,
+        "mouseup",
+        shrinkX,
+        pointerY
+      );
+      Assert.equal(
+        Math.round(gNavToolbox.getBoundingClientRect().width),
+        minWidth,
+        "Pointer dragging is clamped to the minimum width"
+      );
+
+      gZenCompactModeManager._stopSidebarHoverBuffer();
+      gZenCompactModeManager._applySidebarWidth(originalWidth);
+      gZenCompactModeManager.getAndApplySidebarWidth({});
+      gNavToolbox.removeAttribute("zen-has-hover");
+      await setCompactMode(false);
+    }
+  );
 }
 
 add_task(async function test_Compact_Mode_Width() {
@@ -71,4 +263,98 @@ add_task(async function test_Compact_Mode_Hover() {
   gNavToolbox.setAttribute("zen-has-hover", true);
   await testSidebarWidth();
   gNavToolbox.removeAttribute("zen-has-hover");
+});
+
+add_task(async function test_Compact_Mode_Min_Width_Cache() {
+  gZenCompactModeManager._invalidateSidebarMinWidth();
+  const originalWidth = gNavToolbox.getBoundingClientRect().width;
+  const measuredWidth = await gZenCompactModeManager._ensureSidebarMinWidth();
+  Assert.equal(
+    gNavToolbox.getBoundingClientRect().width,
+    originalWidth,
+    "Measuring the minimum restores the original sidebar width"
+  );
+
+  let resizeEvents = 0;
+  const countResize = () => resizeEvents++;
+  window.addEventListener("resize", countResize);
+  const cachedWidth = await gZenCompactModeManager._ensureSidebarMinWidth();
+  window.removeEventListener("resize", countResize);
+  Assert.equal(cachedWidth, measuredWidth, "The cached minimum is reused");
+  Assert.equal(resizeEvents, 0, "A cache hit does not trigger window resize");
+});
+
+add_task(async function test_Compact_Mode_Resize_Handle_Pointer() {
+  await testResizeHandlePointer();
+});
+
+add_task(async function test_Compact_Mode_Resize_Handle_Pointer_Right_Side() {
+  await goToRightSideTabs(testResizeHandlePointer);
+});
+
+add_task(async function test_Compact_Mode_Empty_Tab_Hover_Priority() {
+  await BrowserTestUtils.withNewTab(
+    "data:text/html,<!doctype html><title>Compact mode navigation test</title>",
+    async browser => {
+      const loadedTab = gBrowser.getTabForBrowser(browser);
+      const emptyTab = gZenWorkspaces._emptyTab;
+      window.windowUtils.disableNonTestMouseEvents(true);
+
+      try {
+        gBrowser.selectedTab = emptyTab;
+        await TestUtils.waitForCondition(
+          () => gNavToolbox.hasAttribute("zen-has-empty-tab"),
+          "The sidebar should stay open for an empty tab"
+        );
+        await setCompactMode(true);
+
+        EventUtils.synthesizeMouseAtCenter(loadedTab, { type: "mousemove" });
+        await TestUtils.waitForCondition(
+          () =>
+            gNavToolbox.matches(":hover") &&
+            gNavToolbox.hasAttribute("zen-has-hover"),
+          "The sidebar should register pointer hover before tab selection"
+        );
+        EventUtils.synthesizeMouseAtCenter(loadedTab, {});
+        await TestUtils.waitForCondition(
+          () =>
+            gBrowser.selectedTab === loadedTab &&
+            !gNavToolbox.hasAttribute("zen-has-empty-tab"),
+          "Selecting a loaded tab should leave the empty-tab state"
+        );
+        Assert.ok(
+          gNavToolbox.hasAttribute("zen-has-hover"),
+          "The sidebar stays open when navigation starts from inside it"
+        );
+
+        gBrowser.selectedTab = emptyTab;
+        await TestUtils.waitForCondition(
+          () => gNavToolbox.hasAttribute("zen-has-empty-tab"),
+          "The empty-tab state should be restored"
+        );
+        EventUtils.synthesizeMouseAtCenter(gBrowser.tabpanels, {
+          type: "mousemove",
+        });
+        await TestUtils.waitForCondition(
+          () => !gNavToolbox.matches(":hover"),
+          "The pointer should be outside the sidebar"
+        );
+        gBrowser.selectedTab = loadedTab;
+        await TestUtils.waitForCondition(
+          () => !gNavToolbox.hasAttribute("zen-has-empty-tab"),
+          "Selecting a loaded tab should leave the empty-tab state"
+        );
+        Assert.ok(
+          !gNavToolbox.hasAttribute("zen-has-hover"),
+          "The sidebar hides when navigation starts from outside it"
+        );
+      } finally {
+        window.windowUtils.disableNonTestMouseEvents(false);
+        gZenCompactModeManager._unlockSidebarHover();
+        gZenCompactModeManager._stopSidebarHoverBuffer();
+        gNavToolbox.removeAttribute("zen-has-hover");
+        await setCompactMode(false);
+      }
+    }
+  );
 });

--- a/src/zen/tests/compact_mode/browser_compact_mode_width.js
+++ b/src/zen/tests/compact_mode/browser_compact_mode_width.js
@@ -3,6 +3,10 @@
 
 "use strict";
 
+ChromeUtils.defineESModuleGetters(this, {
+  UrlbarTestUtils: "resource://testing-common/UrlbarTestUtils.sys.mjs",
+});
+
 function goToRightSideTabs(callback) {
   // eslint-disable-next-line no-async-promise-executor
   return new Promise(async resolve => {
@@ -186,9 +190,10 @@ async function testResizeHandlePointer() {
         pointerY
       );
 
+      const hoverBuffer = gZenCompactModeManager.SIDEBAR_HOVER_BUFFER;
       const bufferedX = gZenCompactModeManager.sidebarIsOnRight
-        ? sidebarRect.left - 100
-        : sidebarRect.right + 100;
+        ? sidebarRect.left - hoverBuffer
+        : sidebarRect.right + hoverBuffer;
       dispatchMouseEvent(
         document.documentElement,
         "mousemove",
@@ -200,12 +205,9 @@ async function testResizeHandlePointer() {
         "The sidebar stays open inside the outside hover buffer"
       );
 
-      const outsideOffset = Services.prefs.getIntPref(
-        "zen.view.compact.outside-window-edge-offset.horizontal"
-      );
       const outsideX = gZenCompactModeManager.sidebarIsOnRight
-        ? sidebarRect.left - outsideOffset - 1
-        : sidebarRect.right + outsideOffset + 1;
+        ? sidebarRect.left - hoverBuffer - 1
+        : sidebarRect.right + hoverBuffer + 1;
       dispatchMouseEvent(
         document.documentElement,
         "mousemove",
@@ -357,4 +359,68 @@ add_task(async function test_Compact_Mode_Empty_Tab_Hover_Priority() {
       }
     }
   );
+});
+
+add_task(async function test_Compact_Mode_Empty_Tab_Urlbar_Navigation() {
+  const emptyTab = gZenWorkspaces._emptyTab;
+  let openedTab;
+  window.windowUtils.disableNonTestMouseEvents(true);
+
+  try {
+    gBrowser.selectedTab = emptyTab;
+    await TestUtils.waitForCondition(
+      () => gNavToolbox.hasAttribute("zen-has-empty-tab"),
+      "The sidebar should stay open for an empty tab"
+    );
+    await setCompactMode(true);
+
+    document.getElementById("Browser:OpenLocation").doCommand();
+    await UrlbarTestUtils.promiseAutocompleteResultPopup({
+      window,
+      waitForFocus: SimpleTest.waitForFocus,
+      value: "https://example.com/",
+    });
+    const result = await UrlbarTestUtils.getDetailsOfResultAt(window, 0);
+    EventUtils.synthesizeMouseAtCenter(result.element.row, {
+      type: "mousemove",
+    });
+
+    const titlebarRect = document
+      .getElementById("titlebar")
+      .getBoundingClientRect();
+    const resultRect = result.element.row.getBoundingClientRect();
+    const resultCenterX = (resultRect.left + resultRect.right) / 2;
+    Assert.ok(
+      gZenCompactModeManager.sidebarIsOnRight
+        ? resultCenterX < titlebarRect.left
+        : resultCenterX > titlebarRect.right,
+      "The floating URL bar result should be outside the visible sidebar"
+    );
+
+    const tabOpened = BrowserTestUtils.waitForNewTab(
+      gBrowser,
+      "https://example.com/",
+      true
+    );
+    EventUtils.synthesizeMouseAtCenter(result.element.row, {});
+    openedTab = await tabOpened;
+    await TestUtils.waitForCondition(
+      () => !gNavToolbox.hasAttribute("zen-has-empty-tab"),
+      "URL bar navigation should leave the empty-tab state"
+    );
+    Assert.ok(
+      !gNavToolbox.hasAttribute("zen-has-hover"),
+      "The sidebar hides when URL bar navigation starts outside its bounds"
+    );
+  } finally {
+    window.windowUtils.disableNonTestMouseEvents(false);
+    await UrlbarTestUtils.promisePopupClose(window);
+    if (openedTab) {
+      await BrowserTestUtils.removeTab(openedTab);
+    }
+    gZenCompactModeManager._unlockSidebarHover();
+    gZenCompactModeManager._stopSidebarHoverBuffer();
+    gNavToolbox.removeAttribute("zen-has-hover");
+    await setCompactMode(false);
+  }
 });


### PR DESCRIPTION
## Summary

This PR makes the sidebar resizable while it is revealed in Compact Mode.

- Adds a full-height resize handle aligned with the content-facing edge of the sidebar.
- Supports both left- and right-side tab layouts.
- Reuses the same minimum and maximum widths as the regular sidebar.
- Keeps the selected width when the sidebar is hidden and revealed again.
- Prevents the URL bar and other sidebar content from leaking into the page while hidden.
- Keeps the right-side sidebar aligned within the window without clipping its controls or rounded edge.

## Behavior

The Compact Mode sidebar follows these interaction rules:

- Resizing is clamped to the same minimum and maximum widths used outside Compact Mode.
- Releasing the resize handle while the pointer is outside the sidebar keeps it temporarily visible.
- After resizing outside the sidebar, the pointer must first re-enter the sidebar before leaving it can hide the sidebar.
- Moving outside the sidebar remains within the existing horizontal hover buffer (100 CSS pixels by default) before it is hidden.
- An empty tab keeps the sidebar visible.
- When leaving the empty-tab state:
  - the sidebar remains visible if navigation starts while the pointer is inside it;
  - the sidebar hides automatically if the pointer is outside it.
- The existing regular-mode splitter behavior remains unchanged.

## Motivation

I am a long-time Arc user currently evaluating Zen as a replacement. One of the main interaction gaps I noticed was that the sidebar could be resized in the regular layout, but not while it was revealed in Compact Mode.

This change makes it possible to adjust the sidebar without leaving Compact Mode while preserving Zen's existing sizing and hover behavior.

## Demo

https://github.com/user-attachments/assets/d3fda638-4ab0-4cb0-b490-dc5b001fb9bc

## Testing

- `npm run build:ui`
- `npm run lint`

  - 0 errors
  - 0 warnings
- `npm test -- compact_mode`
  - 28 checks executed
  - 28 expected results
  - 0 unexpected results
- Manually verified on macOS:
  - left- and right-side tab layouts;
  - minimum and maximum width clamping;
  - resize-handle alignment and dragging;
  - hover-buffer behavior after resizing;
  - empty-tab visibility and navigation transitions;
  - hidden-sidebar content clipping;
  - right-side outer spacing and unclipped controls.

## Scope

Keyboard accessibility for sidebar resizers is intentionally not included in this PR. It can be discussed and handled separately for both the regular and Compact Mode splitters so their interaction remains consistent.

Related to #13205.