### PR TITLE
gh-15155: Fix tab moving to bottom of tab list

### DIFF
--- a/src/zen/drag-and-drop/ZenDragAndDrop.js
+++ b/src/zen/drag-and-drop/ZenDragAndDrop.js
@@ -1334,10 +1334,14 @@
         dropElement = dragData.dropElement;
         dropBefore = dragData.dropBefore;
       }
-      // Essentials should be properly handled by ::animateVerticalPinnedGridDragOver
-      if (!dropElement || dropElement.hasAttribute("zen-essential")) {
+      if (!dropElement) {
         this.clearDragOverVisuals();
-        // If dropElement is null or essential, dropElement should be the empty tab
+        return [undefined, null];
+      }
+      // Essentials should be properly handled by ::animateVerticalPinnedGridDragOver
+      if (dropElement.hasAttribute("zen-essential")) {
+        this.clearDragOverVisuals();
+        // If dropElement is essential, dropElement should be the empty tab
         return [dropBefore, gZenWorkspaces._emptyTab];
       }
       if (dropElement.hasAttribute("zen-empty-tab") && dropElement.group) {


### PR DESCRIPTION
when there wasn’t a valid drop target, `ZenDragAndDrop.js` hid the indicator but still used the hidden empty tab as a fallback and dropping after that ended up moving the tab to the bottom of the list.

changed it to return `[undefined, null]` when there’s still no target after checking the previous drag target, so dropping there leaves the tab where it is.

demo showing it doesn't move tab to bottom anymore when no valid drop target:

https://github.com/user-attachments/assets/41f6bf14-0b99-42a3-87a8-235ae0c181af

closes #15155 

