### PR TITLE
gh-15146: Fix bad current view index after removing a group

### DIFF
--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -358,7 +358,9 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     ) {
       return;
     }
-    const currentView = this._data[this._lastOpenedTab.splitViewValue];
+    const currentView = this._data.find(group =>
+      group.tabs.includes(this._lastOpenedTab)
+    );
     if (currentView?.tabs.length >= this.MAX_TABS) {
       return;
     }
@@ -543,7 +545,9 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     const panelsWidth = panelsRect.width;
     const panelsHeight = panelsRect.height;
     let numOfTabsToDivide = 2;
-    const currentView = this._data[this._lastOpenedTab.splitViewValue];
+    const currentView = this._data.find(group =>
+      group.tabs.includes(this._lastOpenedTab)
+    );
     if (currentView) {
       numOfTabsToDivide = currentView.tabs.length + 1;
     }
@@ -1106,7 +1110,6 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
    */
   resetTabState(tab, forUnsplit) {
     tab.splitView = false;
-    delete tab.splitViewValue;
     tab.removeAttribute("split-view");
     tab.linkedBrowser.zenModeActive = false;
     const container = tab.linkedBrowser.closest(".browserSidebarContainer");
@@ -1150,6 +1153,8 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     }
     if (this.currentView === groupIndex) {
       this.deactivateCurrentSplitView();
+    } else if (this.currentView > groupIndex) {
+      this.currentView--;
     }
     for (const tab of this._data[groupIndex].tabs) {
       this.resetTabState(tab, true);
@@ -1641,7 +1646,6 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
   applyGridToTabs(tabs) {
     tabs.forEach(tab => {
       tab.splitView = true;
-      tab.splitViewValue = this.currentView;
       tab.setAttribute("split-view", "true");
       const container = tab.linkedBrowser?.closest(".browserSidebarContainer");
       container.setAttribute("is-zen-split", "true");


### PR DESCRIPTION
Closes https://github.com/zen-browser/desktop/issues/15146

I want to write tests for this, but upon writing the tests I discovered another thing which would change the structure of the tests a little bit and I'm 99% sure this is not intended behavior, but I might as well ask.

In [handleTabClose](https://github.com/zen-browser/desktop/blob/f28e0688fbaccc6799550f56939706053fb0648b/src/zen/split-view/ZenViewSplitter.mjs#L163) we pass `{ forUnsplit: true }` which makes `removeTabFromGroup` default to `changeTab = true`, but this means we will change tabs even if the tab we are closing isn't the current view.
I think the call should look like this:
```javascript
this.removeTabFromGroup(tab, groupIndex, {
  forUnsplit: true,
  changeTab: groupIndex === this.currentView,
});
```

Here is a video of the fix:

https://github.com/user-attachments/assets/b5adc592-0153-46c0-8079-e48de2c87dfa

