### PR TITLE
Prevent partial Zen Mod installations

### DIFF
--- a/src/zen/mods/ZenMods.mjs
+++ b/src/zen/mods/ZenMods.mjs
@@ -358,6 +358,7 @@ class nsZenMods extends nsZenPreloadedFeature {
             url,
             e
           );
+          throw e;
         } else {
           console.warn(
             `[ZenMods]: Download failed (attempt ${attempt} of ${maxRetries}), retrying in ${retryDelayMs}ms...`,
@@ -674,27 +675,52 @@ class nsZenMods extends nsZenPreloadedFeature {
   }
 
   async installMod(mod) {
+    const modPath = PathUtils.join(this.modsRootPath, mod.id);
+    let stagingPath;
+
     try {
-      const modPath = PathUtils.join(this.modsRootPath, mod.id);
-      await IOUtils.makeDirectory(modPath, { ignoreExisting: true });
+      await IOUtils.makeDirectory(this.modsRootPath, { ignoreExisting: true });
+      stagingPath = await IOUtils.createUniqueDirectory(
+        this.modsRootPath,
+        ".installing-"
+      );
 
       await this.#downloadUrlToFile(
         mod.style,
-        PathUtils.join(modPath, "chrome.css")
+        PathUtils.join(stagingPath, "chrome.css")
       );
       await this.#downloadUrlToFile(
         mod.readme,
-        PathUtils.join(modPath, "readme.md")
+        PathUtils.join(stagingPath, "readme.md")
       );
 
       if (mod.preferences) {
         await this.#downloadUrlToFile(
           mod.preferences,
-          PathUtils.join(modPath, "preferences.json")
+          PathUtils.join(stagingPath, "preferences.json")
         );
       }
+
+      await IOUtils.move(stagingPath, modPath, { noOverwrite: true });
+      stagingPath = null;
     } catch (e) {
+      if (stagingPath) {
+        try {
+          await IOUtils.remove(stagingPath, {
+            recursive: true,
+            ignoreAbsent: true,
+          });
+        } catch (cleanupError) {
+          console.error(
+            "[ZenMods]: Error cleaning up failed mod installation",
+            mod.id,
+            cleanupError
+          );
+        }
+      }
+
       console.error("[ZenMods]: Error installing mod", mod.id, e);
+      throw e;
     }
   }
 

--- a/src/zen/tests/mods/browser.toml
+++ b/src/zen/tests/mods/browser.toml
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+[DEFAULT]
+support-files = ["test_chrome.css"]
+
+["browser_mod_install.js"]

--- a/src/zen/tests/mods/browser_mod_install.js
+++ b/src/zen/tests/mods/browser_mod_install.js
@@ -1,0 +1,44 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_partial_mod_install_does_not_leave_directory() {
+  const modId = `test-failed-install-${Services.uuid.generateUUID()}`;
+  const modPath = gZenMods.getModFolder(modId);
+  const testRoot = getRootDirectory(gTestPath).replace(
+    "chrome://mochitests/content/",
+    "https://example.com/"
+  );
+
+  await IOUtils.makeDirectory(gZenMods.modsRootPath, {
+    ignoreExisting: true,
+  });
+  const childrenBeforeInstall = await IOUtils.getChildren(
+    gZenMods.modsRootPath
+  );
+
+  registerCleanupFunction(async () => {
+    await IOUtils.remove(modPath, { recursive: true, ignoreAbsent: true });
+  });
+
+  await Assert.rejects(
+    gZenMods.installMod({
+      id: modId,
+      style: `${testRoot}test_chrome.css`,
+      readme: "ftp://example.com/readme.md",
+    }),
+    /Refusing non-HTTPS mod asset URL/,
+    "A failure after downloading the stylesheet should reject the installation"
+  );
+
+  Assert.ok(
+    !(await IOUtils.exists(modPath)),
+    "A partially downloaded mod should not become an installation"
+  );
+  Assert.deepEqual(
+    (await IOUtils.getChildren(gZenMods.modsRootPath)).sort(),
+    childrenBeforeInstall.sort(),
+    "A failed installation should also remove its staging directory"
+  );
+});

--- a/src/zen/tests/mods/test_chrome.css
+++ b/src/zen/tests/mods/test_chrome.css
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+:root {
+  --test-mod-installed: true;
+}

--- a/src/zen/tests/moz.build
+++ b/src/zen/tests/moz.build
@@ -10,6 +10,7 @@ BROWSER_CHROME_MANIFESTS += [
     "glance/browser.toml",
     "live-folders/browser.toml",
     "media/browser.toml",
+    "mods/browser.toml",
     "pinned/browser.toml",
     "popover/browser.toml",
     "site_control/browser.toml",


### PR DESCRIPTION
## Summary

- Download Zen Mod assets into a unique staging directory.
- Move the staging directory into the final mod location only after every asset has downloaded successfully.
- Clean up staged files and propagate the error when installation fails.
- Add a browser-chrome regression test covering a failure after the stylesheet has already been downloaded.

## Problem

`installMod()` created the final mod directory before downloading its assets, while the download helper swallowed errors after exhausting its retries.

If a later asset failed to download, Zen could leave a partially populated mod directory behind. Since mod synchronization uses the directory's existence to determine whether installation is needed, that incomplete installation could be treated as complete and its partial CSS could be applied.

## Testing

- Added `browser_mod_install.js`, which successfully downloads a stylesheet and then forces the readme download to fail.
- Verified that the installation rejects.
- Verified that neither the final mod directory nor the staging directory remains.
- `node --check src/zen/mods/ZenMods.mjs`
- `node --check src/zen/tests/mods/browser_mod_install.js`
- `git diff --check`
- Validated the new `browser.toml` with Python's TOML parser.

The full browser-chrome test was not run because this checkout does not contain the generated `engine/` tree.