### PR TITLE
emoji-picker: Improve search and rendering performance

### DIFF
--- a/src/zen/common/emojis/ZenEmojiPicker.mjs
+++ b/src/zen/common/emojis/ZenEmojiPicker.mjs
@@ -32,6 +32,7 @@ const SVG_ICONS = [
 
 class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
   #panel;
+  #emojiSearchTags = new WeakMap();
 
   #anchor;
   #emojiAsSVG = false;
@@ -146,25 +147,10 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
   #onSearchInput(event) {
     const input = event.target;
     const value = input.value.trim().toLowerCase();
-    // search for emojis.tags and order by emojis.order
-    const filteredEmojis = this.#emojis
-      .filter(emoji => {
-        return emoji.tags.some(tag => tag.toLowerCase().includes(value));
-      })
-      .sort((a, b) => a.order - b.order);
+
     for (const button of this.emojiList.children) {
-      const buttonEmoji = button.getAttribute("label");
-      const emojiObject = filteredEmojis.find(
-        emoji => emoji.emoji === buttonEmoji
-      );
-      if (emojiObject) {
-        button.hidden = !emojiObject.tags.some(tag =>
-          tag.toLowerCase().includes(value)
-        );
-        button.style.order = emojiObject.order;
-      } else {
-        button.hidden = true;
-      }
+      const tags = this.#emojiSearchTags.get(button);
+      button.hidden = !tags?.some(tag => tag.includes(value));
     }
   }
 
@@ -177,18 +163,26 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
     const allowEmojis = !this.#panel.hasAttribute("only-svg-icons");
     if (allowEmojis) {
       const emojiList = this.emojiList;
+      const emojiFragment = document.createDocumentFragment();
       for (const emoji of this.#emojis) {
         const item = document.createXULElement("toolbarbutton");
         item.className = "toolbarbutton-1 zen-emojis-picker-emoji";
         item.setAttribute("label", emoji.emoji);
         item.setAttribute("tooltiptext", "");
+        item.style.order = emoji.order;
+        this.#emojiSearchTags.set(
+          item,
+          emoji.tags.map(tag => tag.toLowerCase())
+        );
         item.addEventListener("command", () => {
           this.#selectEmoji(emoji.emoji);
         });
-        emojiList.appendChild(item);
+        emojiFragment.appendChild(item);
       }
+      emojiList.appendChild(emojiFragment);
     }
     const svgList = this.svgList;
+    const svgFragment = document.createDocumentFragment();
     for (const icon of SVG_ICONS) {
       const item = document.createXULElement("toolbarbutton");
       item.className = "toolbarbutton-1 zen-emojis-picker-svg";
@@ -199,8 +193,9 @@ class nsZenEmojiPicker extends nsZenDOMOperatedFeature {
       item.addEventListener("command", () => {
         this.#selectEmoji(this.getSVGURL(icon));
       });
-      svgList.appendChild(item);
+      svgFragment.appendChild(item);
     }
+    svgList.appendChild(svgFragment);
   }
 
   #onPopupShown(event) {

--- a/src/zen/tests/emojis/browser.toml
+++ b/src/zen/tests/emojis/browser.toml
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+["browser_emoji_search.js"]

--- a/src/zen/tests/emojis/browser_emoji_search.js
+++ b/src/zen/tests/emojis/browser_emoji_search.js
@@ -1,0 +1,54 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_emoji_search_filters_rendered_buttons() {
+  const panel = document.getElementById("PanelUI-zen-emojis-picker");
+  const anchor = document.getElementById("PanelUI-menu-button");
+  const popupShown = BrowserTestUtils.waitForEvent(panel, "popupshown");
+  const pickerPromise = gZenEmojiPicker.open(anchor);
+  const pickerRejected = Assert.rejects(
+    pickerPromise,
+    /Emoji picker closed without selection/,
+    "Closing without a selection should reject the picker promise"
+  );
+
+  try {
+    await popupShown;
+
+    const buttons = [...gZenEmojiPicker.emojiList.children];
+    const rocketButton = buttons.find(
+      button => button.getAttribute("label") === "🚀"
+    );
+    const grinningButton = buttons.find(
+      button => button.getAttribute("label") === "😀"
+    );
+    const searchInput = gZenEmojiPicker.searchInput;
+
+    Assert.ok(rocketButton, "The picker should render the rocket emoji");
+    Assert.ok(grinningButton, "The picker should render the grinning emoji");
+
+    searchInput.value = "rocket";
+    searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+    Assert.ok(!rocketButton.hidden, "A matching emoji should remain visible");
+    Assert.ok(grinningButton.hidden, "A non-matching emoji should be hidden");
+
+    searchInput.value = "";
+    searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+    Assert.ok(
+      buttons.every(button => !button.hidden),
+      "Clearing the search should show every emoji again"
+    );
+  } finally {
+    if (panel.state !== "closed") {
+      const popupHidden = BrowserTestUtils.waitForEvent(panel, "popuphidden");
+      panel.hidePopup();
+      await popupHidden;
+    }
+
+    await pickerRejected;
+  }
+});

--- a/src/zen/tests/moz.build
+++ b/src/zen/tests/moz.build
@@ -6,6 +6,7 @@ BROWSER_CHROME_MANIFESTS += [
     "boosts/browser.toml",
     "compact_mode/browser.toml",
     "container_essentials/browser.toml",
+    "emojis/browser.toml",
     "folders/browser.toml",
     "glance/browser.toml",
     "live-folders/browser.toml",


### PR DESCRIPTION
## Summary

- Replace the emoji search filter/sort/find pipeline with a single pass over rendered buttons.
- Normalize and associate search tags with each button once during rendering.
- Assign emoji ordering once instead of recalculating it on every search.
- Batch emoji and SVG button insertion with document fragments.
- Add browser-chrome coverage for filtering and clearing the search.

## Problem

The emoji picker contains 1,915 emoji records.

For every search input, the previous implementation:

1. Filtered and sorted the complete emoji dataset.
2. Iterated over every rendered button.
3. Searched the filtered array again with `find()` for each button.
4. Repeated tag normalization while filtering and updating buttons.

This resulted in quadratic lookup behavior. Clearing the search performed approximately 1,834,570 `find()` comparisons. A broad search such as `face` performed approximately 302,445 comparisons.

The new implementation associates normalized tags with buttons during rendering and searches them in one pass. Clearing the search now requires 1,915 tag checks, while the `face` search requires roughly 9,000 tag checks.

The emoji data and rendered elements are still released when the popup closes, so this does not introduce a permanent per-window DOM cache.

## Testing

- Added `browser_emoji_search.js`.
- Verified that a matching rocket emoji remains visible.
- Verified that a non-matching emoji is hidden.
- Verified that clearing the search restores every emoji.
- Verified the picker cleanup and promise rejection path.
- `node --check src/zen/common/emojis/ZenEmojiPicker.mjs`
- `node --check src/zen/tests/emojis/browser_emoji_search.js`
- `git diff --check`
- Validated the new `browser.toml` with Python's TOML parser.

The full browser-chrome test was not run because this checkout does not contain the generated `engine/` tree.