### PR TITLE
gh-15204: Fix creating new empty split causes panes to flash

### DIFF
--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -619,7 +619,7 @@ window.gZenUIManager = {
    * corresponds to a close event.
    *
    * @param {object} closeToken - Token previously passed to handleNewTab.
-   * @param {CustomEvent} event - A ZenURLBarClosed event.
+   * @param {CustomEvent} event - A ZenURLBarAboutToClose or ZenURLBarClosed event.
    * @returns {boolean}
    */
   matchesCloseToken(closeToken, event) {
@@ -647,6 +647,13 @@ window.gZenUIManager = {
     }
 
     const isFocusedBefore = gURLBar.focused;
+
+    window.dispatchEvent(
+      new CustomEvent("ZenURLBarAboutToClose", {
+        detail: { onSwitch, onElementPicked, closeSeq },
+      })
+    );
+
     setTimeout(() => {
       /* If someone else opened the url bar in the meantime don't be
        * stingy and leave it open for them.*/

--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -84,6 +84,8 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
 
   _lastOpenedTab = null;
 
+  #stagedPickPending = false;
+
   MAX_TABS = 4;
 
   init() {
@@ -1523,11 +1525,23 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
   updateSplitView(tab) {
     const oldView = this.currentView;
     const newView = this._data.findIndex(group => group.tabs.includes(tab));
+    const stagingSplit = this.#stagedPickPending;
+    this.#stagedPickPending = false;
 
     if (newView === oldView && oldView < 0) {
       return;
     }
     if (newView < 0 && oldView >= 0) {
+      /* The tab for the staged split has arrived. Don't tear the
+       * group down or we will have to rebuild it which will cause a
+       * visual flash of the tabs expanding to full size and getting
+       * back into position.
+       * Park the tab where it's supposed to be in the split instead.
+       * */
+      if (stagingSplit) {
+        this.#parkInStagedPane(tab);
+        return;
+      }
       this.deactivateCurrentSplitView();
       return;
     }
@@ -1717,7 +1731,11 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
       const browserContainer = splitNode.tab.linkedBrowser.closest(
         ".browserSidebarContainer"
       );
-      browserContainer.style.inset = `${nodeRootPosition.top}% ${nodeRootPosition.right}% ${nodeRootPosition.bottom}% ${nodeRootPosition.left}%`;
+      const inset = `${nodeRootPosition.top}% ${nodeRootPosition.right}% ${nodeRootPosition.bottom}% ${nodeRootPosition.left}%`;
+      browserContainer.style.inset = inset;
+      if (browserContainer.hasAttribute("zen-split-staged")) {
+        this.#setStagedPaneSlot(inset);
+      }
       this._tabToSplitNode.set(splitNode.tab, splitNode);
       return;
     }
@@ -1760,6 +1778,39 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
       }
     });
     this.maybeDisableOpeningTabOnSplitView();
+  }
+
+  /**
+   * Set the rectangle of the staged split
+   *
+   * @param {?string} inset - The staged pane's inset, as written to its container.
+   */
+  #setStagedPaneSlot(inset) {
+    if (!inset) {
+      this.#stagedPickPending = false;
+      this.tabBrowserPanel.removeAttribute("zen-split-staging");
+      this.tabBrowserPanel.style.removeProperty("--zen-staged-pane-inset");
+      this.#parkInStagedPane(null);
+      return;
+    }
+    this.tabBrowserPanel.setAttribute("zen-split-staging", "true");
+    this.tabBrowserPanel.style.setProperty("--zen-staged-pane-inset", inset);
+  }
+
+  /**
+   * Parks a tab's container in the staged pane's rectangle so we don't
+   * get a full-bleed over the split before the pane commits.
+   *
+   * @param {?Tab} tab - The tab to park, or null to empty the slot.
+   */
+  #parkInStagedPane(tab) {
+    const container = tab?.linkedBrowser?.closest(".browserSidebarContainer");
+    const parked = this.tabBrowserPanel.querySelector("[zen-split-parked]");
+    if (parked === container) {
+      return;
+    }
+    parked?.removeAttribute("zen-split-parked");
+    container?.setAttribute("zen-split-parked", "true");
   }
 
   /**
@@ -1967,6 +2018,10 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
    */
   resetContainerStyle(container, removeDeckSelected = false) {
     container.removeAttribute("zen-split");
+    if (container.hasAttribute("zen-split-staged")) {
+      container.removeAttribute("zen-split-staged");
+      this.#setStagedPaneSlot(null);
+    }
     if (removeDeckSelected) {
       container.classList.remove("deck-selected");
     }
@@ -2541,6 +2596,9 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     };
     this.#withoutSplitViewTransition(() => {
       this._data.push(data);
