### PR TITLE
feat: focus existing tab instead of opening a new one for external links

### DIFF
--- a/locales/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/locales/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -64,6 +64,9 @@ zen-tabs-select-recently-used-on-close =
 zen-tabs-close-on-back-with-no-history =
     .label = Close tab and switch to its owner tab (or most recently used tab) when going back with no history
 
+zen-tabs-focus-existing-tab =
+    .label = Focus an existing tab instead of opening a new one when clicking links from external apps
+
 zen-settings-workspaces-sync =
     .label = Sync your sidebar across devices
     .description = Keep your workspaces, pinned tabs and folders in sync on all your devices through your Mozilla account.

--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -1245,6 +1245,11 @@ Preferences.addAll([
     default: true,
   },
   {
+    id: "zen.tabs.focus-existing-tab",
+    type: "bool",
+    default: false,
+  },
+  {
     id: "zen.window-sync.sync-only-pinned-tabs",
     type: "bool",
     default: false,

--- a/src/browser/components/preferences/zenTabsManagement.inc.xhtml
+++ b/src/browser/components/preferences/zenTabsManagement.inc.xhtml
@@ -42,6 +42,8 @@
             hidden="true"/>
       <checkbox data-l10n-id="zen-tabs-select-recently-used-on-close"
             preference="zen.tabs.select-recently-used-on-close"/>
+      <checkbox data-l10n-id="zen-tabs-focus-existing-tab"
+            preference="zen.tabs.focus-existing-tab"/>
 </groupbox>
 
 <hbox id="zenPinnedTabsManagerCategory"

--- a/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
+++ b/src/zen/space-routing/ZenSpaceRoutingManager.sys.mjs
@@ -71,6 +71,52 @@ class nsZenSpaceRoutingManager {
   }
 
   /**
+   * Searches for an existing tab whose URL matches the given URI string.
+   *
+   * @param {string} uriString - The URI to search for
+   * @param {Window} win - The browser window to search in
+   * @returns {Element|null} The matching tab element, or null
+   */
+  #findExistingTabForUri(uriString, win) {
+    if (!win?.gBrowser?.tabs) {
+      return null;
+    }
+
+    const normalizedUri = uriString.replace(/#.*$/, "").replace(/\/+$/, "").toLowerCase();
+
+    for (const tab of win.gBrowser.tabs) {
+      const tabUri = tab.linkedBrowser?.currentURI?.spec;
+      if (tabUri && tabUri.replace(/#.*$/, "").replace(/\/+$/, "").toLowerCase() === normalizedUri) {
+        return tab;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Focuses an existing tab and switches to its workspace if needed.
+   *
+   * @param {Element} tab - The tab to focus
+   * @param {Window} win - The browser window
+   */
+  async #focusTab(tab, win) {
+    try {
+      win.gBrowser.selectedTab = tab;
+
+      const workspaceId = tab.getAttribute("zen-workspace-id");
+      if (workspaceId && win.gZenWorkspaces) {
+        const workspace = win.gZenWorkspaces.getWorkspaceFromId(workspaceId);
+        if (workspace) {
+          await win.gZenWorkspaces.changeWorkspace(workspace);
+        }
+      }
+    } catch (err) {
+      console.error("[ZenSpaceRouting]: Error focusing existing tab:", err);
+    }
+  }
+
+  /**
    * Callback that will be executed from tabbrowser.js
    * This method can be used to stop the tab from being created.
    *
@@ -96,6 +142,20 @@ class nsZenSpaceRoutingManager {
         targetRoute,
         targetWorkspaceName,
       };
+    }
+
+    if (options.fromExternal && this.getFocusExistingTab()) {
+      const existingTab = this.#findExistingTabForUri(uriString, win);
+      if (existingTab) {
+        this.#focusTab(existingTab, win);
+        return {
+          shouldEarlyExit: true,
+          userContextId: null,
+          isRouteFound: false,
+          targetRoute: null,
+          targetWorkspaceName: null,
+        };
+      }
     }
 
     targetRoute = this.routeUri(uriString, options);
@@ -472,6 +532,20 @@ class nsZenSpaceRoutingManager {
    */
   setDefaultExternalRoute(routeType) {
     this.#file.data.defaultRouteExternal = routeType;
+  }
+
+  /**
+   * @returns {boolean} Whether to focus an existing tab instead of opening a new one
+   */
+  getFocusExistingTab() {
+    return Services.prefs.getBoolPref("zen.tabs.focus-existing-tab", false);
+  }
+
+  /**
+   * @param {boolean} value - Enable or disable focusing existing tabs
+   */
+  setFocusExistingTab(value) {
+    Services.prefs.setBoolPref("zen.tabs.focus-existing-tab", !!value);
   }
 
   /**

--- a/src/zen/tests/space_routing/browser.toml
+++ b/src/zen/tests/space_routing/browser.toml
@@ -11,6 +11,8 @@ support-files = [
 
 ["browser_space_routing_dialog.js"]
 
+["browser_space_routing_focus_existing_tab.js"]
+
 ["browser_space_routing_fuzz.js"]
 
 ["browser_space_routing_on_add_tab.js"]

--- a/src/zen/tests/space_routing/browser_space_routing_dialog.js
+++ b/src/zen/tests/space_routing/browser_space_routing_dialog.js
@@ -253,3 +253,4 @@ add_task(async function test_kill_notification_closes_dialog() {
     "A 'zen-space-routing-kill' notification closes the dialog"
   );
 });
+

--- a/src/zen/tests/space_routing/browser_space_routing_focus_existing_tab.js
+++ b/src/zen/tests/space_routing/browser_space_routing_focus_existing_tab.js
@@ -1,0 +1,192 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_setup(async function () {
+  clearAllRoutes();
+  gZenSpaceRoutingManager.setFocusExistingTab(false);
+  registerCleanupFunction(() => {
+    clearAllRoutes();
+    gZenSpaceRoutingManager.setFocusExistingTab(false);
+  });
+});
+
+add_task(async function test_focus_existing_tab_defaults_to_false() {
+  Assert.equal(
+    gZenSpaceRoutingManager.getFocusExistingTab(),
+    false,
+    "focusExistingTab defaults to false"
+  );
+});
+
+add_task(async function test_focus_existing_tab_can_be_toggled() {
+  gZenSpaceRoutingManager.setFocusExistingTab(true);
+  Assert.equal(
+    gZenSpaceRoutingManager.getFocusExistingTab(),
+    true,
+    "focusExistingTab can be set to true"
+  );
+  gZenSpaceRoutingManager.setFocusExistingTab(false);
+  Assert.equal(
+    gZenSpaceRoutingManager.getFocusExistingTab(),
+    false,
+    "focusExistingTab can be set back to false"
+  );
+});
+
+const FOCUS_WS = { uuid: "ws-focus", containerTabId: 10, name: "Focus WS" };
+
+add_task(async function test_onBeforeAddTab_focuses_existing_tab_when_enabled() {
+  clearAllRoutes();
+  gZenSpaceRoutingManager.setFocusExistingTab(true);
+
+  const existingTab = makeFakeTab("https://github.com/user/repo/pull/42", FOCUS_WS.uuid);
+  const win = makeFakeWindow({
+    ready: true,
+    workspaces: [FOCUS_WS],
+    tabs: [existingTab],
+  });
+
+  const result = gZenSpaceRoutingManager.onBeforeAddTab(
+    "https://github.com/user/repo/pull/42",
+    { fromExternal: true },
+    win
+  );
+
+  Assert.equal(result.shouldEarlyExit, true, "Should early exit when existing tab found");
+  Assert.equal(win.gBrowser.selectedTab, existingTab, "The existing tab is selected");
+  await TestUtils.waitForCondition(
+    () => win.gZenWorkspaces.changeCalls.length === 1,
+    "changeWorkspace was called"
+  );
+  Assert.equal(
+    win.gZenWorkspaces.changeCalls[0].uuid,
+    FOCUS_WS.uuid,
+    "Switched to the existing tab's workspace"
+  );
+});
+
+add_task(async function test_onBeforeAddTab_skips_focus_when_disabled() {
+  clearAllRoutes();
+  gZenSpaceRoutingManager.setFocusExistingTab(false);
+
+  const existingTab = makeFakeTab("https://github.com/user/repo/pull/42", FOCUS_WS.uuid);
+  const win = makeFakeWindow({
+    ready: true,
+    workspaces: [FOCUS_WS],
+    tabs: [existingTab],
+  });
+
+  const result = gZenSpaceRoutingManager.onBeforeAddTab(
+    "https://github.com/user/repo/pull/42",
+    { fromExternal: true },
+    win
+  );
+
+  Assert.equal(result.shouldEarlyExit, false, "Should not early exit when setting is off");
+  Assert.equal(win.gBrowser.selectedTab, null, "No tab was selected");
+});
+
+add_task(async function test_onBeforeAddTab_skips_focus_for_internal_links() {
+  clearAllRoutes();
+  gZenSpaceRoutingManager.setFocusExistingTab(true);
+
+  const existingTab = makeFakeTab("https://github.com/user/repo/pull/42", FOCUS_WS.uuid);
+  const win = makeFakeWindow({
+    ready: true,
+    workspaces: [FOCUS_WS],
+    tabs: [existingTab],
+  });
+
+  const result = gZenSpaceRoutingManager.onBeforeAddTab(
+    "https://github.com/user/repo/pull/42",
+    { fromExternal: false },
+    win
+  );
+
+  Assert.equal(result.shouldEarlyExit, false, "Internal links bypass focus-existing-tab");
+});
+
+add_task(async function test_onBeforeAddTab_no_match_proceeds_normally() {
+  clearAllRoutes();
+  gZenSpaceRoutingManager.setFocusExistingTab(true);
+
+  const existingTab = makeFakeTab("https://github.com/user/repo/pull/42", FOCUS_WS.uuid);
+  const win = makeFakeWindow({
+    ready: true,
+    workspaces: [FOCUS_WS],
+    tabs: [existingTab],
+  });
+
+  const result = gZenSpaceRoutingManager.onBeforeAddTab(
+    "https://github.com/user/repo/pull/99",
+    { fromExternal: true },
+    win
+  );
+
+  Assert.equal(result.shouldEarlyExit, false, "No match means normal tab creation");
+});
+
+add_task(async function test_onBeforeAddTab_matches_with_trailing_slash() {
+  clearAllRoutes();
+  gZenSpaceRoutingManager.setFocusExistingTab(true);
+
+  const existingTab = makeFakeTab("https://github.com/", FOCUS_WS.uuid);
+  const win = makeFakeWindow({
+    ready: true,
+    workspaces: [FOCUS_WS],
+    tabs: [existingTab],
+  });
+
+  const result = gZenSpaceRoutingManager.onBeforeAddTab(
+    "https://github.com",
+    { fromExternal: true },
+    win
+  );
+
+  Assert.equal(result.shouldEarlyExit, true, "Trailing slash difference still matches");
+  Assert.equal(win.gBrowser.selectedTab, existingTab, "The existing tab is selected");
+});
+
+add_task(async function test_onBeforeAddTab_matches_case_insensitive() {
+  clearAllRoutes();
+  gZenSpaceRoutingManager.setFocusExistingTab(true);
+
+  const existingTab = makeFakeTab("https://github.com/user/repo", FOCUS_WS.uuid);
+  const win = makeFakeWindow({
+    ready: true,
+    workspaces: [FOCUS_WS],
+    tabs: [existingTab],
+  });
+
+  const result = gZenSpaceRoutingManager.onBeforeAddTab(
+    "https://GitHub.com/User/Repo",
+    { fromExternal: true },
+    win
+  );
+
+  Assert.equal(result.shouldEarlyExit, true, "Case difference still matches");
+  Assert.equal(win.gBrowser.selectedTab, existingTab, "The existing tab is selected");
+});
+
+add_task(async function test_onBeforeAddTab_matches_ignoring_fragment() {
+  clearAllRoutes();
+  gZenSpaceRoutingManager.setFocusExistingTab(true);
+
+  const existingTab = makeFakeTab("https://github.com/user/repo", FOCUS_WS.uuid);
+  const win = makeFakeWindow({
+    ready: true,
+    workspaces: [FOCUS_WS],
+    tabs: [existingTab],
+  });
+
+  const result = gZenSpaceRoutingManager.onBeforeAddTab(
+    "https://github.com/user/repo#section",
+    { fromExternal: true },
+    win
+  );
+
+  Assert.equal(result.shouldEarlyExit, true, "Fragment difference still matches");
+  Assert.equal(win.gBrowser.selectedTab, existingTab, "The existing tab is selected");
+});

--- a/src/zen/tests/space_routing/browser_space_routing_on_add_tab.js
+++ b/src/zen/tests/space_routing/browser_space_routing_on_add_tab.js
@@ -3,7 +3,7 @@
 
 "use strict";
 
-const TARGET_WS = { uuid: "ws-target", containerTabId: 7 };
+const TARGET_WS = { uuid: "ws-target", containerTabId: 7, name: "Target" };
 
 add_setup(async function () {
   clearAllRoutes();
@@ -32,6 +32,7 @@ add_task(async function test_onBeforeAddTab_resolves_container_for_match() {
       userContextId: TARGET_WS.containerTabId,
       isRouteFound: true,
       targetRoute: TARGET_WS.uuid,
+      targetWorkspaceName: TARGET_WS.name,
     },
     "A matching route resolves to the workspace's containerTabId"
   );
@@ -54,6 +55,7 @@ add_task(async function test_onBeforeAddTab_no_match_returns_no_route() {
       userContextId: null,
       isRouteFound: false,
       targetRoute: "most-recent-space",
+      targetWorkspaceName: null,
     },
     "An unmatched URL (most-recent-space) reports no container and no route"
   );
@@ -81,6 +83,7 @@ add_task(async function test_onBeforeAddTab_route_to_missing_workspace() {
       userContextId: null,
       isRouteFound: false,
       targetRoute: "ws-does-not-exist",
+      targetWorkspaceName: null,
     },
     "A route to a non-existent workspace yields no container and no route"
   );
@@ -108,6 +111,7 @@ add_task(async function test_onBeforeAddTab_skips_special_tab_options() {
         userContextId: null,
         isRouteFound: false,
         targetRoute: null,
+        targetWorkspaceName: null,
       },
       `Option '${skipOption}' skips routing even though a rule matches`
     );
@@ -136,6 +140,7 @@ add_task(async function test_onBeforeAddTab_skips_until_startup_ready() {
       userContextId: null,
       isRouteFound: false,
       targetRoute: null,
+      targetWorkspaceName: null,
     },
     "While gZenStartup.isReady is false (session restore), routing is skipped"
   );

--- a/src/zen/tests/space_routing/head.js
+++ b/src/zen/tests/space_routing/head.js
@@ -33,9 +33,20 @@ function makeFakeWindow({
   ready = true,
   workspaces = [],
   workspaceEnabled = true,
+  tabs = [],
 } = {}) {
   return {
     gZenStartup: { isReady: ready },
+    gBrowser: {
+      tabs,
+      _selectedTab: null,
+      get selectedTab() {
+        return this._selectedTab;
+      },
+      set selectedTab(tab) {
+        this._selectedTab = tab;
+      },
+    },
     gZenWorkspaces: {
       workspaceEnabled,
       moveCalls: [],
@@ -51,6 +62,20 @@ function makeFakeWindow({
         this.changeCalls.push(workspace);
         return Promise.resolve();
       },
+    },
+  };
+}
+
+function makeFakeTab(url, workspaceId = null) {
+  return {
+    linkedBrowser: {
+      currentURI: Services.io.newURI(url),
+    },
+    getAttribute(name) {
+      if (name === "zen-workspace-id") {
+        return workspaceId;
+      }
+      return null;
     },
   };
 }


### PR DESCRIPTION
When clicking a link from an external app, if a tab with that URL is already open, focus it and switch to its workspace instead of opening a new tab.

The setting is opt-in (default off) and lives under Settings > Tab Management, backed by the `zen.tabs.focus-existing-tab` pref. only applies to external links (`fromExternal`), not in-browser navigation. Includes trailing slash normalization so `github.com` and `github.com/` match the same tab.

I'm also thinking of doing a similar setting for the "New Tab" dialog ("Switch to tab" instead of opening a new tab).

(for transparency, this code was AI assisted. let me know if it needs fixing!)