### PR TITLE
feat: add automatic inactive tab unloading

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -73,6 +73,23 @@ zen-tabs-cycle-ignore-pending-tabs =
   .label = Ignore Pending tabs when cycling with Ctrl+Tab
 zen-tabs-cycle-by-attribute-warning = Ctrl+Tab will cycle by recently used order, as it is enabled
 
+pane-zen-auto-unload-tabs-title = Tab Unloading
+zen-auto-unload-tabs-header = Automatically unload inactive tabs
+zen-auto-unload-tabs-description = Free memory used by inactive web tabs. Active, pinned, Essential, media, picture-in-picture, sharing, and internal browser tabs are protected.
+zen-auto-unload-tabs-enabled =
+    .label = Unload inactive tabs automatically
+zen-auto-unload-tabs-delay-label = Unload tabs after
+zen-auto-unload-tabs-delay-5 =
+    .label = 5 minutes
+zen-auto-unload-tabs-delay-15 =
+    .label = 15 minutes
+zen-auto-unload-tabs-delay-30 =
+    .label = 30 minutes
+zen-auto-unload-tabs-delay-60 =
+    .label = 1 hour
+zen-auto-unload-tabs-delay-120 =
+    .label = 2 hours
+
 zen-look-and-feel-compact-toolbar-themed =
     .label = Use themed background for compact toolbar
 

--- a/prefs/zen/zen.yaml
+++ b/prefs/zen/zen.yaml
@@ -23,6 +23,12 @@
 - name: zen.tabs.select-recently-used-on-close
   value: true
 
+- name: zen.tabs.auto-unload.enabled
+  value: false
+
+- name: zen.tabs.auto-unload.after-minutes
+  value: 15
+
 - name: zen.tabs.folder-dragover-threshold-percent
   value: 20 # Percentage of folder height to trigger dragover
 

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -731,7 +731,20 @@ var gZenWorkspacesSettings = {
       },
     };
 
+    const updateAutoUnloadDelayState = {
+      observe() {
+        const delay = document.getElementById("zenAutoUnloadTabsDelay");
+        if (delay) {
+          delay.disabled = !Services.prefs.getBoolPref(
+            "zen.tabs.auto-unload.enabled",
+            false
+          );
+        }
+      },
+    };
+
     toggleZenCycleByAttrWarning.observe(); // call it once on initial load
+    updateAutoUnloadDelayState.observe();
 
     Services.prefs.addObserver("zen.glance.enabled", tabsUnloaderPrefListener); // We can use the same listener for both prefs
     Services.prefs.addObserver("zen.workspaces.separate-essentials", tabsUnloaderPrefListener);
@@ -742,6 +755,10 @@ var gZenWorkspacesSettings = {
       toggleZenCycleByAttrWarning
     );
     Services.prefs.addObserver("browser.ctrlTab.sortByRecentlyUsed", toggleZenCycleByAttrWarning);
+    Services.prefs.addObserver(
+      "zen.tabs.auto-unload.enabled",
+      updateAutoUnloadDelayState
+    );
     window.addEventListener("unload", () => {
       Services.prefs.removeObserver("zen.glance.enabled", tabsUnloaderPrefListener);
       Services.prefs.removeObserver("zen.glance.activation-method", tabsUnloaderPrefListener);
@@ -757,6 +774,10 @@ var gZenWorkspacesSettings = {
       Services.prefs.removeObserver(
         "browser.ctrlTab.sortByRecentlyUsed",
         toggleZenCycleByAttrWarning
+      );
+      Services.prefs.removeObserver(
+        "zen.tabs.auto-unload.enabled",
+        updateAutoUnloadDelayState
       );
     });
   },

--- a/src/browser/components/preferences/zenTabsManagement.inc.xhtml
+++ b/src/browser/components/preferences/zenTabsManagement.inc.xhtml
@@ -44,6 +44,34 @@
             preference="zen.tabs.select-recently-used-on-close"/>
 </groupbox>
 
