### PR TITLE
fix(urlbar): include inactive Essential tab titles

### DIFF
--- a/.cursor/skills/zen-mod-testing/SKILL.md
+++ b/.cursor/skills/zen-mod-testing/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: zen-mod-testing
+description: Tests local Zen mods through an isolated headless browser-chrome session. Use when developing or debugging Zen mod CSS, userChrome scripts, privileged browser UI, or files under mods/.
+---
+
+# Zen mod testing
+
+Use the repository's `zenmod` CLI for mod validation. It launches a dedicated
+headless profile, injects the local mod without Sine, runs one operation, and
+closes Zen.
+
+## Workflow
+
+1. Run `npm run zenmod -- doctor`.
+2. If the CLI dependency is missing, run
+   `npm --prefix tools/zen-mod-cli install`, then rerun `doctor`.
+3. Choose the narrowest command:
+   - `load <mod>` verifies manifest, stylesheet, and script injection.
+   - `inspect <mod> --selector <css>` reads browser-chrome DOM and styles.
+   - `eval <mod> --file <function.js>` investigates privileged state.
+   - `test <mod> --file <function.js>` runs assertions with a meaningful exit
+     code.
+   - `console <mod>` captures console events from the session.
+   - `screenshot <mod> --output <png>` captures the headless chrome context.
+4. Keep reusable test functions beside the mod. Use a temporary file for a
+   one-off investigation.
+5. Read screenshot files with the available image-reading tool.
+6. Report the command, result, and any behavior still requiring a visible
+   smoke test.
+
+## Test functions
+
+The file passed to `eval` or `test` contains one function expression. It runs
+inside `chrome://browser/content/browser.xhtml`, so browser globals such as
+`gBrowser`, `Services`, and the mod's `window.__...` interface are available.
+It may be async.
+
+A test returns a boolean, `{ pass: boolean }`, or:
+
+```js
+async () => ({
+  assertions: [
+    {
+      name: "descriptive behavior",
+      pass: true,
+      actual: "optional",
+      expected: "optional",
+    },
+  ],
+})
+```
+
+Clean up tabs, windows, preferences, and observers in `finally` blocks.
+
+## Guardrails
+
+Use the default headless dedicated profile. Treat `--headed` as a final visual
+smoke test because a visible WebDriver session can take macOS focus.
+
+Run only trusted privileged function files. Never point `--profile-parent` at a
+normal Zen profile. Prefer structured DOM assertions over OS-level automation.
+
+Generic HTML drag events do not reproduce Firefox tab drag payloads. Test tab
+drag behavior with a purpose-built privileged function or a headless
+browser-chrome mochitest.
+
+For full command syntax and examples, read
+`tools/zen-mod-cli/README.md` or run `npm run zenmod -- --help`.

--- a/.github/workflows/check-candidate-release.yml
+++ b/.github/workflows/check-candidate-release.yml
@@ -1,8 +1,6 @@
 name: Check Firefox Candidate Release
 
 on:
-  schedule:
-    - cron: "59 4 * * 2"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,7 +1,6 @@
 name: Issue labeler
 on:
-  issues:
-    types: [opened]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -4,8 +4,6 @@ permissions:
   issues: read
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "3 2 1 * *"
 
 jobs:
   build:

--- a/.github/workflows/linux-release-build.yml
+++ b/.github/workflows/linux-release-build.yml
@@ -1,6 +1,25 @@
 name: Linux Release Build
 
 on:
+  workflow_dispatch:
+    inputs:
+      build-version:
+        description: "The version to build"
+        required: true
+        type: string
+      release-branch:
+        description: "The branch to build"
+        required: true
+        type: string
+      MOZ_BUILD_DATE:
+        type: string
+        required: true
+        default: ""
+      use-sccache:
+        description: "Use sccache"
+        required: true
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       build-version:

--- a/.github/workflows/macos-profile-build.yml
+++ b/.github/workflows/macos-profile-build.yml
@@ -4,6 +4,16 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
+    inputs:
+      build-version:
+        description: "The version to build"
+        required: true
+        type: string
+      release-branch:
+        description: "The branch to build"
+        required: true
+        type: string
   workflow_call:
     inputs:
       build-version:

--- a/.github/workflows/macos-release-build.yml
+++ b/.github/workflows/macos-release-build.yml
@@ -4,6 +4,29 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
+    inputs:
+      generate-pgo:
+        required: true
+        type: boolean
+        default: false
+      build-version:
+        description: "The version to build"
+        required: true
+        type: string
+      release-branch:
+        description: "The branch to build"
+        required: true
+        type: string
+      MOZ_BUILD_DATE:
+        type: string
+        required: true
+        default: ""
+      use-sccache:
+        description: "Use sccache"
+        required: true
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       generate-pgo:

--- a/.github/workflows/macos-universal-release-build.yml
+++ b/.github/workflows/macos-universal-release-build.yml
@@ -1,6 +1,16 @@
 name: macOS Release Build
 
 on:
+  workflow_dispatch:
+    inputs:
+      build-version:
+        description: "The version to build"
+        required: true
+        type: string
+      release-branch:
+        description: "The branch to build"
+        required: true
+        type: string
   workflow_call:
     inputs:
       build-version:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -3,9 +3,7 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    branches:
-      - dev
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/twilight-release-schedule.yml
+++ b/.github/workflows/twilight-release-schedule.yml
@@ -1,8 +1,6 @@
 name: Zen Twilight Scheduled Releases
 
 on:
-  schedule:
-    - cron: "0 23 */2 * *"
   workflow_dispatch:
     inputs:
       create_release:

--- a/.github/workflows/windows-profile-build.yml
+++ b/.github/workflows/windows-profile-build.yml
@@ -4,6 +4,20 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
+    inputs:
+      build-version:
+        description: "The version to build"
+        required: true
+        type: string
+      profile-data-path-archive:
+        description: "The path to the zip archive containing the profile data"
+        required: false
+        type: string
+      release-branch:
+        description: "The branch to build"
+        required: true
+        type: string
   workflow_call:
     inputs:
       build-version:

--- a/.github/workflows/windows-release-build.yml
+++ b/.github/workflows/windows-release-build.yml
@@ -4,6 +4,32 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
+    inputs:
+      generate-pgo:
+        required: true
+        type: boolean
+        default: false
+      build-version:
+        description: "The version to build"
+        required: true
+        type: string
+      profile-data-path-archive:
+        description: "The path to the zip archive containing the profile data"
+        type: string
+      release-branch:
+        description: "The branch to build"
+        required: true
+        type: string
+      MOZ_BUILD_DATE:
+        type: string
+        required: true
+        default: ""
+      use-sccache:
+        description: "Use sccache"
+        required: true
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       generate-pgo:

--- a/README.md
+++ b/README.md
@@ -50,3 +50,115 @@ Thanks to all the partners of Zen for their support and contributions:
 <a href="https://blacksmith.sh">
   <img src="./docs/assets/blacksmith-yellow.png" width="350px"/>
 </a>
