### PR TITLE
gh-15144: Add flag to skip update windows certs

### DIFF
--- a/src/external-patches/firefox/override_cert_checks_temp.patch
+++ b/src/external-patches/firefox/override_cert_checks_temp.patch
@@ -1,0 +1,32 @@
+diff --git a/toolkit/mozapps/update/common/registrycertificates.cpp b/toolkit/mozapps/update/common/registrycertificates.cpp
+index f7f5acdfa08879a0ff3095e15eebf7b436cf5092..5915141b3f4a6d3536841cc1040e70afe033e058 100644
+--- a/toolkit/mozapps/update/common/registrycertificates.cpp
++++ b/toolkit/mozapps/update/common/registrycertificates.cpp
+@@ -33,9 +33,21 @@
+  *
+  * @return TRUE if the binary matches any of the allowed certificates.
+  */
++// TEMPORARY: accept any binary without consulting the allowed-certificate
++// values. Those values are only ever written by an installer run, so after a
++// signing certificate change every existing install still names the previous
++// certificate, the maintenance service refuses the newly signed binaries, and
++// updates fall back to prompting for elevation every time. Remove this define
++// and the block below once installs have been migrated.
++#define ZEN_SKIP_ALLOWED_CERTIFICATE_CHECK 1
++
+ BOOL DoesBinaryMatchAllowedCertificates(LPCWSTR basePathForUpdate,
+                                         LPCWSTR filePath,
+                                         BOOL allowFallbackKeySkip) {
++#ifdef ZEN_SKIP_ALLOWED_CERTIFICATE_CHECK
++  LOG(("Skipping the allowed certificate check for \"%ls\"", filePath));
++  return TRUE;
++#else
+ #ifdef DISABLE_UPDATER_AUTHENTICODE_CHECK
+   if (allowFallbackKeySkip) {
+     LOG_WARN(("Skipping authenticode check"));
+@@ -163,4 +175,5 @@ BOOL DoesBinaryMatchAllowedCertificates(LPCWSTR basePathForUpdate,
+   RegCloseKey(baseKey);
+   // No certificates match, :'(
+   return FALSE;
++#endif  // ZEN_SKIP_ALLOWED_CERTIFICATE_CHECK
+ }

--- a/src/external-patches/manifest.json
+++ b/src/external-patches/manifest.json
@@ -54,5 +54,9 @@
   {
     "type": "local",
     "path": "firefox/css_corner_shape_rendering.patch"
+  },
+  {
+    "type": "local",
+    "path": "firefox/override_cert_checks_temp.patch"
   }
 ]


### PR DESCRIPTION
Fixes https://github.com/zen-browser/desktop/issues/15144