### PR TITLE
feat: add --space command line flag to open a link in a specific space

### DIFF
--- a/src/browser/components/BrowserContentHandler-sys-mjs.patch
+++ b/src/browser/components/BrowserContentHandler-sys-mjs.patch
@@ -2,7 +2,7 @@ diff --git a/browser/components/BrowserContentHandler.sys.mjs b/browser/componen
 index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09814422bf 100644
 --- a/browser/components/BrowserContentHandler.sys.mjs
 +++ b/browser/components/BrowserContentHandler.sys.mjs
-@@ -603,6 +603,28 @@ nsBrowserContentHandler.prototype = {
+@@ -603,6 +603,61 @@ nsBrowserContentHandler.prototype = {
        }
      }
  
@@ -27,15 +27,49 @@ index 4bfb4199dafac004486dfc61db954173742a010a..542c156432b9d7c2190c0d14ce9cfd09
 +      }
 +    }
 +
++    try {
++      let zenWorkspaceParam = cmdLine.handleFlagWithParam("space", false);
++      if (zenWorkspaceParam) {
++        let targetWin = lazy.BrowserWindowTracker.getTopWindow({
++          private: false,
++          allowPopups: false,
++        });
++        if (
++          targetWin?.gZenWorkspaces &&
++          !targetWin.gZenWorkspaces.privateWindowOrDisabled
++        ) {
++          targetWin.gZenWorkspaces
++            .changeWorkspaceFromCommandLine(zenWorkspaceParam)
++            .catch(console.error);
++          targetWin.focus();
++          if (!cmdLine.length) {
++            cmdLine.preventDefault = true;
++          }
++        } else {
++          // Cold start: stash the space so the first window that
++          // restores picks it up, and let normal startup open that window.
++          Services.prefs.setStringPref(
++            "zen.workspaces.cmdline-initial-workspace",
++            zenWorkspaceParam
++          );
++        }
++      }
++    } catch (e) {
++      if (e.result != Cr.NS_ERROR_INVALID_ARG) {
++        throw e;
++      }
++    }
++
 +
      var searchParam = cmdLine.handleFlagWithParam("search", false);
      if (searchParam) {
        doSearch(searchParam, cmdLine);
-@@ -672,6 +694,7 @@ nsBrowserContentHandler.prototype = {
+@@ -672,6 +727,8 @@ nsBrowserContentHandler.prototype = {
        "  --new-window <url> Open <url> in a new window.\n" +
        "  --new-tab <url>    Open <url> in a new tab.\n" +
        "  --private-window [<url>] Open <url> in a new private window.\n";
 +    info += "  --blank-window [<url>]  Open the new blank window.\n";
++    info += "  --space <space> [<url>]  Switch to the space with the given name or UUID, and open <url> in it if given.\n";
      if (AppConstants.platform == "win") {
        info += "  --preferences      Open Options dialog.\n";
      } else {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -675,18 +675,15 @@ class nsZenWorkspaces {
     }
   }
 
-  resolveWorkspaceFromString(value) {
+  resolveWorkspaceFromCLIString(value) {
     if (!value) {
       return null;
     }
     try {
       const workspaces = this.getWorkspaces();
       return (
-        workspaces.find(workspace => workspace.uuid === value) ||
-        workspaces.find(
-          workspace =>
-            workspace.name?.toLowerCase() === value.toLowerCase()
-        ) ||
+        workspaces.find(workspace => workspace.uuid === value || 
+          workspace.name?.toLowerCase() === value.toLowerCase()) ||
         null
       );
     } catch {
@@ -769,7 +766,7 @@ class nsZenWorkspaces {
       // window that restores its workspaces; private and unsynced windows
       // must not eat the pref.
       Services.prefs.clearUserPref("zen.workspaces.cmdline-initial-workspace");
-      const initialWorkspace = this.resolveWorkspaceFromString(cmdLineWorkspace);
+      const initialWorkspace = this.resolveWorkspaceFromCLIString(cmdLineWorkspace);
       if (initialWorkspace) {
         this.activeWorkspace = initialWorkspace.uuid;
       }
@@ -1661,7 +1658,7 @@ class nsZenWorkspaces {
    */
   async changeWorkspaceFromCommandLine(workspaceMatch) {
     await this.promiseInitialized;
-    const workspace = this.resolveWorkspaceFromString(workspaceMatch);
+    const workspace = this.resolveWorkspaceFromCLIString(workspaceMatch);
     if (workspace && workspace.uuid !== this.activeWorkspace) {
       await this.changeWorkspaceWithID(workspace.uuid);
     }

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -675,6 +675,25 @@ class nsZenWorkspaces {
     }
   }
 
+  resolveWorkspaceFromString(value) {
+    if (!value) {
+      return null;
+    }
+    try {
+      const workspaces = this.getWorkspaces();
+      return (
+        workspaces.find(workspace => workspace.uuid === value) ||
+        workspaces.find(
+          workspace =>
+            workspace.name?.toLowerCase() === value.toLowerCase()
+        ) ||
+        null
+      );
+    } catch {
+      return null;
+    }
+  }
+
   getWorkspaces(lieToMe = false) {
     if (lieToMe) {
       const { ZenSessionStore } = ChromeUtils.importESModule(
@@ -738,6 +757,23 @@ class nsZenWorkspaces {
       : [this.#createWorkspaceData("Space", undefined)];
     this.activeWorkspace =
       aWinData.activeZenSpace || this._workspaceCache[0].uuid;
+    const cmdLineWorkspace = this.privateWindowOrDisabled
+      ? ""
+      : Services.prefs.getStringPref(
+          "zen.workspaces.cmdline-initial-workspace",
+          ""
+        );
+    if (cmdLineWorkspace) {
+      // Set by the `--space` command line flag on a cold start,
+      // see BrowserContentHandler.sys.mjs. Consumed by the first syncing
+      // window that restores its workspaces; private and unsynced windows
+      // must not eat the pref.
+      Services.prefs.clearUserPref("zen.workspaces.cmdline-initial-workspace");
+      const initialWorkspace = this.resolveWorkspaceFromString(cmdLineWorkspace);
+      if (initialWorkspace) {
+        this.activeWorkspace = initialWorkspace.uuid;
+      }
+    }
     let promise = this.#initializeWorkspaces();
     for (const workspace of spacesFromStore) {
       const element = this.workspaceElement(workspace.uuid);
@@ -1615,6 +1651,20 @@ class nsZenWorkspaces {
   async changeWorkspaceWithID(workspaceID, ...args) {
     const workspace = this.getWorkspaceFromId(workspaceID);
     return await this.changeWorkspace(workspace, ...args);
+  }
+
+  /**
+   * Handles the `--space` command line flag for an already running
+   * browser: switches to the workspace matching the given name or UUID.
+   *
+   * @param {string} workspaceMatch - The workspace UUID or name to switch to
+   */
+  async changeWorkspaceFromCommandLine(workspaceMatch) {
+    await this.promiseInitialized;
+    const workspace = this.resolveWorkspaceFromString(workspaceMatch);
+    if (workspace && workspace.uuid !== this.activeWorkspace) {
+      await this.changeWorkspaceWithID(workspace.uuid);
+    }
   }
 
   async changeWorkspace(workspace, ...args) {

--- a/src/zen/tests/spaces/browser.toml
+++ b/src/zen/tests/spaces/browser.toml
@@ -20,6 +20,8 @@ support-files = [
 
 ["browser_issue_9900.js"]
 
+["browser_zen_workspace_cmdline.js"]
+
 ["browser_overflow_scrollbox.js"]
 
 ["browser_private_mode.js"]

--- a/src/zen/tests/spaces/browser_zen_workspace_cmdline.js
+++ b/src/zen/tests/spaces/browser_zen_workspace_cmdline.js
@@ -18,22 +18,22 @@ add_task(async function test_resolve_workspace_from_string() {
   });
 
   Assert.strictEqual(
-    gZenWorkspaces.resolveWorkspaceFromString(created.uuid)?.uuid,
+    gZenWorkspaces.resolveWorkspaceFromCLIString(created.uuid)?.uuid,
     created.uuid,
     "Workspaces should resolve by UUID."
   );
   Assert.strictEqual(
-    gZenWorkspaces.resolveWorkspaceFromString("cmdline space")?.uuid,
+    gZenWorkspaces.resolveWorkspaceFromCLIString("cmdline space")?.uuid,
     created.uuid,
     "Workspaces should resolve by name, case-insensitively."
   );
   Assert.strictEqual(
-    gZenWorkspaces.resolveWorkspaceFromString("does-not-exist"),
+    gZenWorkspaces.resolveWorkspaceFromCLIString("does-not-exist"),
     null,
     "Unknown workspaces should resolve to null."
   );
   Assert.strictEqual(
-    gZenWorkspaces.resolveWorkspaceFromString(null),
+    gZenWorkspaces.resolveWorkspaceFromCLIString(null),
     null,
     "Empty values should resolve to null."
   );

--- a/src/zen/tests/spaces/browser_zen_workspace_cmdline.js
+++ b/src/zen/tests/spaces/browser_zen_workspace_cmdline.js
@@ -1,0 +1,185 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_resolve_workspace_from_string() {
+  const originalWorkspaceUUID = gZenWorkspaces.activeWorkspace;
+  await gZenWorkspaces.createAndSaveWorkspace("Cmdline Space");
+  const created = gZenWorkspaces
+    .getWorkspaces()
+    .find(workspace => workspace.name === "Cmdline Space");
+  Assert.ok(created, "The new workspace should exist.");
+  registerCleanupFunction(async () => {
+    if (gZenWorkspaces.getWorkspaceFromId(created.uuid)) {
+      await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+      await gZenWorkspaces.removeWorkspace(created.uuid);
+    }
+  });
+
+  Assert.strictEqual(
+    gZenWorkspaces.resolveWorkspaceFromString(created.uuid)?.uuid,
+    created.uuid,
+    "Workspaces should resolve by UUID."
+  );
+  Assert.strictEqual(
+    gZenWorkspaces.resolveWorkspaceFromString("cmdline space")?.uuid,
+    created.uuid,
+    "Workspaces should resolve by name, case-insensitively."
+  );
+  Assert.strictEqual(
+    gZenWorkspaces.resolveWorkspaceFromString("does-not-exist"),
+    null,
+    "Unknown workspaces should resolve to null."
+  );
+  Assert.strictEqual(
+    gZenWorkspaces.resolveWorkspaceFromString(null),
+    null,
+    "Empty values should resolve to null."
+  );
+
+  await gZenWorkspaces.removeWorkspace(created.uuid);
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    originalWorkspaceUUID,
+    "We should be back on the original workspace."
+  );
+});
+
+add_task(async function test_change_workspace_from_command_line() {
+  const originalWorkspaceUUID = gZenWorkspaces.activeWorkspace;
+  await gZenWorkspaces.createAndSaveWorkspace("Cmdline Target");
+  const target = gZenWorkspaces
+    .getWorkspaces()
+    .find(workspace => workspace.name === "Cmdline Target");
+  Assert.ok(target, "The target workspace should exist.");
+  registerCleanupFunction(async () => {
+    if (gZenWorkspaces.getWorkspaceFromId(target.uuid)) {
+      await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+      await gZenWorkspaces.removeWorkspace(target.uuid);
+    }
+  });
+
+  await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    originalWorkspaceUUID,
+    "We should start from the original workspace."
+  );
+
+  // Matching by name is case-insensitive.
+  await gZenWorkspaces.changeWorkspaceFromCommandLine("cmdline target");
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    target.uuid,
+    "The command line flag should switch to the target workspace."
+  );
+
+  await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+  // Matching by UUID also works.
+  await gZenWorkspaces.changeWorkspaceFromCommandLine(target.uuid);
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    target.uuid,
+    "The command line flag should switch to the target workspace by UUID."
+  );
+
+  await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+  await gZenWorkspaces.removeWorkspace(target.uuid);
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    originalWorkspaceUUID,
+    "We should be back on the original workspace."
+  );
+});
+
+add_task(async function test_unknown_workspace_does_not_switch() {
+  const originalWorkspaceUUID = gZenWorkspaces.activeWorkspace;
+
+  await gZenWorkspaces.changeWorkspaceFromCommandLine("does-not-exist");
+
+  Assert.strictEqual(
+    gZenWorkspaces.activeWorkspace,
+    originalWorkspaceUUID,
+    "An unknown workspace should not switch spaces."
+  );
+});
+
+add_task(async function test_initial_workspace_pref_consumed_on_restore() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.testing.enabled", false]],
+  });
+  const originalWorkspaceUUID = gZenWorkspaces.activeWorkspace;
+  await gZenWorkspaces.createAndSaveWorkspace("Cmdline Cold Start");
+  const target = gZenWorkspaces
+    .getWorkspaces()
+    .find(workspace => workspace.name === "Cmdline Cold Start");
+  Assert.ok(target, "The target workspace should exist.");
+  registerCleanupFunction(async () => {
+    Services.prefs.clearUserPref("zen.workspaces.cmdline-initial-workspace");
+    if (gZenWorkspaces.getWorkspaceFromId(target.uuid)) {
+      await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+      await gZenWorkspaces.removeWorkspace(target.uuid);
+    }
+  });
+
+  // Simulates the pref stashed by `--space` on a cold start, see
+  // BrowserContentHandler.sys.mjs.
+  Services.prefs.setStringPref(
+    "zen.workspaces.cmdline-initial-workspace",
+    "cmdline cold start"
+  );
+
+  const newWindow = await BrowserTestUtils.openNewBrowserWindow();
+  await newWindow.gZenWorkspaces.promiseInitialized;
+
+  Assert.strictEqual(
+    newWindow.gZenWorkspaces.activeWorkspace,
+    target.uuid,
+    "The restored window should start on the requested workspace."
+  );
+  Assert.strictEqual(
+    Services.prefs.getStringPref(
+      "zen.workspaces.cmdline-initial-workspace",
+      ""
+    ),
+    "",
+    "The pref should be consumed by the restored window."
+  );
+
+  await BrowserTestUtils.closeWindow(newWindow);
+  await gZenWorkspaces.changeWorkspaceWithID(originalWorkspaceUUID);
+  await gZenWorkspaces.removeWorkspace(target.uuid);
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_initial_workspace_pref_survives_private_window() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.testing.enabled", false]],
+  });
+  Services.prefs.setStringPref(
+    "zen.workspaces.cmdline-initial-workspace",
+    "does-not-matter"
+  );
+  registerCleanupFunction(() => {
+    Services.prefs.clearUserPref("zen.workspaces.cmdline-initial-workspace");
+  });
+
+  const privateWindow = await BrowserTestUtils.openNewBrowserWindow({
+    private: true,
+  });
+  await privateWindow.gZenWorkspaces.promiseInitialized;
+
+  Assert.strictEqual(
+    Services.prefs.getStringPref(
+      "zen.workspaces.cmdline-initial-workspace",
+      ""
+    ),
+    "does-not-matter",
+    "A private window should not consume the initial workspace pref."
+  );
+
+  await BrowserTestUtils.closeWindow(privateWindow);
+  Services.prefs.clearUserPref("zen.workspaces.cmdline-initial-workspace");
+  await SpecialPowers.popPrefEnv();
+});


### PR DESCRIPTION
reopening of #14104

Adds a --space <space> command line flag that switches to the workspace matching the given name (case-insensitive) or UUID:

zen --space work
zen --space "Space Name"
zen --space c2d1e574-3f04-4bd5-9721-2e6dd7f1adf9 # uuid of workspace

Behavior:

    Browser running: delegates to gZenWorkspaces.changeWorkspaceFromCommandLine in the most recent non-private window, which switches to the matching workspace.
    Cold start: the workspace is stashed in the zen.workspaces.cmdline-initial-workspace pref, which is consumed (and cleared) by the first window that restores its workspaces, so the browser starts on the requested space.
    Unknown workspace: no-op — the active workspace stays unchanged.
    When used together with a url invocation, the url would open in the specified space.

Implementation: extends the BrowserContentHandler.sys.mjs patch (same pattern as the existing --blank-window flag) and adds resolveWorkspaceFromString / changeWorkspaceFromCommandLine to ZenSpaceManager. Includes mochitests covering name/UUID resolution, workspace switching, and the unknown-workspace no-op. When used together with a url invocation, the url would open in the specified space.

Useful for OS shortcuts and scripting, e.g. a .desktop entry per workspace.