+
+### Building and installing a local macOS build
+
+This runbook builds the ARM64 app from source and replaces an existing DMG installation without replacing its profile. Zen stores profile data outside the app bundle at `~/Library/Application Support/zen/`.
+
+#### First-time setup
+
+Install GNU Tar, then install the Node dependencies and initialize the Firefox source tree:
+
+```sh
+brew install gnu-tar
+npm ci
+npm run init
+```
+
+Run `npm run init` once per checkout. It downloads and initializes the Firefox source and needs substantial disk space.
+
+#### Build and package
+
+Configure the release brand and build mode:
+
+```sh
+npm run surfer -- config brand release
+npm run surfer -- config buildMode release
+```
+
+Build with the local macOS settings:
+
+```sh
+ZEN_RELEASE=1 ZEN_GA_DISABLE_PGO=1 ZEN_DISABLE_LTO=1 npm run build
+npm run package
+```
+
+For JavaScript-only changes after the first full build, `npm run build:ui` can be used instead of `npm run build`. Use the full build for native or core changes.
+
+#### Choosing a build target
+
+Before rebuilding, inspect the complete working tree, including staged and untracked files:
+
+```sh
+git status --short
+git diff --name-only
+git diff --cached --name-only
+```
+
+Use `npm run build:ui` only when the changes are limited to JavaScript in the UI layer. Use the full `npm run build` for changes to C++, Objective-C or Objective-C++, headers, Rust, Cargo files, build configuration, dependencies, Firefox versions, or any mixed or uncertain change set.
+
+If the Firefox source tree was recreated or is missing, run `npm run init` again. If patch files or generated preferences changed after initialization, rerun the relevant import step before building. When in doubt, use the full build.
+
+#### Compare the installed build with the source
+
+Zen records the source repository and commit SHA in the installed app. Compare that SHA with the checkout before rebuilding:
+
+```sh
+installed_app="/Applications/Zen.app"
+test -f "$installed_app/Contents/Resources/application.ini"
+installed_sha="$(awk -F= '$1 == "SourceStamp" { print $2; exit }' "$installed_app/Contents/Resources/application.ini")"
+source_sha="$(git rev-parse HEAD)"
+
+test -n "$installed_sha"
+git cat-file -e "$installed_sha^{commit}"
+printf 'Installed build: %s\nSource checkout: %s\n' "$installed_sha" "$source_sha"
+git log --oneline "$installed_sha..$source_sha"
+git diff --stat "$installed_sha..$source_sha"
+```
+
+Use `git diff "$installed_sha..$source_sha"` to inspect the committed changes between builds. Also inspect local changes because the embedded SHA does not include uncommitted or untracked files:
+
+```sh
+git status --short
+git diff "$installed_sha"
+git diff --cached
+git ls-files --others --exclude-standard
+```
+
+If the installed SHA is not present in the local repository history, fetch the required history before running the comparison. Use the changed files and their contents to decide between `npm run build:ui` and a full build.
+
+#### Back up the profile and replace the app
+
+Quit every Zen window before copying the profile or replacing the app. Create a backup before each replacement:
+
+```sh
+profile_backup="$HOME/Desktop/zen-backup-$(date +%Y-%m-%d-%H%M%S)"
+test ! -e "$profile_backup"
+ditto "$HOME/Library/Application Support/zen" "$profile_backup"
+```
+
+The packaged ARM64 app is at `engine/obj-aarch64-apple-darwin/dist/Zen.app`. Install it while keeping the previous app as a rollback copy:
+
+```sh
+set -e
+app="engine/obj-aarch64-apple-darwin/dist/Zen.app"
+staged="/Applications/Zen.app.new"
+previous="/Applications/Zen.app.backup-$(date +%Y-%m-%d-%H%M%S)"
+
+test -d "$app"
+test ! -e "$staged"
+test ! -e "$previous"
+ditto "$app" "$staged"
+
+if [ -e /Applications/Zen.app ]; then
+  mv /Applications/Zen.app "$previous"
+fi
+mv "$staged" /Applications/Zen.app
+open -a /Applications/Zen.app
+```
+
+After launch, check `about:profiles` if Zen appears to be a fresh install. Select the existing profile rather than deleting or copying over profile files. The local app is unsigned, so macOS may require opening it through Control-click > Open, and automatic updates may not work.
+
+#### Troubleshooting
+
+If initialization reports that GNU Tar is required, install it with `brew install gnu-tar` and rerun `npm run init`. If a release build reports that no adequate linker was found, use the `ZEN_RELEASE=1 ZEN_GA_DISABLE_PGO=1 ZEN_DISABLE_LTO=1` build command above. An `engine/.git/index.lock` warning can occur during Firefox source initialization; wait for any active Git process to finish before removing a stale lock or retrying.

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ Install GNU Tar, then install the Node dependencies and initialize the Firefox s
 brew install gnu-tar
 npm ci
 npm run init
+python3 scripts/copy_language_pack.py en-US
 ```
 
-Run `npm run init` once per checkout. It downloads and initializes the Firefox source and needs substantial disk space.
+Run `npm run init` once per checkout. It downloads and initializes the Firefox source and needs substantial disk space. The localization copy is required before the first build and whenever the files under `locales/en-US/` change. Without it, Settings and other browser UI can render without labels.
 
 #### Build and package
 
@@ -97,7 +98,7 @@ git diff --cached --name-only
 
 Use `npm run build:ui` only when the changes are limited to JavaScript in the UI layer. Use the full `npm run build` for changes to C++, Objective-C or Objective-C++, headers, Rust, Cargo files, build configuration, dependencies, Firefox versions, or any mixed or uncertain change set.
 
-If the Firefox source tree was recreated or is missing, run `npm run init` again. If patch files or generated preferences changed after initialization, rerun the relevant import step before building. When in doubt, use the full build.
+If the Firefox source tree was recreated or is missing, run `npm run init` again. If patch files or generated preferences changed after initialization, rerun the relevant import step before building. If English Zen localization changed, rerun `python3 scripts/copy_language_pack.py en-US`. When in doubt, use the full build.
 
 #### Compare the installed build with the source
 
@@ -137,25 +138,53 @@ test ! -e "$profile_backup"
 ditto "$HOME/Library/Application Support/zen" "$profile_backup"
 ```
 
-The packaged ARM64 app is at `engine/obj-aarch64-apple-darwin/dist/Zen.app`. Install it while keeping the previous app as a rollback copy:
+Install the app from the generated DMG. Do not copy `engine/obj-aarch64-apple-darwin/dist/Zen.app`; that directory is an unpackaged build artifact with development links and an incomplete runtime resource layout.
 
 ```sh
 set -e
-app="engine/obj-aarch64-apple-darwin/dist/Zen.app"
+version="$(node -p "require('./surfer.json').brands.release.release.displayVersion")"
+dmg="engine/obj-aarch64-apple-darwin/dist/zen-${version}.en-US.mac.dmg"
+mount_dir="$(mktemp -d /tmp/zen-dmg.XXXXXX)"
 staged="/Applications/Zen.app.new"
 previous="/Applications/Zen.app.backup-$(date +%Y-%m-%d-%H%M%S)"
 
-test -d "$app"
+cleanup() {
+  hdiutil detach "$mount_dir" >/dev/null 2>&1 || true
+  rmdir "$mount_dir" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+test -f "$dmg"
 test ! -e "$staged"
 test ! -e "$previous"
-ditto "$app" "$staged"
+hdiutil attach -nobrowse -readonly -mountpoint "$mount_dir" "$dmg"
+test -d "$mount_dir/Zen.app"
+unzip -p \
+  "$mount_dir/Zen.app/Contents/Resources/browser/omni.ja" \
+  "localization/en-US/browser/preferences/zen-preferences.ftl" \
+  >/dev/null
+ditto "$mount_dir/Zen.app" "$staged"
+
+sine_config="/Applications/Zen.app/Contents/Resources/config.js"
+sine_prefs="/Applications/Zen.app/Contents/Resources/defaults/pref/config-prefs.js"
+if [ -e "$sine_config" ] || [ -e "$sine_prefs" ]; then
+  test -f "$sine_config"
+  test -f "$sine_prefs"
+  mkdir -p "$staged/Contents/Resources/defaults/pref"
+  ditto "$sine_config" "$staged/Contents/Resources/config.js"
+  ditto "$sine_prefs" "$staged/Contents/Resources/defaults/pref/config-prefs.js"
+fi
 
 if [ -e /Applications/Zen.app ]; then
   mv /Applications/Zen.app "$previous"
 fi
 mv "$staged" /Applications/Zen.app
-open -a /Applications/Zen.app
+cleanup
+trap - EXIT
+open "/Applications/Zen.app"
 ```
+
+The `unzip` check stops the replacement if the packaged app is missing Zen's English Settings localization. Sine stores its mods and their state in the Zen profile, but its startup loader uses `config.js` and `defaults/pref/config-prefs.js` inside the app bundle. The replacement script preserves both loader files when Sine is installed and aborts rather than copy a partial loader.
 
 After launch, check `about:profiles` if Zen appears to be a fresh install. Select the existing profile rather than deleting or copying over profile files. The local app is unsigned, so macOS may require opening it through Control-click > Open, and automatic updates may not work.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "sync:raw": "surfer update",
     "sync:rc": "python3 scripts/update_ff.py --rc",
     "sync:l10n": "python3 scripts/update_ff.py --just-l10n",
