### PR TITLE
gh-15039: Use Title Case for split view labels

### DIFF
--- a/locales/en-US/browser/browser/zen-split-view.ftl
+++ b/locales/en-US/browser/browser/zen-split-view.ftl
@@ -5,14 +5,14 @@
 tab-zen-split-tabs =
     .label =
         { $tabCount ->
-            [-1] Split out tab
-            [1] Add split view...
+            [-1] Split Out Tab
+            [1] Add Split View...
            *[other] Join { $tabCount } Tabs
         }
     .accesskey = S
 
 zen-split-link =
-    .label = Split link to new tab
+    .label = Split Link to New Tab
     .accesskey = S
 
 zen-split-view-modifier-header = Split View


### PR DESCRIPTION
Surrounding copy is Title Case; these were inconsistent.

Basically the same issue as #15039 (fixed in #15056).

Only touching the base translation, as others seem to be handled via Crowdin.