+<hbox id="zenAutoUnloadTabsCategory"
+      class="subcategory"
+      hidden="true"
+      data-category="paneZenTabManagement">
+      <html:h1 data-l10n-id="pane-zen-auto-unload-tabs-title"/>
+</hbox>
+
+<groupbox id="zenAutoUnloadTabsGroup" data-category="paneZenTabManagement" hidden="true" class="highlighting-group">
+      <label><html:h2 data-l10n-id="zen-auto-unload-tabs-header"/></label>
+      <description class="description-deemphasized" data-l10n-id="zen-auto-unload-tabs-description" />
+
+      <checkbox id="zenAutoUnloadTabsEnabled"
+            data-l10n-id="zen-auto-unload-tabs-enabled"
+            preference="zen.tabs.auto-unload.enabled"/>
+      <hbox align="center">
+            <label data-l10n-id="zen-auto-unload-tabs-delay-label"/>
+            <menulist id="zenAutoUnloadTabsDelay" preference="zen.tabs.auto-unload.after-minutes">
+                  <menupopup>
+                        <menuitem data-l10n-id="zen-auto-unload-tabs-delay-5" value="5"/>
+                        <menuitem data-l10n-id="zen-auto-unload-tabs-delay-15" value="15"/>
+                        <menuitem data-l10n-id="zen-auto-unload-tabs-delay-30" value="30"/>
+                        <menuitem data-l10n-id="zen-auto-unload-tabs-delay-60" value="60"/>
+                        <menuitem data-l10n-id="zen-auto-unload-tabs-delay-120" value="120"/>
+                  </menupopup>
+            </menulist>
+      </hbox>
+</groupbox>
+
 <hbox id="zenPinnedTabsManagerCategory"
       class="subcategory"
       hidden="true"
@@ -78,5 +106,4 @@
 </groupbox>
 
 </html:template>
-
 

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -9,7 +9,12 @@ import { ZenSpacesSwipe } from "resource:///modules/zen/ZenSpacesSwipe.mjs";
 
 const lazy = {};
 
+const AUTO_UNLOAD_CHECK_INTERVAL_MS = 60 * 1000;
+const AUTO_UNLOAD_BATCH_SIZE = 5;
+
 ChromeUtils.defineESModuleGetters(lazy, {
+  TabUnloader:
+    "moz-src:///browser/components/tabbrowser/TabUnloader.sys.mjs",
   ZenSessionStore: "resource:///modules/zen/ZenSessionManager.sys.mjs",
 });
 
