### PR TITLE
glance: Clean up resources when browser windows close

### DIFF
--- a/src/zen/glance/ZenGlanceManager.mjs
+++ b/src/zen/glance/ZenGlanceManager.mjs
@@ -21,6 +21,7 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
   #glances = new Map();
   #currentGlanceID = null;
   #confirmationTimeout = null;
+  #observingQuitRequests = false;
 
   // Animation flags
   animatingOpen = false;
@@ -74,6 +75,8 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
 
   #setupObservers() {
     Services.obs.addObserver(this, "quit-application-requested");
+    this.#observingQuitRequests = true;
+    window.addEventListener("unload", () => this.uninit(), { once: true });
   }
 
   #insertIntoContextMenu() {
@@ -167,13 +170,27 @@ class nsZenGlanceManager extends nsZenDOMOperatedFeature {
   }
 
   /**
+   * Release resources owned by this browser window
+   */
+  uninit() {
+    if (this.#observingQuitRequests) {
+      Services.obs.removeObserver(this, "quit-application-requested");
+      this.#observingQuitRequests = false;
+    }
+
+    for (const glanceID of [...this.#glances.keys()]) {
+      this.#deleteGlance(glanceID);
+    }
+  }
+
+  /**
    * Clean up all glances when the application is unloading
    */
   onUnload() {
-    for (const [, glance] of this.#glances) {
+    for (const [glanceID, glance] of [...this.#glances]) {
       gBrowser.removeTab(glance.tab, { animate: false });
+      this.#deleteGlance(glanceID);
     }
-    this.#glances.clear();
   }
 
   /**

--- a/src/zen/tests/glance/browser.toml
+++ b/src/zen/tests/glance/browser.toml
@@ -21,4 +21,6 @@ support-files = [
 
 ["browser_glance_select_parent.js"]
 
+["browser_glance_window_cleanup.js"]
+
 ["browser_issue_14049.js"]

--- a/src/zen/tests/glance/browser_glance_window_cleanup.js
+++ b/src/zen/tests/glance/browser_glance_window_cleanup.js
@@ -1,0 +1,31 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const QUIT_REQUESTED_TOPIC = "quit-application-requested";
+
+function isObserverRegistered(observerToFind) {
+  return [...Services.obs.enumerateObservers(QUIT_REQUESTED_TOPIC)].includes(
+    observerToFind
+  );
+}
+
+add_task(async function test_glance_manager_cleans_up_on_window_unload() {
+  const testWindow = await BrowserTestUtils.openNewBrowserWindow();
+  const manager = testWindow.gZenGlanceManager;
+
+  try {
+    Assert.ok(
+      isObserverRegistered(manager),
+      "A new window should register its Glance quit observer"
+    );
+  } finally {
+    await BrowserTestUtils.closeWindow(testWindow);
+  }
+
+  Assert.ok(
+    !isObserverRegistered(manager),
+    "Closing a browser window should unregister its Glance manager"
+  );
+});


### PR DESCRIPTION
## Summary

- Unregister each Glance manager's global quit observer when its browser window unloads.
- Release object URLs owned by tracked Glance entries during cleanup.
- Keep quit-request handling separate from window teardown so cancelled quit requests remain supported.
- Add browser-chrome coverage for observer registration and removal.

## Problem

Every browser window creates its own Glance manager and registers it as a strong observer for `quit-application-requested`.

The observer was never removed when an individual browser window closed. As a result, the observer service could retain the manager together with its closed window and DOM resources.

Glance entries were also cleared during application shutdown without releasing their generated object URLs.

## Testing

- Added `browser_glance_window_cleanup.js`.
- The test opens a second browser window and verifies that its Glance manager is registered.
- It then closes the window and verifies that the observer registration has been removed.
- `node --check src/zen/glance/ZenGlanceManager.mjs`
- `node --check src/zen/tests/glance/browser_glance_window_cleanup.js`
- `git diff --check`
- Validated the updated `browser.toml` with Python's TOML parser.

The full browser-chrome test was not run because this checkout does not contain the generated `engine/` tree.