+      emptyTab.linkedBrowser
+        .closest(".browserSidebarContainer")
+        .setAttribute("zen-split-staged", "true");
       this.activateSplitView(data);
       gBrowser.selectedTab = emptyTab;
       setTimeout(() => {
@@ -2559,6 +2617,16 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
           const command = document.getElementById("cmd_zenNewEmptySplit");
           command.removeAttribute("disabled");
         };
+        window.addEventListener(
+          "ZenURLBarAboutToClose",
+          event => {
+            if (!gZenUIManager.matchesCloseToken(closeToken, event)) {
+              return;
+            }
+            this.#stagedPickPending = event.detail.onElementPicked;
+          },
+          { signal: controller.signal }
+        );
         window.addEventListener(
           "ZenURLBarClosed",
           event => {

--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -2583,6 +2583,66 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     }
   }
 
+  /**
+   * Adopt tabs into a given group without disolving the group.
+   * This assumes the count of the passed tabs and the count of the tabs in
+   * the group is the same, because it works by swapping the tabs of each split node
+   * in the group.
+   *
+   * @param {object} group - The group
+   * @param {Array<Tab>} tabs - The tabs to end up with, in the group's order.
+   * @returns {boolean} False if the split has to be rebuilt instead.
+   * That can be done with {@link nsZenViewSplitter#splitTabs}
+   */
+  #adoptStagedPane(group, tabs) {
+    if (group?.tabs.length !== tabs.length) {
+      return false;
+    }
+    if (tabs.some(tab => tab.splitView && !group.tabs.includes(tab))) {
+      // The pick already holds a pane elsewhere, which is a merge, not an
+      // adoption. splitTabs is the one that knows how to do that.
+      return false;
+    }
+    const pinned = tabs.filter(tab => tab.pinned).length;
+    if (
+      (pinned && pinned !== tabs.length) ||
+      tabs.some(tab => tab.hasAttribute("zen-live-folder-item-id"))
+    ) {
+      // if we have to duplicate it defeats the purpose
+      return false;
+    }
+    const nodes = group.tabs.map(tab => this.getSplitNodeFromTab(tab));
+    if (nodes.some(node => !node)) {
+      return false;
+    }
+    const splitGroup = this._getSplitViewGroup(tabs);
+    if (!splitGroup) {
+      return false;
+    }
+    this.#withoutSplitViewTransition(() => {
+      group.tabs.forEach((oldTab, i) => {
+        const newTab = tabs[i];
+        if (oldTab === newTab) {
+          return;
+        }
+        nodes[i].tab = newTab;
+        this._tabToSplitNode.delete(oldTab);
+        this._tabToSplitNode.set(newTab, nodes[i]);
+        group.tabs[i] = newTab;
+        this.resetTabState(oldTab, false);
+      });
+      for (const tab of tabs) {
+        if (tab.group !== splitGroup) {
+          gBrowser.moveTabToExistingGroup(tab, splitGroup);
+        }
+      }
+      group.groupId = splitGroup.id;
+      this.activateSplitView(group, true);
+    });
+    this.#dispatchItemEvent("ZenSplitViewTabsSplit", splitGroup);
+    return true;
+  }
+
   createEmptySplit(side = "right") {
     const selectedTab = gBrowser.selectedTab;
     const emptyTab = gZenWorkspaces._emptyTab;
@@ -2649,18 +2709,17 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
                 cleanup(onSwitch, groupIndex);
                 return;
               }