@@ -48,6 +53,8 @@ class nsZenWorkspaces {
   _workspaceCache = [];
 
   #lastScrollTime = 0;
+  _autoUnloadTimer = null;
+  _autoUnloadInProgress = false;
   #currentSpaceSwitchContext = {
     promise: null,
     animations: [],
@@ -122,6 +129,20 @@ class nsZenWorkspaces {
       "zen.workspaces.open-new-tab-if-last-unpinned-tab-is-closed",
       false
     );
+    XPCOMUtils.defineLazyPreferenceGetter(
+      this,
+      "autoUnloadTabsEnabled",
+      "zen.tabs.auto-unload.enabled",
+      false,
+      () => this._restartAutoUnloadTimer()
+    );
+    XPCOMUtils.defineLazyPreferenceGetter(
+      this,
+      "autoUnloadTabsAfterMinutes",
+      "zen.tabs.auto-unload.after-minutes",
+      15,
+      () => this._restartAutoUnloadTimer()
+    );
     this.containerSpecificEssentials = Services.prefs.getBoolPref(
       "zen.workspaces.separate-essentials",
       false
@@ -142,6 +163,9 @@ class nsZenWorkspaces {
     }
 
     window.addEventListener("resize", this.onWindowResize.bind(this));
+    window.addEventListener("unload", () => this._stopAutoUnloadTimer(), {
+      once: true,
+    });
     this.addPopupListeners();
 
     if (this.privateWindowOrDisabled) {
@@ -190,6 +214,115 @@ class nsZenWorkspaces {
     ) {
       this._swipeManager = new ZenSpacesSwipe();
       this.initializeWorkspaceNavigation();
+    }
+    this._restartAutoUnloadTimer();
+  }
+
+  _stopAutoUnloadTimer() {
+    if (this._autoUnloadTimer) {
+      window.clearInterval(this._autoUnloadTimer);
+      this._autoUnloadTimer = null;
+    }
+  }
+
+  _restartAutoUnloadTimer() {
+    this._stopAutoUnloadTimer();
+    if (!this.autoUnloadTabsEnabled || this.isPrivateWindow || window.closed) {
+      return;
+    }
+
+    this._autoUnloadTimer = window.setInterval(() => {
+      this.unloadInactiveTabs().catch(error =>
+        console.error("Failed to automatically unload inactive tabs", error)
+      );
+    }, AUTO_UNLOAD_CHECK_INTERVAL_MS);
+  }
+
+  _canAutoUnloadTab(tab) {
+    if (
+      !tab ||
+      tab.selected ||
+      tab.closing ||
+      tab.pinned ||
+      tab.undiscardable ||
+      tab.zenModeActive ||
+      tab.splitview?.hasActiveTab
+    ) {
+      return false;
+    }
+
+    const protectedAttributes = [
+      "pending",
+      "busy",
+      "multiselected",
+      "pictureinpicture",
+      "sharing",
+      "soundplaying",
+      "zen-empty-tab",
+      "zen-essential",
+      "zen-glance-tab",
+      "glance-id",
+    ];
+    if (protectedAttributes.some(attribute => tab.hasAttribute(attribute))) {
+      return false;
+    }
+
+    const browser = tab.linkedBrowser;
+    if (
+      !browser?.isConnected ||
+      !browser.isRemoteBrowser ||
+      (!browser.currentURI?.schemeIs("http") &&
+        !browser.currentURI?.schemeIs("https"))
+    ) {
+      return false;
+    }
+
+    return !(
+      window.webrtcUI.browserHasStreams(browser) ||
+      browser.browsingContext?.currentWindowGlobal?.hasActivePeerConnections()
+    );
+  }
+
+  async unloadInactiveTabs(now = Date.now()) {
+    if (
+      !this.autoUnloadTabsEnabled ||
+      this.isPrivateWindow ||
+      this._autoUnloadInProgress
+    ) {
+      return 0;
+    }
+
+    this._autoUnloadInProgress = true;
+    try {
+      const inactiveDuration =
+        Math.max(1, this.autoUnloadTabsAfterMinutes) * 60 * 1000;
+      const sortedTabs = await lazy.TabUnloader.getSortedTabs(inactiveDuration);
+      const tabsToUnload = sortedTabs
+        .filter(
+          tabInfo =>
+            tabInfo.gBrowser === gBrowser &&
+            tabInfo.weight === 0 &&
+            this._canAutoUnloadTab(tabInfo.tab) &&
+            now - tabInfo.tab.lastAccessed >= inactiveDuration
+        )
+        .map(tabInfo => tabInfo.tab)
+        .slice(0, AUTO_UNLOAD_BATCH_SIZE);
+
+      let unloadedCount = 0;
+      for (const tab of tabsToUnload) {
+        await gBrowser.prepareDiscardBrowser(tab);
+        if (
+          this._canAutoUnloadTab(tab) &&
+          now - tab.lastAccessed >= inactiveDuration &&
+          gBrowser.discardBrowser(tab)
+        ) {
+          tab.updateLastUnloadedByTabUnloader();
+          unloadedCount++;
+        }
+      }
+      return unloadedCount;
+    } finally {
+      this._autoUnloadInProgress = false;
     }
   }
 

--- a/src/zen/tests/spaces/browser.toml
+++ b/src/zen/tests/spaces/browser.toml
@@ -10,6 +10,8 @@ support-files = [
 
 ["browser_basic_workspaces.js"]
 
+["browser_auto_unload_inactive_tabs.js"]
+
 ["browser_double_click_newtab.js"]
 
 ["browser_issue_10455.js"]

--- a/src/zen/tests/spaces/browser_auto_unload_inactive_tabs.js
+++ b/src/zen/tests/spaces/browser_auto_unload_inactive_tabs.js
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const INACTIVE_DURATION_MS = 15 * 60 * 1000;
+
+add_setup(async function setup() {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["zen.tabs.auto-unload.enabled", true],
+      ["zen.tabs.auto-unload.after-minutes", 15]
+    ]
+  });
+});
+
+add_task(async function test_respects_disabled_preference() {
+  Services.prefs.setBoolPref("zen.tabs.auto-unload.enabled", false);
+  const inactiveTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.com/?disabled"
+  );
+  const activeTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.org/?disabled-active"
+  );
+  inactiveTab._lastAccessed = Date.now() - INACTIVE_DURATION_MS - 1000;
+
+  const unloadedCount = await gZenWorkspaces.unloadInactiveTabs();
+
+  is(unloadedCount, 0, "Disabled auto unload should not unload tabs");
+  ok(inactiveTab.linkedPanel, "Inactive tab should remain loaded");
+
+  Services.prefs.setBoolPref("zen.tabs.auto-unload.enabled", true);
+  await BrowserTestUtils.removeTab(inactiveTab);
+  await BrowserTestUtils.removeTab(activeTab);
+});
+
+add_task(async function test_unloads_inactive_regular_tab() {
+  const inactiveTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.com/"
+  );
+  const activeTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.org/"
+  );
+  inactiveTab._lastAccessed = Date.now() - INACTIVE_DURATION_MS - 1000;
+
+  const unloadedCount = await gZenWorkspaces.unloadInactiveTabs();
+
+  is(unloadedCount, 1, "One inactive tab should be unloaded");
+  ok(inactiveTab.hasAttribute("pending"), "Inactive tab should be pending");
+  ok(!inactiveTab.linkedPanel, "Inactive tab should release its browser");
+  ok(!activeTab.hasAttribute("pending"), "Active tab should remain loaded");
+
+  await BrowserTestUtils.removeTab(inactiveTab);
+  await BrowserTestUtils.removeTab(activeTab);
+});
+
+add_task(async function test_protects_recent_and_special_tabs() {
+  const recentTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.com/?recent"
+  );
+  const pinnedTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.com/?pinned"
+  );
+  gBrowser.pinTab(pinnedTab);
+  const essentialTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.com/?essential"
+  );
+  essentialTab.setAttribute("zen-essential", "true");
+  const mediaTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.com/?media"
+  );
+  mediaTab.setAttribute("soundplaying", "true");
+  const internalTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "about:preferences"
+  );
+  const activeTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    "https://example.org/?active"
+  );
+
+  for (const tab of [pinnedTab, essentialTab, mediaTab, internalTab]) {
+    tab._lastAccessed = Date.now() - INACTIVE_DURATION_MS - 1000;
+  }
+  recentTab._lastAccessed = Date.now();
+
+  const unloadedCount = await gZenWorkspaces.unloadInactiveTabs();
+
+  is(unloadedCount, 0, "Protected and recent tabs should not be unloaded");
+  for (const tab of [
+    recentTab,
+    pinnedTab,
+    essentialTab,
+    mediaTab,
+    internalTab,
+    activeTab
+  ]) {
+    ok(tab.linkedPanel, `${tab.label} should remain loaded`);
+  }
+
+  mediaTab.removeAttribute("soundplaying");
+  essentialTab.removeAttribute("zen-essential");
+  for (const tab of [
+    recentTab,
+    pinnedTab,
+    essentialTab,
+    mediaTab,
+    internalTab,
+    activeTab
+  ]) {
+    await BrowserTestUtils.removeTab(tab);
+  }
+});


### PR DESCRIPTION
## Summary

- add an opt-in automatic inactive-tab unloading mode with 5/15/30/60/120 minute delays
- reuse Firefox's `TabUnloader.getSortedTabs()` eligibility and weighting instead of maintaining a second discard heuristic
- unload only base-weight 0 tabs through non-forced `discardBrowser`, preserving Firefox's unload protections
- exclude selected, pinned, Essential, media/PiP/WebRTC/sharing, Glance, private, and internal tabs
- process up to five tabs per minute to avoid UI stalls
- add browser tests for disabled, eligible, recent, and protected tabs

## Why this differs from #12465

I understand timer-based unloading was previously declined in favor of memory-pressure-based unloading. This version is disabled by default and layers an explicit user choice on top of Firefox's existing candidate weighting and safety checks; the native low-memory path remains unchanged.

## Validation

- Surfer imported all 69 Zen patches into Firefox 154
- targeted Mozilla ESLint: 0 problems
- `test-manifest-toml`: 0 problems
- Fluent parser: 0 junk nodes
- XHTML/YAML parsing and JavaScript syntax checks passed
- browser-chrome test added; full execution was not run locally because Rust/Cargo and LLD are absent

Related: #8822, https://github.com/zen-browser/desktop/discussions/10494, #12465