### PR TITLE
gh-14921: Ctrl+Shift+DigitOrSymbol keybinds don't work

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1028,7 +1028,7 @@ var gZenCKSSettings = {
     let shortcut;
     if (event.code && event.code.startsWith("Key")) {
       shortcut = event.code.slice(3);
-    } else if (event.code && event.code.startsWith("Digit")) {
+    } else if (!event.shiftKey && event.code && event.code.startsWith("Digit")) {
       shortcut = event.code.slice(5);
     } else {
       // Use physical key mapping for common symbols
@@ -1045,7 +1045,7 @@ var gZenCKSSettings = {
         Minus: "-",
         Equal: "=",
       };
-      shortcut = CODE_TO_KEY_MAP[event.code] || event.key;
+      shortcut = (!event.shiftKey && CODE_TO_KEY_MAP[event.code]) || event.key;
     }
 
     shortcut = shortcut.replace(/Ctrl|Control|Shift|Alt|Option|Cmd|Meta/, ""); // Remove all modifiers


### PR DESCRIPTION
This PR addresses #14921.

Ctrl+Shift+DigitOrSymbol keybinds don't work

Generated with AI assistance and validated against the original
file before submission (syntax check + change-scope check).
Please review carefully — happy to adjust based on feedback.
