### PR TITLE
gh-15188: Fixed invisible download progress bar in Library when unselected

### DIFF
--- a/src/zen/common/styles/zen-theme.css
+++ b/src/zen/common/styles/zen-theme.css
@@ -101,7 +101,7 @@
   ) !important;
   --focus-outline-color: var(--color-accent-primary) !important;
 
-  --toolbarbutton-icon-fill-attention: var(--toolbar-color) !important;
+  --toolbarbutton-icon-fill-attention: var(--toolbar-color, currentColor) !important;
   --toolbarbutton-icon-fill: currentColor !important;
 
   --button-background-color-primary: var(--in-content-primary-button-background) !important;


### PR DESCRIPTION
Fixes #15188

## Problem

The download progress bar's completed portion is invisible in the Library window when the entry is not selected (dark themes on Linux).

## Root cause

Firefox colors the fill via `progressmeter.css` with no fallback:

    --download-progress-fill-color: var(--toolbarbutton-icon-fill-attention);

Zen overrides that variable globally in `zen-theme.css`:

    --toolbarbutton-icon-fill-attention: var(--toolbar-color) !important;

`--toolbar-color` is not defined in `places.xhtml`, so the property becomes invalid and the fill computes to transparent. Verified in the Browser Toolbox: the variable computes to an empty string in Zen's Library window, while vanilla Firefox has a real value there.

It only manifests on Linux because Firefox's Windows and macOS themes hardcode `#3c9af8` on the fill in their `allDownloadsView.css`, masking the invalid variable. The Linux theme has no such override. Selected rows are unaffected because a separate contrast rule switches them to `currentColor`.

## Fix

Add a `currentColor` fallback to the override so windows without `--toolbar-color` degrade to a visible color instead of an invalid property. This keeps the intent of the override (attention icons follow the toolbar text color) and applies the same behavior the existing selected-row contrast rule already uses.

## Testing

The equivalent change was verified by the issue reporter on Arch Linux via userChrome.css: applying `--toolbarbutton-icon-fill-attention: currentColor` in `places.xhtml` makes the unselected progress bar visible. See [this comment](https://github.com/zen-browser/desktop/issues/15188#issuecomment-5554413318).