### PR TITLE
gh-15128: Fix dragging splitter while creating new split view

### DIFF
--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -70,6 +70,134 @@ class nsSplitNode extends nsSplitLeafNode {
   }
 }
 
+/**
+ * @typedef {object} nsSplitViewGesture
+ * @property {Function} begin - gesture start
+ * @property {Function} cancel - gesture stop
+ */
+
+/**
+ * @implements {nsSplitViewGesture}
+ */
+class nsSplitterDrag {
+  /**
+   * The slot this gesture occupies in nsZenViewSplitter._gestures.
+   *
+   * @type {string}
+   */
+  static GESTURE = "splitterDrag";
+
+  _controller = new AbortController();
+
+  /**
+   * The node whose children the splitter sits between.
+   *
+   * @type {nsSplitNode}
+   */
+  node;
+  /**
+   * Sizes of node.children at mousedown.
+   *
+   * @type {number[]}
+   */
+  originalSizes;
+  /**
+   * Which pair of panes the dragged splitter separates: it sits between
+   * node.children[gridIdx] and node.children[gridIdx + 1].
+   *
+   * @type {number}
+   */
+  gridIdx;
+  /**
+   * Pointer position on the dragged axis at mousedown.
+   *
+   * @type {number}
+   */
+  startPosition;
+  /**
+   * The root's extent divided by node's along the dragged axis
+   *
+   * @type {number}
+   */
+  rootToNodeSize;
+  /**
+   * @type {boolean}
+   */
+  isVertical;
+  /**
+   * The tabpanels, which carries the marks begin() puts on screen.
+   *
+   * @type {Element}
+   */
+  _panel;
+
+  /**
+   * @param {object} options
+   * @param {Element} options.panel - The tabpanels
+   * @param {Element} options.splitter - The splitter under the pointer.
+   * @param {MouseEvent} options.event - The mousedown that began the drag.
+   */
+  constructor({ panel, splitter, event }) {
+    this._panel = panel;
+    this.node = splitter.parentSplitNode;
+    this.gridIdx = parseInt(splitter.getAttribute("gridIdx"));
+    this.isVertical = splitter.getAttribute("orient") === "vertical";
+    this.startPosition = event[this.clientAxis];
+    this.originalSizes = this.node.children.map(c => c.sizeInParent);
+    const { top, right, bottom, left } = this.node.positionToRoot;
+    this.rootToNodeSize = this.isVertical
+      ? 100 / (100 - right - left)
+      : 100 / (100 - bottom - top);
+  }
+
+  /**
+   * @type {string}
+   */
+  get dimension() {
+    return this.isVertical ? "width" : "height";
+  }
+
+  /**
+   * @type {string}
+   */
+  get clientAxis() {
+    return this.isVertical ? "clientX" : "clientY";
+  }
+
+  /**
+   * Can be used to abort the drag prematurely.
+   *
+   * @type {AbortSignal}
+   */
+  get signal() {
+    return this._controller.signal;
+  }
+
+  /**
+   * @type {boolean}
+   */
+  get cancelled() {
+    return this._controller.signal.aborted;
+  }
+
+  begin() {
+    this._panel.setAttribute("zen-split-resizing", true);
+    window.setCursor(this.isVertical ? "ew-resize" : "ns-resize");
+  }
+
+  cancel() {
+    this._controller.abort();
+    this._panel.removeAttribute("zen-split-resizing");
+    window.setCursor("auto");
+  }
+
+  resetSizes() {
+    this.originalSizes.forEach(
+      (size, i) => (this.node.children[i].sizeInParent = size)
+    );
+  }
+}
+
 class nsZenViewSplitter extends nsZenDOMOperatedFeature {
   currentView = -1;
   _data = [];
@@ -83,6 +211,11 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
   minResizeWidth;
 
   _lastOpenedTab = null;
+
+  /**
+   * @type {{splitterDrag: ?nsSplitterDrag}}
+   */
+  _gestures = { [nsSplitterDrag.GESTURE]: null };
 
   MAX_TABS = 4;
 
@@ -661,11 +794,42 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
   }
 
   /**
+   * Takes over a gesture slot, calling off whatever was in it.
+   *
+   * @param {string} name - Key into _gestures.
+   * @param {nsSplitViewGesture} gesture
+   * @returns {nsSplitViewGesture} The same gesture, begun.
+   * @private
+   */
+  _beginGesture(name, gesture) {
+    this._cancelGesture(name);
+    this._gestures[name] = gesture;
+    gesture.begin();
+    return gesture;
+  }
+
+  /**
+   * Calls off the gesture in a slot, if there is one.
+   *
+   * @param {string} name - Key into _gestures.
+   * @private
+   */
+  _cancelGesture(name) {
+    const gesture = this._gestures[name];
+    if (!gesture) {
+      return;
+    }
+    this._gestures[name] = null;
+    gesture.cancel();
+  }
+
+  /**
    * @param {object} node
    * @param {boolean} recursive
    * @private
    */
   _removeNodeSplitters(node, recursive) {
+    this._cancelGesture(nsSplitterDrag.GESTURE);
     this.getSplitters(node)?.forEach(s => s.remove());
     this._splitNodeToSplitters.delete(node);
     if (!recursive) {
@@ -1795,6 +1959,7 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
   }
 
   removeSplitters() {
+    this._cancelGesture(nsSplitterDrag.GESTURE);
     [...this.overlay.children]
       .filter(c => c.classList.contains("zen-split-view-splitter"))
       .forEach(s => s.remove());
@@ -1837,36 +2002,30 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
   };
 
   handleSplitterMouseDown = event => {
-    this.tabBrowserPanel.setAttribute("zen-split-resizing", true);
-    const isVertical = event.target.getAttribute("orient") === "vertical";
-    const dimension = isVertical ? "width" : "height";
-    const clientAxis = isVertical ? "clientX" : "clientY";
-
-    const gridIdx = parseInt(event.target.getAttribute("gridIdx"));
-    const startPosition = event[clientAxis];
-    const splitNode = event.target.parentSplitNode;
-    let rootToNodeSize;
-    if (isVertical) {
-      rootToNodeSize =
-        100 /
-        (100 - splitNode.positionToRoot.right - splitNode.positionToRoot.left);
-    } else {
-      rootToNodeSize =
-        100 /
-        (100 - splitNode.positionToRoot.bottom - splitNode.positionToRoot.top);
-    }
-    const originalSizes = splitNode.children.map(c => c.sizeInParent);
+    const drag = this._beginGesture(
+      nsSplitterDrag.GESTURE,
+      new nsSplitterDrag({
+        panel: this.tabBrowserPanel,
+        splitter: event.target,
+        event,
+      })
+    );
+    const { node, originalSizes, gridIdx } = drag;
 
     const dragFunc = dEvent => {
       requestAnimationFrame(() => {
-        originalSizes.forEach(
-          (s, i) => (splitNode.children[i].sizeInParent = s)
-        ); // reset changes
+        // The split can be torn down mid-gesture, between the mousemove and the
+        // frame it asked for.
+        if (drag.cancelled) {
+          return;
+        }
+        drag.resetSizes();
 
-        const movement = dEvent[clientAxis] - startPosition;
+        const movement = dEvent[drag.clientAxis] - drag.startPosition;
         let movementPercent =
-          (movement / this.tabBrowserPanel.getBoundingClientRect()[dimension]) *
-          rootToNodeSize *
+          (movement /
+            this.tabBrowserPanel.getBoundingClientRect()[drag.dimension]) *
+          drag.rootToNodeSize *
           100;
 
         let reducingMovement = Math.max(movementPercent, -movementPercent);
@@ -1880,7 +2039,7 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
             this.minResizeWidth,
             current - reducingMovement
           );
-          splitNode.children[i].sizeInParent = newSize;
+          node.children[i].sizeInParent = newSize;
           const amountReduced = current - newSize;
           reducingMovement -= amountReduced;
           if (reducingMovement <= 0) {
@@ -1890,22 +2049,17 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
         const increasingMovement =
           Math.max(movementPercent, -movementPercent) - reducingMovement;
         const increaseIndex = gridIdx + (movementPercent < 0 ? 1 : 0);
-        splitNode.children[increaseIndex].sizeInParent =
+        node.children[increaseIndex].sizeInParent =
           originalSizes[increaseIndex] + increasingMovement;
-        this.applyGridLayout(splitNode);
+        this.applyGridLayout(node);
       });
     };
 
-    window.setCursor(isVertical ? "ew-resize" : "ns-resize");
-    document.addEventListener("mousemove", dragFunc);
+    document.addEventListener("mousemove", dragFunc, { signal: drag.signal });
     document.addEventListener(
       "mouseup",
-      () => {
-        document.removeEventListener("mousemove", dragFunc);
-        window.setCursor("auto");
-        this.tabBrowserPanel.removeAttribute("zen-split-resizing");
-      },
-      { once: true }
+      () => this._cancelGesture(nsSplitterDrag.GESTURE),
+      { signal: drag.signal }
     );
   };
 

--- a/src/zen/tests/split_view/browser.toml
+++ b/src/zen/tests/split_view/browser.toml
@@ -16,6 +16,8 @@ support-files = [
 
 ["browser_split_inset_checks.js"]
 
+["browser_split_resize_teardown.js"]
+
 ["browser_split_view_empty.js"]
 
 ["browser_split_view_with_folders.js"]

--- a/src/zen/tests/split_view/browser_split_resize_teardown.js
+++ b/src/zen/tests/split_view/browser_split_resize_teardown.js
@@ -1,0 +1,108 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const SPLITTER_SELECTOR = ".zen-split-view-splitter";
+
+function dispatchMouse(target, type, clientX, clientY) {
+  target.dispatchEvent(
+    new MouseEvent(type, { bubbles: true, clientX, clientY })
+  );
+}
+
+function nextFrame() {
+  return new Promise(resolve => requestAnimationFrame(() => resolve()));
+}
+
+function splitContainers() {
+  return [
+    ...document.querySelectorAll('.browserSidebarContainer[zen-split="true"]'),
+  ];
+}
+
+add_task(async function test_Splitter_Drag_Resizes() {
+  await basicSplitNTabs(async () => {
+    const splitter = document.querySelector(SPLITTER_SELECTOR);
+    ok(splitter, "There should be a splitter between the two panes");
+
+    const panel = gZenViewSplitter.tabBrowserPanel;
+    const rect = panel.getBoundingClientRect();
+    const startX = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+
+    dispatchMouse(splitter, "mousedown", startX, y);
+    ok(gZenViewSplitter._gestures.splitterDrag, "The drag should be in flight");
+    ok(
+      panel.hasAttribute("zen-split-resizing"),
+      "The panel should be marked as resizing"
+    );
+
+    dispatchMouse(document, "mousemove", startX - rect.width * 0.1, y);
+    await nextFrame();
+    Assert.notEqual(
+      splitContainers()[0].style.inset,
+      "0% 50% 0% 0%",
+      "The drag should have moved the boundary between the panes"
+    );
+
+    dispatchMouse(document, "mouseup", startX - rect.width * 0.1, y);
+    Assert.equal(
+      gZenViewSplitter._gestures.splitterDrag,
+      null,
+      "Mouseup should release the gesture slot"
+    );
+    ok(
+      !panel.hasAttribute("zen-split-resizing"),
+      "Mouseup should unmark the panel"
+    );
+  });
+});
+
+add_task(async function test_Split_Torn_Down_Mid_Drag() {
+  await basicSplitNTabs(async tabs => {
+    const containers = tabs.map(tab =>
+      tab.linkedBrowser.closest(".browserSidebarContainer")
+    );
+    const splitter = document.querySelector(SPLITTER_SELECTOR);
+    const panel = gZenViewSplitter.tabBrowserPanel;
+    const rect = panel.getBoundingClientRect();
+    const startX = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+
+    dispatchMouse(splitter, "mousedown", startX, y);
+    ok(gZenViewSplitter._gestures.splitterDrag, "The drag should be in flight");
+
+    gZenViewSplitter.removeTabFromGroup(tabs[1], undefined, {
+      forUnsplit: true,
+    });
+    Assert.equal(
+      gZenViewSplitter._gestures.splitterDrag,
+      null,
+      "Tearing the split down should call the drag off"
+    );
+    ok(
+      !panel.hasAttribute("zen-split-resizing"),
+      "The panel should no longer be marked as resizing"
+    );
+    for (const container of containers) {
+      Assert.equal(
+        container.style.inset,
+        "",
+        "The teardown should have cleared the inset"
+      );
+    }
+
+    dispatchMouse(document, "mousemove", startX - rect.width * 0.1, y);
+    await nextFrame();
+    for (const container of containers) {
+      Assert.equal(
+        container.style.inset,
+        "",
+        "A cancelled drag should not write an inset onto an unsplit container"
+      );
+    }
+
+    dispatchMouse(document, "mouseup", startX - rect.width * 0.1, y);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/zen-browser/desktop/issues/15128

The cause of the bug is described in the issue.

I decided to generalize for gestures in this fix.

This fix in particular can probably be done with just one field to hold the abort controller for the drag, but I think this is better since other types of gestures that need their state preserved for whatever reason (in this case being able to abort the event prematurely) can be later added (and existing ones can be put in there).

Here is a video showing  the fix doing its job:

https://github.com/user-attachments/assets/fde12bef-66d1-4716-8823-2f4d280c5b45