### PR TITLE
Add pinned tabs to URL bar results, loaded or unloaded

### DIFF
--- a/src/browser/components/urlbar/UrlbarMuxerStandard-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarMuxerStandard-sys-mjs.patch
@@ -1,8 +1,16 @@
 diff --git a/browser/components/urlbar/UrlbarMuxerStandard.sys.mjs b/browser/components/urlbar/UrlbarMuxerStandard.sys.mjs
-index 65bd41b2ea14c26d490632d4a5348d6cf33ee9dd..80fbd685156949b6c7e93ed9d0ef56350dd1a0fe 100644
+index 82c9d771ed1fb5c98a4a594db5f1badbafa284ba..b03be688dc4153b1b2eb05a0f7ada50f811e9e3c 100644
 --- a/browser/components/urlbar/UrlbarMuxerStandard.sys.mjs
 +++ b/browser/components/urlbar/UrlbarMuxerStandard.sys.mjs
-@@ -925,11 +925,16 @@ class MuxerUnifiedComplete extends UrlbarMuxer {
+@@ -119,6 +119,7 @@ class MuxerUnifiedComplete extends UrlbarMuxer {
+       urlToTabResultType: new Map(),
+       addedRemoteTabUrls: new Set(),
+       addedSwitchTabUrls: new Set(),
++      zenPinnedTabUrls: new Set(),
+       addedResultUrls: new Set(),
+       canShowPrivateSearch: unsortedResults.length > 1,
+       canShowTailSuggestions: true,
+@@ -919,11 +920,16 @@ class MuxerUnifiedComplete extends UrlbarMuxer {
        result.providerName == "UrlbarProviderHeuristicFallback" &&
        state.context.heuristicResult?.providerName !=
          "UrlbarProviderHeuristicFallback"
@@ -19,11 +27,49 @@ index 65bd41b2ea14c26d490632d4a5348d6cf33ee9dd..80fbd685156949b6c7e93ed9d0ef5635
        // Discard the result if a tab-to-search result was added already.
        if (!state.canAddTabToSearch) {
          return false;
-@@ -1593,7 +1598,9 @@ class MuxerUnifiedComplete extends UrlbarMuxer {
+@@ -1022,6 +1028,20 @@ class MuxerUnifiedComplete extends UrlbarMuxer {
+       }
+     }
+ 
++    // Zen: discard switch-to-tab and history rows that point at the same page
++    // as a pinned tab result, so a loaded pin is not listed twice.
++    if (
++      state.zenPinnedTabUrls.size &&
++      !result.heuristic &&
++      result.providerName != "ZenUrlbarProviderPinnedTabs" &&
++      (result.type == lazy.UrlbarShared.RESULT_TYPE.TAB_SWITCH ||
++        result.type == lazy.UrlbarShared.RESULT_TYPE.URL) &&
++      result.payload.url &&
++      state.zenPinnedTabUrls.has(stripUrlForDedupe(result.payload.url))
++    ) {
++      return false;
++    }
++
+     // Discard switch-to-tab results that dupes another switch-to-tab result.
+     if (
+       result.type == lazy.UrlbarShared.RESULT_TYPE.TAB_SWITCH &&
+@@ -1205,6 +1225,16 @@ class MuxerUnifiedComplete extends UrlbarMuxer {
+       return;
+     }
+ 
++    // Zen: remember the pages pinned tab results point at, used by
++    // _canAddResult to drop native rows for the same page.
++    if (result.providerName == "ZenUrlbarProviderPinnedTabs") {
++      for (let url of [result.payload.pinnedUrl, result.payload.tabUrl]) {
++        if (url) {
++          state.zenPinnedTabUrls.add(stripUrlForDedupe(url));
++        }
++      }
++    }
++
+     // Keep track of the largest heuristic result span.
+     if (result.heuristic && this._canAddResult(result, state)) {
+       state.maxHeuristicResultSpan = Math.max(
+@@ -1582,7 +1612,9 @@ class MuxerUnifiedComplete extends UrlbarMuxer {
        usedLimits.maxResultCount++;
      }
  
-+    if (!(result.heuristic && result.source == lazy.UrlbarShared.RESULT_SOURCE.ZEN_ACTIONS)) {
++    if (!(result.heuristic && (result.source == lazy.UrlbarShared.RESULT_SOURCE.ZEN_ACTIONS || result.source == lazy.UrlbarShared.RESULT_SOURCE.ZEN_PINNED_TABS))) {
      state.usedResultSpan += span;
 +    }
      this._updateStatePostAdd(result, state);

--- a/src/browser/components/urlbar/UrlbarPrefs-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarPrefs-sys-mjs.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/urlbar/UrlbarPrefs.sys.mjs b/browser/components/urlbar/UrlbarPrefs.sys.mjs
-index e48f0295d803ba9eac5ab9d01ebb3b3dacbc9d4b..cb78b74230f63a47479404767b5ab5883278dfba 100644
+index e48f0295d803ba9eac5ab9d01ebb3b3dacbc9d4b..e0f19b7e892bf86e733a4ea4aadcd91b7cb4c5ae 100644
 --- a/browser/components/urlbar/UrlbarPrefs.sys.mjs
 +++ b/browser/components/urlbar/UrlbarPrefs.sys.mjs
 @@ -161,6 +161,9 @@ const PREF_URLBAR_DEFAULTS = /** @type {PreferenceDefinition[]} */ ([
@@ -20,10 +20,11 @@ index e48f0295d803ba9eac5ab9d01ebb3b3dacbc9d4b..cb78b74230f63a47479404767b5ab588
  
    // Boolean to determine if the providers defined in `exposureResults`
    // should be displayed in search results. This can be set by a
-@@ -854,6 +858,8 @@ function makeDefaultResultGroups({
+@@ -854,6 +858,9 @@ function makeDefaultResultGroups({
     */
    let rootGroup = {
      children: [
++      { children: [{ group: lazy.UrlbarShared.RESULT_GROUP.ZEN_PINNED_TAB }] },
 +      { children: [{ group: lazy.UrlbarShared.RESULT_GROUP.ZEN_ACTION }] },
 +      { children: [{ group: lazy.UrlbarShared.RESULT_GROUP.ZEN_WORKSPACE }] },
        // heuristic

--- a/src/browser/components/urlbar/UrlbarProvidersManager-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarProvidersManager-sys-mjs.patch
@@ -1,8 +1,8 @@
 diff --git a/browser/components/urlbar/UrlbarProvidersManager.sys.mjs b/browser/components/urlbar/UrlbarProvidersManager.sys.mjs
-index 67f51c7996c24549f39594c9a518bc5316350ce7..d66969f2411bb687c15448ad828b64ddf43c3389 100644
+index f6f5e4d74296afc22e5ae651bbefeb9b0b963511..2b01feaea5558cba50c5a59944a751694a3788e2 100644
 --- a/browser/components/urlbar/UrlbarProvidersManager.sys.mjs
 +++ b/browser/components/urlbar/UrlbarProvidersManager.sys.mjs
-@@ -914,6 +914,7 @@ export class Query {
+@@ -931,6 +931,7 @@ export class Query {
      if (
        result.heuristic &&
        this.context.searchMode &&
@@ -10,7 +10,7 @@ index 67f51c7996c24549f39594c9a518bc5316350ce7..d66969f2411bb687c15448ad828b64dd
        (!this.context.trimmedSearchString ||
          (!this.context.searchMode.engineName && !result.autofill))
      ) {
-@@ -1060,6 +1061,7 @@ function updateSourcesIfEmpty(context) {
+@@ -1082,6 +1083,7 @@ function updateSourcesIfEmpty(context) {
              lazy.UrlbarShared.TOKEN_TYPE.RESTRICT_TITLE,
              lazy.UrlbarShared.TOKEN_TYPE.RESTRICT_URL,
              lazy.UrlbarShared.TOKEN_TYPE.RESTRICT_ACTION,
@@ -18,10 +18,18 @@ index 67f51c7996c24549f39594c9a518bc5316350ce7..d66969f2411bb687c15448ad828b64dd
            ].includes(t.type)
          );
  
-@@ -1119,6 +1121,14 @@ function updateSourcesIfEmpty(context) {
+@@ -1141,6 +1143,22 @@ function updateSourcesIfEmpty(context) {
            acceptedSources.push(source);
          }
          break;
++      case lazy.UrlbarShared.RESULT_SOURCE.ZEN_PINNED_TABS:
++        if (
++          restrictTokenType === lazy.UrlbarShared.TOKEN_TYPE.RESTRICT_OPENPAGE ||
++          !restrictTokenType
++        ) {
++          acceptedSources.push(source);
++        }
++        break;
 +      case lazy.UrlbarShared.RESULT_SOURCE.WORKSPACES:
 +        if (
 +          restrictTokenType === lazy.UrlbarShared.TOKEN_TYPE.RESTRICT_WORKSPACE ||

--- a/src/browser/components/urlbar/UrlbarUtils-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarUtils-sys-mjs.patch
@@ -1,8 +1,8 @@
 diff --git a/browser/components/urlbar/UrlbarUtils.sys.mjs b/browser/components/urlbar/UrlbarUtils.sys.mjs
-index 178cd5e84fda74a28b2de59b671b3399cc28fac4..b03c6e06de4ee9a95dcb4d33d7ac9f0b053be4e1 100644
+index 178cd5e84fda74a28b2de59b671b3399cc28fac4..8a02b9b0781b848e306e9aae3330405c0052fad1 100644
 --- a/browser/components/urlbar/UrlbarUtils.sys.mjs
 +++ b/browser/components/urlbar/UrlbarUtils.sys.mjs
-@@ -214,6 +214,11 @@ export var UrlbarUtils = {
+@@ -214,6 +214,13 @@ export var UrlbarUtils = {
            return UrlbarShared.RESULT_GROUP.HEURISTIC_FALLBACK;
          case "UrlbarProviderHistoryUrlHeuristic":
            return UrlbarShared.RESULT_GROUP.HEURISTIC_HISTORY_URL;
@@ -11,6 +11,8 @@ index 178cd5e84fda74a28b2de59b671b3399cc28fac4..b03c6e06de4ee9a95dcb4d33d7ac9f0b
 +            return UrlbarShared.RESULT_GROUP.ZEN_WORKSPACE;
 +          }
 +          return UrlbarShared.RESULT_GROUP.ZEN_ACTION;
++        case "ZenUrlbarProviderPinnedTabs":
++          return UrlbarShared.RESULT_GROUP.ZEN_PINNED_TAB;
          case "UrlbarProviderOmnibox":
            return UrlbarShared.RESULT_GROUP.HEURISTIC_OMNIBOX;
          case "UrlbarProviderRestrictKeywordsAutofill":

--- a/src/browser/components/urlbar/content/UrlbarShared-mjs.patch
+++ b/src/browser/components/urlbar/content/UrlbarShared-mjs.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/urlbar/content/UrlbarShared.mjs b/browser/components/urlbar/content/UrlbarShared.mjs
-index 4e67dad66ae006842abc6eed547e4a244320d57a..393b61b4d2543c73e60afd334a353f36119ae73e 100644
+index 4e67dad66ae006842abc6eed547e4a244320d57a..a7d26259a481b206176de0d51e989ecd5eecaeab 100644
 --- a/browser/components/urlbar/content/UrlbarShared.mjs
 +++ b/browser/components/urlbar/content/UrlbarShared.mjs
 @@ -100,6 +100,7 @@ export const UrlbarShared = {
@@ -18,25 +18,27 @@ index 4e67dad66ae006842abc6eed547e4a244320d57a..393b61b4d2543c73e60afd334a353f36
    }),
  
    // Defines UrlbarResult types.
-@@ -165,6 +167,8 @@ export const UrlbarShared = {
+@@ -165,6 +167,9 @@ export const UrlbarShared = {
      OTHER_NETWORK: 6,
      ADDON: 7,
      ACTIONS: 8,
 +    ZEN_ACTIONS: 9,
 +    WORKSPACES: 10,
++    ZEN_PINNED_TABS: 11,
    }),
  
    // Results are categorized into groups to help the muxer compose them.  See
-@@ -200,6 +204,8 @@ export const UrlbarShared = {
+@@ -200,6 +205,9 @@ export const UrlbarShared = {
      SEMANTIC_HISTORY: "semanticHistory",
      SUGGESTED_INDEX: "suggestedIndex",
      TAIL_SUGGESTION: "tailSuggestion",
 +    ZEN_ACTION: "zenAction",
 +    ZEN_WORKSPACE: "zenWorkspace",
++    ZEN_PINNED_TAB: "zenPinnedTab",
    }),
  
    // Defines provider types.
-@@ -385,6 +391,14 @@ export const UrlbarShared = {
+@@ -385,6 +393,14 @@ export const UrlbarShared = {
          telemetryLabel: "actions",
          uiLabel: "urlbar-searchmode-actions3",
        },
@@ -51,7 +53,7 @@ index 4e67dad66ae006842abc6eed547e4a244320d57a..393b61b4d2543c73e60afd334a353f36
      ]);
    },
  
-@@ -402,6 +416,7 @@ export const UrlbarShared = {
+@@ -402,6 +418,7 @@ export const UrlbarShared = {
      if (UrlbarPrefs.get("scotchBonnet.enableOverride")) {
        keys.push(this.RESTRICT_TOKENS.ACTION);
      }

--- a/src/zen/tests/ub-actions/browser.toml
+++ b/src/zen/tests/ub-actions/browser.toml
@@ -4,5 +4,7 @@
 
 [DEFAULT]
 
+["browser_pinned_tabs_search.js"]
+
 ["browser_ub_actions_search.js"]
 ["browser_workspace_restrict_search.js"]

--- a/src/zen/tests/ub-actions/browser_pinned_tabs_search.js
+++ b/src/zen/tests/ub-actions/browser_pinned_tabs_search.js
@@ -1,0 +1,125 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+ChromeUtils.defineESModuleGetters(this, {
+  UrlbarTestUtils: "resource://testing-common/UrlbarTestUtils.sys.mjs",
+});
+
+const PROVIDER_NAME = "ZenUrlbarProviderPinnedTabs";
+
+async function searchAndGetFirstRow(value) {
+  await UrlbarTestUtils.promiseAutocompleteResultPopup({
+    window,
+    waitForFocus,
+    value,
+  });
+  const { result } = await UrlbarTestUtils.getRowAt(window, 0);
+  return result;
+}
+
+async function pickFirstRow() {
+  await UrlbarTestUtils.promisePopupClose(window, () => {
+    EventUtils.synthesizeKey("KEY_Enter");
+  });
+}
+
+add_task(async function test_pinned_tab_found_by_custom_label() {
+  await BrowserTestUtils.withNewTab(
+    { gBrowser, url: "https://example.com/pinned" },
+    async browser => {
+      const tab = gBrowser.getTabForBrowser(browser);
+      gBrowser.pinTab(tab);
+      tab.zenStaticLabel = "Pinned Example";
+      await gBrowser.TabStateFlusher.flush(browser);
+
+      const otherTab = await BrowserTestUtils.openNewForegroundTab(
+        gBrowser,
+        "about:blank"
+      );
+      const tabCount = gBrowser.tabs.length;
+
+      const result = await searchAndGetFirstRow("pinned ex");
+      Assert.equal(result.providerName, PROVIDER_NAME);
+      Assert.equal(result.payload.title, "Pinned Example");
+      Assert.ok(result.heuristic, "The best pin match is the heuristic row");
+
+      await pickFirstRow();
+      Assert.equal(
+        gBrowser.selectedTab,
+        tab,
+        "Enter switched to the pinned tab"
+      );
+      Assert.equal(gBrowser.tabs.length, tabCount, "No new tab was opened");
+
+      BrowserTestUtils.removeTab(otherTab);
+      gBrowser.unpinTab(tab);
+    }
+  );
+});
+
+add_task(async function test_unloaded_pinned_tab_found_by_host() {
+  await BrowserTestUtils.withNewTab(
+    { gBrowser, url: "https://example.com/unloaded" },
+    async browser => {
+      const tab = gBrowser.getTabForBrowser(browser);
+      gBrowser.pinTab(tab);
+      await gBrowser.TabStateFlusher.flush(browser);
+
+      const otherTab = await BrowserTestUtils.openNewForegroundTab(
+        gBrowser,
+        "about:blank"
+      );
+      gBrowser.discardBrowser(tab, true);
+      Assert.ok(tab.hasAttribute("pending"), "The pinned tab is unloaded");
+      const tabCount = gBrowser.tabs.length;
+
+      const result = await searchAndGetFirstRow("example.co");
+      Assert.notEqual(
+        result.providerName,
+        PROVIDER_NAME,
+        "URL-like input keeps Firefox's heuristic first"
+      );
+      const { result: second } = await UrlbarTestUtils.getRowAt(window, 1);
+      Assert.equal(second.providerName, PROVIDER_NAME);
+      Assert.ok(second.payload.isPending, "The row knows the pin is unloaded");
+      Assert.equal(second.payload.host, "example.com");
+
+      await UrlbarTestUtils.promisePopupClose(window, () => {
+        EventUtils.synthesizeKey("KEY_ArrowDown");
+        EventUtils.synthesizeKey("KEY_Enter");
+      });
+      Assert.equal(gBrowser.selectedTab, tab, "Enter switched to the pin");
+      await BrowserTestUtils.waitForCondition(
+        () => !tab.hasAttribute("pending"),
+        "The pinned tab was restored"
+      );
+      Assert.equal(gBrowser.tabs.length, tabCount, "No new tab was opened");
+
+      BrowserTestUtils.removeTab(otherTab);
+      gBrowser.unpinTab(tab);
+    }
+  );
+});
+
+add_task(async function test_disabled_by_pref() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["zen.urlbar.suggestions.pinned-tabs", false]],
+  });
+  await BrowserTestUtils.withNewTab(
+    { gBrowser, url: "https://example.com/disabled" },
+    async browser => {
+      const tab = gBrowser.getTabForBrowser(browser);
+      gBrowser.pinTab(tab);
+      tab.zenStaticLabel = "Disabled Pin";
+      await gBrowser.TabStateFlusher.flush(browser);
+
+      const result = await searchAndGetFirstRow("disabled pi");
+      Assert.notEqual(result.providerName, PROVIDER_NAME);
+      await UrlbarTestUtils.promisePopupClose(window, () => gURLBar.blur());
+      gBrowser.unpinTab(tab);
+    }
+  );
+  await SpecialPowers.popPrefEnv();
+});

--- a/src/zen/urlbar/ZenUBPinnedTabsProvider.sys.mjs
+++ b/src/zen/urlbar/ZenUBPinnedTabsProvider.sys.mjs
@@ -1,0 +1,584 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { XPCOMUtils } from "resource://gre/modules/XPCOMUtils.sys.mjs";
+import { UrlbarProvider } from "moz-src:///browser/components/urlbar/UrlbarUtils.sys.mjs";
+import { UrlbarShared } from "chrome://browser/content/urlbar/UrlbarShared.mjs";
+
+const lazy = {};
+
+const DYNAMIC_TYPE_NAME = "zen-pinned-tab";
+
+// Most pinned tab rows shown for a single query.
+const MAX_PINNED_RESULTS = 5;
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  UrlbarResult: "chrome://browser/content/urlbar/UrlbarResult.mjs",
+  BrowserWindowTracker: "resource:///modules/BrowserWindowTracker.sys.mjs",
+});
+
+ChromeUtils.defineLazyGetter(lazy, "l10n", () => {
+  return new Localization(["browser/browser.ftl"], true);
+});
+
+XPCOMUtils.defineLazyPreferenceGetter(
+  lazy,
+  "enabledPref",
+  "zen.urlbar.suggestions.pinned-tabs",
+  true
+);
+
+XPCOMUtils.defineLazyPreferenceGetter(
+  lazy,
+  "allSpacesPref",
+  "zen.urlbar.suggestions.pinned-tabs.all-spaces",
+  false
+);
+
+/**
+ * Whether the typed text should be treated as a URL, in which case the
+ * heuristic row must stay Firefox's own and pinned tabs go below it.
+ *
+ * @param {string} text The trimmed search string.
+ * @returns {boolean}
+ */
+function looksLikeUrl(text) {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(text)) {
+    return true;
+  }
+  return !/\s/.test(text) && text.includes(".");
+}
+
+function hostOf(url) {
+  try {
+    let host = new URL(url).hostname;
+    if (host.startsWith("www.")) {
+      host = host.slice(4);
+    }
+    return host;
+  } catch (e) {
+    return "";
+  }
+}
+
+/**
+ * Returns the labels of the folders containing a tab, outermost first.
+ *
+ * @param {MozTabbrowserTab} tab The tab.
+ * @returns {string[]}
+ */
+function folderPath(tab) {
+  const names = [];
+  let element = tab.parentElement;
+  while (element) {
+    const folder = element.closest("zen-folder");
+    if (!folder) {
+      break;
+    }
+    const label = (folder.label || folder.getAttribute("label") || "").trim();
+    if (label) {
+      names.unshift(label);
+    }
+    element = folder.parentElement;
+  }
+  return names;
+}
+
+function tabIcon(tab, url) {
+  const image =
+    tab.getAttribute("image") ||
+    tab.zenStaticIcon ||
+    tab._zenPinnedInitialState?.image ||
+    "";
+  if (image) {
+    return image;
+  }
+  if (url && /^https?:/i.test(url)) {
+    return "page-icon:" + url;
+  }
+  return "chrome://browser/skin/zen-icons/pin.svg";
+}
+
+function wordStartsWith(text, needle) {
+  if (text.startsWith(needle)) {
+    return true;
+  }
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp("[\\s\\-_./:]" + escaped).test(text);
+}
+
+function isSubsequence(text, needle) {
+  let i = 0;
+  for (const ch of text) {
+    if (ch === needle[i]) {
+      i++;
+      if (i === needle.length) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Scores a candidate against the query. Higher is better, 0 is no match.
+ * Label matches rank above host matches, which rank above URL matches.
+ *
+ * @param {object} candidate A candidate built by #describeTab.
+ * @param {string} query The lower case query.
+ * @param {string[]} tokens The lower case query tokens.
+ * @returns {number}
+ */
+function scoreCandidate(candidate, query, tokens) {
+  const { labelLower, hostLower, urlLower, pinnedUrlLower } = candidate;
+  if (labelLower === query) {
+    return 1000;
+  }
+  if (labelLower.startsWith(query)) {
+    return 900;
+  }
+  if (wordStartsWith(labelLower, query)) {
+    return 850;
+  }
+  if (labelLower.includes(query)) {
+    return 800;
+  }
+  if (hostLower && hostLower.startsWith(query)) {
+    return 700;
+  }
+  if (hostLower && hostLower.includes(query)) {
+    return 600;
+  }
+  if (urlLower.includes(query) || pinnedUrlLower.includes(query)) {
+    return 500;
+  }
+  if (tokens.length > 1) {
+    const haystack = `${labelLower} ${hostLower} ${urlLower}`;
+    if (tokens.every(token => haystack.includes(token))) {
+      return 400;
+    }
+  }
+  if (query.length >= 2 && isSubsequence(labelLower, query)) {
+    return 300;
+  }
+  return 0;
+}
+
+function highlightsFor(tokens, text) {
+  if (!text || !tokens.length) {
+    return [];
+  }
+  return UrlbarShared.getTokenMatches(
+    tokens,
+    text,
+    UrlbarShared.HIGHLIGHT.TYPED
+  );
+}
+
+/**
+ * A provider that offers pinned tabs and Essentials of the current space as
+ * switch-to-tab results, whether or not the tab is loaded. Firefox's own
+ * switch-to-tab results only cover browsers registered in the open pages
+ * table, which unloaded pins are not.
+ *
+ * Results are DYNAMIC rather than TAB_SWITCH on purpose: picking a TAB_SWITCH
+ * result calls `switchToTabHavingURI(uri, true)`, which opens a new tab when no
+ * browser's current URI matches, and that is exactly the state of a pin that
+ * is being restored from session store. Selecting the tab ourselves in
+ * `onEngagement` is the same path a click in the sidebar takes.
+ */
+export class ZenUrlbarProviderPinnedTabs extends UrlbarProvider {
+  #tabsByKey = new Map();
+  #keyCounter = 0;
+
+  get name() {
+    return "ZenUrlbarProviderPinnedTabs";
+  }
+
+  /**
+   * @returns {Values<typeof UrlbarShared.PROVIDER_TYPE>}
+   */
+  get type() {
+    // Heuristic so the rows arrive with the first batch of results and the
+    // list does not reorder once the pins show up. The query is synchronous
+    // and only walks the pinned tabs of the window.
+    return UrlbarShared.PROVIDER_TYPE.HEURISTIC;
+  }
+
+  /**
+   * Whether this provider should be invoked for the given context.
+   *
+   * @param {UrlbarQueryContext} queryContext The query context object
+   */
+  async isActive(queryContext) {
+    if (!lazy.enabledPref || queryContext.isPrivate) {
+      return false;
+    }
+    const window = lazy.BrowserWindowTracker.getTopWindow();
+    if (
+      !window?.gZenWorkspaces ||
+      window.gZenWorkspaces.privateWindowOrDisabled
+    ) {
+      return false;
+    }
+    const mode = queryContext.searchMode;
+    if (
+      mode &&
+      (mode.engineName || mode.source != UrlbarShared.RESULT_SOURCE.TABS)
+    ) {
+      return false;
+    }
+    if (this.#hasForeignRestrictToken(queryContext)) {
+      return false;
+    }
+    const query = this.#queryText(queryContext);
+    return !!query && query.length < UrlbarShared.MAX_TEXT_LENGTH;
+  }
+
+  #hasForeignRestrictToken(queryContext) {
+    const T = UrlbarShared.TOKEN_TYPE;
+    return (queryContext.tokens || []).some(
+      t =>
+        t.type === T.RESTRICT_HISTORY ||
+        t.type === T.RESTRICT_BOOKMARK ||
+        t.type === T.RESTRICT_TAG ||
+        t.type === T.RESTRICT_SEARCH ||
+        t.type === T.RESTRICT_ACTION ||
+        t.type === T.RESTRICT_WORKSPACE
+    );
+  }
+
+  #textTokens(queryContext) {
+    const T = UrlbarShared.TOKEN_TYPE;
+    const restrict = new Set([
+      T.RESTRICT_HISTORY,
+      T.RESTRICT_BOOKMARK,
+      T.RESTRICT_TAG,
+      T.RESTRICT_OPENPAGE,
+      T.RESTRICT_SEARCH,
+      T.RESTRICT_TITLE,
+      T.RESTRICT_URL,
+      T.RESTRICT_ACTION,
+      T.RESTRICT_WORKSPACE,
+    ]);
+    return (queryContext.tokens || []).filter(
+      t => !restrict.has(t.type) && t.lowerCaseValue
+    );
+  }
+
+  #queryText(queryContext) {
+    const tokens = this.#textTokens(queryContext);
+    if (tokens.length) {
+      return tokens.map(t => t.lowerCaseValue).join(" ");
+    }
+    return queryContext.trimmedLowerCaseSearchString || "";
+  }
+
+  #describeTab(tab, window, index) {
+    const pinnedUrl = tab._zenPinnedInitialState?.entry?.url || "";
+    let tabUrl = "";
+    try {
+      // For a lazy browser this getter returns the session entry, which is
+      // the URL the tab restores to, not about:blank.
+      tabUrl = tab.linkedBrowser?.currentURI?.spec || "";
+    } catch (e) {
+      tabUrl = "";
+    }
+    if (!tabUrl || tabUrl == "about:blank") {
+      tabUrl = pinnedUrl;
+    }
+    const url = tabUrl || pinnedUrl;
+    const host = hostOf(url);
+    const label = (
+      tab.zenStaticLabel ||
+      tab.label ||
+      tab._zenPinnedInitialState?.entry?.title ||
+      host ||
+      url
+    ).trim();
+    const isEssential = tab.hasAttribute("zen-essential");
+    const workspaceId = tab.getAttribute("zen-workspace-id") || "";
+    let spaceName = "";
+    if (!isEssential && workspaceId) {
+      spaceName =
+        window.gZenWorkspaces.getWorkspaceFromId(workspaceId)?.name || "";
+    }
+    return {
+      tab,
+      index,
+      label,
+      labelLower: label.toLowerCase(),
+      url,
+      urlLower: url.toLowerCase(),
+      pinnedUrl,
+      pinnedUrlLower: pinnedUrl.toLowerCase(),
+      host,
+      folders: folderPath(tab),
+      spaceName,
+      isEssential,
+      isPending: tab.hasAttribute("pending"),
+      icon: tabIcon(tab, url),
+    };
+  }
+
+  /**
+   * Collects pinned tabs and Essentials visible in the active space, in
+   * sidebar order, pins first.
+   *
+   * @param {Window} window The browser window.
+   * @returns {object[]}
+   */
+  #collectCandidates(window) {
+    const gZenWorkspaces = window.gZenWorkspaces;
+    const workspaces = gZenWorkspaces.getWorkspaces();
+    const active = gZenWorkspaces.getActiveWorkspaceFromCache();
+    const pins = [];
+    const essentials = [];
+    let index = 0;
+    for (const tab of gZenWorkspaces.allStoredTabs) {
+      if (
+        !tab.pinned ||
+        tab.closing ||
+        !tab.isConnected ||
+        tab.hasAttribute("zen-empty-tab") ||
+        tab.hasAttribute("zen-glance-tab")
+      ) {
+        continue;
+      }
+      const isEssential = tab.hasAttribute("zen-essential");
+      if (
+        !lazy.allSpacesPref &&
+        active &&
+        !gZenWorkspaces._shouldShowTab(
+          tab,
+          active.uuid,
+          active.containerTabId,
+          workspaces
+        )
+      ) {
+        continue;
+      }
+      (isEssential ? essentials : pins).push(
+        this.#describeTab(tab, window, index++)
+      );
+    }
+    return pins.concat(essentials);
+  }
+
+  /**
+   * Starts a search query among the pinned tabs of the current window.
+   *
+   * @param {UrlbarQueryContext} queryContext
+   * @param {(provider: UrlbarProvider, result: UrlbarResult) => void} addCallback
+   */
+  async startQuery(queryContext, addCallback) {
+    const window = lazy.BrowserWindowTracker.getTopWindow();
+    if (!window?.gZenWorkspaces) {
+      return;
+    }
+    const tokens = this.#textTokens(queryContext);
+    const query = this.#queryText(queryContext);
+    if (!query) {
+      return;
+    }
+    const tokenValues = tokens.map(t => t.lowerCaseValue);
+    const inTabsMode =
+      queryContext.searchMode?.source == UrlbarShared.RESULT_SOURCE.TABS;
+
+    const matches = this.#collectCandidates(window)
+      .map(candidate => ({
+        candidate,
+        score: scoreCandidate(candidate, query, tokenValues),
+      }))
+      .filter(match => match.score > 0)
+      .sort(
+        (a, b) => b.score - a.score || a.candidate.index - b.candidate.index
+      )
+      .slice(0, MAX_PINNED_RESULTS);
+    if (!matches.length) {
+      return;
+    }
+
+    // The best match is the heuristic, so it is pre-selected and Enter
+    // switches to it. That is skipped when the input looks like a URL (the
+    // heuristic must stay Firefox's own) and in tabs search mode, where
+    // Firefox drops heuristic results.
+    const takeTop =
+      !inTabsMode && !looksLikeUrl(queryContext.trimmedSearchString || query);
+    let nextIndex = inTabsMode ? 0 : 1;
+    const source = inTabsMode
+      ? UrlbarShared.RESULT_SOURCE.TABS
+      : UrlbarShared.RESULT_SOURCE.ZEN_PINNED_TABS;
+    const actionLabel = lazy.l10n.formatValueSync(
+      "urlbar-result-action-switch-tab"
+    );
+
+    this.#tabsByKey.clear();
+    let isFirst = true;
+    for (const { candidate } of matches) {
+      const key = String(++this.#keyCounter);
+      this.#tabsByKey.set(key, new WeakRef(candidate.tab));
+
+      const crumbs = [];
+      if (lazy.allSpacesPref && candidate.spaceName) {
+        crumbs.push(candidate.spaceName);
+      }
+      crumbs.push(...candidate.folders);
+      const breadcrumb = crumbs.join(" / ");
+
+      const heuristic = isFirst && takeTop;
+      const result = new lazy.UrlbarResult({
+        type: UrlbarShared.RESULT_TYPE.DYNAMIC,
+        source,
+        payload: {
+          dynamicType: DYNAMIC_TYPE_NAME,
+          title: candidate.label,
+          titleHighlights: highlightsFor(tokens, candidate.label),
+          breadcrumb,
+          breadcrumbHighlights: highlightsFor(tokens, breadcrumb),
+          host: candidate.host,
+          hostHighlights: highlightsFor(tokens, candidate.host),
+          // Deliberately not `url`: a url payload would make the input load
+          // it on pick instead of leaving the switch to onEngagement.
+          tabUrl: candidate.url,
+          pinnedUrl: candidate.pinnedUrl,
+          icon: candidate.icon,
+          isPending: candidate.isPending,
+          isEssential: candidate.isEssential,
+          actionLabel,
+          // Keeps the typed text in the input when the row is arrowed onto.
+          query: queryContext.searchString,
+          pinKey: key,
+          tabId: candidate.tab.id || "",
+        },
+        heuristic,
+        suggestedIndex: heuristic ? undefined : nextIndex++,
+      });
+      addCallback(this, result);
+      isFirst = false;
+    }
+  }
+
+  getPriority() {
+    return 0;
+  }
+
+  getViewTemplate() {
+    return {
+      name: "root",
+      attributes: {
+        selectable: true,
+      },
+      children: [
+        {
+          name: "icon",
+          tag: "img",
+          classList: ["urlbarView-favicon"],
+        },
+        {
+          name: "title",
+          tag: "span",
+          classList: ["urlbarView-title", "urlbarView-overflowable"],
+        },
+        {
+          name: "separator",
+          tag: "span",
+          classList: ["urlbarView-title-separator"],
+        },
+        {
+          name: "breadcrumb",
+          tag: "span",
+          classList: [
+            "urlbarView-url",
+            "urlbarView-overflowable",
+            "zen-pinned-tab-breadcrumb",
+          ],
+        },
+        {
+          name: "breadcrumbSeparator",
+          tag: "span",
+          classList: ["urlbarView-title-separator"],
+        },
+        {
+          name: "url",
+          tag: "span",
+          classList: ["urlbarView-url", "urlbarView-overflowable"],
+        },
+        {
+          name: "action",
+          tag: "span",
+          classList: ["urlbarView-action"],
+        },
+      ],
+    };
+  }
+
+  getViewUpdate(result) {
+    const payload = result.payload;
+    const hasBreadcrumb = !!payload.breadcrumb;
+    const hasHost = !!payload.host;
+    return {
+      root: {
+        attributes: {
+          "zen-pending": !!payload.isPending,
+          "zen-essential": !!payload.isEssential,
+        },
+      },
+      icon: {
+        attributes: { src: payload.icon || "" },
+      },
+      title: {
+        textContent: payload.title,
+        highlights: payload.titleHighlights,
+        attributes: { dir: "auto" },
+      },
+      separator: {
+        attributes: { hidden: !(hasBreadcrumb || hasHost) },
+      },
+      breadcrumb: {
+        textContent: payload.breadcrumb || "",
+        highlights: payload.breadcrumbHighlights,
+        attributes: { hidden: !hasBreadcrumb, dir: "auto" },
+      },
+      breadcrumbSeparator: {
+        attributes: { hidden: !(hasBreadcrumb && hasHost) },
+      },
+      url: {
+        textContent: payload.host || "",
+        highlights: payload.hostHighlights,
+        attributes: { hidden: !hasHost, dir: "ltr" },
+      },
+      action: {
+        textContent: payload.actionLabel,
+      },
+    };
+  }
+
+  onEngagement(queryContext, controller, details) {
+    const result = details.result;
+    if (result?.providerName != this.name) {
+      return;
+    }
+    const ownerGlobal = details.element.documentGlobal;
+    const payload = result.payload;
+    let tab = this.#tabsByKey.get(payload.pinKey)?.deref();
+    if ((!tab || !tab.isConnected) && payload.tabId) {
+      tab = ownerGlobal.document.getElementById(payload.tabId);
+    }
+    if (
+      !tab ||
+      !ownerGlobal.gBrowser.isTab(tab) ||
+      tab.closing ||
+      !tab.isConnected
+    ) {
+      return;
+    }
+    // Same call a sidebar click makes: Zen's setter switches space when the
+    // tab lives elsewhere and session store restores a pending pin.
+    if (ownerGlobal.gBrowser.selectedTab !== tab) {
+      ownerGlobal.gBrowser.selectedTab = tab;
+    }
+    tab.linkedBrowser?.focus();
+  }
+}

--- a/src/zen/urlbar/ZenUBProvider.sys.mjs
+++ b/src/zen/urlbar/ZenUBProvider.sys.mjs
@@ -9,6 +9,8 @@ ChromeUtils.defineESModuleGetters(lazy, {
   /* eslint-disable mozilla/valid-lazy */
   ZenUrlbarProviderGlobalActions:
     "resource:///modules/ZenUBActionsProvider.sys.mjs",
+  ZenUrlbarProviderPinnedTabs:
+    "resource:///modules/ZenUBPinnedTabsProvider.sys.mjs",
 });
 
 export function registerZenUrlbarProviders() {

--- a/src/zen/urlbar/moz.build
+++ b/src/zen/urlbar/moz.build
@@ -6,6 +6,7 @@ EXTRA_JS_MODULES += [
   "ZenSiteDataPanel.sys.mjs",
   "ZenUBActionsProvider.sys.mjs",
   "ZenUBGlobalActions.sys.mjs",
+  "ZenUBPinnedTabsProvider.sys.mjs",
   "ZenUBProvider.sys.mjs",
   "ZenUBResultsLearner.sys.mjs",
 ]


### PR DESCRIPTION
Fixes #15223

## What

Pinned tabs and Essentials of the current space show up as switch-to-tab rows in the URL bar when the typed text matches their custom label, hostname or URL, whether or not the tab is loaded. Pins inside collapsed folders are included, with the folder path shown as a breadcrumb.

Today the native "Switch to Tab" rows come from the open pages table, which unloaded pins are not in, so a renamed pin stops being findable the moment it is unloaded (see the issue for repro steps on 1.21.16b).

## How

- New `ZenUrlbarProviderPinnedTabs` in `src/zen/urlbar/`, registered next to the global actions provider and written in the same style (heuristic-type provider, DYNAMIC rows, `getViewTemplate` / `getViewUpdate`, `onEngagement`).
- Matching walks `gZenWorkspaces.allStoredTabs` and scores label, host and URL (exact, prefix, word prefix, substring, fuzzy). Ties keep sidebar order, pins before Essentials.
- The best match is the heuristic row, so `Enter` switches to it. When the input looks like a URL (scheme, or a dot and no spaces) the pins sit below Firefox's own heuristic instead. In `%` tabs mode they are listed first but not pre-selected, since heuristics are dropped in search modes.
- Picking a row runs `gBrowser.selectedTab = tab`, the same path as a sidebar click: the space switches if needed and session store restores an unloaded pin. The rows are deliberately DYNAMIC rather than `TAB_SWITCH`, because `pickResult` for `TAB_SWITCH` calls `switchToTabHavingURI(uri, true)` and that opens a new tab while a restoring pin is still at `about:blank`.
- Patches: `ZEN_PINNED_TAB` result group (first root group) and `ZEN_PINNED_TABS` source in `UrlbarShared`, group mapping in `UrlbarUtils.getResultGroup`, the source accepted in `updateSourcesIfEmpty` (also under `%`), heuristic span exemption in the muxer like `ZEN_ACTIONS`, and a muxer rule that drops native switch-to-tab and history rows pointing at the same page as a pinned tab row so loaded pins are not listed twice.
- Prefs: `zen.urlbar.suggestions.pinned-tabs` (default `true`) and `zen.urlbar.suggestions.pinned-tabs.all-spaces` (default `false`, searches every space and prefixes the space name).
- Reuses Firefox's `urlbar-result-action-switch-tab` string, so no l10n change.

## Testing

- `src/zen/tests/ub-actions/browser_pinned_tabs_search.js` covers: custom label match with `Enter` switching and no new tab, an unloaded pin found by host with URL-like input keeping Firefox's heuristic first and the pin restoring on pick, and the pref turning the provider off.
- I have not built Zen locally, so the mochitest has only been checked for syntax and formatting, not run. The provider logic itself has been running for a day as an fx-autoconfig userscript on 1.21.16b (same code paths, source at https://github.com/spirosbax/zen-pinsearch); the in-tree version differs only in using proper result group and source constants instead of borrowing the actions group, and a muxer rule instead of wrapping `sort`. Happy to adjust anything CI or review turns up.
- The five patch files were regenerated with `git diff --full-index` against pristine Firefox 155.0 sources with the current dev patches applied, and re-verified to apply cleanly.

## Notes for review

- Placement of the `ZEN_PINNED_TAB` group ahead of `ZEN_ACTION` is a judgment call (a pin named exactly what you typed beats a learned command). It is a one-line move if you prefer actions first.
- While a pin is the heuristic, Firefox's autofill for that query does not apply (autofill only fires when the autofill result is first). URL-like input restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sg99ACeu6sQL5t2mMSWnGC