+    "zenmod": "node tools/zen-mod-cli/bin/zenmod.mjs",
+    "test:zenmod": "npm --prefix tools/zen-mod-cli test",
     "lint": "cd engine && ./mach lint zen",
     "lint:fix": "npm run lint -- --fix",
     "reset-ff": "surfer reset",

--- a/src/browser/components/urlbar/UrlbarProviderOpenTabs-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarProviderOpenTabs-sys-mjs.patch
@@ -1,0 +1,61 @@
+diff --git a/browser/components/urlbar/UrlbarProviderOpenTabs.sys.mjs b/browser/components/urlbar/UrlbarProviderOpenTabs.sys.mjs
+index e732e7a..b2386e6 100644
+--- a/browser/components/urlbar/UrlbarProviderOpenTabs.sys.mjs
++++ b/browser/components/urlbar/UrlbarProviderOpenTabs.sys.mjs
+@@ -15,7 +15,9 @@ import {
+ const lazy = {};
+ 
+ ChromeUtils.defineESModuleGetters(lazy, {
++  BrowserWindowTracker: "resource:///modules/BrowserWindowTracker.sys.mjs",
+   PlacesUtils: "resource://gre/modules/PlacesUtils.sys.mjs",
++  PrivateBrowsingUtils: "resource://gre/modules/PrivateBrowsingUtils.sys.mjs",
+   ProvidersManager:
+     "moz-src:///browser/components/urlbar/UrlbarProvidersManager.sys.mjs",
+   UrlbarResult: "chrome://browser/content/urlbar/UrlbarResult.mjs",
+@@ -139,6 +141,46 @@ export class UrlbarProviderOpenTabs extends UrlbarProvider {
+     return uniqueUrls;
+   }
+ 
++  /**
++   * Return the live title of an open tab.
++   *
++   * @param {string} url The tab URL
++   * @param {number|string} userContextId Containers user context id
++   * @param {?string} groupId The id of the group the tab belongs to
++   * @returns {?string} The matching tab title
++   */
++  static getOpenTabTitle(url, userContextId, groupId) {
++    userContextId = parseInt(`${userContextId}`);
++    groupId = groupId ?? null;
++    let isInPrivateWindow = userContextId == PRIVATE_USER_CONTEXT_ID;
++
++    for (let window of lazy.BrowserWindowTracker.orderedWindows) {
++      if (
++        lazy.PrivateBrowsingUtils.isWindowPrivate(window) != isInPrivateWindow
++      ) {
++        continue;
++      }
++
++      for (let tab of window.gBrowser.tabs) {
++        if (
++          tab.closing ||
++          (!isInPrivateWindow && tab.userContextId != userContextId) ||
++          (tab.group?.id ?? null) != groupId
++        ) {
++          continue;
++        }
++
++        let browser = tab.linkedBrowser;
++        let tabUrl =
++          browser?.registeredOpenURI?.spec ?? browser?.currentURI?.spec;
++        if (tabUrl == url) {
++          return tab.label || null;
++        }
++      }
++    }
++    return null;
++  }
++
+   /**
+    * Return urls registered in the memory table.
+    * This is mostly for testing purposes.

--- a/src/browser/components/urlbar/UrlbarProviderOpenTabs-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarProviderOpenTabs-sys-mjs.patch
@@ -12,7 +12,7 @@ index e732e7a..b2386e6 100644
    ProvidersManager:
      "moz-src:///browser/components/urlbar/UrlbarProvidersManager.sys.mjs",
    UrlbarResult: "chrome://browser/content/urlbar/UrlbarResult.mjs",
-@@ -139,6 +141,46 @@ export class UrlbarProviderOpenTabs extends UrlbarProvider {
+@@ -139,6 +141,47 @@ export class UrlbarProviderOpenTabs extends UrlbarProvider {
      return uniqueUrls;
    }
  
@@ -36,7 +36,8 @@ index e732e7a..b2386e6 100644
 +        continue;
 +      }
 +
-+      for (let tab of window.gBrowser.tabs) {
++      let tabs = window.gZenWorkspaces?.allStoredTabs ?? window.gBrowser.tabs;
++      for (let tab of tabs) {
 +        if (
 +          tab.closing ||
 +          (!isInPrivateWindow && tab.userContextId != userContextId) ||

--- a/src/browser/components/urlbar/UrlbarProviderPlaces-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarProviderPlaces-sys-mjs.patch
@@ -1,0 +1,17 @@
+diff --git a/browser/components/urlbar/UrlbarProviderPlaces.sys.mjs b/browser/components/urlbar/UrlbarProviderPlaces.sys.mjs
+index aa9a291..8814d89 100644
+--- a/browser/components/urlbar/UrlbarProviderPlaces.sys.mjs
++++ b/browser/components/urlbar/UrlbarProviderPlaces.sys.mjs
+@@ -1225,6 +1225,12 @@ class Search {
+         return;
+       }
+       // Actions are enabled and the page is open.  Add a switch-to-tab result.
++      match.comment =
++        lazy.UrlbarProviderOpenTabs.getOpenTabTitle(
++          match.value,
++          match.userContextId,
++          match.tabGroup
++        ) || match.comment;
+       match.value = makeActionUrl("switchtab", { url: match.value });
+       match.style = "action switchtab";
+     } else if (

--- a/src/zen/tests/urlbar/browser.toml
+++ b/src/zen/tests/urlbar/browser.toml
@@ -9,6 +9,8 @@ support-files = [
   "!/browser/components/urlbar/tests/browser/head.js",
 ]
 
+["browser_container_tab_titles.js"]
+
 ["browser_floating_urlbar.js"]
 
 ["browser_issue_7385.js"]

--- a/src/zen/tests/urlbar/browser.toml
+++ b/src/zen/tests/urlbar/browser.toml
@@ -10,6 +10,7 @@ support-files = [
 ]
 
 ["browser_container_tab_titles.js"]
+prefs = ["zen.workspaces.separate-essentials=true"]
 
 ["browser_floating_urlbar.js"]
 

--- a/src/zen/tests/urlbar/browser_container_tab_titles.js
+++ b/src/zen/tests/urlbar/browser_container_tab_titles.js
@@ -1,0 +1,84 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { PlacesTestUtils } = ChromeUtils.importESModule(
+  "resource://testing-common/PlacesTestUtils.sys.mjs"
+);
+const { UrlbarProviderOpenTabs } = ChromeUtils.importESModule(
+  "moz-src:///browser/components/urlbar/UrlbarProviderOpenTabs.sys.mjs"
+);
+
+const TEST_URL = "https://example.com/?zen-urlbar-container-title-test=617db8";
+
+add_setup(async function () {
+  await PlacesUtils.promiseLargeCacheDBConnection();
+  await UrlbarProviderOpenTabs.promiseDBPopulated;
+});
+
+add_task(async function test_container_tabs_use_their_live_labels() {
+  const tabs = [];
+
+  try {
+    for (const userContextId of [1, 2]) {
+      const tab = BrowserTestUtils.addTab(gBrowser, TEST_URL, {
+        skipAnimation: true,
+        userContextId,
+      });
+      tabs.push(tab);
+      await BrowserTestUtils.browserLoaded(tab.linkedBrowser);
+    }
+
+    const labels = ["Personal Gmail", "Work Gmail"];
+    tabs.forEach((tab, index) => {
+      tab.zenStaticLabel = labels[index];
+      gBrowser._setTabLabel(tab, labels[index], {
+        _zenChangeLabelFlag: true,
+      });
+    });
+    Assert.deepEqual(
+      tabs.map(tab => tab.label),
+      labels,
+      "The container tabs should have distinct live labels"
+    );
+
+    await PlacesTestUtils.promiseAsyncUpdates();
+
+    const searchTab = await BrowserTestUtils.openNewForegroundTab(
+      gBrowser,
+      "about:newtab"
+    );
+    tabs.push(searchTab);
+
+    await UrlbarTestUtils.promiseAutocompleteResultPopup({
+      window,
+      waitForFocus,
+      value: "% zen-urlbar-container-title-test",
+    });
+
+    const queryContext = await gURLBar.lastQueryContextPromise;
+    const results = queryContext.results
+      .filter(result => result.payload.url == TEST_URL)
+      .map(result => ({
+        title: result.payload.title,
+        userContextId: result.payload.userContextId,
+      }))
+      .sort((a, b) => a.userContextId - b.userContextId);
+
+    Assert.deepEqual(
+      results,
+      [
+        { title: labels[0], userContextId: 1 },
+        { title: labels[1], userContextId: 2 },
+      ],
+      "Switch-to-tab results should use each container tab's live label"
+    );
+  } finally {
+    for (const tab of tabs.reverse()) {
+      if (gBrowser.tabs.includes(tab)) {
+        BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});

--- a/src/zen/tests/urlbar/browser_container_tab_titles.js
+++ b/src/zen/tests/urlbar/browser_container_tab_titles.js
@@ -11,6 +11,12 @@ const { UrlbarProviderOpenTabs } = ChromeUtils.importESModule(
 );
 
 const TEST_URL = "https://example.com/?zen-urlbar-container-title-test=617db8";
+const ESSENTIAL_TEST_URL =
+  "https://example.com/?zen-urlbar-essential-title-test=617db8";
+const WORKSPACE_NAMES = [
+  "URLbar Personal Container 617db8",
+  "URLbar Work Container 617db8",
+];
 
 add_setup(async function () {
   await PlacesUtils.promiseLargeCacheDBConnection();
@@ -78,6 +84,122 @@ add_task(async function test_container_tabs_use_their_live_labels() {
     for (const tab of tabs.reverse()) {
       if (gBrowser.tabs.includes(tab)) {
         BrowserTestUtils.removeTab(tab);
+      }
+    }
+  }
+});
+
+add_task(async function test_inactive_container_essential_uses_live_label() {
+  const originalWorkspaceId = gZenWorkspaces.activeWorkspace;
+  const workspaceIds = [];
+  const tabs = [];
+  const labels = ["Personal Gmail", "Work Gmail"];
+
+  try {
+    for (let index = 0; index < WORKSPACE_NAMES.length; index++) {
+      await gZenWorkspaces.createAndSaveWorkspace(
+        WORKSPACE_NAMES[index],
+        undefined,
+        false,
+        index + 1
+      );
+      const workspace = gZenWorkspaces
+        .getWorkspaces()
+        .find(candidate => candidate.name == WORKSPACE_NAMES[index]);
+      Assert.ok(workspace, `Created ${WORKSPACE_NAMES[index]}`);
+      workspaceIds.push(workspace.uuid);
+
+      await gZenWorkspaces.changeWorkspace(workspace);
+      const tab = BrowserTestUtils.addTab(gBrowser, ESSENTIAL_TEST_URL, {
+        skipAnimation: true,
+        userContextId: index + 1,
+      });
+      tabs.push(tab);
+      await BrowserTestUtils.browserLoaded(tab.linkedBrowser);
+
+      tab.zenStaticLabel = labels[index];
+      gBrowser._setTabLabel(tab, labels[index], {
+        _zenChangeLabelFlag: true,
+      });
+      Assert.ok(
+        gZenPinnedTabManager.addToEssentials(tab),
+        `Added ${labels[index]} to Essentials`
+      );
+      await TestUtils.waitForCondition(
+        () =>
+          tab.hasAttribute("zen-essential") &&
+          tab.parentNode?.getAttribute("container") == String(index + 1),
+        `${labels[index]} should enter its container-specific Essential section`
+      );
+    }
+
+    const activeWorkspace = gZenWorkspaces
+      .getWorkspaces()
+      .find(workspace => workspace.uuid == workspaceIds[1]);
+    await gZenWorkspaces.changeWorkspace(activeWorkspace);
+
+    Assert.ok(
+      !gBrowser.tabs.includes(tabs[0]),
+      "The inactive workspace Essential should not be in gBrowser.tabs"
+    );
+    Assert.ok(
+      gZenWorkspaces.allStoredTabs.includes(tabs[0]),
+      "The inactive workspace Essential should remain in allStoredTabs"
+    );
+
+    const searchTab = BrowserTestUtils.addTab(gBrowser, "about:newtab", {
+      skipAnimation: true,
+      userContextId: 2,
+    });
+    tabs.push(searchTab);
+    await BrowserTestUtils.switchTab(gBrowser, searchTab);
+
+    await UrlbarTestUtils.promiseAutocompleteResultPopup({
+      window,
+      waitForFocus,
+      value: "% zen-urlbar-essential-title-test",
+    });
+
+    const queryContext = await gURLBar.lastQueryContextPromise;
+    const results = queryContext.results
+      .filter(result => result.payload.url == ESSENTIAL_TEST_URL)
+      .map(result => ({
+        title: result.payload.title,
+        userContextId: result.payload.userContextId,
+      }))
+      .sort((a, b) => a.userContextId - b.userContextId);
+
+    Assert.deepEqual(
+      results,
+      [
+        { title: labels[0], userContextId: 1 },
+        { title: labels[1], userContextId: 2 },
+      ],
+      "Switch-to-tab results should include the inactive Essential's live label"
+    );
+  } finally {
+    if (UrlbarTestUtils.isPopupOpen(window)) {
+      await UrlbarTestUtils.promisePopupClose(window);
+    }
+    for (const tab of tabs.reverse()) {
+      if (gZenWorkspaces.allStoredTabs.includes(tab)) {
+        await BrowserTestUtils.removeTab(tab);
+      }
+    }
+    if (
+      gZenWorkspaces
+        .getWorkspaces()
+        .some(workspace => workspace.uuid == originalWorkspaceId)
+    ) {
+      await gZenWorkspaces.changeWorkspace(originalWorkspaceId);
+    }
+    for (const workspaceId of workspaceIds.reverse()) {
+      if (
+        gZenWorkspaces
+          .getWorkspaces()
+          .some(workspace => workspace.uuid == workspaceId)
+      ) {
+        await gZenWorkspaces.removeWorkspace(workspaceId);
       }
     }
   }

--- a/tools/zen-mod-cli/README.md
+++ b/tools/zen-mod-cli/README.md
@@ -1,0 +1,130 @@
+# Zen Mod CLI
+
+`zenmod` runs local Zen browser-chrome mods in an isolated Zen profile. It
+launches Zen headlessly by default, selects the privileged
+`chrome://browser/content/browser.xhtml` context, injects the mod stylesheet
+and scripts, performs one operation, then exits.
+
+The CLI does not require Sine. It reads `sine-mod.json` when present and falls
+back to `chrome.css`, `preferences.json`, and `*.uc.js` by convention. CSS is
+loaded through Zen's mods backend and scripts are loaded with Gecko's
+privileged script loader.
+
+## Setup
+
+Install the CLI's pinned dependencies once:
+
+```bash
+npm --prefix tools/zen-mod-cli install
+```
+
+Check the local environment:
+
+```bash
+npm run zenmod -- doctor
+```
+
+Zen must be installed at `/Applications/Zen.app/Contents/MacOS/zen`, or supplied
+with `--zen-path` or `ZEN_PATH`.
+
+## Commands
+
+Load a mod and report what was injected:
+
+```bash
+npm run zenmod -- load mods/zen-inbox
+```
+
+Inspect browser-chrome DOM without showing a window:
+
+```bash
+npm run zenmod -- inspect mods/zen-inbox \
+  --selector ".zen-inbox-header"
+```
+
+Save a screenshot:
+
+```bash
+npm run zenmod -- screenshot mods/zen-inbox \
+  --output /tmp/zen-inbox.png
+```
+
+Read browser console events generated after the automation session starts:
+
+```bash
+npm run zenmod -- console mods/zen-inbox
+```
+
+Use `--headed` only for a final visual smoke test. Other commands use a
+headless window and do not consume macOS keyboard or pointer focus.
+
+## Privileged functions
+
+`eval` and `test` read a JavaScript function expression from a file. The
+function runs in the browser window's privileged context and may be async.
+
+An evaluation function can return any WebDriver BiDi serializable value:
+
+```js
+() => ({
+  hasApi: Boolean(window.__zenInbox),
+  workspace: window.gZenWorkspaces?.activeWorkspace,
+})
+```
+
+Run it with:
+
+```bash
+npm run zenmod -- eval mods/zen-inbox --file /tmp/inspect-inbox.js
+```
+
+A test function returns a boolean, `{ pass: boolean }`, or an object containing
+an `assertions` array whose entries each have a boolean `pass` field:
+
+```js
+async () => {
+  const principal = Services.scriptSecurityManager.getSystemPrincipal();
+  const tab = gBrowser.addTab("about:blank", { triggeringPrincipal: principal });
+
+  try {
+    window.__zenInbox.setInbox([tab], true);
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    return {
+      assertions: [
+        {
+          name: "tab enters Inbox",
+          pass: tab.getAttribute("zen-inbox") === "true",
+        },
+      ],
+    };
+  } finally {
+    gBrowser.removeTab(tab);
+  }
+}
+```
+
+The command exits nonzero when the returned test result fails.
+
+## Profile and security
+
+The default profile parent is `~/.zenmod`. The underlying browser adapter
+creates `~/.zenmod/zen_devtools_mcp_profile` and never connects to the normal
+Zen profile. Override the parent with `--profile-parent` or
+`ZENMOD_PROFILE_PARENT`.
+
+Privileged functions can access browser internals and local system facilities.
+Run functions from the repository or another trusted location. Do not point
+this CLI at a profile containing personal cookies, passwords, or browsing
+sessions.
+
+## Implementation
+
+The browser lifecycle and WebDriver BiDi connection come from the pinned
+[`zen-devtools-mcp`](https://github.com/simon-ami/zen-devtools-mcp) package.
+The CLI calls its reusable `ZenDevTools` class directly, so no MCP server or
+MCP client is involved. That project is available under MIT or Apache-2.0.
+
+The CLI adds the mod-specific interface: local manifest discovery, Zen mods
+stylesheet injection, privileged userChrome script loading, deterministic JSON
+output, test-result exit codes, and isolated-session cleanup.

--- a/tools/zen-mod-cli/bin/zenmod.mjs
+++ b/tools/zen-mod-cli/bin/zenmod.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+process.env.NODE_ENV ??= "production";
+
+const { main } = await import("../src/cli.mjs");
+process.exitCode = await main();

--- a/tools/zen-mod-cli/package-lock.json
+++ b/tools/zen-mod-cli/package-lock.json
@@ -1,0 +1,1792 @@
+{
+  "name": "@zen-browser/zen-mod-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zen-browser/zen-mod-cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "zen-devtools-mcp": "0.2.0"
+      },
+      "bin": {
+        "zenmod": "bin/zenmod.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@bazel/runfiles": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.5.0.tgz",
+      "integrity": "sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.8.60",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.60.tgz",
+      "integrity": "sha512-pULv0waMlnKAUUxrsuAOa0ADONGRuhdHORtuXVgClNlScDB5YjImCV8DZrE1SicaROyE6MwGkH8CLJ+o4Nx07g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geckodriver": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.0.2.tgz",
+      "integrity": "sha512-5C4cejCvcz4yFiBHP0FEWKwSZKhr3WMkshNBQ7cSb9PqfrdSNVAbe2RTNxsdBkk3Fmqcu6PNnffiJa0T+JZGFQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "^9.1.3",
+        "@zip.js/zip.js": "^2.7.54",
+        "decamelize": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "modern-tar": "^0.3.4"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loglevel-plugin-prefix": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/modern-tar": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.3.5.tgz",
+      "integrity": "sha512-TIALaZ8AjtEHFOZj1wRreDfaobCybvzPkvevpup/XtKOha3TmJWSwrh0ghc/QwAdAtt6oqIN6z6eIlo+HbDnzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/selenium-webdriver": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.36.0.tgz",
+      "integrity": "sha512-rZGqjXiqNVL6QNqKNEk5DPaIMPbvApcmAS9QsXyt5wT3sfTSHGCh4AX/YKeDTOwei1BOZDlPOKBd82WCosUt9w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/SeleniumHQ"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/selenium"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bazel/runfiles": "^6.3.1",
+        "jszip": "^3.10.1",
+        "tmp": "^0.2.5",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zen-devtools-mcp": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/zen-devtools-mcp/-/zen-devtools-mcp-0.2.0.tgz",
+      "integrity": "sha512-GngB1lilqWlp9qo7wSzSoG7GAvGnxs3LE+lQA1dJUSjkDdTwddRfcOx0l6yyU/lFc8GRjKxZBPV5O3Yj2Go3EQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "geckodriver": "6.0.2",
+        "selenium-webdriver": "4.36.0",
+        "ws": "8.21.0",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "zen-devtools-mcp": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/tools/zen-mod-cli/package.json
+++ b/tools/zen-mod-cli/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@zen-browser/zen-mod-cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Headless browser-chrome test CLI for local Zen mods",
+  "type": "module",
+  "bin": {
+    "zenmod": "bin/zenmod.mjs"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=20.19.0"
+  },
+  "dependencies": {
+    "zen-devtools-mcp": "0.2.0"
+  }
+}

--- a/tools/zen-mod-cli/src/args.mjs
+++ b/tools/zen-mod-cli/src/args.mjs
@@ -1,0 +1,122 @@
+const VALUE_OPTIONS = new Map([
+  ["--file", "file"],
+  ["--output", "output"],
+  ["--profile-parent", "profileParent"],
+  ["--selector", "selector"],
+  ["--styles", "styles"],
+  ["--wait", "wait"],
+  ["--width", "width"],
+  ["--height", "height"],
+  ["--zen-path", "zenPath"],
+]);
+
+const BOOLEAN_OPTIONS = new Map([
+  ["--headed", "headed"],
+  ["--help", "help"],
+]);
+
+export const COMMANDS = new Set([
+  "console",
+  "doctor",
+  "eval",
+  "inspect",
+  "load",
+  "screenshot",
+  "test",
+]);
+
+function readNumber(name, value, minimum) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < minimum) {
+    throw new Error(`${name} must be a number greater than or equal to ${minimum}`);
+  }
+  return parsed;
+}
+
+export function parseCliArgs(argv) {
+  const options = {
+    headed: false,
+    height: 900,
+    help: false,
+    prefs: [],
+    wait: 500,
+    width: 1440,
+  };
+  const positionals = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (!argument.startsWith("--")) {
+      positionals.push(argument);
+      continue;
+    }
+
+    if (argument === "--pref") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error("--pref requires name=value");
+      }
+      options.prefs.push(value);
+      index += 1;
+      continue;
+    }
+
+    const booleanName = BOOLEAN_OPTIONS.get(argument);
+    if (booleanName) {
+      options[booleanName] = true;
+      continue;
+    }
+
+    const valueName = VALUE_OPTIONS.get(argument);
+    if (!valueName) {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${argument} requires a value`);
+    }
+    options[valueName] = value;
+    index += 1;
+  }
+
+  if (options.help && positionals.length === 0) {
+    return { command: null, options, positionals: [] };
+  }
+
+  const [command, ...rest] = positionals;
+  if (!command) {
+    throw new Error("A command is required");
+  }
+  if (!COMMANDS.has(command)) {
+    throw new Error(`Unknown command: ${command}`);
+  }
+
+  options.wait = readNumber("--wait", options.wait, 0);
+  options.width = readNumber("--width", options.width, 320);
+  options.height = readNumber("--height", options.height, 240);
+
+  return { command, options, positionals: rest };
+}
+
+export function parsePreferenceOverrides(values) {
+  return Object.fromEntries(
+    values.map(value => {
+      const separator = value.indexOf("=");
+      if (separator < 1) {
+        throw new Error(`Invalid preference override: ${value}`);
+      }
+
+      const name = value.slice(0, separator);
+      const rawValue = value.slice(separator + 1);
+      if (rawValue === "true" || rawValue === "false") {
+        return [name, rawValue === "true"];
+      }
+      if (rawValue !== "" && Number.isFinite(Number(rawValue))) {
+        return [name, Number(rawValue)];
+      }
+      return [name, rawValue];
+    })
+  );
+}

--- a/tools/zen-mod-cli/src/cli.mjs
+++ b/tools/zen-mod-cli/src/cli.mjs
@@ -1,0 +1,237 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parseCliArgs, parsePreferenceOverrides } from "./args.mjs";
+import { readMod } from "./mod.mjs";
+import {
+  DEFAULT_PROFILE_PARENT,
+  DEFAULT_ZEN_PATH,
+  ZenModSession,
+} from "./session.mjs";
+
+const DEFAULT_STYLES = [
+  "background-color",
+  "color",
+  "display",
+  "height",
+  "opacity",
+  "visibility",
+  "width",
+];
+
+const HELP = `Usage:
+  zenmod doctor [options]
+  zenmod load <mod-directory> [options]
+  zenmod inspect <mod-directory> --selector <css> [--styles a,b] [options]
+  zenmod eval <mod-directory> --file <function.js> [options]
+  zenmod test <mod-directory> --file <function.js> [options]
+  zenmod console <mod-directory> [options]
+  zenmod screenshot <mod-directory> --output <image.png> [options]
+
+Options:
+  --headed                    Show the isolated Zen window
+  --height <pixels>           Browser height (default: 900)
+  --pref <name=value>         Override a Zen preference; repeatable
+  --profile-parent <path>     Isolated profile parent (default: ~/.zenmod)
+  --wait <milliseconds>       Wait after mod injection (default: 500)
+  --width <pixels>            Browser width (default: 1440)
+  --zen-path <path>           Zen executable
+  --help                      Show this help
+
+JavaScript files passed to eval and test must contain a function expression.
+The function executes in chrome://browser/content/browser.xhtml and may be async.`;
+
+let activeSession = null;
+
+function print(value, stream = process.stdout) {
+  stream.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function commandModPath(positionals) {
+  if (positionals.length !== 1) {
+    throw new Error("This command requires exactly one mod directory");
+  }
+  return positionals[0];
+}
+
+function testPassed(result) {
+  if (typeof result === "boolean") {
+    return result;
+  }
+  if (!result || typeof result !== "object") {
+    throw new Error(
+      "A test function must return a boolean or an object containing pass/assertions"
+    );
+  }
+  if (typeof result.pass === "boolean") {
+    return result.pass;
+  }
+  if (Array.isArray(result.assertions)) {
+    return result.assertions.every(assertion => assertion?.pass === true);
+  }
+  throw new Error(
+    "A test result object must contain pass or an assertions array"
+  );
+}
+
+async function readFunction(filePath) {
+  if (!filePath) {
+    throw new Error("--file is required");
+  }
+  const source = (await readFile(path.resolve(filePath), "utf8")).trim();
+  if (!source) {
+    throw new Error(`Function file is empty: ${filePath}`);
+  }
+  return source;
+}
+
+async function runDoctor(options) {
+  const zenPath = path.resolve(
+    options.zenPath ?? process.env.ZEN_PATH ?? DEFAULT_ZEN_PATH
+  );
+  const profileParent = path.resolve(
+    options.profileParent ??
+      process.env.ZENMOD_PROFILE_PARENT ??
+      DEFAULT_PROFILE_PARENT
+  );
+  const checks = {
+    node: {
+      ok: Number(process.versions.node.split(".")[0]) >= 20,
+      version: process.versions.node,
+    },
+    profile: {
+      ok: true,
+      parent: profileParent,
+      resolved: path.join(profileParent, "zen_devtools_mcp_profile"),
+    },
+    zen: {
+      ok: existsSync(zenPath),
+      path: zenPath,
+    },
+  };
+  print({
+    checks,
+    ok: Object.values(checks).every(check => check.ok),
+  });
+  return Object.values(checks).every(check => check.ok) ? 0 : 1;
+}
+
+async function withLoadedMod(parsed, operation) {
+  const mod = await readMod(commandModPath(parsed.positionals));
+  const session = new ZenModSession({
+    headless: !parsed.options.headed,
+    height: parsed.options.height,
+    prefs: parsePreferenceOverrides(parsed.options.prefs),
+    profileParent: parsed.options.profileParent,
+    width: parsed.options.width,
+    zenPath: parsed.options.zenPath,
+  });
+  activeSession = session;
+
+  try {
+    await session.start();
+    const loaded = await session.loadMod(mod);
+    if (parsed.options.wait > 0) {
+      await new Promise(resolve => setTimeout(resolve, parsed.options.wait));
+    }
+    return await operation({ loaded, mod, session });
+  } finally {
+    await session.close();
+    activeSession = null;
+  }
+}
+
+async function runBrowserCommand(parsed) {
+  return withLoadedMod(parsed, async ({ loaded, session }) => {
+    switch (parsed.command) {
+      case "load":
+        print({ loaded, ok: true });
+        return 0;
+      case "inspect": {
+        if (!parsed.options.selector) {
+          throw new Error("--selector is required");
+        }
+        const styleNames = parsed.options.styles
+          ? parsed.options.styles.split(",").map(name => name.trim())
+          : DEFAULT_STYLES;
+        const elements = await session.inspect(
+          parsed.options.selector,
+          styleNames.filter(Boolean)
+        );
+        print({
+          count: elements.length,
+          elements,
+          loaded,
+          ok: true,
+          selector: parsed.options.selector,
+        });
+        return 0;
+      }
+      case "eval": {
+        const result = await session.evaluateFunction(
+          await readFunction(parsed.options.file)
+        );
+        print({ loaded, ok: true, result });
+        return 0;
+      }
+      case "test": {
+        const result = await session.evaluateFunction(
+          await readFunction(parsed.options.file)
+        );
+        const passed = testPassed(result);
+        print({ loaded, ok: passed, result });
+        return passed ? 0 : 1;
+      }
+      case "console": {
+        const messages = await session.consoleMessages();
+        print({ loaded, messages, ok: true });
+        return 0;
+      }
+      case "screenshot": {
+        if (!parsed.options.output) {
+          throw new Error("--output is required");
+        }
+        const output = path.resolve(parsed.options.output);
+        await mkdir(path.dirname(output), { recursive: true });
+        const image = Buffer.from(await session.screenshot(), "base64");
+        await writeFile(output, image);
+        print({ bytes: image.length, loaded, ok: true, output });
+        return 0;
+      }
+      default:
+        throw new Error(`Unsupported browser command: ${parsed.command}`);
+    }
+  });
+}
+
+async function cleanupAndExit(signal) {
+  await activeSession?.close();
+  print({ error: `Interrupted by ${signal}`, ok: false }, process.stderr);
+  process.exit(130);
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  try {
+    const parsed = parseCliArgs(argv);
+    if (parsed.options.help || !parsed.command) {
+      process.stdout.write(`${HELP}\n`);
+      return 0;
+    }
+    if (parsed.command === "doctor") {
+      return runDoctor(parsed.options);
+    }
+    return runBrowserCommand(parsed);
+  } catch (error) {
+    print(
+      {
+        error: error instanceof Error ? error.message : String(error),
+        ok: false,
+      },
+      process.stderr
+    );
+    return 1;
+  }
+}
+
+process.once("SIGINT", () => void cleanupAndExit("SIGINT"));
+process.once("SIGTERM", () => void cleanupAndExit("SIGTERM"));

--- a/tools/zen-mod-cli/src/mod.mjs
+++ b/tools/zen-mod-cli/src/mod.mjs
@@ -1,0 +1,121 @@
+import { access, readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+async function exists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveModFile(root, relativePath) {
+  const resolved = path.resolve(root, relativePath);
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Mod file escapes its directory: ${relativePath}`);
+  }
+  return resolved;
+}
+
+async function readJson(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    throw new Error(`Could not read ${filePath}: ${error.message}`);
+  }
+}
+
+async function readManifest(root) {
+  const manifestPath = path.join(root, "sine-mod.json");
+  if (!(await exists(manifestPath))) {
+    return null;
+  }
+
+  const manifest = await readJson(manifestPath);
+  const entries = Object.entries(manifest);
+  if (entries.length !== 1) {
+    throw new Error("sine-mod.json must contain exactly one local mod");
+  }
+
+  const [id, definition] = entries[0];
+  if (!definition || typeof definition !== "object") {
+    throw new Error(`Invalid manifest entry for ${id}`);
+  }
+  return { definition, id, manifestPath };
+}
+
+function scriptNames(definition) {
+  if (!definition?.scripts) {
+    return [];
+  }
+  if (Array.isArray(definition.scripts)) {
+    return definition.scripts;
+  }
+  return Object.entries(definition.scripts)
+    .filter(([, config]) => {
+      const includes = config?.include;
+      return (
+        !Array.isArray(includes) ||
+        includes.includes("chrome://browser/content/browser.xhtml")
+      );
+    })
+    .map(([name]) => name);
+}
+
+export async function readMod(modDirectory) {
+  const root = path.resolve(modDirectory);
+  if (!(await exists(root))) {
+    throw new Error(`Mod directory does not exist: ${root}`);
+  }
+
+  const manifest = await readManifest(root);
+  const directoryEntries = await readdir(root);
+  const fallbackScripts = directoryEntries
+    .filter(name => name.endsWith(".uc.js"))
+    .sort();
+  const scripts = (
+    manifest ? scriptNames(manifest.definition) : fallbackScripts
+  ).map(name => resolveModFile(root, name));
+
+  for (const script of scripts) {
+    if (!(await exists(script))) {
+      throw new Error(`Manifest script does not exist: ${script}`);
+    }
+  }
+
+  const styleConfig = manifest?.definition?.style;
+  const styleName =
+    typeof styleConfig === "string"
+      ? styleConfig
+      : styleConfig?.chrome ||
+        (directoryEntries.includes("chrome.css") ? "chrome.css" : null);
+  const stylePath = styleName ? resolveModFile(root, styleName) : null;
+  if (stylePath && !(await exists(stylePath))) {
+    throw new Error(`Manifest stylesheet does not exist: ${stylePath}`);
+  }
+
+  const preferencesName = manifest?.definition?.preferences;
+  const preferencesPath = preferencesName
+    ? resolveModFile(root, preferencesName)
+    : directoryEntries.includes("preferences.json")
+      ? path.join(root, "preferences.json")
+      : null;
+  const preferences =
+    preferencesPath && (await exists(preferencesPath))
+      ? await readJson(preferencesPath)
+      : [];
+  if (!Array.isArray(preferences)) {
+    throw new Error("preferences.json must contain an array");
+  }
+
+  return {
+    definition: manifest?.definition ?? {},
+    id: manifest?.id ?? path.basename(root),
+    preferences,
+    root,
+    scripts,
+    stylePath,
+  };
+}

--- a/tools/zen-mod-cli/src/session.mjs
+++ b/tools/zen-mod-cli/src/session.mjs
@@ -1,0 +1,282 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { ZenDevTools } from "zen-devtools-mcp";
+
+export const DEFAULT_PROFILE_PARENT = path.join(os.homedir(), ".zenmod");
+export const DEFAULT_ZEN_PATH = "/Applications/Zen.app/Contents/MacOS/zen";
+const BROWSER_DOCUMENT = "chrome://browser/content/browser.xhtml";
+
+function remoteValueToNative(remoteValue) {
+  if (!remoteValue || typeof remoteValue !== "object") {
+    return remoteValue;
+  }
+
+  const { type, value } = remoteValue;
+  switch (type) {
+    case "undefined":
+      return undefined;
+    case "null":
+      return null;
+    case "string":
+    case "boolean":
+    case "number":
+    case "date":
+      return value;
+    case "bigint":
+      return `${value}n`;
+    case "array":
+    case "set":
+      return value.map(remoteValueToNative);
+    case "object":
+      return Object.fromEntries(
+        value.map(([key, item]) => [key, remoteValueToNative(item)])
+      );
+    case "map":
+      return Object.fromEntries(
+        value.map(([key, item]) => [
+          String(remoteValueToNative(key)),
+          remoteValueToNative(item),
+        ])
+      );
+    case "regexp":
+      return `/${value.pattern}/${value.flags ?? ""}`;
+    default:
+      return `[${type}]`;
+  }
+}
+
+function exceptionMessage(details) {
+  const exception = remoteValueToNative(details?.exception);
+  const suffix = exception ? `\n${JSON.stringify(exception, null, 2)}` : "";
+  return `${details?.text ?? "Privileged script failed"}${suffix}`;
+}
+
+export class ZenModSession {
+  constructor(options = {}) {
+    this.options = {
+      headless: options.headless ?? true,
+      height: options.height ?? 900,
+      prefs: options.prefs ?? {},
+      profileParent:
+        options.profileParent ??
+        process.env.ZENMOD_PROFILE_PARENT ??
+        DEFAULT_PROFILE_PARENT,
+      width: options.width ?? 1440,
+      zenPath: options.zenPath ?? process.env.ZEN_PATH ?? DEFAULT_ZEN_PATH,
+    };
+    this.client = null;
+    this.contextId = null;
+  }
+
+  async start() {
+    this.client = new ZenDevTools({
+      env: {
+        MOZ_REMOTE_ALLOW_SYSTEM_ACCESS: "1",
+      },
+      headless: this.options.headless,
+      prefs: {
+        "remote.prefs.recommended": false,
+        ...this.options.prefs,
+      },
+      profilePath: this.options.profileParent,
+      viewport: {
+        height: this.options.height,
+        width: this.options.width,
+      },
+      zenPath: this.options.zenPath,
+    });
+
+    try {
+      await this.client.connect();
+      await this.selectBrowserChrome();
+    } catch (error) {
+      await this.close();
+      throw error;
+    }
+  }
+
+  async selectBrowserChrome() {
+    const tree = await this.client.sendBiDiCommand("browsingContext.getTree", {
+      "moz:scope": "chrome",
+    });
+    const contexts = tree.contexts ?? [];
+    const browserContext =
+      contexts.find(context => context.url === BROWSER_DOCUMENT) ?? contexts[0];
+    if (!browserContext) {
+      throw new Error(
+        "Zen exposed no privileged contexts. This build may not support MOZ_REMOTE_ALLOW_SYSTEM_ACCESS."
+      );
+    }
+
+    const driver = this.client.getDriver();
+    await driver.switchTo().window(browserContext.context);
+    await driver.setContext("chrome");
+    await driver.manage().setTimeouts({ script: 15000 });
+    this.client.setCurrentContextId(browserContext.context);
+    this.contextId = browserContext.context;
+  }
+
+  async loadMod(mod) {
+    if (!this.client || !this.contextId) {
+      throw new Error("Zen session has not started");
+    }
+
+    await this.applyPreferences(mod);
+    if (mod.stylePath) {
+      await this.applyStyle(mod.stylePath);
+    }
+    for (const scriptPath of mod.scripts) {
+      await this.loadScript(scriptPath);
+    }
+
+    return {
+      id: mod.id,
+      preferences: mod.preferences.length,
+      scripts: mod.scripts,
+      style: mod.stylePath,
+    };
+  }
+
+  async applyPreferences(mod) {
+    const driver = this.client.getDriver();
+    await driver.executeScript(
+      `
+        const [modName, preferences] = arguments;
+        const sanitizedName =
+          "theme-" + String(modName).replaceAll(/\\s/g, "-").replaceAll(/[^A-Za-z_-]+/g, "");
+        const root = document.documentElement;
+
+        for (const preference of preferences) {
+          const { property, type, defaultValue } = preference;
+          if (!property || defaultValue === undefined) {
+            continue;
+          }
+
+          if (Services.prefs.getPrefType(property) === Services.prefs.PREF_INVALID) {
+            if (type === "checkbox") {
+              Services.prefs.setBoolPref(property, Boolean(defaultValue));
+            } else {
+              Services.prefs.setStringPref(property, String(defaultValue));
+            }
+          }
+
+          const sanitizedProperty = property.replaceAll(".", "-");
+          if (type === "dropdown") {
+            let marker = document.getElementById(sanitizedName);
+            if (!marker) {
+              marker = document.createElement("div");
+              marker.hidden = true;
+              marker.id = sanitizedName;
+              document.body.appendChild(marker);
+            }
+            marker.setAttribute(
+              sanitizedProperty,
+              Services.prefs.getStringPref(property, String(defaultValue))
+            );
+          } else if (type === "string") {
+            root.style.setProperty(
+              "--" + sanitizedProperty,
+              Services.prefs.getStringPref(property, String(defaultValue))
+            );
+          }
+        }
+      `,
+      mod.definition.name ?? mod.id,
+      mod.preferences
+    );
+  }
+
+  async applyStyle(stylePath) {
+    const css = await readFile(stylePath, "utf8");
+    const driver = this.client.getDriver();
+    const result = await driver.executeScript(
+      `
+        const backend = Cc["@mozilla.org/zen/mods-backend;1"].getService(
+          Ci.nsIZenModsBackend
+        );
+        return backend.rebuildModsStyles(arguments[0]);
+      `,
+      css
+    );
+    if (result !== 0 && result !== undefined && result !== null) {
+      throw new Error(`Zen rejected ${stylePath} with result ${result}`);
+    }
+  }
+
+  async loadScript(scriptPath) {
+    const driver = this.client.getDriver();
+    await driver.executeScript(
+      `
+        const file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
+        file.initWithPath(arguments[0]);
+        const uri = Services.io.newFileURI(file);
+        Services.scriptloader.loadSubScript(uri.spec, window, "UTF-8");
+      `,
+      scriptPath
+    );
+  }
+
+  async evaluateFunction(functionDeclaration) {
+    const result = await this.client.sendBiDiCommand("script.callFunction", {
+      arguments: [],
+      awaitPromise: true,
+      functionDeclaration,
+      target: { context: this.contextId },
+    });
+
+    if (result.type === "success") {
+      return remoteValueToNative(result.result);
+    }
+    if (result.type === "exception") {
+      throw new Error(exceptionMessage(result.exceptionDetails));
+    }
+    throw new Error(`Unexpected privileged script result: ${result.type}`);
+  }
+
+  async inspect(selector, styleNames) {
+    const serializedSelector = JSON.stringify(selector);
+    const serializedStyles = JSON.stringify(styleNames);
+    return this.evaluateFunction(`() => {
+      const selector = ${serializedSelector};
+      const styleNames = ${serializedStyles};
+      return Array.from(document.querySelectorAll(selector)).map(element => {
+        const bounds = element.getBoundingClientRect();
+        const computed = getComputedStyle(element);
+        return {
+          attributes: Object.fromEntries(
+            Array.from(element.attributes, attribute => [attribute.name, attribute.value])
+          ),
+          bounds: {
+            height: bounds.height,
+            width: bounds.width,
+            x: bounds.x,
+            y: bounds.y,
+          },
+          hidden: element.hidden,
+          styles: Object.fromEntries(
+            styleNames.map(name => [name, computed.getPropertyValue(name)])
+          ),
+          tag: element.localName,
+          text: element.textContent?.trim() ?? "",
+        };
+      });
+    }`);
+  }
+
+  async consoleMessages() {
+    return this.client.getConsoleMessages();
+  }
+
+  async screenshot() {
+    return this.client.takeScreenshotPage();
+  }
+
+  async close() {
+    if (this.client) {
+      await this.client.close();
+      this.client = null;
+      this.contextId = null;
+    }
+  }
+}

--- a/tools/zen-mod-cli/test/args.test.mjs
+++ b/tools/zen-mod-cli/test/args.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseCliArgs, parsePreferenceOverrides } from "../src/args.mjs";
+
+test("parses a browser command and repeated preferences", () => {
+  const parsed = parseCliArgs([
+    "inspect",
+    "mods/example",
+    "--selector",
+    ".example",
+    "--pref",
+    "feature.enabled=true",
+    "--pref",
+    "feature.delay=12",
+    "--headed",
+  ]);
+
+  assert.equal(parsed.command, "inspect");
+  assert.deepEqual(parsed.positionals, ["mods/example"]);
+  assert.equal(parsed.options.selector, ".example");
+  assert.equal(parsed.options.headed, true);
+  assert.deepEqual(parsePreferenceOverrides(parsed.options.prefs), {
+    "feature.delay": 12,
+    "feature.enabled": true,
+  });
+});
+
+test("rejects unknown options", () => {
+  assert.throws(
+    () => parseCliArgs(["doctor", "--wat"]),
+    /Unknown option: --wat/
+  );
+});
+
+test("rejects invalid preference overrides", () => {
+  assert.throws(
+    () => parsePreferenceOverrides(["missing-separator"]),
+    /Invalid preference override/
+  );
+});

--- a/tools/zen-mod-cli/test/mod.test.mjs
+++ b/tools/zen-mod-cli/test/mod.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { readMod } from "../src/mod.mjs";
+
+async function withFixture(files, operation) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zenmod-test-"));
+  try {
+    await Promise.all(
+      Object.entries(files).map(([name, contents]) =>
+        writeFile(path.join(root, name), contents)
+      )
+    );
+    return await operation(root);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+test("reads a Sine local mod manifest", async () => {
+  await withFixture(
+    {
+      "chrome.css": ".example { display: block; }",
+      "preferences.json": JSON.stringify([
+        {
+          defaultValue: true,
+          property: "example.enabled",
+          type: "checkbox",
+        },
+      ]),
+      "sine-mod.json": JSON.stringify({
+        example: {
+          name: "Example",
+          preferences: "preferences.json",
+          scripts: {
+            "example.uc.js": {
+              include: ["chrome://browser/content/browser.xhtml"],
+            },
+          },
+          style: { chrome: "chrome.css" },
+        },
+      }),
+      "example.uc.js": "window.__example = true;",
+    },
+    async root => {
+      const mod = await readMod(root);
+
+      assert.equal(mod.id, "example");
+      assert.equal(mod.scripts.length, 1);
+      assert.equal(path.basename(mod.stylePath), "chrome.css");
+      assert.equal(mod.preferences[0].property, "example.enabled");
+    }
+  );
+});
+
+test("discovers conventional files without a manifest", async () => {
+  await withFixture(
+    {
+      "chrome.css": "",
+      "example.uc.js": "",
+    },
+    async root => {
+      const mod = await readMod(root);
+
+      assert.equal(mod.id, path.basename(root));
+      assert.deepEqual(mod.scripts.map(script => path.basename(script)), [
+        "example.uc.js",
+      ]);
+      assert.equal(path.basename(mod.stylePath), "chrome.css");
+    }
+  );
+});
+
+test("rejects manifest paths outside the mod", async () => {
+  await withFixture(
+    {
+      "sine-mod.json": JSON.stringify({
+        example: {
+          scripts: {
+            "../outside.uc.js": {},
+          },
+        },
+      }),
+    },
+    async root => {
+      await assert.rejects(() => readMod(root), /escapes its directory/);
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- search Zen's stored workspace tabs when resolving live switch-to-tab titles
- preserve distinct container-specific Essential labels while another workspace is active
- add regression coverage for active and inactive workspace Essentials sharing a URL

## Test plan
- [x] validate the Surfer patch against the clean Firefox source index
- [x] run URLbar and regression-test lint
- [x] build the browser UI
- [x] reproduce two container-specific Essentials in separate workspaces and verify Cmd+T returns both live labels


Made with [Cursor](https://cursor.com)