### PR TITLE
gh-15204: Fix creating new empty split causes panes to flash

### DIFF
--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabbrowser.js b/browser/components/tabbrowser/content/tabbrowser.js
-index 43180487a2fac15b7a65fac94f233eeed9094990..ae1288974cae29da929f27b78ff8db542566eba2 100644
+index 43180487a2fac15b7a65fac94f233eeed9094990..3107b0d9fff57a9bde4a6c92c0fd61983a19e45d 100644
 --- a/browser/components/tabbrowser/content/tabbrowser.js
 +++ b/browser/components/tabbrowser/content/tabbrowser.js
 @@ -514,6 +514,7 @@
@@ -203,7 +203,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ae1288974cae29da929f27b78ff8db54
  
        let activeEl = document.activeElement;
 +      if (gURLBar._zenHandleUrlbarClose) {
-+        gURLBar._zenHandleUrlbarClose(true);
++        gURLBar._zenHandleUrlbarClose(true, false, newTab);
 +      }
        // If focus is on the old tab, move it to the new tab.
        if (activeEl == oldTab) {

--- a/src/browser/components/urlbar/content/UrlbarInput-mjs.patch
+++ b/src/browser/components/urlbar/content/UrlbarInput-mjs.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/urlbar/content/UrlbarInput.mjs b/browser/components/urlbar/content/UrlbarInput.mjs
-index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1a95e28b8 100644
+index 319fb6870ec18d87b9f1263bd960edaa39b0447c..8e1c6776b63cdcfd1428c195ad96a86c8864c6bd 100644
 --- a/browser/components/urlbar/content/UrlbarInput.mjs
 +++ b/browser/components/urlbar/content/UrlbarInput.mjs
 @@ -88,6 +88,13 @@ const lazy = XPCOMUtils.declareLazy({
@@ -61,20 +61,38 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
    }
  
    /**
-@@ -1726,7 +1755,11 @@ ${
+@@ -1595,8 +1624,16 @@ ${
+    *   asynchronously and must target the tab selected when it was committed.
+    *   Defaults to the parent resolving the selected browser at load time.
+    */
++  pickResult(options) {
++    try {
++      return this.#zenPickResult(options);
++    } finally {
++      this._zenSettlePick?.();
++    }
++  }
++
+   // eslint-disable-next-line complexity
+-  pickResult({ result, event, element = null, browserId = null }) {
++  #zenPickResult({ result, event, element = null, browserId = null }) {
+     if (element?.classList.contains("urlbarView-button-menu")) {
+       this.view.openResultMenu(result, element);
+       return;
+@@ -1726,7 +1763,11 @@ ${
      openParams.avoidBrowserFocus = keepViewOpen;
  
      if (!this.#providesSearchMode(result) && !keepViewOpen) {
 -      this.view.close({ elementPicked: true });
 +      if (this._zenHandleUrlbarClose) {
-+        this._zenHandleUrlbarClose(true, true);
++        this._zenOnPickStart();
 +      } else {
 +        this.window.setTimeout(() => this.view.close({ elementPicked: true }), 0);
 +      }
      }
  
      if (isCanonized) {
-@@ -3016,6 +3049,42 @@ ${
+@@ -3016,6 +3057,42 @@ ${
      await this.#updateLayoutBreakoutDimensions();
    }
  
@@ -117,7 +135,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
    startLayoutExtend() {
      if (!this.#allowBreakout || this.hasAttribute("breakout-extend")) {
        // Do not expand if the Urlbar does not support being expanded or it is
-@@ -3030,6 +3099,13 @@ ${
+@@ -3030,6 +3107,13 @@ ${
      this.toggleAttribute("breakout-extend", true);
      this.#updateTextboxPosition();
  
@@ -131,11 +149,11 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
      // Enable the animation only after the first extend call to ensure it
      // doesn't run when opening a new window.
      if (!this.hasAttribute("breakout-extend-animate")) {
-@@ -3053,6 +3129,29 @@ ${
+@@ -3053,6 +3137,29 @@ ${
        return;
      }
  
-+    if (this._zenHandleUrlbarClose) {
++    if (this._zenHandleUrlbarClose && !this._zenPickPending) {
 +      this._zenHandleUrlbarClose();
 +    } else if (!this._untrimmedValue || (this.#isAddressbar && (this.searchMode || this.window.gZenVerticalTabsManager._hasSetSingleToolbar))) {
 +      // Restore the current page URL when the urlbar is empty on blur
@@ -161,7 +179,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
      this.toggleAttribute("breakout-extend", false);
      this.#updateTextboxPosition();
    }
-@@ -3091,7 +3190,7 @@ ${
+@@ -3091,7 +3198,7 @@ ${
      forceUnifiedSearchButtonAvailable = false
    ) {
      let prevState = this.getAttribute("pageproxystate");
@@ -170,7 +188,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
      this.setAttribute("pageproxystate", state);
      this._inputContainer.setAttribute("pageproxystate", state);
      this._identityBox?.setAttribute("pageproxystate", state);
-@@ -3355,10 +3454,12 @@ ${
+@@ -3355,10 +3462,12 @@ ${
      }
  
      this.style.top = px(
@@ -183,7 +201,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
      );
    }
  
-@@ -3417,9 +3518,10 @@ ${
+@@ -3417,9 +3526,10 @@ ${
            return;
          }
  
@@ -195,7 +213,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
          );
  
          if (this.#breakoutBlockerCount) {
-@@ -3929,6 +4031,7 @@ ${
+@@ -3929,6 +4039,7 @@ ${
    }
  
    _toggleActionOverride(event) {
@@ -203,7 +221,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
      if (
        event.keyCode == KeyEvent.DOM_VK_SHIFT ||
        event.keyCode == KeyEvent.DOM_VK_ALT ||
-@@ -4027,9 +4130,10 @@ ${
+@@ -4027,9 +4138,10 @@ ${
      if (!this.#isAddressbar) {
        return val;
      }
@@ -217,7 +235,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
      // Only trim value if the directionality doesn't change to RTL and we're not
      // showing a strikeout https protocol.
      return this.controller.isTextDirectionRTL(trimmedValue) ||
-@@ -4235,6 +4339,11 @@ ${
+@@ -4235,6 +4347,11 @@ ${
      keepViewOpen = false,
      browserId = null,
    }) {
@@ -229,7 +247,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
      let userTypedValue;
      if (this.#isAddressbar && where == "current") {
        // Make sure URL is formatted properly (don't show punycode).
-@@ -4576,6 +4685,7 @@ ${
+@@ -4576,6 +4693,7 @@ ${
        this.setResultForCurrentValue(null);
        this.handleCommand();
        this.controller.clearLastQueryContextCache();
@@ -237,7 +255,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
  
        this._suppressStartQuery = false;
      });
-@@ -4583,7 +4693,6 @@ ${
+@@ -4583,7 +4701,6 @@ ${
      contextMenu.addEventListener("popupshowing", () => {
        // Close the results pane when the input field contextual menu is open,
        // because paste and go doesn't want a result selection.
@@ -245,7 +263,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
  
        let controller =
          this.document.commandDispatcher.getControllerForCommand("cmd_paste");
-@@ -4850,7 +4959,11 @@ ${
+@@ -4850,7 +4967,11 @@ ${
      if (!engineName && !source && !this.hasAttribute("searchmode")) {
        return;
      }
@@ -258,7 +276,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
      if (this._searchModeIndicatorTitle) {
        this._searchModeIndicatorTitle.textContent = "";
        this._searchModeIndicatorTitle.removeAttribute("data-l10n-id");
-@@ -5149,6 +5262,7 @@ ${
+@@ -5149,6 +5270,7 @@ ${
  
      this.document.l10n.setAttributes(
        this.inputField,
@@ -266,7 +284,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
        l10nId,
        l10nId == "urlbar-placeholder-with-name"
          ? { name: engineName }
-@@ -5199,6 +5313,12 @@ ${
+@@ -5199,6 +5321,12 @@ ${
      }
  
      lazy.logger.debug("Blur Event");
@@ -279,7 +297,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
      // We cannot count every blur events after a missed engagement as abandoment
      // because the user may have clicked on some view element that executes
      // a command causing a focus change. For example opening preferences from
-@@ -5276,6 +5396,11 @@ ${
+@@ -5276,6 +5404,11 @@ ${
    }
  
    _on_click(event) {
@@ -291,7 +309,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
      switch (event.target) {
        case this.inputField:
        case this._inputContainer:
-@@ -5371,10 +5496,11 @@ ${
+@@ -5371,10 +5504,11 @@ ${
        }
        if (untrim) {
          this.setValue(this._untrimmedValue);
@@ -304,7 +322,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
        this.view.autoOpen({ event });
      } else {
        if (this._untrimOnFocusAfterKeydown) {
-@@ -5414,9 +5540,16 @@ ${
+@@ -5414,9 +5548,16 @@ ${
    }
  
    _on_mousedown(event) {
@@ -322,7 +340,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
          if (
            event.composedTarget != this.inputField &&
            event.composedTarget != this._inputContainer
-@@ -5426,6 +5559,10 @@ ${
+@@ -5426,6 +5567,10 @@ ${
  
          this.focusedViaMousedown = !this.focused;
          this.#preventClickSelectsAll = this.focused;
@@ -333,7 +351,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
  
          // Keep the focus status, since the attribute may be changed
          // upon calling this.focus().
-@@ -5463,7 +5600,7 @@ ${
+@@ -5463,7 +5608,7 @@ ${
          // view open on tab switch, and the TabSelect event arrived earlier.
          // Also ignore mousedown on the urlbarView context menu: opening/closing the
          // view is already handled by the result opening flow.
@@ -342,7 +360,7 @@ index 319fb6870ec18d87b9f1263bd960edaa39b0447c..554cc90fb2307450ddc68033968cefd1
            break;
          }
  
-@@ -5754,7 +5891,7 @@ ${
+@@ -5754,7 +5899,7 @@ ${
      // When we are in actions search mode we can show more results so
      // increase the limit.
      let maxResults =

--- a/src/browser/modules/URILoadingHelper-sys-mjs.patch
+++ b/src/browser/modules/URILoadingHelper-sys-mjs.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/modules/URILoadingHelper.sys.mjs b/browser/modules/URILoadingHelper.sys.mjs
-index b60820ef0cc62c27a8bab127218d625012153791..04cdd58ed4426af802f2868310140a8a33ec092b 100644
+index b0f17c20bcca640c519b547149179cc03a86aa54..6cf34eda8f36d344dc9c8273cc4b5a041ff4b655 100644
 --- a/browser/modules/URILoadingHelper.sys.mjs
 +++ b/browser/modules/URILoadingHelper.sys.mjs
 @@ -231,6 +231,7 @@ function openInWindow(url, params, sourceWindow) {
@@ -19,7 +19,7 @@ index b60820ef0cc62c27a8bab127218d625012153791..04cdd58ed4426af802f2868310140a8a
          where = "tab";
          targetBrowser = null;
        } else if (
-@@ -981,7 +982,7 @@ export const URILoadingHelper = {
+@@ -978,7 +979,7 @@ export const URILoadingHelper = {
          ignoreQueryString || replaceQueryString,
          ignoreFragmentWhenComparing
        );
@@ -28,11 +28,22 @@ index b60820ef0cc62c27a8bab127218d625012153791..04cdd58ed4426af802f2868310140a8a
        for (let i = 0; i < browsers.length; i++) {
          let browser = browsers[i];
          let browserCompare = cleanURL(
-@@ -1037,7 +1038,7 @@ export const URILoadingHelper = {
+@@ -1034,7 +1035,18 @@ export const URILoadingHelper = {
                }
                aSplitView.documentGlobal.focus();
              } else {
 -              aWindow.gBrowser.tabContainer.selectedIndex = i;
++              if (
++                aWindow == window &&
++                window.gURLBar?._zenPickPending &&
++                window.gURLBar._zenHandleUrlbarClose
++              ) {
++                window.gURLBar._zenHandleUrlbarClose(
++                  true,
++                  true,
++                  aWindow.gBrowser.getTabForBrowser(browser)
++                );
++              }
 +              aWindow.gZenWorkspaces.switchIfNeeded(browser);
              }
            }

--- a/src/zen/common/modules/ZenUIManager.mjs
+++ b/src/zen/common/modules/ZenUIManager.mjs
@@ -592,8 +592,43 @@ window.gZenUIManager = {
     this._prevUrlbarLabel = gURLBar._untrimmedValue || "";
 
     // Set up URL bar for new tab
-    gURLBar._zenHandleUrlbarClose = (onSwitch, onElementPicked) =>
-      this.handleUrlbarClose(closeSeq, onSwitch, onElementPicked);
+    gURLBar._zenPickPending = null;
+    gURLBar._zenHandleUrlbarClose = (onSwitch, onElementPicked, tab) => {
+      const pending = gURLBar._zenPickPending;
+      gURLBar._zenPickPending = null;
+      this.handleUrlbarClose(
+        closeSeq,
+        onSwitch,
+        onElementPicked || !!pending,
+        tab ?? null,
+        pending ? pending.focused : gURLBar.focused
+      );
+    };
+    gURLBar._zenOnPickStart = () => {
+      gURLBar._zenPickPending = {
+        focused: gURLBar.focused,
+        tab: gBrowser.selectedTab,
+      };
+    };
+    gURLBar._zenSettlePick = () => {
+      const pending = gURLBar._zenPickPending;
+      if (!pending) {
+        return;
+      }
+      if (!gURLBar._zenHandleUrlbarClose) {
+        gURLBar._zenPickPending = null;
+        return;
+      }
+      /* _zenSettlePick is invoked synchronously after _zenOnPickStart at the
+       * end of the pick. If the selected tab changed in the meantime it should
+       * be safe to assume it was because it was picked by the url bar. */
+      const switched = gBrowser.selectedTab !== pending.tab;
+      gURLBar._zenHandleUrlbarClose(
+        switched,
+        true,
+        switched ? gBrowser.selectedTab : null
+      );
+    };
     this._urlbarOwner = closeSeq;
     gURLBar.setAttribute("zen-newtab", true);
 
@@ -634,7 +669,13 @@ window.gZenUIManager = {
     this._lastSearch = "";
   },
 
-  handleUrlbarClose(closeSeq, onSwitch = false, onElementPicked = false) {
+  handleUrlbarClose(
+    closeSeq,
+    onSwitch = false,
+    onElementPicked = false,
+    tab = null,
+    focused = gURLBar.focused
+  ) {
     // Validate browser state first
     if (!this._validateBrowserState()) {
       console.warn("Browser state invalid for URL bar close operation");
@@ -646,69 +687,68 @@ window.gZenUIManager = {
       gURLBar._zenHandleUrlbarClose = null;
     }
 
-    const isFocusedBefore = gURLBar.focused;
+    const isFocusedBefore = focused;
+
+    window.dispatchEvent(
+      new CustomEvent("ZenURLBarClosed", {
+        detail: { onSwitch, onElementPicked, closeSeq, tab },
+      })
+    );
+
+    if (!this._isOwner(closeSeq)) {
+      return;
+    }
     setTimeout(() => {
       /* If someone else opened the url bar in the meantime don't be
        * stingy and leave it open for them.*/
-      if (this._isOwner(closeSeq)) {
-        // We use this attribute on Tabbrowser::addTab
-        gURLBar.removeAttribute("zen-newtab");
+      // We use this attribute on Tabbrowser::addTab
+      gURLBar.removeAttribute("zen-newtab");
 
-        // Safely restore tab visual state with proper validation
-        if (
-          this._lastTab &&
-          !this._lastTab.closing &&
-          this._lastTab.documentGlobal &&
-          !this._lastTab.documentGlobal.closed &&
-          gBrowser.selectedTab === this._lastTab
-        ) {
-          this._lastTab._visuallySelected = true;
-          this._lastTab = null;
-        }
-
-        // Reset newtab buttons
-        for (const button of this.newtabButtons) {
-          button.removeAttribute("in-urlbar");
-        }
-
-        // Handle search data
-        if (onSwitch) {
-          this.clearUrlbarData();
-        } else {
-          this._lastSearch = gURLBar._untrimmedValue || "";
-
-          if (this._clearTimeout) {
-            clearTimeout(this._clearTimeout);
-          }
-
-          this._clearTimeout = setTimeout(() => {
-            this.clearUrlbarData();
-          }, this.urlbarWaitToClear);
-        }
-
-        // Safely restore URL bar state with proper validation
-        if (this._prevUrlbarLabel) {
-          gURLBar.setURI({
-            uri: this._prevUrlbarLabel,
-            dueToTabSwitch: onSwitch,
-            isSameDocument: !onSwitch,
-          });
-        }
-
-        gURLBar.handleRevert();
+      // Safely restore tab visual state with proper validation
+      if (
+        this._lastTab &&
+        !this._lastTab.closing &&
+        this._lastTab.documentGlobal &&
+        !this._lastTab.documentGlobal.closed &&
+        gBrowser.selectedTab === this._lastTab
+      ) {
+        this._lastTab._visuallySelected = true;
+        this._lastTab = null;
       }
+
+      // Reset newtab buttons
+      for (const button of this.newtabButtons) {
+        button.removeAttribute("in-urlbar");
+      }
+
+      // Handle search data
+      if (onSwitch) {
+        this.clearUrlbarData();
+      } else {
+        this._lastSearch = gURLBar._untrimmedValue || "";
+
+        if (this._clearTimeout) {
+          clearTimeout(this._clearTimeout);
+        }
+
+        this._clearTimeout = setTimeout(() => {
+          this.clearUrlbarData();
+        }, this.urlbarWaitToClear);
+      }
+
+      // Safely restore URL bar state with proper validation
+      if (this._prevUrlbarLabel) {
+        gURLBar.setURI({
+          uri: this._prevUrlbarLabel,
+          dueToTabSwitch: onSwitch,
+          isSameDocument: !onSwitch,
+        });
+      }
+
+      gURLBar.handleRevert();
 
       if (isFocusedBefore) {
         setTimeout(() => {
-          window.dispatchEvent(
-            new CustomEvent("ZenURLBarClosed", {
-              detail: { onSwitch, onElementPicked, closeSeq },
-            })
-          );
-
-          if (!this._isOwner(closeSeq)) {
-            return;
-          }
           this._urlbarOwner = null;
 
           gURLBar.view.close({ elementPicked: onElementPicked });

--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -2536,6 +2536,66 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     }
   }
 
+  /**
+   * Adopt tabs into a given group without dissolving the group.
+   * This assumes the count of the passed tabs and the count of the tabs in
+   * the group is the same, because it works by swapping the tabs of each split
+   * node in the group.
+   *
+   * @param {object} group - The group.
+   * @param {Array<Tab>} tabs - The tabs to end up with, in the group's order.
+   * @returns {boolean} False if the split has to be rebuilt instead.
+   * That can be done with {@link nsZenViewSplitter#splitTabs}
+   */
+  #adoptStagedPane(group, tabs) {
+    if (group?.tabs.length !== tabs.length) {
+      return false;
+    }
+    if (tabs.some(tab => tab.splitView && !group.tabs.includes(tab))) {
+      // The pick already holds a pane elsewhere, which is a merge, not an
+      // adoption. splitTabs is the one that knows how to do that.
+      return false;
+    }
+    const pinned = tabs.filter(tab => tab.pinned).length;
+    if (
+      (pinned && pinned !== tabs.length) ||
+      tabs.some(tab => tab.hasAttribute("zen-live-folder-item-id"))
+    ) {
+      // if we have to duplicate it defeats the purpose
+      return false;
+    }
+    const nodes = group.tabs.map(tab => this.getSplitNodeFromTab(tab));
+    if (nodes.some(node => !node)) {
+      return false;
+    }
+    const splitGroup = this._getSplitViewGroup(tabs);
+    if (!splitGroup) {
+      return false;
+    }
+    this.#withoutSplitViewTransition(() => {
+      group.tabs.forEach((oldTab, i) => {
+        const newTab = tabs[i];
+        if (oldTab === newTab) {
+          return;
+        }
+        nodes[i].tab = newTab;
+        this._tabToSplitNode.delete(oldTab);
+        this._tabToSplitNode.set(newTab, nodes[i]);
+        group.tabs[i] = newTab;
+        this.resetTabState(oldTab, false);
+      });
+      for (const tab of tabs) {
+        if (tab.group !== splitGroup) {
+          gBrowser.moveTabToExistingGroup(tab, splitGroup);
+        }
+      }
+      group.groupId = splitGroup.id;
+      this.activateSplitView(group, true);
+    });
+    this.#dispatchItemEvent("ZenSplitViewTabsSplit", splitGroup);
+    return true;
+  }
+
   createEmptySplit(side = "right") {
     const selectedTab = gBrowser.selectedTab;
     const emptyTab = gZenWorkspaces._emptyTab;
@@ -2574,35 +2634,45 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
               return;
             }
             controller.abort();
-            const { onElementPicked, onSwitch } = event.detail;
+            const {
+              onElementPicked,
+              onSwitch,
+              tab: newSelectedTab,
+            } = event.detail;
             const groupIndex = this._data.findIndex(group =>
               group.tabs.includes(emptyTab)
             );
-            const newSelectedTab = gBrowser.selectedTab;
-            if (onElementPicked) {
-              if (
-                newSelectedTab === emptyTab ||
-                newSelectedTab === selectedTab ||
-                selectedTab.getAttribute("zen-workspace-id") !==
-                  newSelectedTab.getAttribute("zen-workspace-id")
-              ) {
-                cleanup(onSwitch, groupIndex);
-                return;
-              }
-              this.removeTabFromGroup(emptyTab, groupIndex, {
-                forUnsplit: true,
-              });
-              gBrowser.selectedTab = selectedTab;
-              this.resetTabState(emptyTab, false);
-              this.splitTabs(
-                topOrLeft
-                  ? [newSelectedTab, selectedTab]
-                  : [selectedTab, newSelectedTab],
-                gridType,
-                topOrLeft ? 0 : 1
-              );
-            } else {
+            if (groupIndex < 0) {
+              document
+                .getElementById("cmd_zenNewEmptySplit")
+                .removeAttribute("disabled");
+              return;
+            }
+            if (!onElementPicked || !onSwitch || !newSelectedTab) {
               cleanup(onSwitch, groupIndex);
+              return;
+            }
+            if (
+              newSelectedTab === emptyTab ||
+              newSelectedTab === selectedTab ||
+              selectedTab.getAttribute("zen-workspace-id") !==
+                newSelectedTab.getAttribute("zen-workspace-id")
+            ) {
+              cleanup(onSwitch, groupIndex);
+              return;
+            }
+            const tabs = topOrLeft
+              ? [newSelectedTab, selectedTab]
+              : [selectedTab, newSelectedTab];
+            if (!this.#adoptStagedPane(this._data[groupIndex], tabs)) {
+              setTimeout(() => {
+                this.removeTabFromGroup(emptyTab, groupIndex, {
+                  forUnsplit: true,
+                });
+                gBrowser.selectedTab = selectedTab;
+                this.resetTabState(emptyTab, false);
+                this.splitTabs(tabs, gridType, topOrLeft ? 0 : 1);
+              });
             }
           },
           { signal: controller.signal }

--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -1594,6 +1594,8 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
       );
     }
 
+    this.applyGridLayout(splitData.layoutTree);
+
     // Apply grid to tabs first to set zen-split attribute on containers
     // before setting zen-split-view on parents. This prevents the black flash
     // caused by CSS rules that hide containers without zen-split attribute
@@ -1605,7 +1607,6 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
       .getElementById("tabbrowser-tabbox")
       .setAttribute("zen-split-view", "true");
 
-    this.applyGridLayout(splitData.layoutTree);
     this.setTabsDocShellState(splitData.tabs, true);
     this.toggleWrapperDisplay(true);
     window.dispatchEvent(new CustomEvent("ZenViewSplitter:SplitViewActivated"));
@@ -1705,6 +1706,9 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
 
   /**
    * Apply grid layout to tabBrowserPanel
+   *
+   * This should be invoked before {@link nsZenViewSplitter#applyGridToTabs} to
+   * make sure all tabs are in the correct position before they are shown.
    *
    * @param {nsSplitNode} splitNode nsSplitNode
    */

--- a/src/zen/split-view/ZenViewSplitter.mjs
+++ b/src/zen/split-view/ZenViewSplitter.mjs
@@ -2526,9 +2526,13 @@ class nsZenViewSplitter extends nsZenDOMOperatedFeature {
     try {
       return callback();
     } finally {
+      // Flush the new geometry now. Otherwise, because requestAnimationFrame
+      // runs before style computations, the zen-split-view-no-transition class
+      // is never even seen and we get a transition anyway.
+      this.tabBrowserPanel.getBoundingClientRect();
       requestAnimationFrame(() => {
         this.tabBrowserPanel.classList.remove("zen-split-view-no-transition");
-      }, 0);
+      });
     }
   }
 


### PR DESCRIPTION
Continuation of https://github.com/zen-browser/desktop/pull/15207

While looking for a solution I found a few more subtle issues that needed a fix (the first two commits here)

This works by making `ZenURLBarClosed` synchronous and moving the handler invocation inside of `UrlbarInput::pickResult` at the bottom instead of the top. This allows the handler to be invoked with specific arguments earlier inside the function, which is used to pass the specific tab being picked to the handler before that tab is shown, which allows us to set all necessary insets and whatever other styling beforehand. Then that invocation at the end of `pickResult` becomes more of a general fallback in case  `_zenHandleUrlbarClose`  never got invoked inside of the function.
It also solves the "math equation in the url bar" issue for free.

https://github.com/user-attachments/assets/578c99d9-0383-4583-9a85-07eb4c1d0f2e


