### PR TITLE
gh-15039: Fix New Blank Window menu entry not in Title Case

### DIFF
--- a/locales/en-US/browser/browser/zen-general.ftl
+++ b/locales/en-US/browser/browser/zen-general.ftl
@@ -164,5 +164,5 @@ zen-window-sync-migration-dialog-learn-more = Learn More
 zen-window-sync-migration-dialog-accept = Got It
 
 zen-appmenu-new-blank-window =
-    .label = New blank window
+    .label = New Blank Window
 


### PR DESCRIPTION
Fixes #15039

First contribution here, so I took an easy one. I just did a cmd+F for "new blank window" across the codebase and noticed the app menu entry was the only one not in Title Case, the menubar, command palette and preferences already say "New Blank Window". So this just makes it consistent with its neighbours

Only touched the en-US source string, the other locales are handled by Crowdin so I left them alone