### PR TITLE
gh-15112: Fix iCloud Passwords authorization popup on Apple silicon

### DIFF
--- a/src/toolkit/modules/subprocess/subprocess_shared_unix-js.patch
+++ b/src/toolkit/modules/subprocess/subprocess_shared_unix-js.patch
@@ -1,0 +1,18 @@
+diff --git a/toolkit/modules/subprocess/subprocess_shared_unix.js b/toolkit/modules/subprocess/subprocess_shared_unix.js
+--- a/toolkit/modules/subprocess/subprocess_shared_unix.js
++++ b/toolkit/modules/subprocess/subprocess_shared_unix.js
+@@ -54,12 +54,13 @@
+ 
+   dup: [ctypes.default_abi, ctypes.int, ctypes.int],
+ 
++  // Variadic arguments use a different calling convention on Apple silicon.
+   fcntl: [
+     ctypes.default_abi,
+     ctypes.int,
+     ctypes.int /* fildes */,
+     ctypes.int /* cmd */,
+-    ctypes.int /* ... */,
++    "...",
+   ],
+ 
+   getcwd: [

--- a/src/toolkit/modules/subprocess/subprocess_shared_unix-js.patch
+++ b/src/toolkit/modules/subprocess/subprocess_shared_unix-js.patch
@@ -1,7 +1,8 @@
 diff --git a/toolkit/modules/subprocess/subprocess_shared_unix.js b/toolkit/modules/subprocess/subprocess_shared_unix.js
+index afa2b92eee680d9e2deb44a805904dccd85fb526..2900bf133987728a73db75a0704f9e77fc6b3494 100644
 --- a/toolkit/modules/subprocess/subprocess_shared_unix.js
 +++ b/toolkit/modules/subprocess/subprocess_shared_unix.js
-@@ -54,12 +54,13 @@
+@@ -54,12 +54,13 @@ var libc = new Library("libc", LIBC_CHOICES, {
  
    dup: [ctypes.default_abi, ctypes.int, ctypes.int],
  

--- a/src/toolkit/modules/subprocess/subprocess_unix-sys-mjs.patch
+++ b/src/toolkit/modules/subprocess/subprocess_unix-sys-mjs.patch
@@ -1,7 +1,8 @@
 diff --git a/toolkit/modules/subprocess/subprocess_unix.sys.mjs b/toolkit/modules/subprocess/subprocess_unix.sys.mjs
+index f4c7f1bd3eb097c8261cdc65a2eb15d651389edd..1606d4d4fb352ef1e6e5234d1bc95b56734caec4 100644
 --- a/toolkit/modules/subprocess/subprocess_unix.sys.mjs
 +++ b/toolkit/modules/subprocess/subprocess_unix.sys.mjs
-@@ -36,9 +36,9 @@
+@@ -36,9 +36,9 @@ class UnixPromiseWorker extends PromiseWorker {
  
      this.signalFd = fds[1];
  

--- a/src/toolkit/modules/subprocess/subprocess_unix-sys-mjs.patch
+++ b/src/toolkit/modules/subprocess/subprocess_unix-sys-mjs.patch
@@ -1,0 +1,16 @@
+diff --git a/toolkit/modules/subprocess/subprocess_unix.sys.mjs b/toolkit/modules/subprocess/subprocess_unix.sys.mjs
+--- a/toolkit/modules/subprocess/subprocess_unix.sys.mjs
++++ b/toolkit/modules/subprocess/subprocess_unix.sys.mjs
+@@ -36,9 +36,9 @@
+ 
+     this.signalFd = fds[1];
+ 
+-    libc.fcntl(fds[0], LIBC.F_SETFL, LIBC.O_NONBLOCK);
+-    libc.fcntl(fds[0], LIBC.F_SETFD, LIBC.FD_CLOEXEC);
+-    libc.fcntl(fds[1], LIBC.F_SETFD, LIBC.FD_CLOEXEC);
++    libc.fcntl(fds[0], LIBC.F_SETFL, ctypes.int(LIBC.O_NONBLOCK));
++    libc.fcntl(fds[0], LIBC.F_SETFD, ctypes.int(LIBC.FD_CLOEXEC));
++    libc.fcntl(fds[1], LIBC.F_SETFD, ctypes.int(LIBC.FD_CLOEXEC));
+ 
+     this.call("init", [{ signalFd: fds[0] }]);
+   }

--- a/src/toolkit/modules/subprocess/subprocess_unix-worker-js.patch
+++ b/src/toolkit/modules/subprocess/subprocess_unix-worker-js.patch
@@ -1,0 +1,16 @@
+diff --git a/toolkit/modules/subprocess/subprocess_unix.worker.js b/toolkit/modules/subprocess/subprocess_unix.worker.js
+--- a/toolkit/modules/subprocess/subprocess_unix.worker.js
++++ b/toolkit/modules/subprocess/subprocess_unix.worker.js
+@@ -351,9 +351,9 @@
+         our_pipes.push(new OutputPipe(this, fds[1]));
+       }
+ 
+-      libc.fcntl(fds[0], LIBC.F_SETFD, LIBC.FD_CLOEXEC);
+-      libc.fcntl(fds[1], LIBC.F_SETFD, LIBC.FD_CLOEXEC);
+-      libc.fcntl(fds[1], LIBC.F_SETFL, LIBC.O_NONBLOCK);
++      libc.fcntl(fds[0], LIBC.F_SETFD, ctypes.int(LIBC.FD_CLOEXEC));
++      libc.fcntl(fds[1], LIBC.F_SETFD, ctypes.int(LIBC.FD_CLOEXEC));
++      libc.fcntl(fds[1], LIBC.F_SETFL, ctypes.int(LIBC.O_NONBLOCK));
+ 
+       return fds[0];
+     };

--- a/src/toolkit/modules/subprocess/subprocess_unix-worker-js.patch
+++ b/src/toolkit/modules/subprocess/subprocess_unix-worker-js.patch
@@ -1,7 +1,8 @@
 diff --git a/toolkit/modules/subprocess/subprocess_unix.worker.js b/toolkit/modules/subprocess/subprocess_unix.worker.js
+index 5aa734cf876267c3b8506ff58f7ae2311172801a..6cf9e0a8ecce85b4b5f2014ae9fe61f9e87d5240 100644
 --- a/toolkit/modules/subprocess/subprocess_unix.worker.js
 +++ b/toolkit/modules/subprocess/subprocess_unix.worker.js
-@@ -351,9 +351,9 @@
+@@ -351,9 +351,9 @@ class Process extends BaseProcess {
          our_pipes.push(new OutputPipe(this, fds[1]));
        }
  

--- a/src/toolkit/modules/subprocess/test/xpcshell/test_subprocess_pipe_flags.js
+++ b/src/toolkit/modules/subprocess/test/xpcshell/test_subprocess_pipe_flags.js
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+add_task(async function test_subprocess_pipe_flags() {
+  const { Subprocess, getSubprocessImplForTest } = ChromeUtils.importESModule(
+    "resource://gre/modules/Subprocess.sys.mjs"
+  );
+  const { ctypes } = ChromeUtils.importESModule(
+    "resource://gre/modules/ctypes.sys.mjs"
+  );
+  const constants = ChromeUtils.getLibcConstants();
+  const library = ctypes.open("a.out");
+  const fcntl = library.declare(
+    "fcntl",
+    ctypes.default_abi,
+    ctypes.int,
+    ctypes.int,
+    ctypes.int,
+    "..."
+  );
+  // Darwin's fcntl commands for reading descriptor and file status flags.
+  const F_GETFD = 1;
+  const F_GETFL = 3;
+  let process;
+
+  try {
+    const worker = getSubprocessImplForTest().Process.getWorker();
+    Assert.equal(
+      fcntl(worker.signalFd, F_GETFD),
+      constants.FD_CLOEXEC,
+      "The main-thread signal pipe has exactly FD_CLOEXEC set"
+    );
+
+    process = await Subprocess.call({
+      command: "/bin/cat",
+      stderr: "pipe",
+      disclaim: true,
+    });
+    const fds = await worker.call("getFds", [process.id]);
+    // Only inspect the descriptors while the worker owns them and cat is alive.
+    // Exact flags also rule out an unintended FD_CLOFORK on macOS.
+    for (const fd of fds) {
+      Assert.equal(
+        fcntl(fd, F_GETFD),
+        constants.FD_CLOEXEC,
+        "Worker pipes have exactly FD_CLOEXEC set"
+      );
+      Assert.equal(
+        fcntl(fd, F_GETFL) & constants.O_NONBLOCK,
+        constants.O_NONBLOCK,
+        "Worker pipes are nonblocking"
+      );
+    }
+
+    const output = process.stdout.readString(5);
+    await process.stdin.write("hello");
+    Assert.equal(await output, "hello", "The subprocess pipes transfer data");
+    await process.stdin.close();
+    Assert.equal(
+      (await process.wait()).exitCode,
+      0,
+      "The subprocess exits cleanly"
+    );
+  } finally {
+    if (process && process.exitCode === null) {
+      await process.kill();
+    }
+    library.close();
+  }
+});

--- a/src/toolkit/modules/subprocess/test/xpcshell/xpcshell-toml.patch
+++ b/src/toolkit/modules/subprocess/test/xpcshell/xpcshell-toml.patch
@@ -1,7 +1,8 @@
 diff --git a/toolkit/modules/subprocess/test/xpcshell/xpcshell.toml b/toolkit/modules/subprocess/test/xpcshell/xpcshell.toml
+index 9249030461ca0981b392e3bd9408db313bc4a406..ef901f4ea1191aba9e1fa7e2606181033175226b 100644
 --- a/toolkit/modules/subprocess/test/xpcshell/xpcshell.toml
 +++ b/toolkit/modules/subprocess/test/xpcshell/xpcshell.toml
-@@ -27,4 +27,7 @@
+@@ -27,4 +27,7 @@ skip-if = [
  ["test_subprocess_perf.js"]
  requesttimeoutfactor = 2  # Slow on Windows
  

--- a/src/toolkit/modules/subprocess/test/xpcshell/xpcshell-toml.patch
+++ b/src/toolkit/modules/subprocess/test/xpcshell/xpcshell-toml.patch
@@ -1,0 +1,11 @@
+diff --git a/toolkit/modules/subprocess/test/xpcshell/xpcshell.toml b/toolkit/modules/subprocess/test/xpcshell/xpcshell.toml
+--- a/toolkit/modules/subprocess/test/xpcshell/xpcshell.toml
++++ b/toolkit/modules/subprocess/test/xpcshell/xpcshell.toml
+@@ -27,4 +27,7 @@
+ ["test_subprocess_perf.js"]
+ requesttimeoutfactor = 2  # Slow on Windows
+ 
++["test_subprocess_pipe_flags.js"]
++run-if = ["os == 'mac'"]
++
+ ["test_subprocess_polling.js"]


### PR DESCRIPTION
Opening iCloud Passwords in Zen on Apple silicon running macOS 27 can show six code-entry fields without launching the native verification-code window. This corrects the Unix subprocess `fcntl` binding so the pipe flags reach macOS correctly and the native helper can start.

Fixes #15112. Related to #15123.

### Cause and fix

The binding declares `fcntl(int, int, int)`, but the native function is `fcntl(int, int, ...)`. Apple silicon passes fixed and variadic arguments differently. Local runtime probes found that requesting `FD_CLOEXEC` (`1`) could instead set `0` or `FD_CLOFORK` (`2`); launches with the unintended close-on-fork flag failed. See [Apple's calling-convention documentation](https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms).

Firefox's current main, beta, release, ESR 153, and ESR 140 sources retain [the same incorrect declaration](https://github.com/mozilla-firefox/firefox/blob/156018d359c66937b49d1794a8414f11c2f28cfd/toolkit/modules/subprocess/subprocess_shared_unix.js#L57), so the ABI mismatch is present upstream too, even when a particular Firefox build does not exhibit the same visible symptom. A controlled comparison has not established which build change first exposed it in Zen.

The patch declares `fcntl` as variadic and passes `ctypes.int` flags at all six Unix subprocess call sites. A macOS xpcshell test checks the actual signaling and worker pipe flags, nonblocking mode, data transfer, and child exit. All four patches were generated with `npm run export`.

### Validation

Environment: Apple silicon, macOS 27.0 build 26A5425a, Zen 1.22b / Firefox 155.0.1 source, macOS 26.5 SDK. Runtime behavior on macOS 26 has not been tested.

- Followed the documented download, clean import, bootstrap, and English language-pack steps. All 262 Git patches imported successfully.
- `npm run build -- --jobs 8` passed as a full development build with tests enabled.
- Reversed only the three production patches in the generated source and ran `npm run build:ui`. The real xpcshell regression test failed because a worker pipe's `O_NONBLOCK` bit was `0`, expected `4`.
- Restored the fix, rebuilt the JavaScript, and ran the complete subprocess suite:

  ```sh
  cd engine
  ./mach xpcshell-test toolkit/modules/subprocess/test/xpcshell
  ```

  **8 tests passed, 0 failed, 0 retried.** This includes the new regression test.

The exporter-only follow-up produces source files byte-for-byte identical to the build used for those tests.

### Native popup verification

With official iCloud Passwords 3.3.0, the missing native window was reproduced in a separate, unmodified Zen runtime with a fresh profile. Loading the patched modules made the native **Verification Code** window appear in two fresh browser processes and profiles, without warm-up spawns or an extension-reload workaround. I also manually tested the extension and confirmed iCloud Passwords works.

The popup checks used a separate signed official Zen copy with temporary resource-module routing to load the patched JavaScript before installing the extension, preserving the executable's signing identity for Apple's helper. The freshly compiled development build was validated through xpcshell; its native iCloud popup was not retested.

### CI scope

The PR workflow downloads and bootstraps Firefox, imports the patches on Ubuntu, and runs `mach lint zen`. That lint target does not cover these subprocess files, and the workflow does not run xpcshell. The local macOS build, failing baseline test, passing subprocess suite, and native popup checks above provide the runtime evidence for this change.