-              this.removeTabFromGroup(emptyTab, groupIndex, {
-                forUnsplit: true,
-              });
-              gBrowser.selectedTab = selectedTab;
-              this.resetTabState(emptyTab, false);
-              this.splitTabs(
-                topOrLeft
-                  ? [newSelectedTab, selectedTab]
-                  : [selectedTab, newSelectedTab],
-                gridType,
-                topOrLeft ? 0 : 1
-              );
+              const tabs = topOrLeft
+                ? [newSelectedTab, selectedTab]
+                : [selectedTab, newSelectedTab];
+              if (!this.#adoptStagedPane(this._data[groupIndex], tabs)) {
+                this.removeTabFromGroup(emptyTab, groupIndex, {
+                  forUnsplit: true,
+                });
+                gBrowser.selectedTab = selectedTab;
+                this.resetTabState(emptyTab, false);
+                this.splitTabs(tabs, gridType, topOrLeft ? 0 : 1);
+              }
             } else {
               cleanup(onSwitch, groupIndex);
             }

--- a/src/zen/split-view/zen-split-view.css
+++ b/src/zen/split-view/zen-split-view.css
@@ -68,6 +68,22 @@
   margin-top: 0 !important;
 }
 
+/*
+ * Unfortunately the first rule here is needed, because in the case the tab already exists
+ * we don't get to set zen-split-parked before it's shown, which leads to the tab briefly
+ * covering the entire split before settling into position.
+ * */
+#tabbrowser-tabpanels[zen-split-view="true"][zen-split-staging="true"] > .browserSidebarContainer.deck-selected:not([zen-split="true"]):not(.zen-glance-overlay),
+#tabbrowser-tabpanels[zen-split-view="true"] > .browserSidebarContainer[zen-split-parked="true"] {
+  inset: var(--zen-staged-pane-inset);
+  margin: var(--zen-split-column-gap) var(--zen-split-row-gap);
+  margin-bottom: 0;
+  margin-left: 0;
+  overflow: hidden;
+  /*Make sure the real always comes above the staging tab.*/
+  z-index: 1;
+}
+
 #tabbrowser-tabpanels[zen-split-view="true"]:not(.zen-split-view-no-transition):not([zen-split-resizing]) > [zen-split="true"] {
   --zen-active-split-outline-color: light-dark(hsl(from var(--zen-primary-color) h s calc(l - 20)), var(--button-background-color-primary));
 


### PR DESCRIPTION
Closes https://github.com/zen-browser/desktop/issues/15204

Note that this solution is kind of hacky in terms of parking the newly picked tab into the staged pane before commiting. To get it working a new  `ZenURLBarAboutToClose` was introduced that's fired synchronously at `handleUrlbarClose` before any timeouts. This is done, because `updateSplitView` is invoked synchronously after `handleUrlbarClose`
I checked this under `browser/components/urlbar/content/UrlbarInput.mjs` (`UrlbarInput::pickResult`)
That means when we get a `ZenURLBarAboutToClose` with `onElementPicked = true` it's safe to assume the next invocation of `updateSplitView` is going to be for the tab the url bar picked. In that case instead of letting the tab take up the whole screen we immediately position it into the staged pane.

I think the most proper solution here would be to stamp every tab with the url bar's session id so we know exactly which tab was picked by the url bar, but I couldn't really figure out a way to do this without a pretty big patch surface on top of the firefox source, which isn't worth it in my opinion.

Here is a video of this fixed:

https://github.com/user-attachments/assets/0a623d8f-5d79-4651-80c2-ac0374ec3a64

