### PR TITLE
gh-14732: Preserve pinned extension order in single toolbar

### DIFF
--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -1348,16 +1348,35 @@ window.gZenVerticalTabsManager = {
 
       if (isSingleToolbar) {
         this._navbarParent = navBar.parentElement;
-        let elements = document.querySelectorAll(
+        const elements = document.querySelectorAll(
           '#nav-bar-customization-target > :is([cui-areatype="toolbar"], .chromeclass-toolbar-additional):not(#urlbar-container):not(toolbarspring)'
         );
-        elements = Array.from(elements).reverse();
+        const overflowWebExtensions = Services.prefs.getBoolPref(
+          "zen.view.overflow-webext-toolbar",
+          true
+        );
+        const extensionButtons = [];
+        const otherButtons = [];
+        for (const button of elements) {
+          if (
+            button.hasAttribute("data-extensionid") &&
+            overflowWebExtensions
+          ) {
+            extensionButtons.push(button);
+          } else {
+            otherButtons.push(button);
+          }
+        }
+        // Regular buttons are inserted after a shared separator, so they need
+        // reverse processing. Extensions are appended to a separate target and
+        // must keep their original toolbar order.
+        otherButtons.reverse();
         // Add separator if it doesn't exist
         if (!this._hasSetSingleToolbar) {
           buttonsTarget.append(this._topButtonsSeparatorElement);
         }
         this._hasSetSingleToolbar = true;
-        for (const button of elements) {
+        for (const button of [...otherButtons, ...extensionButtons]) {
           this.appendCustomizableItem(this._topButtonsSeparatorElement, button);
         }
         buttonsTarget.prepend(

--- a/src/zen/tests/customizable_ui/browser.toml
+++ b/src/zen/tests/customizable_ui/browser.toml
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+[DEFAULT]
+
+["browser_extension_order.js"]

--- a/src/zen/tests/customizable_ui/browser_extension_order.js
+++ b/src/zen/tests/customizable_ui/browser_extension_order.js
@@ -1,0 +1,85 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const TEST_WIDGET_IDS = [
+  "zen-test-extension-one",
+  "zen-test-extension-two",
+  "zen-test-extension-three"
+];
+
+function createExtensionWidget(id) {
+  CustomizableUI.createWidget({
+    id,
+    type: "custom",
+    defaultArea: CustomizableUI.AREA_NAVBAR,
+    onBuild(doc) {
+      const button = doc.createXULElement("toolbarbutton");
+      button.id = id;
+      button.classList.add("toolbarbutton-1", "chromeclass-toolbar-additional");
+      button.setAttribute("data-extensionid", `${id}@example.com`);
+      return button;
+    }
+  });
+}
+
+function getDocumentOrder(ids) {
+  return ids
+    .map(id => document.getElementById(id))
+    .sort((first, second) =>
+      first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING
+        ? -1
+        : 1
+    )
+    .map(button => button.id);
+}
+
+add_task(async function test_extension_order_in_single_toolbar() {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["zen.view.sidebar-expanded", true],
+      ["zen.view.use-single-toolbar", false],
+      ["zen.view.overflow-webext-toolbar", true]
+    ]
+  });
+
+  for (const id of TEST_WIDGET_IDS) {
+    createExtensionWidget(id);
+  }
+
+  try {
+    Assert.deepEqual(
+      CustomizableUI.getWidgetIdsInArea(CustomizableUI.AREA_NAVBAR).filter(id =>
+        TEST_WIDGET_IDS.includes(id)
+      ),
+      TEST_WIDGET_IDS,
+      "test extensions start in their customizable toolbar order"
+    );
+
+    Services.prefs.setBoolPref("zen.view.use-single-toolbar", true);
+
+    await TestUtils.waitForCondition(
+      () =>
+        TEST_WIDGET_IDS.every(id => {
+          const button = document.getElementById(id);
+          return (
+            button &&
+            button.parentElement?.id !== "nav-bar-customization-target"
+          );
+        }),
+      "test extensions move into the single toolbar"
+    );
+
+    Assert.deepEqual(
+      getDocumentOrder(TEST_WIDGET_IDS),
+      TEST_WIDGET_IDS,
+      "single toolbar preserves the pinned extension order"
+    );
+  } finally {
+    for (const id of TEST_WIDGET_IDS) {
+      CustomizableUI.destroyWidget(id);
+    }
+    await SpecialPowers.popPrefEnv();
+  }
+});

--- a/src/zen/tests/moz.build
+++ b/src/zen/tests/moz.build
@@ -6,6 +6,7 @@ BROWSER_CHROME_MANIFESTS += [
     "boosts/browser.toml",
     "compact_mode/browser.toml",
     "container_essentials/browser.toml",
+    "customizable_ui/browser.toml",
     "folders/browser.toml",
     "glance/browser.toml",
     "live-folders/browser.toml",


### PR DESCRIPTION
## Summary

- Preserve the original order of pinned extension buttons when moving them into the single-toolbar layout.
- Continue reverse-processing regular toolbar items that are inserted after the shared separator.
- Add a browser-chrome regression test covering extension button ordering.

## Testing

- `node --check src/zen/common/modules/ZenUIManager.mjs`
- `node --check src/zen/tests/customizable_ui/browser_extension_order.js`
- `git diff --check`
- Validated the new browser test manifest with Python's TOML parser.

The full browser-chrome test was not run because this checkout does not contain the generated `engine/` tree.

Fixes #14732