### PR TITLE
gh-15264: Add optional NVIDIA Video Super Resolution for Linux

### DIFF
--- a/prefs/zen/video-super-resolution.yaml
+++ b/prefs/zen/video-super-resolution.yaml
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+- name: zen.video.super-resolution.enabled
+  value: false
+  condition: "defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)"
+  mirror: always
+  cpptype: RelaxedAtomicBool
+  type: static
+- name: zen.video.super-resolution.scale-mode
+  value: 0
+  condition: "defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)"
+  mirror: always
+  cpptype: RelaxedAtomicUint32
+  type: static
+- name: zen.video.super-resolution.scale
+  value: 200
+  condition: "defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)"
+  mirror: always
+  cpptype: RelaxedAtomicUint32
+  type: static
+- name: zen.video.super-resolution.quality
+  value: 3
+  condition: "defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)"
+  mirror: always
+  cpptype: RelaxedAtomicUint32
+  type: static

--- a/src/gfx/layers/composite/GPUVideoTextureHost-cpp.patch
+++ b/src/gfx/layers/composite/GPUVideoTextureHost-cpp.patch
@@ -1,0 +1,19 @@
+diff --git a/gfx/layers/composite/GPUVideoTextureHost.cpp b/gfx/layers/composite/GPUVideoTextureHost.cpp
+index f8a4e6ecb1195ac9e7e8c4d24f77567abc076849..73db98d330a79284a8a72b1d8e2518a29aa66910 100644
+--- a/gfx/layers/composite/GPUVideoTextureHost.cpp
++++ b/gfx/layers/composite/GPUVideoTextureHost.cpp
+@@ -268,5 +268,14 @@ bool GPUVideoTextureHost::NeedsYFlip() const {
+   return mWrappedTextureHost->NeedsYFlip();
+ }
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++uint64_t GPUVideoTextureHost::GetVideoSourceIdentity() const {
++  if (!mWrappedTextureHost) {
++    return 0;
++  }
++  return mWrappedTextureHost->GetVideoSourceIdentity();
++}
++#endif
++
+ }  // namespace layers
+ }  // namespace mozilla

--- a/src/gfx/layers/composite/GPUVideoTextureHost-h.patch
+++ b/src/gfx/layers/composite/GPUVideoTextureHost-h.patch
@@ -1,0 +1,15 @@
+diff --git a/gfx/layers/composite/GPUVideoTextureHost.h b/gfx/layers/composite/GPUVideoTextureHost.h
+index 1fb7d286fca956dd334cad29b83432cbcf0f1973..b9a835fcc4911ad21a80dcf98b709892416c8f2c 100644
+--- a/gfx/layers/composite/GPUVideoTextureHost.h
++++ b/gfx/layers/composite/GPUVideoTextureHost.h
+@@ -34,6 +34,10 @@ class GPUVideoTextureHost final : public TextureHost {
+ 
+   bool NeedsYFlip() const override;
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  uint64_t GetVideoSourceIdentity() const override;
++#endif
++
+   gfx::IntSize GetSize() const override;
+ 
+   bool IsValid() override;

--- a/src/gfx/layers/composite/RemoteTextureHostWrapper-cpp.patch
+++ b/src/gfx/layers/composite/RemoteTextureHostWrapper-cpp.patch
@@ -1,0 +1,20 @@
+diff --git a/gfx/layers/composite/RemoteTextureHostWrapper.cpp b/gfx/layers/composite/RemoteTextureHostWrapper.cpp
+index cd9132cd68ba849ad3abd4e01d3ea79f5868a083..3dbe4904519353657b0eb10836eee7bc925d19d8 100644
+--- a/gfx/layers/composite/RemoteTextureHostWrapper.cpp
++++ b/gfx/layers/composite/RemoteTextureHostWrapper.cpp
+@@ -86,6 +86,15 @@ gfx::IntSize RemoteTextureHostWrapper::GetSize() const {
+   return mRemoteTexture->GetSize();
+ }
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++uint64_t RemoteTextureHostWrapper::GetVideoSourceIdentity() const {
++  if (!mRemoteTexture) {
++    return 0;
++  }
++  return mRemoteTexture->GetVideoSourceIdentity();
++}
++#endif
++
+ gfx::SurfaceFormat RemoteTextureHostWrapper::GetFormat() const {
+   MOZ_ASSERT(mRemoteTexture, "TextureHost isn't valid yet");
+   if (!mRemoteTexture) {

--- a/src/gfx/layers/composite/RemoteTextureHostWrapper-h.patch
+++ b/src/gfx/layers/composite/RemoteTextureHostWrapper-h.patch
@@ -1,0 +1,15 @@
+diff --git a/gfx/layers/composite/RemoteTextureHostWrapper.h b/gfx/layers/composite/RemoteTextureHostWrapper.h
+index bc260cc420f8831b09e130c235b22a728275927a..a1498021a76a98dc11580638f4e7fcbcc12d3813 100644
+--- a/gfx/layers/composite/RemoteTextureHostWrapper.h
++++ b/gfx/layers/composite/RemoteTextureHostWrapper.h
+@@ -37,6 +37,10 @@ class RemoteTextureHostWrapper : public TextureHost {
+ 
+   gfx::IntSize GetSize() const override;
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  uint64_t GetVideoSourceIdentity() const override;
++#endif
++
+   bool IsValid() override;
+ 
+ #ifdef MOZ_LAYERS_HAVE_LOG

--- a/src/gfx/layers/composite/TextureHost-h.patch
+++ b/src/gfx/layers/composite/TextureHost-h.patch
@@ -1,0 +1,46 @@
+diff --git a/gfx/layers/composite/TextureHost.h b/gfx/layers/composite/TextureHost.h
+index 97242d426d0cff4738de086ef62224a0828e380c..b07e3866bcd30518ba5ed8051f15a87969bb68ab 100644
+--- a/gfx/layers/composite/TextureHost.h
++++ b/gfx/layers/composite/TextureHost.h
+@@ -744,6 +744,29 @@ class TextureHost : public AtomicRefCountedWithFinalize<TextureHost> {
+     mDestroyedCallback = std::move(aDestroyedCallback);
+   }
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  void SetVideoFrameIdentity(uint32_t aProducer, int32_t aFrame) {
++    mVideoProducerId = aProducer;
++    mVideoFrameId = aFrame;
++    mHasVideoFrameIdentity = true;
++  }
++
++  bool GetVideoFrameIdentity(uint32_t* aProducer, int32_t* aFrame) const {
++    if (!mHasVideoFrameIdentity) {
++      return false;
++    }
++    if (aProducer) {
++      *aProducer = mVideoProducerId;
++    }
++    if (aFrame) {
++      *aFrame = mVideoFrameId;
++    }
++    return true;
++  }
++
++  virtual uint64_t GetVideoSourceIdentity() const { return 0; }
++#endif
++
+  protected:
+   virtual void ReadUnlock();
+ 
+@@ -770,6 +793,11 @@ class TextureHost : public AtomicRefCountedWithFinalize<TextureHost> {
+   uint64_t mFwdTransactionId;
+   bool mReadLocked;
+   wr::MaybeExternalImageId mExternalImageId;
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  uint32_t mVideoProducerId = 0;
++  int32_t mVideoFrameId = 0;
++  bool mHasVideoFrameIdentity = false;
++#endif
+ 
+   std::function<void()> mDestroyedCallback;
+ 

--- a/src/gfx/layers/opengl/DMABUFTextureHostOGL-cpp.patch
+++ b/src/gfx/layers/opengl/DMABUFTextureHostOGL-cpp.patch
@@ -1,0 +1,27 @@
+diff --git a/gfx/layers/opengl/DMABUFTextureHostOGL.cpp b/gfx/layers/opengl/DMABUFTextureHostOGL.cpp
+index e2a3315f7ec22c56ab585d70c48c4326133914a0..fbb978920021ccc92845ee290c0a471e396bd723 100644
+--- a/gfx/layers/opengl/DMABUFTextureHostOGL.cpp
++++ b/gfx/layers/opengl/DMABUFTextureHostOGL.cpp
+@@ -186,6 +186,7 @@ void DMABUFTextureHostOGL::PushDisplayItems(
+   bool preferCompositorSurface =
+       aFlags.contains(PushDisplayItemFlag::PREFER_COMPOSITOR_SURFACE);
+   bool supportsDirectComposition =
++      !aFlags.contains(PushDisplayItemFlag::EXTERNAL_COMPOSITING_DISABLED) &&
+       widget::GetGlobalDMABufFormats()->SupportsDirectComposition(
+           mSurface->GetFormat());
+ 
+@@ -251,4 +252,14 @@ void DMABUFTextureHostOGL::PushDisplayItems(
+   }
+ }
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++uint64_t DMABUFTextureHostOGL::GetVideoSourceIdentity() const {
++  if (!mSurface || !mSurface->GetUID()) {
++    return 0;
++  }
++  return (static_cast<uint64_t>(mSurface->GetPID()) << 32) |
++         static_cast<uint64_t>(mSurface->GetUID());
++}
++#endif
++
+ }  // namespace mozilla::layers

--- a/src/gfx/layers/opengl/DMABUFTextureHostOGL-h.patch
+++ b/src/gfx/layers/opengl/DMABUFTextureHostOGL-h.patch
@@ -1,0 +1,15 @@
+diff --git a/gfx/layers/opengl/DMABUFTextureHostOGL.h b/gfx/layers/opengl/DMABUFTextureHostOGL.h
+index c4f95d6317b006ef712d367d6f0e7ec06266ca09..646bffd946bda51aee5a60de47a16b38f65e5693 100644
+--- a/gfx/layers/opengl/DMABUFTextureHostOGL.h
++++ b/gfx/layers/opengl/DMABUFTextureHostOGL.h
+@@ -44,6 +44,10 @@ class DMABUFTextureHostOGL : public TextureHost {
+   gfx::ColorRange GetColorRange() const override;
+   gfx::TransferFunction GetTransferFunction() const override;
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  uint64_t GetVideoSourceIdentity() const override;
++#endif
++
+   void CreateRenderTexture(
+       const wr::ExternalImageId& aExternalImageId) override;
+ 

--- a/src/gfx/layers/wr/AsyncImagePipelineManager-cpp.patch
+++ b/src/gfx/layers/wr/AsyncImagePipelineManager-cpp.patch
@@ -1,0 +1,347 @@
+diff --git a/gfx/layers/wr/AsyncImagePipelineManager.cpp b/gfx/layers/wr/AsyncImagePipelineManager.cpp
+index 48819d982fae25c959e7a08dff56fae8998b997e..b8410a7989010bc4a58b8f6ac85f0591ffcaa5d2 100644
+--- a/gfx/layers/wr/AsyncImagePipelineManager.cpp
++++ b/gfx/layers/wr/AsyncImagePipelineManager.cpp
+@@ -21,10 +21,15 @@
+ #include "mozilla/webrender/RenderThread.h"
+ #include "mozilla/webrender/WebRenderAPI.h"
+ #include "mozilla/webrender/WebRenderTypes.h"
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++#include "mozilla/zen/VideoSuperResolutionCoordinator.h"
++#include "mozilla/zen/VideoSuperResolutionProfiler.h"
++#include "mozilla/zen/VideoSuperResolutionScalePolicy.h"
++#include "mozilla/zen/VideoSuperResolutionTexturePool.h"
++#endif
+ 
+ namespace mozilla {
+ namespace layers {
+-
+ AsyncImagePipelineManager::ForwardingExternalImage::~ForwardingExternalImage() {
+   DebugOnly<bool> released = SharedSurfacesParent::Release(mImageId);
+   MOZ_ASSERT(released);
+@@ -195,6 +200,13 @@ void AsyncImagePipelineManager::RemoveAsyncImagePipeline(
+     for (wr::ImageKey key : holder->mKeys) {
+       aTxn.DeleteImage(key);
+     }
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++    if (holder->mSuperResolutionKey.isSome()) {
++      aTxn.DeleteImage(holder->mSuperResolutionKey.ref());
++    }
++    zen::VideoSuperResolutionCoordinator::Get().InvalidatePipeline(id);
++    zen::VideoSuperResolutionTexturePool::Get().ReleasePipeline(id, epoch.mHandle);
++#endif
+     entry.Remove();
+     RemovePipeline(aPipelineId, epoch);
+   }
+@@ -216,6 +228,36 @@ void AsyncImagePipelineManager::UpdateAsyncImagePipeline(
+   pipeline->Update(aScBounds, aRotation, aFilter, aMixBlendMode);
+ }
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++bool AsyncImagePipelineManager::EnsureSuperResolutionKey(
++    AsyncImagePipeline* aPipeline, wr::TransactionBuilder& aSceneBuilderTxn,
++    bool aActive, uint64_t aPipelineId) {
++  if (!aActive ||
++      !zen::VideoSuperResolutionTexturePool::Get().EnsureInitialized()) {
++    if (aPipeline->mSuperResolutionKey.isSome()) {
++      aSceneBuilderTxn.DeleteImage(aPipeline->mSuperResolutionKey.ref());
++      aPipeline->mSuperResolutionKey.reset();
++    }
++    return false;
++  }
++  const bool isAdd = aPipeline->mSuperResolutionKey.isNothing();
++  if (isAdd) {
++    aPipeline->mSuperResolutionKey = Some(GenerateImageKey());
++  }
++  if (!zen::VideoSuperResolutionTexturePool::Get().EnsureKeyResource(
++          aSceneBuilderTxn, isAdd, aPipeline->mSuperResolutionKey.ref(), aPipelineId)) {
++    if (isAdd) {
++      aPipeline->mSuperResolutionKey.reset();
++    } else {
++      aSceneBuilderTxn.DeleteImage(aPipeline->mSuperResolutionKey.ref());
++      aPipeline->mSuperResolutionKey.reset();
++    }
++    return false;
++  }
++  return !isAdd;
++}
++#endif
++
+ Maybe<TextureHost::ResourceUpdateOp> AsyncImagePipelineManager::UpdateImageKeys(
+     const wr::Epoch& aEpoch, const wr::PipelineId& aPipelineId,
+     AsyncImagePipeline* aPipeline, TextureHost* aTexture,
+@@ -432,9 +474,145 @@ void AsyncImagePipelineManager::ApplyAsyncImageForPipeline(
+   auto op = UpdateImageKeys(aEpoch, aPipelineId, aPipeline, aTexture, keys,
+                             aSceneBuilderTxn, aMaybeFastTxn);
+ 
++  bool superResolutionSelected = false;
++  bool forceTextured = false;
++  bool superResolutionChanged = false;
++  bool directCompositionChanged = false;
++
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  bool wantSuperResolution = false;
++  bool superResolutionFailed = false;
++  zen::SuperResolutionFrameToken currentToken;
++  const uint64_t pipelineId = wr::AsUint64(aPipelineId);
++  auto& superResolutionPool = zen::VideoSuperResolutionTexturePool::Get();
++  const bool superResolutionEnabled = superResolutionPool.VfxEnabled();
++  uint64_t configGen = 0;
++  if (superResolutionEnabled && aPipeline->mUseExternalImage && aTexture &&
++      aTexture->GetFormat() == gfx::SurfaceFormat::NV12 &&
++      aTexture->GetColorRange() == gfx::ColorRange::LIMITED &&
++      aTexture->GetTransferFunction() == gfx::TransferFunction::BT709) {
++    configGen = zen::VideoSuperResolutionCoordinator::Get().SyncConfigFromPrefs();
++    const bool isHardware =
++        aSceneBuilderTxn.GetCapabilities().mBackendType !=
++        WebRenderBackend::SOFTWARE;
++    wantSuperResolution = superResolutionPool.ShouldActivate(isHardware);
++    if (wantSuperResolution &&
++        superResolutionPool.HasFailed()) {
++      wantSuperResolution = false;
++      superResolutionFailed = true;
++    }
++    if (wantSuperResolution) {
++      uint32_t producer = 0;
++      int32_t frame = 0;
++      if (aTexture->GetVideoFrameIdentity(&producer, &frame)) {
++        const gfx::IntSize size = aTexture->GetSize();
++        const auto targetDecision =
++            zen::VideoSuperResolutionScalePolicy::EvaluateTarget(
++                size, aPipeline->mScBounds.Width(),
++                aPipeline->mScBounds.Height());
++
++        if (targetDecision.eligible &&
++            superResolutionPool.CanClaimOwner(
++                pipelineId, aPipeline->mScBounds.Width(),
++                aPipeline->mScBounds.Height())) {
++          currentToken.producer = producer;
++          currentToken.frame = frame;
++          currentToken.sessionGeneration =
++              superResolutionPool.GetSessionGeneration();
++          currentToken.configGeneration = configGen;
++          currentToken.contextGeneration =
++              superResolutionPool.GetContextGeneration(
++                  pipelineId);
++          currentToken.sourceWidth = size.width;
++          currentToken.sourceHeight = size.height;
++          currentToken.outputWidth = targetDecision.outputWidth;
++          currentToken.outputHeight = targetDecision.outputHeight;
++          zen::VideoSuperResolutionCoordinator::Get().NoteSelected(
++              wr::AsUint64(aPipelineId), currentToken);
++          superResolutionPool.BindPipelineImageHost(
++              wr::AsUint64(aPipelineId), aPipeline->mImageHost,
++              mIdNamespace.mHandle);
++        } else {
++          wantSuperResolution = false;
++        }
++      } else {
++        wantSuperResolution = false;
++      }
++    }
++  }
++  if (wantSuperResolution) {
++    superResolutionPool.EnsureInitialized();
++    superResolutionPool.RequestSnapshot(
++        currentToken, pipelineId,
++        aPipeline->mCurrentTexture->GetVideoSourceIdentity());
++  } else if (superResolutionEnabled || aPipeline->mSuperResolutionActive ||
++             aPipeline->mSuperResolutionForceTextured ||
++             aPipeline->mSuperResolutionKey.isSome()) {
++    zen::VideoSuperResolutionCoordinator::Get().InvalidatePipeline(pipelineId);
++    superResolutionPool.ReleasePipeline(pipelineId, aEpoch.mHandle);
++  }
++  zen::SuperResolutionFrameToken matchedToken;
++  const bool tokenMatched =
++      wantSuperResolution &&
++      zen::VideoSuperResolutionCoordinator::Get().LookupReady(
++          pipelineId, currentToken, &matchedToken);
++  int slot = -1;
++  if (tokenMatched &&
++      zen::VideoSuperResolutionTexturePool::Get().EnsureInitialized()) {
++    slot = zen::VideoSuperResolutionTexturePool::Get().FindReadySlot(
++        matchedToken, mIdNamespace.mHandle);
++  }
++  const bool published =
++      slot >= 0 &&
++      zen::VideoSuperResolutionTexturePool::Get().Publish(
++          pipelineId, slot, matchedToken, nullptr);
++  const bool wasActiveBefore = aPipeline->mSuperResolutionActive;
++  zen::SuperResolutionFrameToken heldToken;
++  const bool held =
++      !published && wantSuperResolution && wasActiveBefore &&
++      zen::VideoSuperResolutionTexturePool::Get().TryHoldPublished(
++          pipelineId, currentToken, &heldToken);
++  const bool wantSelected = published || held;
++  superResolutionSelected = EnsureSuperResolutionKey(
++      aPipeline, aSceneBuilderTxn, wantSelected, pipelineId);
++  superResolutionChanged = superResolutionSelected != wasActiveBefore;
++  aPipeline->mSuperResolutionActive = superResolutionSelected;
++  if (superResolutionSelected && published) {
++    zen::VideoSuperResolutionCoordinator::Get().NotePresented(pipelineId,
++                                                              matchedToken);
++  } else if (superResolutionSelected && held) {
++    zen::VideoSuperResolutionCoordinator::Get().NotePresented(pipelineId,
++                                                              heldToken);
++  }
++  if (!wantSelected) {
++    zen::VideoSuperResolutionTexturePool::Get().Unpublish(pipelineId);
++  }
++
++  forceTextured = wantSuperResolution;
++  directCompositionChanged =
++      forceTextured != aPipeline->mSuperResolutionForceTextured;
++  MOZ_ASSERT(!superResolutionSelected || wantSuperResolution);
++  MOZ_ASSERT(!superResolutionSelected || aPipeline->mSuperResolutionKey.isSome());
++  if (superResolutionChanged || directCompositionChanged) {
++    const zen::SuperResolutionCompositionReason transition =
++        superResolutionSelected
++            ? zen::SuperResolutionCompositionReason::OwnerActivated
++            : !wantSuperResolution
++                  ? (superResolutionFailed
++                         ? zen::SuperResolutionCompositionReason::Failure
++                         : zen::SuperResolutionCompositionReason::OwnerLost)
++                  : zen::SuperResolutionCompositionReason::OwnerSelected;
++    const char* reasonStr =
++        zen::SuperResolutionCompositionReasonToString(transition);
++    zen::MarkComposition(pipelineId, superResolutionSelected, reasonStr);
++  }
++
++#endif
++
+   bool updateDisplayList =
+       aPipeline->mInitialised &&
+-      (aPipeline->mIsChanged || op == Some(TextureHost::ADD_IMAGE)) &&
++      (aPipeline->mIsChanged || op == Some(TextureHost::ADD_IMAGE) ||
++       superResolutionChanged || directCompositionChanged) &&
+       !!aPipeline->mCurrentTexture;
+ 
+   if (!updateDisplayList) {
+@@ -445,6 +623,11 @@ void AsyncImagePipelineManager::ApplyAsyncImageForPipeline(
+     // Use transaction of scene builder thread to notify epoch.
+     // It is for making epoch update consistent.
+     aSceneBuilderTxn.UpdateEpoch(aPipelineId, aEpoch);
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++    zen::VideoSuperResolutionTexturePool::Get().NoteTransaction(
++        pipelineId, aEpoch.mHandle);
++    zen::VideoSuperResolutionTexturePool::Get().NotePipelineComposite(pipelineId);
++#endif
+     if (aPipeline->mCurrentTexture) {
+       HoldExternalImage(aPipelineId, aEpoch, aPipeline->mCurrentTexture);
+     }
+@@ -453,6 +636,9 @@ void AsyncImagePipelineManager::ApplyAsyncImageForPipeline(
+ 
+   aPipeline->mIsChanged = false;
+   // A single image at integral coordinates: no normalization to be exact about.
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  aPipeline->mSuperResolutionForceTextured = forceTextured;
++#endif
+   aPipeline->mDLBuilder.Begin(AppUnitsPerCSSPixel());
+ 
+   float opacity = 1.0f;
+@@ -462,7 +648,8 @@ void AsyncImagePipelineManager::ApplyAsyncImageForPipeline(
+ 
+   wr::WrComputedTransformData computedTransform;
+   computedTransform.vertical_flip =
+-      aPipeline->mCurrentTexture && aPipeline->mCurrentTexture->NeedsYFlip();
++      !superResolutionSelected && aPipeline->mCurrentTexture &&
++      aPipeline->mCurrentTexture->NeedsYFlip();
+   computedTransform.scale_from = {
+       float(aPipeline->mCurrentTexture->GetSize().width),
+       float(aPipeline->mCurrentTexture->GetSize().height)};
+@@ -488,6 +675,40 @@ void AsyncImagePipelineManager::ApplyAsyncImageForPipeline(
+ 
+     if (aPipeline->mUseExternalImage) {
+       MOZ_ASSERT(aPipeline->mCurrentTexture->AsWebRenderTextureHost());
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++      if (superResolutionSelected && aPipeline->mSuperResolutionKey.isSome()) {
++        const wr::LayoutRect bounds = wr::ToLayoutRect(rect);
++        aPipeline->mDLBuilder.PushImage(
++            bounds, bounds, true, false, aPipeline->mFilter,
++            aPipeline->mSuperResolutionKey.ref(), true,
++            wr::ColorF{1.0f, 1.0f, 1.0f, 1.0f}, false, false);
++        HoldExternalImage(aPipelineId, aEpoch, aPipeline->mCurrentTexture);
++      } else {
++        Range<wr::ImageKey> range_keys(&keys[0], keys.Length());
++        TextureHost::PushDisplayItemFlagSet flags;
++        if (!forceTextured) {
++          flags += TextureHost::PushDisplayItemFlag::PREFER_COMPOSITOR_SURFACE;
++        }
++        if (forceTextured) {
++          flags +=
++              TextureHost::PushDisplayItemFlag::EXTERNAL_COMPOSITING_DISABLED;
++        }
++        if (aPipeline->mVideoOverlayDisabled &&
++            aPipeline->mDLBuilder.GetBackendType() !=
++                WebRenderBackend::SOFTWARE) {
++          flags +=
++              TextureHost::PushDisplayItemFlag::EXTERNAL_COMPOSITING_DISABLED;
++        }
++        if (mApi->GetCapabilities().mSupportsExternalBufferTextures) {
++          flags += TextureHost::PushDisplayItemFlag::
++              SUPPORTS_EXTERNAL_BUFFER_TEXTURES;
++        }
++        aPipeline->mCurrentTexture->PushDisplayItems(
++            aPipeline->mDLBuilder, wr::ToLayoutRect(rect),
++            wr::ToLayoutRect(rect), aPipeline->mFilter, range_keys, flags);
++        HoldExternalImage(aPipelineId, aEpoch, aPipeline->mCurrentTexture);
++      }
++#else
+       Range<wr::ImageKey> range_keys(&keys[0], keys.Length());
+       TextureHost::PushDisplayItemFlagSet flags;
+       flags += TextureHost::PushDisplayItemFlag::PREFER_COMPOSITOR_SURFACE;
+@@ -505,6 +726,7 @@ void AsyncImagePipelineManager::ApplyAsyncImageForPipeline(
+           aPipeline->mDLBuilder, wr::ToLayoutRect(rect), wr::ToLayoutRect(rect),
+           aPipeline->mFilter, range_keys, flags);
+       HoldExternalImage(aPipelineId, aEpoch, aPipeline->mCurrentTexture);
++#endif
+     } else {
+       MOZ_ASSERT(keys.Length() == 1);
+       aPipeline->mDLBuilder.PushImage(wr::ToLayoutRect(rect),
+@@ -521,6 +743,11 @@ void AsyncImagePipelineManager::ApplyAsyncImageForPipeline(
+ 
+   aSceneBuilderTxn.SetDisplayList(aEpoch, mIdNamespace, aPipelineId, dl.dl_desc,
+                                   dl.dl_items, dl.dl_spatial_tree);
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  zen::VideoSuperResolutionTexturePool::Get().NoteTransaction(
++      pipelineId, aEpoch.mHandle);
++  zen::VideoSuperResolutionTexturePool::Get().NotePipelineComposite(pipelineId);
++#endif
+ }
+ 
+ void AsyncImagePipelineManager::ApplyAsyncImageForPipeline(
+@@ -671,6 +898,10 @@ void AsyncImagePipelineManager::NotifyPipelinesUpdated(
+   MOZ_ASSERT(aLatestFrameId.IsValid());
+ 
+   mLastCompletedFrameId = aLastCompletedFrameId.mId;
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  zen::VideoSuperResolutionTexturePool::Get().NoteCompletedRender(
++      mIdNamespace.mHandle, aLastCompletedFrameId.mId);
++#endif
+ 
+   {
+     // We need to lock for mRenderSubmittedUpdates because it can be accessed
+@@ -727,6 +958,11 @@ void AsyncImagePipelineManager::ProcessPipelineUpdates() {
+ void AsyncImagePipelineManager::ProcessPipelineRendered(
+     const wr::PipelineId& aPipelineId, const wr::Epoch& aEpoch,
+     wr::RenderedFrameId aRenderedFrameId) {
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  zen::VideoSuperResolutionTexturePool::Get().NotePipelineRendered(
++      wr::AsUint64(aPipelineId), aEpoch.mHandle, aRenderedFrameId.mId,
++      mIdNamespace.mHandle, mLastCompletedFrameId);
++#endif
+   if (auto entry = mPipelineTexturesHolders.Lookup(wr::AsUint64(aPipelineId))) {
+     const auto& holder = entry.Data();
+     // For TextureHosts that can be released on render submission, using aEpoch
+@@ -796,6 +1032,11 @@ void AsyncImagePipelineManager::ProcessPipelineRendered(
+ void AsyncImagePipelineManager::ProcessPipelineRemoved(
+     const wr::RemovedPipeline& aRemovedPipeline,
+     wr::RenderedFrameId aRenderedFrameId) {
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  zen::VideoSuperResolutionTexturePool::Get().NotePipelineRemoved(
++      wr::AsUint64(aRemovedPipeline.pipeline_id), aRenderedFrameId.mId,
++      mIdNamespace.mHandle, mLastCompletedFrameId);
++#endif
+   if (mDestroyed) {
+     return;
+   }

--- a/src/gfx/layers/wr/AsyncImagePipelineManager-h.patch
+++ b/src/gfx/layers/wr/AsyncImagePipelineManager-h.patch
@@ -1,0 +1,36 @@
+diff --git a/gfx/layers/wr/AsyncImagePipelineManager.h b/gfx/layers/wr/AsyncImagePipelineManager.h
+index 47d64a09a4f40a0bd6ead72a6dd1cc723167f5eb..75d5c6617c30738e752bf47da4d81750d46d5e10 100644
+--- a/gfx/layers/wr/AsyncImagePipelineManager.h
++++ b/gfx/layers/wr/AsyncImagePipelineManager.h
+@@ -146,6 +146,7 @@ class AsyncImagePipelineManager final {
+   TextureFactoryIdentifier GetTextureFactoryIdentifier() const {
+     return mTextureFactoryIdentifier;
+   }
++  uint32_t GetIdNamespaceHandle() const { return mIdNamespace.mHandle; }
+ 
+  private:
+   void ProcessPipelineRendered(const wr::PipelineId& aPipelineId,
+@@ -221,6 +222,11 @@ class AsyncImagePipelineManager final {
+     nsTArray<wr::ImageKey> mKeys;
+     wr::DisplayListBuilder mDLBuilder;
+     bool mVideoOverlayDisabled = false;
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++    Maybe<wr::ImageKey> mSuperResolutionKey;
++    bool mSuperResolutionActive = false;
++    bool mSuperResolutionForceTextured = false;
++#endif
+   };
+ 
+   void ApplyAsyncImageForPipeline(const wr::Epoch& aEpoch,
+@@ -237,6 +243,11 @@ class AsyncImagePipelineManager final {
+   Maybe<TextureHost::ResourceUpdateOp> UpdateWithoutExternalImage(
+       TextureHost* aTexture, wr::ImageKey aKey, TextureHost::ResourceUpdateOp,
+       wr::TransactionBuilder& aTxn);
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  bool EnsureSuperResolutionKey(AsyncImagePipeline* aPipeline,
++                                wr::TransactionBuilder& aSceneBuilderTxn,
++                                bool aActive, uint64_t aPipelineId);
++#endif
+ 
+   void CheckForTextureHostsNotUsedByGPU();
+ 

--- a/src/gfx/layers/wr/WebRenderImageHost-cpp.patch
+++ b/src/gfx/layers/wr/WebRenderImageHost-cpp.patch
@@ -1,0 +1,111 @@
+diff --git a/gfx/layers/wr/WebRenderImageHost.cpp b/gfx/layers/wr/WebRenderImageHost.cpp
+index 20441740bff4a633bebfe8b10b20ba1301da6a9c..c300fdf29fb158a0a5b6bad9dbbb5d63f5723e5c 100644
+--- a/gfx/layers/wr/WebRenderImageHost.cpp
++++ b/gfx/layers/wr/WebRenderImageHost.cpp
+@@ -19,6 +19,13 @@
+ #include "mozilla/layers/RemoteTextureMap.h"
+ #include "mozilla/layers/WebRenderBridgeParent.h"
+ #include "mozilla/layers/WebRenderTextureHost.h"
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++#include "GLContext.h"
++#include "mozilla/webrender/RenderThread.h"
++#include "mozilla/webrender/RendererOGL.h"
++#include "mozilla/webrender/WebRenderAPI.h"
++#include "mozilla/zen/VideoSuperResolutionTexturePool.h"
++#endif
+ #include "nsAString.h"
+ #include "nsDebug.h"          // for NS_WARNING, NS_ASSERTION
+ #include "nsPrintfCString.h"  // for nsPrintfCString
+@@ -37,6 +44,25 @@ namespace layers {
+ 
+ class ISurfaceAllocator;
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++class SuperResolutionPollEvent final : public wr::RendererEvent {
++ public:
++  void Run(wr::RenderThread& aRenderThread, wr::WindowId aWindowId) override {
++    if (aRenderThread.IsDestroyed(aWindowId)) {
++      return;
++    }
++    auto* renderer = aRenderThread.GetRenderer(aWindowId);
++    auto* gl = renderer ? renderer->gl() : nullptr;
++    if (gl && gl->MakeCurrent()) {
++      zen::VideoSuperResolutionTexturePool::Get().ProcessPendingSnapshots(gl);
++      zen::VideoSuperResolutionTexturePool::Get().PollVfxResults(gl);
++    }
++  }
++
++  const char* Name() override { return "SuperResolutionPollEvent"; }
++};
++#endif
++
+ WebRenderImageHost::WebRenderImageHost(const TextureInfo& aTextureInfo)
+     : CompositableHost(aTextureInfo), mCurrentAsyncImageManager(nullptr) {}
+ 
+@@ -367,6 +393,11 @@ TextureHost* WebRenderImageHost::GetAsTextureHostForComposite(
+       PROFILER_MARKER_TEXT("WebRenderImageHost", GRAPHICS, {}, str);
+     }
+   }
++#endif
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  if (texture) {
++    texture->SetVideoFrameIdentity(img->mProducerID, img->mFrameID);
++  }
+ #endif
+   SetCurrentTextureHost(texture);
+ 
+@@ -423,5 +454,54 @@ void WebRenderImageHost::ClearWrBridge(const wr::PipelineId& aPipelineId,
+   SetCurrentTextureHost(nullptr);
+ }
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++bool WebRenderImageHost::RequestSuperResolutionRenderPoll() {
++  if (!CompositorThreadHolder::IsInCompositorThread()) {
++    RefPtr<WebRenderImageHost> self = this;
++    nsresult rv = CompositorThread()->Dispatch(NS_NewRunnableFunction(
++        "WebRenderImageHost::RequestSuperResolutionRenderPoll",
++        [self] { self->RequestSuperResolutionRenderPoll(); }));
++    return NS_SUCCEEDED(rv);
++  }
++  auto* renderThread = wr::RenderThread::Get();
++  if (!renderThread) {
++    return false;
++  }
++  bool requested = false;
++  for (const auto& it : mWrBridges) {
++    RefPtr<WebRenderBridgeParent> wrBridge = it.second->WrBridge();
++    if (!wrBridge) {
++      continue;
++    }
++    RefPtr<wr::WebRenderAPI> api = wrBridge->GetWebRenderAPI();
++    if (!api) {
++      continue;
++    }
++    renderThread->PostEvent(api->GetId(), MakeUnique<SuperResolutionPollEvent>());
++    requested = true;
++  }
++  return requested;
++}
++
++void WebRenderImageHost::RequestSuperResolutionComposition() {
++  if (!CompositorThreadHolder::IsInCompositorThread()) {
++    RefPtr<WebRenderImageHost> self = this;
++    if (NS_FAILED(CompositorThread()->Dispatch(NS_NewRunnableFunction(
++            "WebRenderImageHost::RequestSuperResolutionComposition",
++            [self] { self->RequestSuperResolutionComposition(); })))) {
++      return;
++    }
++    return;
++  }
++  for (const auto& it : mWrBridges) {
++    RefPtr<WebRenderBridgeParent> wrBridge = it.second->WrBridge();
++    if (wrBridge && wrBridge->CompositorScheduler()) {
++      wrBridge->CompositorScheduler()->ScheduleComposition(
++          wr::RenderReasons::ASYNC_IMAGE);
++    }
++  }
++}
++#endif
++
+ }  // namespace layers
+ }  // namespace mozilla

--- a/src/gfx/layers/wr/WebRenderImageHost-h.patch
+++ b/src/gfx/layers/wr/WebRenderImageHost-h.patch
@@ -1,0 +1,15 @@
+diff --git a/gfx/layers/wr/WebRenderImageHost.h b/gfx/layers/wr/WebRenderImageHost.h
+index b1e6ce026cc4c40724997becf47d9524dfae73b7..9b8a8f216a8b3bc0d1ebb135522bc52a2a76bc85 100644
+--- a/gfx/layers/wr/WebRenderImageHost.h
++++ b/gfx/layers/wr/WebRenderImageHost.h
+@@ -59,6 +59,10 @@ class WebRenderImageHost : public CompositableHost, public ImageComposite {
+ 
+   void ClearWrBridge(const wr::PipelineId& aPipelineId,
+                      WebRenderBridgeParent* aWrBridge);
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  bool RequestSuperResolutionRenderPoll();
++  void RequestSuperResolutionComposition();
++#endif
+ 
+   TextureHost* GetCurrentTextureHost() { return mCurrentTextureHost; }
+ 

--- a/src/gfx/layers/wr/WebRenderTextureHost-h.patch
+++ b/src/gfx/layers/wr/WebRenderTextureHost-h.patch
@@ -1,0 +1,17 @@
+diff --git a/gfx/layers/wr/WebRenderTextureHost.h b/gfx/layers/wr/WebRenderTextureHost.h
+index baaf5f4a09b0a05b0bd63c08724b57a1ccad6f08..ca26855938563515e5414f17c0106090daff5ee7 100644
+--- a/gfx/layers/wr/WebRenderTextureHost.h
++++ b/gfx/layers/wr/WebRenderTextureHost.h
+@@ -51,6 +51,12 @@ class WebRenderTextureHost final : public TextureHost {
+ 
+   bool NeedsYFlip() const override;
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  uint64_t GetVideoSourceIdentity() const override {
++    return mWrappedTextureHost->GetVideoSourceIdentity();
++  }
++#endif
++
+   gfx::IntSize GetSize() const override;
+ 
+ #ifdef MOZ_LAYERS_HAVE_LOG

--- a/src/gfx/webrender_bindings/RenderDMABUFTextureHost-cpp.patch
+++ b/src/gfx/webrender_bindings/RenderDMABUFTextureHost-cpp.patch
@@ -1,0 +1,75 @@
+diff --git a/gfx/webrender_bindings/RenderDMABUFTextureHost.cpp b/gfx/webrender_bindings/RenderDMABUFTextureHost.cpp
+index 4728ccfc9995452e421645ca8d44f6065e851b78..32c4aec29d9e969544f06688e13a6f5f3389b876 100644
+--- a/gfx/webrender_bindings/RenderDMABUFTextureHost.cpp
++++ b/gfx/webrender_bindings/RenderDMABUFTextureHost.cpp
+@@ -7,16 +7,35 @@
+ #include "GLContextEGL.h"
+ #include "ScopedGLHelpers.h"
+ #include "mozilla/gfx/Logging.h"
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++#include "mozilla/StaticPrefs_zen.h"
++#include "mozilla/zen/VideoSuperResolutionTexturePool.h"
++#endif
+ 
+ namespace mozilla::wr {
+ 
+ RenderDMABUFTextureHost::RenderDMABUFTextureHost(DMABufSurface* aSurface)
+     : mSurface(aSurface) {
+   MOZ_COUNT_CTOR_INHERITED(RenderDMABUFTextureHost, RenderTextureHost);
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  if (mSurface && mSurface->GetUID()) {
++    const uint64_t id = (static_cast<uint64_t>(mSurface->GetPID()) << 32) |
++                        static_cast<uint64_t>(mSurface->GetUID());
++    zen::VideoSuperResolutionTexturePool::Get().RegisterSourceSurface(id,
++                                                                        mSurface);
++  }
++#endif
+ }
+ 
+ RenderDMABUFTextureHost::~RenderDMABUFTextureHost() {
+   MOZ_COUNT_DTOR_INHERITED(RenderDMABUFTextureHost, RenderTextureHost);
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  if (mSurface && mSurface->GetUID()) {
++    const uint64_t id = (static_cast<uint64_t>(mSurface->GetPID()) << 32) |
++                        static_cast<uint64_t>(mSurface->GetUID());
++    zen::VideoSuperResolutionTexturePool::Get().UnregisterSourceSurface(id, mSurface);
++  }
++#endif
+   DeleteTextureHandle();
+ }
+ 
+@@ -59,6 +78,34 @@ wr::WrExternalImage RenderDMABUFTextureHost::Lock(uint8_t aChannelIndex,
+     mSurface->MaybeSemaphoreWait(texture);
+   }
+ 
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  if (aChannelIndex == 0 &&
++      StaticPrefs::zen_video_super_resolution_enabled()) {
++    if (mSurface->GetUID()) {
++      const uint64_t id =
++          (static_cast<uint64_t>(mSurface->GetPID()) << 32) |
++          static_cast<uint64_t>(mSurface->GetUID());
++      zen::VideoSuperResolutionTexturePool::Get().RegisterSourceSurface(id,
++                                                                         mSurface);
++    }
++    const int planeCount = mSurface->GetTextureCount();
++    for (int i = 0; i < planeCount; ++i) {
++      if (!mSurface->GetTexture(i)) {
++        if (!mSurface->CreateTexture(mGL, i)) {
++          break;
++        }
++        ActivateBindAndTexParameteri(mGL, LOCAL_GL_TEXTURE0,
++                                     LOCAL_GL_TEXTURE_2D,
++                                     mSurface->GetTexture(i));
++      }
++    }
++    for (int i = 0; i < planeCount; ++i) {
++      if (auto texture = mSurface->GetTexture(i)) {
++        mSurface->MaybeSemaphoreWait(texture);
++      }
++    }
++  }
++#endif
+   return NativeTextureToWrExternalImage(
+       mSurface->GetTexture(aChannelIndex), 0.0, 0.0,
+       static_cast<float>(size.width), static_cast<float>(size.height));

--- a/src/gfx/webrender_bindings/RendererOGL-cpp.patch
+++ b/src/gfx/webrender_bindings/RendererOGL-cpp.patch
@@ -1,0 +1,38 @@
+diff --git a/gfx/webrender_bindings/RendererOGL.cpp b/gfx/webrender_bindings/RendererOGL.cpp
+index bdc8146983a873ebefdc8b0efc0e8985fe7a601a..2a3bc8799d48439a2f622f3ddaa35948a2a30253 100644
+--- a/gfx/webrender_bindings/RendererOGL.cpp
++++ b/gfx/webrender_bindings/RendererOGL.cpp
+@@ -19,6 +19,10 @@
+ #include "mozilla/webrender/RenderCompositor.h"
+ #include "mozilla/webrender/RenderTextureHost.h"
+ #include "mozilla/widget/CompositorWidget.h"
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++#include "mozilla/layers/AsyncImagePipelineManager.h"
++#include "mozilla/zen/VideoSuperResolutionTexturePool.h"
++#endif
+ 
+ #ifdef MOZ_WIDGET_ANDROID
+ #  include "GLContextEGL.h"
+@@ -137,13 +141,21 @@ RendererOGL::~RendererOGL() {
+     mPendingScreenPixelsRequest->mPromise->Reject(NS_ERROR_ABORT, __func__);
+   }
+ #endif
+-  if (!mCompositor->MakeCurrent()) {
++  const bool glCurrent = mCompositor->MakeCurrent();
++  if (!glCurrent) {
+     gfxCriticalNote
+         << "Failed to make render context current during destroying.";
+     // Leak resources!
+   } else {
+     wr_renderer_delete(mRenderer);
+   }
++#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
++  if (RefPtr<layers::AsyncImagePipelineManager> manager =
++          mBridge->GetAsyncImagePipelineManager()) {
++    zen::VideoSuperResolutionTexturePool::Get().OnRendererDestroyed(
++        manager->GetIdNamespaceHandle(), glCurrent ? mCompositor->gl() : nullptr);
++  }
++#endif
+ }
+ 
+ wr::WrExternalImageHandler RendererOGL::GetExternalImageHandler() {

--- a/src/modules/libpref/moz-build.patch
+++ b/src/modules/libpref/moz-build.patch
@@ -1,8 +1,8 @@
 diff --git a/modules/libpref/moz.build b/modules/libpref/moz.build
-index fa05921295e8f028c4893c3cc224415d1251b877..acfcecaf6b0ae5f0aef5b540d9e60a3f5ffd02f4 100644
+index 2c8b218c618f8fa73ab4b21f4155d5f063bc1bb4..e8b525665d41e10309b4bb1779547d4b47e08f90 100644
 --- a/modules/libpref/moz.build
 +++ b/modules/libpref/moz.build
-@@ -91,6 +91,7 @@ pref_groups = [
+@@ -90,6 +90,7 @@ pref_groups = [
      "view_source",
      "webgl",
      "widget",
@@ -10,3 +10,13 @@ index fa05921295e8f028c4893c3cc224415d1251b877..acfcecaf6b0ae5f0aef5b540d9e60a3f
      "zoom",
  ]
  if CONFIG["OS_TARGET"] == "Android":
+@@ -140,8 +141,8 @@ GeneratedFile(
+     script="init/generate_static_pref_list.py",
+     entry_point="emit_code",
+     inputs=gen_inputs,
++    extra_deps=["init/zen-static-prefs.inc"],
+ )
+-
+ PYTHON_UNITTEST_MANIFESTS += [
+     "test/python.toml",
+ ]

--- a/src/zen/moz.build
+++ b/src/zen/moz.build
@@ -24,3 +24,6 @@ DIRS += [
     "sync",
     "window-drag",
 ]
+
+if CONFIG["OS_TARGET"] == "Linux" and CONFIG["MOZ_WIDGET_TOOLKIT"] == "gtk":
+    DIRS += ["video-super-resolution"]

--- a/src/zen/video-super-resolution/CudaGlInterop.cpp
+++ b/src/zen/video-super-resolution/CudaGlInterop.cpp
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "CudaGlInterop.h"
+
+namespace mozilla::zen {
+
+bool RegisterGlTexture(NvidiaVfxLoader& aLoader, unsigned int aTexture,
+                       CuGraphicsResource* aOut) {
+  if (!aLoader.HasGlInterop() || !aOut) {
+    return false;
+  }
+  *aOut = nullptr;
+  int rc = aLoader.GraphicsGLRegisterImage(
+      aOut, aTexture, kGlTexture2D, kCuGraphicsRegisterNone);
+  return rc == 0 && *aOut != nullptr;
+}
+
+bool UnregisterGlTexture(NvidiaVfxLoader& aLoader, CuGraphicsResource aRes) {
+  if (!aLoader.HasGlInterop() || !aRes) {
+    return false;
+  }
+  return aLoader.GraphicsUnregisterResource(aRes) == 0;
+}
+
+bool MapResource(NvidiaVfxLoader& aLoader, CuGraphicsResource aRes,
+                 CuStream aStream) {
+  if (!aLoader.HasGlInterop() || !aRes) {
+    return false;
+  }
+  CuGraphicsResource resList[1] = {aRes};
+  return aLoader.GraphicsMapResources(1, resList, aStream) == 0;
+}
+
+bool UnmapResource(NvidiaVfxLoader& aLoader, CuGraphicsResource aRes,
+                   CuStream aStream) {
+  if (!aLoader.HasGlInterop() || !aRes) {
+    return false;
+  }
+  CuGraphicsResource resList[1] = {aRes};
+  return aLoader.GraphicsUnmapResources(1, resList, aStream) == 0;
+}
+
+bool CopyImage(NvidiaVfxLoader& aLoader, CuDevicePtr aDst, size_t aDstPitch,
+               CuDevicePtr aSrc, size_t aSrcPitch, size_t aWidthBytes,
+               size_t aHeight, CuStream aStream) {
+  if (!aDst || !aSrc || aWidthBytes == 0 || aHeight == 0) {
+    return false;
+  }
+  NvidiaVfxLoader::Memcpy2DParams p;
+  p.srcMemoryType = 2;
+  p.srcDevice = aSrc;
+  p.srcPitch = aSrcPitch;
+  p.dstMemoryType = 2;
+  p.dstDevice = aDst;
+  p.dstPitch = aDstPitch;
+  p.widthInBytes = aWidthBytes;
+  p.height = aHeight;
+  return aLoader.CuMemcpy2DAsync(&p, aStream) == 0;
+}
+
+bool CopyArrayToImage(NvidiaVfxLoader& aLoader, CuDevicePtr aDst,
+                      size_t aDstPitch, void* aSrcArray, size_t aWidthBytes,
+                      size_t aHeight, CuStream aStream) {
+  if (!aDst || !aSrcArray || aWidthBytes == 0 || aHeight == 0) {
+    return false;
+  }
+  NvidiaVfxLoader::Memcpy2DParams p;
+  p.srcMemoryType = 3;
+  p.srcArray = aSrcArray;
+  p.dstMemoryType = 2;
+  p.dstDevice = aDst;
+  p.dstPitch = aDstPitch;
+  p.widthInBytes = aWidthBytes;
+  p.height = aHeight;
+  return aLoader.CuMemcpy2DAsync(&p, aStream) == 0;
+}
+
+bool CopyImageToArray(NvidiaVfxLoader& aLoader, void* aDstArray,
+                      CuDevicePtr aSrc, size_t aSrcPitch, size_t aWidthBytes,
+                      size_t aHeight, CuStream aStream) {
+  if (!aDstArray || !aSrc || aWidthBytes == 0 || aHeight == 0) {
+    return false;
+  }
+  NvidiaVfxLoader::Memcpy2DParams p;
+  p.srcMemoryType = 2;
+  p.srcDevice = aSrc;
+  p.srcPitch = aSrcPitch;
+  p.dstMemoryType = 3;
+  p.dstArray = aDstArray;
+  p.widthInBytes = aWidthBytes;
+  p.height = aHeight;
+  return aLoader.CuMemcpy2DAsync(&p, aStream) == 0;
+}
+
+}  // namespace mozilla::zen

--- a/src/zen/video-super-resolution/CudaGlInterop.h
+++ b/src/zen/video-super-resolution/CudaGlInterop.h
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_zen_CudaGlInterop_h
+#define mozilla_zen_CudaGlInterop_h
+
+#include <cstddef>
+
+#include "NvidiaVfxLoader.h"
+#include "VideoSuperResolutionTypes.h"
+
+namespace mozilla::zen {
+
+inline constexpr int kGlTexture2D = 0x0DE1;
+inline constexpr unsigned int kCuGraphicsRegisterNone = 0;
+inline constexpr unsigned int kCuStreamNonBlocking = 1;
+
+bool RegisterGlTexture(NvidiaVfxLoader& aLoader, unsigned int aTexture,
+                       CuGraphicsResource* aOut);
+
+bool UnregisterGlTexture(NvidiaVfxLoader& aLoader, CuGraphicsResource aRes);
+
+bool MapResource(NvidiaVfxLoader& aLoader, CuGraphicsResource aRes,
+                 CuStream aStream);
+
+bool UnmapResource(NvidiaVfxLoader& aLoader, CuGraphicsResource aRes,
+                   CuStream aStream);
+
+bool CopyImage(NvidiaVfxLoader& aLoader, CuDevicePtr aDst, size_t aDstPitch,
+               CuDevicePtr aSrc, size_t aSrcPitch, size_t aWidthBytes,
+               size_t aHeight, CuStream aStream);
+
+bool CopyArrayToImage(NvidiaVfxLoader& aLoader, CuDevicePtr aDst,
+                      size_t aDstPitch, void* aSrcArray, size_t aWidthBytes,
+                      size_t aHeight, CuStream aStream);
+
+bool CopyImageToArray(NvidiaVfxLoader& aLoader, void* aDstArray,
+                      CuDevicePtr aSrc, size_t aSrcPitch, size_t aWidthBytes,
+                      size_t aHeight, CuStream aStream);
+
+}  // namespace mozilla::zen
+
+#endif  // mozilla_zen_CudaGlInterop_h

--- a/src/zen/video-super-resolution/NvidiaVfxLoader.cpp
+++ b/src/zen/video-super-resolution/NvidiaVfxLoader.cpp
@@ -1,0 +1,469 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "NvidiaVfxLoader.h"
+
+#include <dlfcn.h>
+#include <iterator>
+
+#include "mozilla/Logging.h"
+
+namespace mozilla::zen {
+
+static LazyLogModule sVideoSuperResolutionLog("VideoSuperResolution");
+
+NvidiaVfxLoader& NvidiaVfxLoader::GetInstance() {
+  static NvidiaVfxLoader sInstance;
+  return sInstance;
+}
+
+static const char* const kRequiredLibraries[] = {
+    "libnppc.so.12",
+    "libnppial.so.12",
+    "libnppig.so.12",
+    "libnppicc.so.12",
+    "libnppidei.so.12",
+    "libnppif.so.12",
+    "libnppim.so.12",
+    "libnppist.so.12",
+    "libnppitc.so.12",
+    "libcudnn.so.9",
+    "libnvinfer.so.10",
+    "libnvinfer_plugin.so.10",
+    "libnvonnxparser.so.10",
+    "libNVCVImage.so",
+    "libnvngxruntime.so",
+    "libVideoFXLocal.so",
+    "libVideoFX.so",
+    "libnvVFXVideoSuperRes.so",
+    "libnvidia-ngx-vsr.so.1.8.2",
+};
+
+bool NvidiaVfxLoader::OpenLibraries() {
+  for (const char* name : kRequiredLibraries) {
+    if (mLibCount == std::size(mLibHandles)) {
+      return false;
+    }
+    void* handle = dlopen(name, RTLD_NOW | RTLD_GLOBAL);
+    if (!handle) {
+      MOZ_LOG(sVideoSuperResolutionLog, LogLevel::Warning,
+              ("VSR unavailable: NVIDIA VFX runtime missing (%s)", name));
+      return false;
+    }
+    mLibHandles[mLibCount++] = handle;
+  }
+  return true;
+}
+
+void* NvidiaVfxLoader::Resolve(const char* aSymbol) {
+  for (size_t i = 0; i < mLibCount; i++) {
+    void* sym = dlsym(mLibHandles[i], aSymbol);
+    if (sym) {
+      return sym;
+    }
+  }
+  return nullptr;
+}
+
+void NvidiaVfxLoader::CloseLibraries() {
+  for (size_t i = 0; i < mLibCount; i++) {
+    if (mLibHandles[i]) {
+      dlclose(mLibHandles[i]);
+      mLibHandles[i] = nullptr;
+    }
+  }
+  mLibCount = 0;
+}
+
+void NvidiaVfxLoader::ClearFunctions() {
+  mFnCreateEffect = nullptr;
+  mFnDestroyEffect = nullptr;
+  mFnSetS32 = nullptr;
+  mFnGetS32 = nullptr;
+  mFnSetU32 = nullptr;
+  mFnSetImage = nullptr;
+  mFnSetCudaStream = nullptr;
+  mFnLoad = nullptr;
+  mFnRun = nullptr;
+  mFnImageAlloc = nullptr;
+  mFnImageFree = nullptr;
+  mFnCuInit = nullptr;
+  mFnCuDeviceGetCount = nullptr;
+  mFnCuDeviceGet = nullptr;
+  mFnCuDeviceGetAttribute = nullptr;
+  mFnCuDeviceGetName = nullptr;
+  mFnCuDeviceGetUuid = nullptr;
+  mFnCuGLGetDevices = nullptr;
+  mFnCuCtxCreate = nullptr;
+  mFnCuCtxDestroy = nullptr;
+  mFnCuCtxPushCurrent = nullptr;
+  mFnCuCtxPopCurrent = nullptr;
+  mFnCuStreamCreate = nullptr;
+  mFnCuStreamDestroy = nullptr;
+  mFnCuStreamSynchronize = nullptr;
+  mFnCuMemcpy2DAsync = nullptr;
+  mFnCuEventCreate = nullptr;
+  mFnCuEventDestroy = nullptr;
+  mFnCuEventRecord = nullptr;
+  mFnCuEventQuery = nullptr;
+  mFnCuLaunchHostFunc = nullptr;
+  mFnGraphicsGLRegisterImage = nullptr;
+  mFnGraphicsUnregisterResource = nullptr;
+  mFnGraphicsMapResources = nullptr;
+  mFnGraphicsUnmapResources = nullptr;
+  mFnGraphicsSubResourceGetMappedArray = nullptr;
+}
+
+#define RESOLVE_REQUIRED(field, name) \
+  mFn##field = Resolve(name);         \
+  if (!mFn##field) {                  \
+    goto failed;                      \
+  }
+
+bool NvidiaVfxLoader::EnsureCudaLib() {
+  if (mCudaLibOk) {
+    return true;
+  }
+  MutexAutoLock lock(mLoadLock);
+  if (mCudaLibOk) {
+    return true;
+  }
+  void* cuda = dlopen("libcuda.so.1", RTLD_NOW | RTLD_LOCAL);
+  if (!cuda) {
+    return false;
+  }
+  if (mLibCount == std::size(mLibHandles)) {
+    dlclose(cuda);
+    return false;
+  }
+  mLibHandles[mLibCount++] = cuda;
+  mFnCuInit = Resolve("cuInit");
+  mFnCuGLGetDevices = Resolve("cuGLGetDevices");
+  mFnCuDeviceGetCount = Resolve("cuDeviceGetCount");
+  mFnCuDeviceGet = Resolve("cuDeviceGet");
+  mFnCuDeviceGetName = Resolve("cuDeviceGetName");
+  mFnCuDeviceGetAttribute = Resolve("cuDeviceGetAttribute");
+  mFnCuDeviceGetUuid = Resolve("cuDeviceGetUuid");
+  mFnCuCtxCreate = Resolve("cuCtxCreate_v2");
+  mFnCuCtxDestroy = Resolve("cuCtxDestroy_v2");
+  mFnCuCtxPushCurrent = Resolve("cuCtxPushCurrent_v2");
+  mFnCuCtxPopCurrent = Resolve("cuCtxPopCurrent_v2");
+  mFnCuStreamCreate = Resolve("cuStreamCreate");
+  mFnCuStreamDestroy = Resolve("cuStreamDestroy_v2");
+  mFnCuStreamSynchronize = Resolve("cuStreamSynchronize");
+  mFnCuMemcpy2DAsync = Resolve("cuMemcpy2DAsync_v2");
+  mFnCuEventCreate = Resolve("cuEventCreate");
+  mFnCuEventDestroy = Resolve("cuEventDestroy_v2");
+  mFnCuEventRecord = Resolve("cuEventRecord");
+  mFnCuEventQuery = Resolve("cuEventQuery");
+  mFnCuLaunchHostFunc = Resolve("cuLaunchHostFunc");
+  mFnGraphicsGLRegisterImage = Resolve("cuGraphicsGLRegisterImage");
+  mFnGraphicsUnregisterResource = Resolve("cuGraphicsUnregisterResource");
+  mFnGraphicsMapResources = Resolve("cuGraphicsMapResources");
+  mFnGraphicsUnmapResources = Resolve("cuGraphicsUnmapResources");
+  mFnGraphicsSubResourceGetMappedArray =
+      Resolve("cuGraphicsSubResourceGetMappedArray");
+  if (!mFnCuInit || !mFnCuDeviceGetCount || !mFnCuDeviceGet ||
+      !mFnCuDeviceGetAttribute || !mFnCuDeviceGetName || !mFnCuDeviceGetUuid ||
+      !mFnCuGLGetDevices || !mFnCuCtxCreate || !mFnCuCtxDestroy ||
+      !mFnCuCtxPushCurrent || !mFnCuCtxPopCurrent || !mFnCuStreamCreate ||
+      !mFnCuStreamDestroy || !mFnCuStreamSynchronize || !mFnCuMemcpy2DAsync ||
+      !mFnCuEventCreate || !mFnCuEventDestroy || !mFnCuEventRecord ||
+      !mFnCuEventQuery || !mFnGraphicsGLRegisterImage ||
+      !mFnGraphicsUnregisterResource || !mFnGraphicsMapResources ||
+      !mFnGraphicsUnmapResources || !mFnGraphicsSubResourceGetMappedArray) {
+    CloseLibraries();
+    ClearFunctions();
+    return false;
+  }
+  mCudaLibOk = true;
+  return true;
+}
+
+bool NvidiaVfxLoader::EnsureLoaded() {
+  if (mLoaded) {
+    return true;
+  }
+  if (!EnsureCudaLib()) {
+    return false;
+  }
+  MutexAutoLock lock(mLoadLock);
+  if (mLoaded) {
+    return true;
+  }
+  if (!OpenLibraries()) {
+    CloseLibraries();
+    ClearFunctions();
+    mCudaLibOk = false;
+    return false;
+  }
+  RESOLVE_REQUIRED(CreateEffect, "NvVFX_CreateEffect");
+  RESOLVE_REQUIRED(DestroyEffect, "NvVFX_DestroyEffect");
+  RESOLVE_REQUIRED(SetS32, "NvVFX_SetS32");
+  RESOLVE_REQUIRED(GetS32, "NvVFX_GetS32");
+  RESOLVE_REQUIRED(SetU32, "NvVFX_SetU32");
+  RESOLVE_REQUIRED(SetImage, "NvVFX_SetImage");
+  RESOLVE_REQUIRED(SetCudaStream, "NvVFX_SetCudaStream");
+  RESOLVE_REQUIRED(Load, "NvVFX_Load");
+  RESOLVE_REQUIRED(Run, "NvVFX_Run");
+  RESOLVE_REQUIRED(ImageAlloc, "NvCVImage_Alloc");
+  RESOLVE_REQUIRED(ImageFree, "NvCVImage_Dealloc");
+  mLoaded = true;
+  return true;
+
+failed:
+  CloseLibraries();
+  ClearFunctions();
+  mLoaded = false;
+  mCudaLibOk = false;
+  return false;
+}
+
+#undef RESOLVE_REQUIRED
+
+int NvidiaVfxLoader::CreateEffect(const char* aSelector, void** aHandle) {
+  if (!mFnCreateEffect) return -1;
+  return reinterpret_cast<int (*)(const char*, void**)>(mFnCreateEffect)(
+      aSelector, aHandle);
+}
+
+void NvidiaVfxLoader::DestroyEffect(void* aHandle) {
+  if (!mFnDestroyEffect || !aHandle) return;
+  reinterpret_cast<void (*)(void*)>(mFnDestroyEffect)(aHandle);
+}
+
+int NvidiaVfxLoader::SetS32(void* aHandle, const char* aParam, int aValue) {
+  if (!mFnSetS32) return -1;
+  return reinterpret_cast<int (*)(void*, const char*, int)>(mFnSetS32)(
+      aHandle, aParam, aValue);
+}
+
+int NvidiaVfxLoader::GetS32(void* aHandle, const char* aParam, int* aValue) {
+  if (!mFnGetS32 || !aValue) return -1;
+  return reinterpret_cast<int (*)(void*, const char*, int*)>(mFnGetS32)(
+      aHandle, aParam, aValue);
+}
+
+int NvidiaVfxLoader::SetU32(void* aHandle, const char* aParam,
+                            unsigned int aValue) {
+  if (!mFnSetU32) return -1;
+  return reinterpret_cast<int (*)(void*, const char*, unsigned int)>(
+      mFnSetU32)(aHandle, aParam, aValue);
+}
+
+int NvidiaVfxLoader::SetImage(void* aHandle, const char* aParam,
+                              NvCVImage* aImage) {
+  if (!mFnSetImage) return -1;
+  return reinterpret_cast<int (*)(void*, const char*, NvCVImage*)>(
+      mFnSetImage)(aHandle, aParam, aImage);
+}
+
+int NvidiaVfxLoader::SetCudaStream(void* aHandle, const char* aParam,
+                                   CuStream aStream) {
+  if (!mFnSetCudaStream) return -1;
+  return reinterpret_cast<int (*)(void*, const char*, CuStream)>(
+      mFnSetCudaStream)(aHandle, aParam, aStream);
+}
+
+int NvidiaVfxLoader::LoadEffect(void* aHandle) {
+  if (!mFnLoad) return -1;
+  return reinterpret_cast<int (*)(void*)>(mFnLoad)(aHandle);
+}
+
+int NvidiaVfxLoader::RunEffect(void* aHandle, int aAsync) {
+  if (!mFnRun) return -1;
+  return reinterpret_cast<int (*)(void*, int)>(mFnRun)(aHandle, aAsync);
+}
+
+int NvidiaVfxLoader::ImageAlloc(NvCVImage* aImage, unsigned int aW,
+                                unsigned int aH, int aFormat, int aType,
+                                int aLayout, unsigned int aMemSpace,
+                                unsigned int aAlignment) {
+  if (!mFnImageAlloc) return -1;
+  return reinterpret_cast<int (*)(NvCVImage*, unsigned int, unsigned int, int,
+                                  int, int, unsigned int, unsigned int)>(
+      mFnImageAlloc)(aImage, aW, aH, aFormat, aType, aLayout, aMemSpace,
+                     aAlignment);
+}
+
+int NvidiaVfxLoader::ImageFree(NvCVImage* aImage) {
+  if (!mFnImageFree) return -1;
+  return reinterpret_cast<int (*)(NvCVImage*)>(mFnImageFree)(aImage);
+}
+
+int NvidiaVfxLoader::CuInit(unsigned int aFlags) {
+  if (!mFnCuInit) return -1;
+  return reinterpret_cast<int (*)(unsigned int)>(mFnCuInit)(aFlags);
+}
+
+int NvidiaVfxLoader::CuDeviceGetCount(int* aCount) {
+  if (!mFnCuDeviceGetCount) return -1;
+  return reinterpret_cast<int (*)(int*)>(mFnCuDeviceGetCount)(aCount);
+}
+
+int NvidiaVfxLoader::CuDeviceGet(CuDevice* aDevice, int aOrdinal) {
+  if (!mFnCuDeviceGet) return -1;
+  return reinterpret_cast<int (*)(CuDevice*, int)>(mFnCuDeviceGet)(
+      aDevice, aOrdinal);
+}
+
+int NvidiaVfxLoader::CuDeviceGetAttribute(int* aValue, int aAttrib,
+                                          CuDevice aDevice) {
+  if (!mFnCuDeviceGetAttribute) return -1;
+  return reinterpret_cast<int (*)(int*, int, CuDevice)>(
+      mFnCuDeviceGetAttribute)(aValue, aAttrib, aDevice);
+}
+
+int NvidiaVfxLoader::CuDeviceGetName(char* aName, int aLen,
+                                     CuDevice aDevice) {
+  if (!mFnCuDeviceGetName) return -1;
+  return reinterpret_cast<int (*)(char*, int, CuDevice)>(
+      mFnCuDeviceGetName)(aName, aLen, aDevice);
+}
+
+int NvidiaVfxLoader::CuDeviceGetUuid(CudaDeviceUuid* aUuid,
+                                     CuDevice aDevice) {
+  if (!mFnCuDeviceGetUuid) return -1;
+  return reinterpret_cast<int (*)(CudaDeviceUuid*, CuDevice)>(
+      mFnCuDeviceGetUuid)(aUuid, aDevice);
+}
+
+int NvidiaVfxLoader::CuGLGetDevices(unsigned int* aCount,
+                                    CuDevice* aDevices,
+                                    unsigned int aCapacity,
+                                    unsigned int aDeviceList) {
+  if (!mFnCuGLGetDevices) return -1;
+  return reinterpret_cast<int (*)(unsigned int*, CuDevice*, unsigned int,
+                                  unsigned int)>(mFnCuGLGetDevices)(
+      aCount, aDevices, aCapacity, aDeviceList);
+}
+
+int NvidiaVfxLoader::CuCtxCreate(CuContext* aCtx, unsigned int aFlags,
+                                 CuDevice aDevice) {
+  if (!mFnCuCtxCreate) return -1;
+  return reinterpret_cast<int (*)(CuContext*, unsigned int, CuDevice)>(
+      mFnCuCtxCreate)(aCtx, aFlags, aDevice);
+}
+
+int NvidiaVfxLoader::CuCtxDestroy(CuContext aCtx) {
+  if (!mFnCuCtxDestroy) return -1;
+  return reinterpret_cast<int (*)(CuContext)>(mFnCuCtxDestroy)(aCtx);
+}
+
+int NvidiaVfxLoader::CuCtxPushCurrent(CuContext aCtx) {
+  if (!mFnCuCtxPushCurrent) return -1;
+  return reinterpret_cast<int (*)(CuContext)>(mFnCuCtxPushCurrent)(aCtx);
+}
+
+int NvidiaVfxLoader::CuCtxPopCurrent(CuContext* aCtx) {
+  if (!mFnCuCtxPopCurrent) return -1;
+  return reinterpret_cast<int (*)(CuContext*)>(mFnCuCtxPopCurrent)(aCtx);
+}
+
+int NvidiaVfxLoader::CuStreamCreate(CuStream* aStream,
+                                    unsigned int aFlags) {
+  if (!mFnCuStreamCreate) return -1;
+  return reinterpret_cast<int (*)(CuStream*, unsigned int)>(mFnCuStreamCreate)(
+      aStream, aFlags);
+}
+
+int NvidiaVfxLoader::CuStreamDestroy(CuStream aStream) {
+  if (!mFnCuStreamDestroy) return -1;
+  return reinterpret_cast<int (*)(CuStream)>(mFnCuStreamDestroy)(aStream);
+}
+
+int NvidiaVfxLoader::CuStreamSynchronize(CuStream aStream) {
+  if (!mFnCuStreamSynchronize) return -1;
+  return reinterpret_cast<int (*)(CuStream)>(mFnCuStreamSynchronize)(aStream);
+}
+
+int NvidiaVfxLoader::CuMemcpy2DAsync(const Memcpy2DParams* aParams,
+                                     CuStream aStream) {
+  if (!mFnCuMemcpy2DAsync) return -1;
+  return reinterpret_cast<int (*)(const Memcpy2DParams*, CuStream)>(
+      mFnCuMemcpy2DAsync)(aParams, aStream);
+}
+
+int NvidiaVfxLoader::CuEventCreate(void** aEvent, unsigned int aFlags) {
+  if (!mFnCuEventCreate) return -1;
+  return reinterpret_cast<int (*)(void**, unsigned int)>(mFnCuEventCreate)(
+      aEvent, aFlags);
+}
+
+int NvidiaVfxLoader::CuEventDestroy(void* aEvent) {
+  if (!mFnCuEventDestroy) return -1;
+  return reinterpret_cast<int (*)(void*)>(mFnCuEventDestroy)(aEvent);
+}
+
+int NvidiaVfxLoader::CuEventRecord(void* aEvent, CuStream aStream) {
+  if (!mFnCuEventRecord) return -1;
+  return reinterpret_cast<int (*)(void*, CuStream)>(mFnCuEventRecord)(
+      aEvent, aStream);
+}
+
+int NvidiaVfxLoader::CuEventQuery(void* aEvent) {
+  if (!mFnCuEventQuery) return -1;
+  return reinterpret_cast<int (*)(void*)>(mFnCuEventQuery)(aEvent);
+}
+
+bool NvidiaVfxLoader::HasStreamHostCallback() const {
+  return mFnCuLaunchHostFunc != nullptr;
+}
+
+int NvidiaVfxLoader::CuLaunchHostFunc(CuStream aStream,
+                                      void (*aCallback)(void*),
+                                      void* aUserData) {
+  if (!mFnCuLaunchHostFunc) return -1;
+  return reinterpret_cast<int (*)(CuStream, void (*)(void*), void*)>(
+      mFnCuLaunchHostFunc)(aStream, aCallback, aUserData);
+}
+
+bool NvidiaVfxLoader::HasGlInterop() const {
+  return mFnGraphicsGLRegisterImage && mFnGraphicsUnregisterResource &&
+         mFnGraphicsMapResources && mFnGraphicsUnmapResources &&
+         mFnGraphicsSubResourceGetMappedArray;
+}
+
+int NvidiaVfxLoader::GraphicsGLRegisterImage(
+    CuGraphicsResource* aResource, unsigned int aTexture, int aTarget,
+    unsigned int aFlags) {
+  if (!mFnGraphicsGLRegisterImage) return -1;
+  return reinterpret_cast<int (*)(CuGraphicsResource*, unsigned int, int,
+                                  unsigned int)>(mFnGraphicsGLRegisterImage)(
+      aResource, aTexture, aTarget, aFlags);
+}
+
+int NvidiaVfxLoader::GraphicsUnregisterResource(
+    CuGraphicsResource aResource) {
+  if (!mFnGraphicsUnregisterResource) return -1;
+  return reinterpret_cast<int (*)(CuGraphicsResource)>(
+      mFnGraphicsUnregisterResource)(aResource);
+}
+
+int NvidiaVfxLoader::GraphicsMapResources(
+    unsigned int aCount, CuGraphicsResource* aResources,
+    CuStream aStream) {
+  if (!mFnGraphicsMapResources) return -1;
+  return reinterpret_cast<int (*)(unsigned int, CuGraphicsResource*, CuStream)>(
+      mFnGraphicsMapResources)(aCount, aResources, aStream);
+}
+
+int NvidiaVfxLoader::GraphicsUnmapResources(
+    unsigned int aCount, CuGraphicsResource* aResources,
+    CuStream aStream) {
+  if (!mFnGraphicsUnmapResources) return -1;
+  return reinterpret_cast<int (*)(unsigned int, CuGraphicsResource*, CuStream)>(
+      mFnGraphicsUnmapResources)(aCount, aResources, aStream);
+}
+
+int NvidiaVfxLoader::GraphicsSubResourceGetMappedArray(
+    void** aArray, CuGraphicsResource aResource, unsigned int aIndex,
+    unsigned int aLevel) {
+  if (!mFnGraphicsSubResourceGetMappedArray) return -1;
+  return reinterpret_cast<int (*)(void**, CuGraphicsResource, unsigned int,
+                                  unsigned int)>(
+      mFnGraphicsSubResourceGetMappedArray)(aArray, aResource, aIndex, aLevel);
+}
+
+}  // namespace mozilla::zen

--- a/src/zen/video-super-resolution/NvidiaVfxLoader.h
+++ b/src/zen/video-super-resolution/NvidiaVfxLoader.h
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_zen_NvidiaVfxLoader_h
+#define mozilla_zen_NvidiaVfxLoader_h
+
+#include "VideoSuperResolutionTypes.h"
+
+#include <cstddef>
+
+#include "mozilla/Atomics.h"
+#include "mozilla/Mutex.h"
+
+namespace mozilla::zen {
+
+using CuDevice = int;
+using CuContext = void*;
+using CuStream = void*;
+using CuDevicePtr = unsigned long long;
+using CuGraphicsResource = void*;
+
+class NvidiaVfxLoader {
+ public:
+  static NvidiaVfxLoader& GetInstance();
+
+  bool EnsureLoaded();
+  bool EnsureCudaLib();
+
+  bool IsLoaded() const { return mLoaded; }
+  bool IsCudaLibOk() const { return mCudaLibOk; }
+
+  int CreateEffect(const char* aSelector, void** aHandle);
+  void DestroyEffect(void* aHandle);
+  int SetS32(void* aHandle, const char* aParam, int aValue);
+  int GetS32(void* aHandle, const char* aParam, int* aValue);
+  int SetU32(void* aHandle, const char* aParam, unsigned int aValue);
+  int SetImage(void* aHandle, const char* aParam, NvCVImage* aImage);
+  int SetCudaStream(void* aHandle, const char* aParam, CuStream aStream);
+  int LoadEffect(void* aHandle);
+  int RunEffect(void* aHandle, int aAsync);
+  int ImageAlloc(NvCVImage* aImage, unsigned int aW, unsigned int aH,
+                 int aFormat, int aType, int aLayout, unsigned int aMemSpace,
+                 unsigned int aAlignment);
+  int ImageFree(NvCVImage* aImage);
+
+  int CuInit(unsigned int aFlags);
+  int CuDeviceGetCount(int* aCount);
+  int CuDeviceGet(CuDevice* aDevice, int aOrdinal);
+  int CuDeviceGetAttribute(int* aValue, int aAttrib, CuDevice aDevice);
+  int CuDeviceGetName(char* aName, int aLen, CuDevice aDevice);
+  int CuDeviceGetUuid(CudaDeviceUuid* aUuid, CuDevice aDevice);
+  int CuGLGetDevices(unsigned int* aCount, CuDevice* aDevices,
+                     unsigned int aCapacity, unsigned int aDeviceList);
+  int CuCtxCreate(CuContext* aCtx, unsigned int aFlags, CuDevice aDevice);
+  int CuCtxDestroy(CuContext aCtx);
+  int CuCtxPushCurrent(CuContext aCtx);
+  int CuCtxPopCurrent(CuContext* aCtx);
+  int CuStreamCreate(CuStream* aStream, unsigned int aFlags);
+  int CuStreamDestroy(CuStream aStream);
+  int CuStreamSynchronize(CuStream aStream);
+
+  struct Memcpy2DParams {
+    size_t srcXInBytes = 0;
+    size_t srcY = 0;
+    int srcMemoryType = 0;
+    const void* srcHost = nullptr;
+    CuDevicePtr srcDevice = 0;
+    void* srcArray = nullptr;
+    size_t srcPitch = 0;
+    size_t dstXInBytes = 0;
+    size_t dstY = 0;
+    int dstMemoryType = 0;
+    void* dstHost = nullptr;
+    CuDevicePtr dstDevice = 0;
+    void* dstArray = nullptr;
+    size_t dstPitch = 0;
+    size_t widthInBytes = 0;
+    size_t height = 0;
+  };
+  static_assert(sizeof(Memcpy2DParams) == 128,
+                "Memcpy2DParams must match CUDA_MEMCPY2D (64-bit)");
+
+  int CuMemcpy2DAsync(const Memcpy2DParams* aParams, CuStream aStream);
+  int CuEventCreate(void** aEvent, unsigned int aFlags);
+  int CuEventDestroy(void* aEvent);
+  int CuEventRecord(void* aEvent, CuStream aStream);
+  int CuEventQuery(void* aEvent);
+  bool HasStreamHostCallback() const;
+  int CuLaunchHostFunc(CuStream aStream, void (*aCallback)(void*),
+                       void* aUserData);
+
+  bool HasGlInterop() const;
+  int GraphicsGLRegisterImage(CuGraphicsResource* aResource,
+                              unsigned int aTexture, int aTarget,
+                              unsigned int aFlags);
+  int GraphicsUnregisterResource(CuGraphicsResource aResource);
+  int GraphicsMapResources(unsigned int aCount,
+                           CuGraphicsResource* aResources,
+                           CuStream aStream);
+  int GraphicsUnmapResources(unsigned int aCount,
+                             CuGraphicsResource* aResources,
+                             CuStream aStream);
+  int GraphicsSubResourceGetMappedArray(void** aArray,
+                                        CuGraphicsResource aResource,
+                                        unsigned int aIndex,
+                                        unsigned int aLevel);
+
+ private:
+  NvidiaVfxLoader() = default;
+  ~NvidiaVfxLoader() = default;
+  NvidiaVfxLoader(const NvidiaVfxLoader&) = delete;
+  NvidiaVfxLoader& operator=(const NvidiaVfxLoader&) = delete;
+
+  bool OpenLibraries();
+  void* Resolve(const char* aSymbol);
+  void CloseLibraries();
+  void ClearFunctions();
+
+  Mutex mLoadLock{"VfxLoader"};
+  Atomic<bool> mLoaded{false};
+  Atomic<bool> mCudaLibOk{false};
+  void* mLibHandles[32] = {};
+  size_t mLibCount = 0;
+
+  void* mFnCreateEffect = nullptr;
+  void* mFnDestroyEffect = nullptr;
+  void* mFnSetS32 = nullptr;
+  void* mFnGetS32 = nullptr;
+  void* mFnSetU32 = nullptr;
+  void* mFnSetImage = nullptr;
+  void* mFnSetCudaStream = nullptr;
+  void* mFnLoad = nullptr;
+  void* mFnRun = nullptr;
+  void* mFnImageAlloc = nullptr;
+  void* mFnImageFree = nullptr;
+  void* mFnCuInit = nullptr;
+  void* mFnCuDeviceGetCount = nullptr;
+  void* mFnCuDeviceGet = nullptr;
+  void* mFnCuDeviceGetAttribute = nullptr;
+  void* mFnCuDeviceGetName = nullptr;
+  void* mFnCuDeviceGetUuid = nullptr;
+  void* mFnCuGLGetDevices = nullptr;
+  void* mFnCuCtxCreate = nullptr;
+  void* mFnCuCtxDestroy = nullptr;
+  void* mFnCuCtxPushCurrent = nullptr;
+  void* mFnCuCtxPopCurrent = nullptr;
+  void* mFnCuStreamCreate = nullptr;
+  void* mFnCuStreamDestroy = nullptr;
+  void* mFnCuStreamSynchronize = nullptr;
+  void* mFnCuMemcpy2DAsync = nullptr;
+  void* mFnCuEventCreate = nullptr;
+  void* mFnCuEventDestroy = nullptr;
+  void* mFnCuEventRecord = nullptr;
+  void* mFnCuEventQuery = nullptr;
+  void* mFnCuLaunchHostFunc = nullptr;
+  void* mFnGraphicsGLRegisterImage = nullptr;
+  void* mFnGraphicsUnregisterResource = nullptr;
+  void* mFnGraphicsMapResources = nullptr;
+  void* mFnGraphicsUnmapResources = nullptr;
+  void* mFnGraphicsSubResourceGetMappedArray = nullptr;
+};
+
+}  // namespace mozilla::zen
+
+#endif  // mozilla_zen_NvidiaVfxLoader_h

--- a/src/zen/video-super-resolution/NvidiaVfxSession.cpp
+++ b/src/zen/video-super-resolution/NvidiaVfxSession.cpp
@@ -1,0 +1,854 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "NvidiaVfxSession.h"
+
+#include <iterator>
+
+#include "CudaGlInterop.h"
+#include "GLContext.h"
+#include "mozilla/Logging.h"
+#include "NvidiaVfxLoader.h"
+#include "VideoSuperResolutionProfiler.h"
+#include "VideoSuperResolutionTexturePool.h"
+#include "nsCOMPtr.h"
+#include "nsIRunnable.h"
+#include "nsIThread.h"
+#include "nsIThreadManager.h"
+#include "nsThreadUtils.h"
+
+namespace mozilla::zen {
+
+static LazyLogModule sVideoSuperResolutionLog("VideoSuperResolution");
+
+struct CompletionSignal {
+  SuperResolutionFrameToken token;
+};
+
+static void OnStreamComplete(void* aUserData) {
+  auto* signal = static_cast<CompletionSignal*>(aUserData);
+  if (!signal) {
+    return;
+  }
+  VideoSuperResolutionTexturePool::Get().NotifyVfxStreamComplete(signal->token);
+  delete signal;
+}
+
+NvidiaVfxSession::NvidiaVfxSession() = default;
+
+NvidiaVfxSession::~NvidiaVfxSession() {
+  MOZ_ASSERT(mState == SuperResolutionSessionState::Uninitialized ||
+             mState == SuperResolutionSessionState::Failed);
+}
+
+SuperResolutionSessionState NvidiaVfxSession::State() const {
+  MonitorAutoLock lock(mLock);
+  return mState;
+}
+
+void NvidiaVfxSession::FailLocked(const char* aWhere) {
+  mLock.AssertCurrentThreadOwns();
+  if (mState != SuperResolutionSessionState::Failed) {
+    MOZ_LOG(sVideoSuperResolutionLog, LogLevel::Warning,
+            ("VSR disabled after %s failure", aWhere));
+  }
+  mState = SuperResolutionSessionState::Failed;
+  mEffectReady = false;
+}
+
+uint64_t NvidiaVfxSession::EnsureWorker(
+    int aVideoW, int aVideoH, int aOutW, int aOutH,
+    SuperResolutionQuality aQuality, CuDevice aGlCudaDevice, int aCudaOrdinal) {
+  if (aVideoW < 160 || aVideoH < 90 || aVideoW > 3840 || aVideoH > 2160 ||
+      aOutW <= 0 || aOutH <= 0 || aOutW > 7680 || aOutH > 4320 ||
+      aGlCudaDevice < 0 || aCudaOrdinal < 0) {
+    return 0;
+  }
+
+  uint64_t generation = 0;
+  bool needSpawn = false;
+  bool dispatchRebind = false;
+  nsCOMPtr<nsIThread> worker;
+  {
+    MonitorAutoLock lock(mLock);
+    if (mState == SuperResolutionSessionState::ShuttingDown ||
+        mState == SuperResolutionSessionState::Failed) {
+      return 0;
+    }
+
+    const bool sameBinding =
+        mVideoW == aVideoW && mVideoH == aVideoH && mOutW == aOutW &&
+        mOutH == aOutH && mGlCudaDevice == aGlCudaDevice &&
+        mCudaOrdinal == aCudaOrdinal;
+
+    if (sameBinding) {
+      if (mRequestedQuality != aQuality) {
+        mRequestedQuality = aQuality;
+      }
+      if (mState == SuperResolutionSessionState::Ready) {
+        return mGeneration;
+      }
+      return mState == SuperResolutionSessionState::Loading ? mGeneration : 0;
+    }
+
+    mVideoW = aVideoW;
+    mVideoH = aVideoH;
+    mOutW = aOutW;
+    mOutH = aOutH;
+    mRequestedQuality = aQuality;
+    mGlCudaDevice = aGlCudaDevice;
+    mCudaOrdinal = aCudaOrdinal;
+    mHasReady = false;
+    mWorkerBusy = false;
+    mEffectReady = false;
+    mState = SuperResolutionSessionState::Loading;
+    generation = ++mGeneration;
+    needSpawn = !mWorkerThread;
+    if (!mRebindQueued) {
+      mRebindQueued = true;
+      dispatchRebind = true;
+    }
+  }
+
+  UnregisterAllGl();
+  RefPtr<NvidiaVfxSession> self = this;
+  if (needSpawn) {
+    nsIThreadManager::ThreadCreationOptions opts;
+    opts.stackSize = 8 * 1024 * 1024;
+    nsCOMPtr<nsIThread> thread;
+    nsresult rv = NS_NewNamedThread(
+        "VfxWorker", getter_AddRefs(thread), nullptr, opts);
+    if (NS_FAILED(rv) || !thread) {
+      MonitorAutoLock lock(mLock);
+      FailLocked("spawn worker thread");
+      return 0;
+    }
+    {
+      MonitorAutoLock lock(mLock);
+      mWorkerThread = thread;
+      worker = mWorkerThread;
+    }
+    if (NS_FAILED(worker->Dispatch(
+        NS_NewRunnableFunction("WorkerInit", [self]() { self->WorkerInit(); }),
+        NS_DISPATCH_NORMAL))) {
+      MonitorAutoLock lock(mLock);
+      mRebindQueued = false;
+      FailLocked("dispatch worker init");
+      return 0;
+    }
+  } else if (dispatchRebind) {
+    {
+      MonitorAutoLock lock(mLock);
+      worker = mWorkerThread;
+    }
+    if (!worker || NS_FAILED(worker->Dispatch(
+        NS_NewRunnableFunction("WorkerRebind", [self]() { self->WorkerRebind(); }),
+        NS_DISPATCH_NORMAL))) {
+      MonitorAutoLock lock(mLock);
+      mRebindQueued = false;
+      FailLocked("dispatch worker rebind");
+      return 0;
+    }
+  }
+
+  return generation;
+}
+
+bool NvidiaVfxSession::SubmitInput(const SuperResolutionFrameToken& aToken,
+                                   unsigned int aStagingTex, int aStagingW,
+                                   int aStagingH) {
+  if (!aToken.HasIdentity() || aStagingTex == 0 || aStagingW <= 0 ||
+      aStagingH <= 0) {
+    return false;
+  }
+
+  nsCOMPtr<nsIThread> worker;
+  {
+    MonitorAutoLock lock(mLock);
+    if (mState != SuperResolutionSessionState::Ready || !mEffectReady) {
+      return false;
+    }
+    if (mGeneration != aToken.sessionGeneration) {
+      return false;
+    }
+    if (mVideoW != aStagingW || mVideoH != aStagingH) {
+      return false;
+    }
+    if (mWorkerBusy) {
+      return false;
+    }
+    if (mHasReady) {
+      return false;
+    }
+    mWorkerBusy = true;
+    mWorkingToken = aToken;
+    worker = mWorkerThread;
+  }
+
+  if (!MapAndCopyToInput(aStagingTex, aStagingW, aStagingH)) {
+    MonitorAutoLock lock(mLock);
+    mWorkerBusy = false;
+    FailLocked("input interop");
+    return false;
+  }
+
+  RefPtr<NvidiaVfxSession> self = this;
+  if (!worker || NS_FAILED(worker->Dispatch(
+      NS_NewRunnableFunction("WorkerProcessFrame",
+                             [self]() { self->WorkerProcessFrame(); }),
+      NS_DISPATCH_NORMAL))) {
+    MonitorAutoLock lock(mLock);
+    mWorkerBusy = false;
+    return false;
+  }
+  return true;
+}
+
+bool NvidiaVfxSession::PeekReady(SuperResolutionFrameToken* aToken) {
+  MonitorAutoLock lock(mLock);
+  if (!mHasReady) {
+    return false;
+  }
+  if (aToken) {
+    *aToken = mReadyToken;
+  }
+  return true;
+}
+
+bool NvidiaVfxSession::IsReadyComplete() {
+  CuContext context = nullptr;
+  void* event = nullptr;
+  {
+    MonitorAutoLock lock(mLock);
+    if (!mHasReady || !mReadyEvent || !mCudaCtx) {
+      return false;
+    }
+    context = mCudaCtx;
+    event = mReadyEvent;
+  }
+  NvidiaVfxLoader& loader = NvidiaVfxLoader::GetInstance();
+  if (loader.CuCtxPushCurrent(context) != 0) {
+    return false;
+  }
+  const bool complete = loader.CuEventQuery(event) == 0;
+  CuContext popped = nullptr;
+  loader.CuCtxPopCurrent(&popped);
+  return complete;
+}
+
+bool NvidiaVfxSession::TakeReady(SuperResolutionFrameToken* aToken) {
+  MonitorAutoLock lock(mLock);
+  if (!mHasReady) {
+    return false;
+  }
+  if (aToken) {
+    *aToken = mReadyToken;
+  }
+  mHasReady = false;
+  mReadyToken = SuperResolutionFrameToken{};
+  return true;
+}
+
+bool NvidiaVfxSession::DownloadSlot(size_t aSlot, unsigned int aSlotTex,
+                                     int aSlotW, int aSlotH) {
+  {
+    MonitorAutoLock lock(mLock);
+    if (!mHasReady || aSlotW != mOutW || aSlotH != mOutH) {
+      return false;
+    }
+  }
+  return CopyOutputToSlot(aSlot, aSlotTex, aSlotW, aSlotH);
+}
+
+bool NvidiaVfxSession::UnregisterTexture(unsigned int aTex) {
+  if (aTex == 0) {
+    return true;
+  }
+  MutexAutoLock interopLock(mInteropLock);
+  bool ok = true;
+  if (mStagingReg.glTexture == aTex) {
+    ok = ReleaseRegistration(mStagingReg) && ok;
+  }
+  for (auto& slot : mSlotRegs) {
+    if (slot.glTexture == aTex) {
+      ok = ReleaseRegistration(slot) && ok;
+    }
+  }
+  if (!ok) {
+    MonitorAutoLock lock(mLock);
+    FailLocked("unregister interop");
+  }
+  return ok;
+}
+
+bool NvidiaVfxSession::ReleaseRegistration(GlRegistration& aReg) {
+  if (!aReg.resource) {
+    aReg = GlRegistration{};
+    return true;
+  }
+  NvidiaVfxLoader& loader = NvidiaVfxLoader::GetInstance();
+  CuContext context = nullptr;
+  CuStream stream = nullptr;
+  {
+    MonitorAutoLock lock(mLock);
+    context = mCudaCtx;
+    stream = mCudaStream;
+  }
+  if (!context || loader.CuCtxPushCurrent(context) != 0) {
+    return false;
+  }
+  bool ok = true;
+  if (aReg.mapped) {
+    ok = UnmapResource(loader, aReg.resource, stream);
+  }
+  if (ok) {
+    ok = UnregisterGlTexture(loader, aReg.resource);
+  }
+  CuContext popped = nullptr;
+  loader.CuCtxPopCurrent(&popped);
+  if (!ok) {
+    return false;
+  }
+  aReg = GlRegistration{};
+  return true;
+}
+
+bool NvidiaVfxSession::EnsureRegistration(GlRegistration& aReg,
+                                           unsigned int aTex, int aW, int aH) {
+  if (aReg.resource && aReg.glTexture == aTex && aReg.width == aW &&
+      aReg.height == aH) {
+    return true;
+  }
+  if (!ReleaseRegistration(aReg)) {
+    return false;
+  }
+  CuContext context = nullptr;
+  {
+    MonitorAutoLock lock(mLock);
+    context = mCudaCtx;
+  }
+  if (!context) {
+    return false;
+  }
+  NvidiaVfxLoader& loader = NvidiaVfxLoader::GetInstance();
+  if (loader.CuCtxPushCurrent(context) != 0) {
+    return false;
+  }
+  CuGraphicsResource res = nullptr;
+  const bool ok = RegisterGlTexture(loader, aTex, &res);
+  CuContext popped = nullptr;
+  loader.CuCtxPopCurrent(&popped);
+  if (!ok || !res) {
+    return false;
+  }
+  aReg.glTexture = aTex;
+  aReg.resource = res;
+  aReg.width = aW;
+  aReg.height = aH;
+  aReg.mapped = false;
+  return true;
+}
+
+void NvidiaVfxSession::UnregisterAllGl() {
+  MutexAutoLock interopLock(mInteropLock);
+  bool ok = ReleaseRegistration(mStagingReg);
+  for (auto& slot : mSlotRegs) {
+    ok = ReleaseRegistration(slot) && ok;
+  }
+  if (!ok) {
+    MonitorAutoLock lock(mLock);
+    FailLocked("unregister interop");
+  }
+}
+
+void NvidiaVfxSession::WorkerProcessFrame() {
+  NvidiaVfxLoader& loader = NvidiaVfxLoader::GetInstance();
+  SuperResolutionQuality requestedQuality = kDefaultQuality;
+  {
+    MonitorAutoLock lock(mLock);
+    if (mState != SuperResolutionSessionState::Ready || !mEffectReady ||
+        !mCudaCtx || !mEffect) {
+      if (mWorkerBusy) {
+        mWorkerBusy = false;
+      }
+      return;
+    }
+    requestedQuality = mRequestedQuality;
+  }
+
+  if (loader.CuCtxPushCurrent(mCudaCtx) != 0) {
+    MonitorAutoLock lock(mLock);
+    FailLocked("worker context");
+    return;
+  }
+
+  bool ok = false;
+  do {
+    if (requestedQuality != mAppliedQuality &&
+        loader.SetU32(mEffect, kQualityLevelParam,
+                      SuperResolutionQualityToNvVfx(requestedQuality)) != 0) {
+      break;
+    }
+    mAppliedQuality = requestedQuality;
+
+    MarkToken(kMarkerVfxStart, mWorkingToken);
+    const int runRc = loader.RunEffect(mEffect, 0);
+    MarkToken(kMarkerVfxEnd, mWorkingToken);
+    if (runRc != 0) {
+      break;
+    }
+
+    if (loader.CuEventRecord(mReadyEvent, mCudaStream) != 0) {
+      break;
+    }
+
+    if (loader.HasStreamHostCallback()) {
+      auto* signal = new CompletionSignal();
+      signal->token = mWorkingToken;
+      if (loader.CuLaunchHostFunc(mCudaStream, OnStreamComplete, signal) != 0) {
+        delete signal;
+      }
+    }
+    ok = true;
+  } while (false);
+
+  CuContext popped = nullptr;
+  loader.CuCtxPopCurrent(&popped);
+
+  MonitorAutoLock lock(mLock);
+  if (!ok) {
+    mWorkerBusy = false;
+    FailLocked("worker frame");
+  } else {
+    mReadyToken = mWorkingToken;
+    mHasReady = true;
+    mWorkerBusy = false;
+  }
+}
+
+bool NvidiaVfxSession::MapAndCopyToInput(unsigned int aTex, int aW, int aH) {
+  NvidiaVfxLoader& loader = NvidiaVfxLoader::GetInstance();
+  CuContext ctx = nullptr;
+  CuStream stream = nullptr;
+  CuDevicePtr stagingIn = 0;
+  size_t inputPitch = 0;
+  {
+    MonitorAutoLock lock(mLock);
+    if (mState != SuperResolutionSessionState::Ready || !mCudaCtx ||
+        !mCudaStream || !mEffectReady || aW != mVideoW || aH != mVideoH) {
+      return false;
+    }
+    ctx = mCudaCtx;
+    stream = mCudaStream;
+    stagingIn = reinterpret_cast<CuDevicePtr>(mInImage.pixels);
+    inputPitch = static_cast<size_t>(mInImage.pitch);
+  }
+  if (!stagingIn || inputPitch < static_cast<size_t>(aW * 4)) {
+    return false;
+  }
+
+  MutexAutoLock interopLock(mInteropLock);
+  if (!EnsureRegistration(mStagingReg, aTex, aW, aH)) {
+    return false;
+  }
+  const CuGraphicsResource resource = mStagingReg.resource;
+
+  if (loader.CuCtxPushCurrent(ctx) != 0) {
+    return false;
+  }
+
+  bool ok = false;
+  do {
+    if (!MapResource(loader, resource, stream)) {
+      break;
+    }
+    mStagingReg.mapped = true;
+    void* mappedArray = nullptr;
+    if (loader.GraphicsSubResourceGetMappedArray(&mappedArray, resource, 0, 0) != 0 ||
+        !mappedArray) {
+      mStagingReg.mapped = !UnmapResource(loader, resource, stream);
+      break;
+    }
+    const size_t widthBytes = static_cast<size_t>(aW) * 4;
+    ok = CopyArrayToImage(loader, stagingIn, inputPitch, mappedArray,
+                          widthBytes, static_cast<size_t>(aH), stream);
+    mStagingReg.mapped = !UnmapResource(loader, resource, stream);
+  } while (false);
+
+  CuContext popped = nullptr;
+  loader.CuCtxPopCurrent(&popped);
+  if (!ok) {
+    MonitorAutoLock lock(mLock);
+    FailLocked("input interop");
+  }
+  return ok;
+}
+
+bool NvidiaVfxSession::CopyOutputToSlot(size_t aSlot, unsigned int aTex,
+                                         int aW, int aH) {
+  if (aSlot >= std::size(mSlotRegs) || aTex == 0 || aW <= 0 || aH <= 0) {
+    return false;
+  }
+
+  NvidiaVfxLoader& loader = NvidiaVfxLoader::GetInstance();
+  CuContext ctx = nullptr;
+  CuStream stream = nullptr;
+  CuDevicePtr vfxOut = 0;
+  size_t outputPitch = 0;
+  {
+    MonitorAutoLock lock(mLock);
+    if (mState != SuperResolutionSessionState::Ready || !mCudaCtx ||
+        !mCudaStream || !mEffectReady || aW != mOutW || aH != mOutH) {
+      return false;
+    }
+    ctx = mCudaCtx;
+    stream = mCudaStream;
+    vfxOut = reinterpret_cast<CuDevicePtr>(mOutImage.pixels);
+    outputPitch = static_cast<size_t>(mOutImage.pitch);
+  }
+  if (!vfxOut || outputPitch < static_cast<size_t>(aW * 4)) {
+    return false;
+  }
+
+  MutexAutoLock interopLock(mInteropLock);
+  if (!EnsureRegistration(mSlotRegs[aSlot], aTex, aW, aH)) {
+    return false;
+  }
+  const CuGraphicsResource resource = mSlotRegs[aSlot].resource;
+
+  if (loader.CuCtxPushCurrent(ctx) != 0) {
+    return false;
+  }
+
+  bool ok = false;
+  do {
+    if (!MapResource(loader, resource, stream)) {
+      break;
+    }
+    mSlotRegs[aSlot].mapped = true;
+    void* mappedArray = nullptr;
+    if (loader.GraphicsSubResourceGetMappedArray(&mappedArray, resource, 0, 0) != 0 ||
+        !mappedArray) {
+      mSlotRegs[aSlot].mapped = !UnmapResource(loader, resource, stream);
+      break;
+    }
+    const size_t widthBytes = static_cast<size_t>(aW) * 4;
+    ok = CopyImageToArray(loader, mappedArray, vfxOut, outputPitch,
+                          widthBytes, static_cast<size_t>(aH), stream);
+    mSlotRegs[aSlot].mapped = !UnmapResource(loader, resource, stream);
+  } while (false);
+
+  CuContext popped = nullptr;
+  loader.CuCtxPopCurrent(&popped);
+  if (!ok) {
+    MonitorAutoLock lock(mLock);
+    FailLocked("output interop");
+  }
+  return ok;
+}
+
+bool NvidiaVfxSession::InitCudaOnWorker(const WorkerBinding& aBinding) {
+  NvidiaVfxLoader& loader = NvidiaVfxLoader::GetInstance();
+  if (!loader.EnsureLoaded()) {
+    return false;
+  }
+  if (loader.CuInit(0) != 0) {
+    return false;
+  }
+
+  CuContext ctx = nullptr;
+  if (loader.CuCtxCreate(&ctx, 0, aBinding.glDevice) != 0 || !ctx) {
+    return false;
+  }
+
+  CuStream stream = nullptr;
+  if (loader.CuStreamCreate(&stream, kCuStreamNonBlocking) != 0 || !stream) {
+    loader.CuCtxDestroy(ctx);
+    return false;
+  }
+
+  void* readyEvent = nullptr;
+  if (loader.CuEventCreate(&readyEvent, 0) != 0 || !readyEvent) {
+    loader.CuStreamDestroy(stream);
+    loader.CuCtxDestroy(ctx);
+    return false;
+  }
+
+  CuContext popped = nullptr;
+  loader.CuCtxPopCurrent(&popped);
+
+  MonitorAutoLock lock(mLock);
+  mCudaCtx = ctx;
+  mCudaStream = stream;
+  mReadyEvent = readyEvent;
+  return true;
+}
+
+bool NvidiaVfxSession::InitEffectOnWorker(const WorkerBinding& aBinding) {
+  NvidiaVfxLoader& loader = NvidiaVfxLoader::GetInstance();
+  if (!mCudaCtx || loader.CuCtxPushCurrent(mCudaCtx) != 0) {
+    return false;
+  }
+
+  bool ok = false;
+  do {
+    if (loader.SetS32(nullptr, kGpuParam, aBinding.ordinal) != 0) {
+      break;
+    }
+    int vfxOrdinal = -1;
+    if (loader.GetS32(nullptr, kGpuParam, &vfxOrdinal) != 0 ||
+        vfxOrdinal != aBinding.ordinal) {
+      break;
+    }
+    if (loader.CreateEffect(kVideoSuperResEffect, &mEffect) != 0 || !mEffect) {
+      break;
+    }
+    if (loader.SetU32(mEffect, kQualityLevelParam,
+                      SuperResolutionQualityToNvVfx(aBinding.quality)) != 0) {
+      break;
+    }
+    mAppliedQuality = aBinding.quality;
+
+    if (loader.ImageAlloc(&mInImage, (unsigned)aBinding.videoW,
+                          (unsigned)aBinding.videoH, kNvFormatRGBA,
+                          kNvTypeU8, kNvChunky, kNvGpuMem, 32) != 0) {
+      break;
+    }
+    if (loader.ImageAlloc(&mOutImage, (unsigned)aBinding.outW,
+                          (unsigned)aBinding.outH, kNvFormatRGBA,
+                          kNvTypeU8, kNvChunky, kNvGpuMem, 32) != 0) {
+      break;
+    }
+    if (mInImage.pitch < aBinding.videoW * 4 ||
+        mOutImage.pitch < aBinding.outW * 4) {
+      break;
+    }
+    if (loader.SetImage(mEffect, kSrcImageParam, &mInImage) != 0) {
+      break;
+    }
+    if (loader.SetImage(mEffect, kDstImageParam, &mOutImage) != 0) {
+      break;
+    }
+    if (loader.SetCudaStream(mEffect, kCudaStreamParam, mCudaStream) != 0) {
+      break;
+    }
+    if (loader.LoadEffect(mEffect) != 0) {
+      break;
+    }
+    bool warmed = true;
+    for (int i = 0; i < 3; ++i) {
+      if (loader.RunEffect(mEffect, 0) != 0) {
+        warmed = false;
+        break;
+      }
+    }
+    if (!warmed || loader.CuStreamSynchronize(mCudaStream) != 0) {
+      break;
+    }
+    ok = true;
+  } while (false);
+
+  CuContext popped = nullptr;
+  loader.CuCtxPopCurrent(&popped);
+
+  if (!ok) {
+    DestroyEffectOnWorker();
+    return false;
+  }
+
+  MonitorAutoLock lock(mLock);
+  mEffectReady = true;
+  return true;
+}
+
+bool NvidiaVfxSession::DestroyEffectOnWorker() {
+  MonitorAutoLock lock(mLock);
+  NvidiaVfxLoader& loader = NvidiaVfxLoader::GetInstance();
+  bool ok = true;
+  if (mCudaCtx && loader.CuCtxPushCurrent(mCudaCtx) == 0) {
+    if (mInImage.pixels) {
+      loader.ImageFree(&mInImage);
+      mInImage = NvCVImage{};
+    }
+    if (mOutImage.pixels) {
+      loader.ImageFree(&mOutImage);
+      mOutImage = NvCVImage{};
+    }
+    if (mEffect) {
+      loader.DestroyEffect(mEffect);
+      mEffect = nullptr;
+    }
+    CuContext popped = nullptr;
+    loader.CuCtxPopCurrent(&popped);
+  } else if (mEffect || mInImage.pixels || mOutImage.pixels) {
+    ok = false;
+  }
+  mEffectReady = false;
+  mHasReady = false;
+  mWorkerBusy = false;
+  return ok;
+}
+
+bool NvidiaVfxSession::DestroyCudaOnWorker() {
+  MonitorAutoLock lock(mLock);
+  NvidiaVfxLoader& loader = NvidiaVfxLoader::GetInstance();
+  if (mCudaCtx && loader.CuCtxPushCurrent(mCudaCtx) == 0) {
+    if (mReadyEvent) {
+      loader.CuEventDestroy(mReadyEvent);
+      mReadyEvent = nullptr;
+    }
+    if (mCudaStream) {
+      loader.CuStreamDestroy(mCudaStream);
+      mCudaStream = nullptr;
+    }
+    CuContext popped = nullptr;
+    loader.CuCtxPopCurrent(&popped);
+    loader.CuCtxDestroy(mCudaCtx);
+    mCudaCtx = nullptr;
+  }
+  return true;
+}
+
+void NvidiaVfxSession::WorkerInit() {
+  WorkerBinding binding;
+  {
+    MonitorAutoLock lock(mLock);
+    mRebindQueued = false;
+    if (mState == SuperResolutionSessionState::Failed ||
+        mState == SuperResolutionSessionState::ShuttingDown) {
+      return;
+    }
+    binding = SnapshotBinding();
+  }
+
+  if (!InitCudaOnWorker(binding)) {
+    MonitorAutoLock lock(mLock);
+    mState = SuperResolutionSessionState::Failed;
+    return;
+  }
+  if (!InitEffectOnWorker(binding)) {
+    DestroyCudaOnWorker();
+    MonitorAutoLock lock(mLock);
+    mState = SuperResolutionSessionState::Failed;
+    return;
+  }
+
+  MonitorAutoLock lock(mLock);
+  if (mState == SuperResolutionSessionState::ShuttingDown ||
+      mState == SuperResolutionSessionState::Failed ||
+      !BindingIsCurrent(binding)) {
+    return;
+  }
+  mState = SuperResolutionSessionState::Ready;
+}
+
+void NvidiaVfxSession::WorkerRebind() {
+  WorkerBinding binding;
+  {
+    MonitorAutoLock lock(mLock);
+    mRebindQueued = false;
+    if (mState == SuperResolutionSessionState::ShuttingDown ||
+        mState == SuperResolutionSessionState::Failed) {
+      return;
+    }
+    binding = SnapshotBinding();
+  }
+
+  DestroyEffectOnWorker();
+  DestroyCudaOnWorker();
+
+  if (!InitCudaOnWorker(binding)) {
+    MonitorAutoLock lock(mLock);
+    mState = SuperResolutionSessionState::Failed;
+    return;
+  }
+  if (!InitEffectOnWorker(binding)) {
+    DestroyCudaOnWorker();
+    MonitorAutoLock lock(mLock);
+    mState = SuperResolutionSessionState::Failed;
+    return;
+  }
+
+  MonitorAutoLock lock(mLock);
+  if (mState == SuperResolutionSessionState::ShuttingDown ||
+      mState == SuperResolutionSessionState::Failed ||
+      !BindingIsCurrent(binding)) {
+    return;
+  }
+  mState = SuperResolutionSessionState::Ready;
+}
+
+NvidiaVfxSession::WorkerBinding NvidiaVfxSession::SnapshotBinding() {
+  WorkerBinding binding;
+  binding.videoW = mVideoW;
+  binding.videoH = mVideoH;
+  binding.outW = mOutW;
+  binding.outH = mOutH;
+  binding.quality = mRequestedQuality;
+  binding.glDevice = mGlCudaDevice;
+  binding.ordinal = mCudaOrdinal;
+  return binding;
+}
+
+bool NvidiaVfxSession::BindingIsCurrent(const WorkerBinding& aBinding) {
+  return mVideoW == aBinding.videoW && mVideoH == aBinding.videoH &&
+         mOutW == aBinding.outW && mOutH == aBinding.outH &&
+         mGlCudaDevice == aBinding.glDevice && mCudaOrdinal == aBinding.ordinal;
+}
+
+void NvidiaVfxSession::WorkerShutdown() {
+  CuContext context = nullptr;
+  CuStream stream = nullptr;
+  {
+    MonitorAutoLock lock(mLock);
+    context = mCudaCtx;
+    stream = mCudaStream;
+  }
+  if (context && NvidiaVfxLoader::GetInstance().CuCtxPushCurrent(context) == 0) {
+    NvidiaVfxLoader::GetInstance().CuStreamSynchronize(stream);
+    CuContext popped = nullptr;
+    NvidiaVfxLoader::GetInstance().CuCtxPopCurrent(&popped);
+  }
+  DestroyEffectOnWorker();
+  DestroyCudaOnWorker();
+  MonitorAutoLock lock(mLock);
+  mStagingReg = GlRegistration{};
+  for (auto& slot : mSlotRegs) {
+    slot = GlRegistration{};
+  }
+  mState = SuperResolutionSessionState::Uninitialized;
+}
+
+void NvidiaVfxSession::Shutdown() {
+  nsCOMPtr<nsIThread> worker;
+  {
+    MonitorAutoLock lock(mLock);
+    mState = SuperResolutionSessionState::ShuttingDown;
+    worker = std::move(mWorkerThread);
+  }
+  UnregisterAllGl();
+  if (worker) {
+    RefPtr<NvidiaVfxSession> self = this;
+    if (NS_FAILED(worker->Dispatch(
+        NS_NewRunnableFunction("WorkerShutdown",
+                               [self]() { self->WorkerShutdown(); }),
+        NS_DISPATCH_NORMAL))) {
+      MonitorAutoLock lock(mLock);
+      FailLocked("dispatch worker shutdown");
+      return;
+    }
+    worker->Shutdown();
+  } else {
+    DestroyEffectOnWorker();
+    DestroyCudaOnWorker();
+    MonitorAutoLock lock(mLock);
+    mState = SuperResolutionSessionState::Uninitialized;
+  }
+  MonitorAutoLock lock(mLock);
+  mVideoW = mVideoH = mOutW = mOutH = 0;
+  mHasReady = false;
+  mWorkerBusy = false;
+}
+
+}  // namespace mozilla::zen

--- a/src/zen/video-super-resolution/NvidiaVfxSession.h
+++ b/src/zen/video-super-resolution/NvidiaVfxSession.h
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_zen_NvidiaVfxSession_h
+#define mozilla_zen_NvidiaVfxSession_h
+
+#include "CudaGlInterop.h"
+#include "NvidiaVfxLoader.h"
+#include "VideoSuperResolutionTypes.h"
+
+#include <cstddef>
+#include <cstdint>
+
+#include "mozilla/Monitor.h"
+#include "mozilla/Mutex.h"
+#include "nsCOMPtr.h"
+
+class nsIThread;
+
+namespace mozilla::zen {
+
+class NvidiaVfxSession {
+ public:
+  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(NvidiaVfxSession)
+
+  NvidiaVfxSession();
+
+  uint64_t EnsureWorker(int aVideoW, int aVideoH, int aOutW, int aOutH,
+                        SuperResolutionQuality aQuality, CuDevice aGlCudaDevice,
+                        int aCudaOrdinal);
+
+  bool SubmitInput(const SuperResolutionFrameToken& aToken, unsigned int aStagingTex,
+                   int aStagingW, int aStagingH);
+
+  bool PeekReady(SuperResolutionFrameToken* aToken);
+  bool IsReadyComplete();
+  bool TakeReady(SuperResolutionFrameToken* aToken);
+
+  bool DownloadSlot(size_t aSlot, unsigned int aSlotTex, int aSlotW, int aSlotH);
+  bool UnregisterTexture(unsigned int aTex);
+
+  SuperResolutionSessionState State() const;
+
+  void Shutdown();
+
+ private:
+  virtual ~NvidiaVfxSession();
+
+  struct GlRegistration {
+    unsigned int glTexture = 0;
+    CuGraphicsResource resource = nullptr;
+    int width = 0;
+    int height = 0;
+    bool mapped = false;
+  };
+
+  struct WorkerBinding {
+    int videoW = 0;
+    int videoH = 0;
+    int outW = 0;
+    int outH = 0;
+    SuperResolutionQuality quality = kDefaultQuality;
+    CuDevice glDevice = -1;
+    int ordinal = -1;
+  };
+
+  void WorkerInit();
+  void WorkerRebind();
+  void WorkerProcessFrame();
+  void WorkerShutdown();
+
+  bool InitCudaOnWorker(const WorkerBinding& aBinding);
+  bool InitEffectOnWorker(const WorkerBinding& aBinding);
+  bool DestroyEffectOnWorker();
+  bool DestroyCudaOnWorker();
+
+  bool MapAndCopyToInput(unsigned int aTex, int aW, int aH);
+  bool CopyOutputToSlot(size_t aSlot, unsigned int aTex, int aW, int aH);
+  void UnregisterAllGl();
+
+  bool EnsureRegistration(GlRegistration& aReg, unsigned int aTex, int aW, int aH);
+  bool ReleaseRegistration(GlRegistration& aReg);
+  void FailLocked(const char* aWhere);
+
+  WorkerBinding SnapshotBinding();
+  bool BindingIsCurrent(const WorkerBinding& aBinding);
+
+  mutable Monitor mLock{"NvidiaVfxSession"};
+  Mutex mInteropLock{"NvidiaVfxSessionInterop"};
+  SuperResolutionSessionState mState = SuperResolutionSessionState::Uninitialized;
+  uint64_t mGeneration = 0;
+
+  int mVideoW = 0;
+  int mVideoH = 0;
+  int mOutW = 0;
+  int mOutH = 0;
+  SuperResolutionQuality mRequestedQuality = kDefaultQuality;
+  SuperResolutionQuality mAppliedQuality = kDefaultQuality;
+  CuDevice mGlCudaDevice = -1;
+  int mCudaOrdinal = -1;
+
+  CuContext mCudaCtx = nullptr;
+  CuStream mCudaStream = nullptr;
+  void* mReadyEvent = nullptr;
+  void* mEffect = nullptr;
+  NvCVImage mInImage{};
+  NvCVImage mOutImage{};
+
+  GlRegistration mStagingReg;
+  GlRegistration mSlotRegs[4];
+
+  bool mEffectReady = false;
+  bool mWorkerBusy = false;
+  bool mHasReady = false;
+  bool mRebindQueued = false;
+  SuperResolutionFrameToken mWorkingToken;
+  SuperResolutionFrameToken mReadyToken;
+
+  nsCOMPtr<nsIThread> mWorkerThread;
+
+};
+
+}  // namespace mozilla::zen
+
+#endif  // mozilla_zen_NvidiaVfxSession_h

--- a/src/zen/video-super-resolution/VideoSuperResolutionCapability.cpp
+++ b/src/zen/video-super-resolution/VideoSuperResolutionCapability.cpp
@@ -1,0 +1,290 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "VideoSuperResolutionCapability.h"
+
+#include <dirent.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "GLContext.h"
+#include "mozilla/Logging.h"
+#include "NvidiaVfxLoader.h"
+
+#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
+#include "mozilla/StaticPrefs_zen.h"
+#endif
+
+namespace mozilla::zen {
+
+static LazyLogModule sVideoSuperResolutionLog("VideoSuperResolution");
+
+VideoSuperResolutionCapability& VideoSuperResolutionCapability::Get() {
+  static VideoSuperResolutionCapability sInstance;
+  return sInstance;
+}
+
+bool VideoSuperResolutionCapability::ParseNvmlVersion(
+    const char* aVersionStr, DriverVersion* aOut) {
+  if (!aVersionStr || !aOut) {
+    return false;
+  }
+  int maj = 0, min = 0, patch = 0;
+  if (sscanf(aVersionStr, "%d.%d.%d", &maj, &min, &patch) >= 2) {
+    aOut->major = maj;
+    aOut->minor = min;
+    aOut->patch = patch;
+    aOut->isKnown = true;
+    return true;
+  }
+  return false;
+}
+
+bool VideoSuperResolutionCapability::CheckDriverSupport(
+    const DriverVersion& aDriver, const char** aReasonStr) {
+  if (!aDriver.isKnown) {
+    if (aReasonStr) *aReasonStr = "unknown-driver-version";
+    return false;
+  }
+
+  if (aDriver.major < 570) {
+    if (aReasonStr) *aReasonStr = "below-min-major-570";
+    return false;
+  }
+
+  if (aDriver.major == 570) {
+    if (aDriver.minor < 190) {
+      if (aReasonStr) *aReasonStr = "570-branch-below-floor";
+      return false;
+    }
+    if (aReasonStr) *aReasonStr = "supported-570-branch";
+    return true;
+  }
+
+  if (aDriver.major == 580) {
+    if (aDriver.minor < 82) {
+      if (aReasonStr) *aReasonStr = "580-branch-below-floor";
+      return false;
+    }
+    if (aReasonStr) *aReasonStr = "supported-580-branch";
+    return true;
+  }
+
+  if (aDriver.major == 590) {
+    if (aDriver.minor < 44) {
+      if (aReasonStr) *aReasonStr = "590-branch-below-floor";
+      return false;
+    }
+    if (aReasonStr) *aReasonStr = "supported-590-branch";
+    return true;
+  }
+
+  if (aReasonStr) *aReasonStr = "future-driver-branch";
+  return true;
+}
+
+void VideoSuperResolutionCapability::Invalidate(gl::GLContext* aGL) {
+  if (!aGL || mLastProbedGL == aGL) {
+    mState = SuperResolutionCapabilityState::Unknown;
+    mReason = CapabilityReason::None;
+    mLastProbedGL = nullptr;
+    mGpuInfo = GpuDeviceInfo{};
+    mDriverVersion = DriverVersion{};
+    mTopology = SystemGpuTopology{};
+  }
+}
+
+bool VideoSuperResolutionCapability::Probe(gl::GLContext* aGL) {
+  if (!aGL) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::None;
+    return false;
+  }
+
+#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
+  if (!StaticPrefs::zen_video_super_resolution_enabled()) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::DisabledByPref;
+    mLastProbedGL = nullptr;
+    mGpuInfo = GpuDeviceInfo{};
+    mDriverVersion = DriverVersion{};
+    mTopology = SystemGpuTopology{};
+    return false;
+  }
+#endif
+
+  if (mState != SuperResolutionCapabilityState::Unknown && mLastProbedGL == aGL) {
+    return mState == SuperResolutionCapabilityState::Available;
+  }
+
+  mLastProbedGL = aGL;
+  mState = SuperResolutionCapabilityState::Probing;
+
+  mTopology = SystemGpuTopology{};
+  if (const char* rend = (const char*)aGL->fGetString(LOCAL_GL_RENDERER)) {
+    snprintf(mTopology.activeGlRenderer, sizeof(mTopology.activeGlRenderer), "%s", rend);
+  }
+  if (const char* vend = (const char*)aGL->fGetString(LOCAL_GL_VENDOR)) {
+    snprintf(mTopology.activeGlVendorString, sizeof(mTopology.activeGlVendorString), "%s", vend);
+  }
+
+  DIR* dir = opendir("/dev/dri");
+  if (dir) {
+    struct dirent* entry;
+    int renderCount = 0;
+    while ((entry = readdir(dir)) != nullptr) {
+      if (strncmp(entry->d_name, "renderD", 7) == 0) {
+        if (renderCount == 0) {
+          snprintf(mTopology.renderNode, sizeof(mTopology.renderNode),
+                   "/dev/dri/%s", entry->d_name);
+        }
+        renderCount++;
+      }
+    }
+    closedir(dir);
+    mTopology.hybridSystem = (renderCount > 1);
+  }
+
+  if (aGL->Vendor() != gl::GLVendor::NVIDIA) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::NonNvidiaGL;
+    return false;
+  }
+
+  NvidiaVfxLoader& loader = NvidiaVfxLoader::GetInstance();
+  if (!loader.EnsureCudaLib()) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::CudaLibraryMissing;
+    MOZ_LOG(sVideoSuperResolutionLog, LogLevel::Warning,
+            ("VSR unavailable: CUDA driver library missing"));
+    return false;
+  }
+  if (loader.CuInit(0) != 0) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::CudaInitFailed;
+    return false;
+  }
+
+  unsigned int count = 0;
+  CuDevice devices[4] = {-1, -1, -1, -1};
+  const char* glMode = "CURRENT_FRAME";
+  int glRc = loader.CuGLGetDevices(&count, devices, 4, 0x02);
+  if (glRc != 0 || count == 0) {
+    glMode = "ALL";
+    glRc = loader.CuGLGetDevices(&count, devices, 4, 0x01);
+  }
+  if (glRc != 0 || count == 0) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::NoGlCudaDevice;
+    return false;
+  }
+  if (count > 1) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::AmbiguousGlCudaDevice;
+    return false;
+  }
+
+  mGpuInfo.glDeviceMode = glMode;
+  CuDevice glDevice = devices[0];
+  mGpuInfo.glCudaDevice = glDevice;
+
+  int devCount = 0;
+  if (loader.CuDeviceGetCount(&devCount) != 0 || devCount <= 0) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::NoGlCudaDevice;
+    return false;
+  }
+  int resolvedOrdinal = -1;
+  for (int i = 0; i < devCount; ++i) {
+    CuDevice cand = -1;
+    if (loader.CuDeviceGet(&cand, i) == 0 && cand == glDevice) {
+      resolvedOrdinal = i;
+      break;
+    }
+  }
+  if (resolvedOrdinal < 0) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::GpuOrdinalResolutionFailed;
+    return false;
+  }
+  mGpuInfo.cudaOrdinal = resolvedOrdinal;
+
+  loader.CuDeviceGetName(mGpuInfo.name, sizeof(mGpuInfo.name),
+                         mGpuInfo.glCudaDevice);
+  loader.CuDeviceGetAttribute(&mGpuInfo.computeMajor, 75,
+                              mGpuInfo.glCudaDevice);
+  loader.CuDeviceGetAttribute(&mGpuInfo.computeMinor, 76,
+                              mGpuInfo.glCudaDevice);
+  loader.CuDeviceGetUuid(&mGpuInfo.uuid, mGpuInfo.glCudaDevice);
+  CuDevice crossCheckDevice = -1;
+  CudaDeviceUuid crossCheckUuid{};
+  if (loader.CuDeviceGet(&crossCheckDevice, resolvedOrdinal) != 0 ||
+      loader.CuDeviceGetUuid(&crossCheckUuid, crossCheckDevice) != 0 ||
+      memcmp(mGpuInfo.uuid.bytes, crossCheckUuid.bytes,
+             sizeof(mGpuInfo.uuid.bytes)) != 0) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::GpuOrdinalResolutionFailed;
+    return false;
+  }
+
+  mDriverVersion = DriverVersion{};
+  void* nvml = dlopen("libnvidia-ml.so.1", RTLD_NOW | RTLD_LOCAL);
+  if (!nvml) {
+    nvml = dlopen("libnvidia-ml.so", RTLD_NOW | RTLD_LOCAL);
+  }
+  if (nvml) {
+    auto fnInit = (int (*)())dlsym(nvml, "nvmlInit_v2");
+    if (!fnInit) fnInit = (int (*)())dlsym(nvml, "nvmlInit");
+    auto fnVer = (int (*)(char*, unsigned int))dlsym(nvml, "nvmlSystemGetDriverVersion");
+    auto fnShutdown = (int (*)())dlsym(nvml, "nvmlShutdown");
+
+    if (fnInit && fnVer && fnInit() == 0) {
+      char vBuf[64] = {0};
+      if (fnVer(vBuf, sizeof(vBuf)) == 0) {
+        ParseNvmlVersion(vBuf, &mDriverVersion);
+      }
+      if (fnShutdown) fnShutdown();
+    }
+    dlclose(nvml);
+  }
+
+  if (mDriverVersion.isKnown && !CheckDriverSupport(mDriverVersion)) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::DriverTooOld;
+    return false;
+  }
+
+  if (!loader.HasGlInterop()) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::InteropFailed;
+    MOZ_LOG(sVideoSuperResolutionLog, LogLevel::Warning,
+            ("VSR unavailable: CUDA/GL interop unavailable"));
+    return false;
+  }
+
+  if (!loader.EnsureLoaded()) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::VfxCoreMissing;
+    return false;
+  }
+  if (loader.SetS32(nullptr, kGpuParam, resolvedOrdinal) != 0) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::VideoSuperResMissing;
+    return false;
+  }
+  int vfxOrdinal = -1;
+  if (loader.GetS32(nullptr, kGpuParam, &vfxOrdinal) != 0 ||
+      vfxOrdinal != resolvedOrdinal) {
+    mState = SuperResolutionCapabilityState::Unavailable;
+    mReason = CapabilityReason::GpuOrdinalResolutionFailed;
+    return false;
+  }
+
+  mState = SuperResolutionCapabilityState::Available;
+  mReason = CapabilityReason::Available;
+  return true;
+}
+
+}  // namespace mozilla::zen

--- a/src/zen/video-super-resolution/VideoSuperResolutionCapability.h
+++ b/src/zen/video-super-resolution/VideoSuperResolutionCapability.h
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_zen_VideoSuperResolutionCapability_h
+#define mozilla_zen_VideoSuperResolutionCapability_h
+
+#include "VideoSuperResolutionTypes.h"
+
+namespace mozilla::gl {
+class GLContext;
+}
+
+namespace mozilla::zen {
+
+enum class CapabilityReason {
+  None,
+  Available,
+  DisabledByPref,
+  NonNvidiaGL,
+  CudaLibraryMissing,
+  CudaInitFailed,
+  NoGlCudaDevice,
+  AmbiguousGlCudaDevice,
+  GpuOrdinalResolutionFailed,
+  DriverTooOld,
+  DriverVersionUnknown,
+  VfxCoreMissing,
+  VideoSuperResMissing,
+  InteropFailed,
+  TerminalRuntimeFailure,
+};
+
+inline const char* CapabilityReasonToString(CapabilityReason aReason) {
+  switch (aReason) {
+    case CapabilityReason::None:
+      return "none";
+    case CapabilityReason::Available:
+      return "available";
+    case CapabilityReason::DisabledByPref:
+      return "disabled-by-pref";
+    case CapabilityReason::NonNvidiaGL:
+      return "non-nvidia-gl";
+    case CapabilityReason::CudaLibraryMissing:
+      return "cuda-library-missing";
+    case CapabilityReason::CudaInitFailed:
+      return "cuda-init-failed";
+    case CapabilityReason::NoGlCudaDevice:
+      return "no-gl-cuda-device";
+    case CapabilityReason::AmbiguousGlCudaDevice:
+      return "ambiguous-gl-cuda-device";
+    case CapabilityReason::GpuOrdinalResolutionFailed:
+      return "gpu-ordinal-resolution-failed";
+    case CapabilityReason::DriverTooOld:
+      return "driver-too-old";
+    case CapabilityReason::DriverVersionUnknown:
+      return "driver-version-unknown";
+    case CapabilityReason::VfxCoreMissing:
+      return "vfx-core-missing";
+    case CapabilityReason::VideoSuperResMissing:
+      return "video-super-res-missing";
+    case CapabilityReason::InteropFailed:
+      return "interop-failed";
+    case CapabilityReason::TerminalRuntimeFailure:
+      return "terminal-runtime-failure";
+  }
+  return "unknown";
+}
+
+struct DriverVersion {
+  int major = 0;
+  int minor = 0;
+  int patch = 0;
+  bool isKnown = false;
+};
+
+struct GpuDeviceInfo {
+  char name[128] = {0};
+  int computeMajor = 0;
+  int computeMinor = 0;
+  CudaDeviceHandle glCudaDevice = -1;
+  int cudaOrdinal = -1;
+  CudaDeviceUuid uuid{};
+  const char* glDeviceMode = "NONE";
+};
+
+struct SystemGpuTopology {
+  bool hybridSystem = false;
+  char renderNode[64] = {0};
+  char activeGlRenderer[128] = {0};
+  char activeGlVendorString[64] = {0};
+};
+
+class VideoSuperResolutionCapability {
+ public:
+  static VideoSuperResolutionCapability& Get();
+
+  bool Probe(gl::GLContext* aGL);
+  void Invalidate(gl::GLContext* aGL);
+
+  SuperResolutionCapabilityState GetState() const { return mState; }
+  CapabilityReason GetReason() const { return mReason; }
+  CudaDeviceHandle GetGlCudaDevice() const { return mGpuInfo.glCudaDevice; }
+  int GetCudaOrdinal() const { return mGpuInfo.cudaOrdinal; }
+  const GpuDeviceInfo& GetGpuInfo() const { return mGpuInfo; }
+  const DriverVersion& GetDriverVersion() const { return mDriverVersion; }
+  const SystemGpuTopology& GetTopology() const { return mTopology; }
+
+  static bool CheckDriverSupport(const DriverVersion& aDriver,
+                                 const char** aReasonStr = nullptr);
+  static bool ParseNvmlVersion(const char* aVersionStr, DriverVersion* aOut);
+
+ private:
+  VideoSuperResolutionCapability() = default;
+  ~VideoSuperResolutionCapability() = default;
+  VideoSuperResolutionCapability(const VideoSuperResolutionCapability&) = delete;
+  VideoSuperResolutionCapability& operator=(const VideoSuperResolutionCapability&) = delete;
+
+  SuperResolutionCapabilityState mState = SuperResolutionCapabilityState::Unknown;
+  CapabilityReason mReason = CapabilityReason::None;
+  gl::GLContext* mLastProbedGL = nullptr;
+  GpuDeviceInfo mGpuInfo;
+  DriverVersion mDriverVersion;
+  SystemGpuTopology mTopology;
+};
+
+}  // namespace mozilla::zen
+
+#endif  // mozilla_zen_VideoSuperResolutionCapability_h

--- a/src/zen/video-super-resolution/VideoSuperResolutionCoordinator.cpp
+++ b/src/zen/video-super-resolution/VideoSuperResolutionCoordinator.cpp
@@ -1,0 +1,189 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "VideoSuperResolutionCoordinator.h"
+
+#include "VideoSuperResolutionScalePolicy.h"
+
+namespace mozilla::zen {
+
+VideoSuperResolutionCoordinator& VideoSuperResolutionCoordinator::Get() {
+  static VideoSuperResolutionCoordinator sInstance;
+  return sInstance;
+}
+
+VideoSuperResolutionCoordinator::VideoSuperResolutionCoordinator() = default;
+
+VideoSuperResolutionCoordinator::PipelineState*
+VideoSuperResolutionCoordinator::FindPipeline(uint64_t aPipeline) {
+  for (auto& state : mPipelines) {
+    if (state.pipeline == aPipeline) {
+      return &state;
+    }
+  }
+  return nullptr;
+}
+
+VideoSuperResolutionCoordinator::PipelineState&
+VideoSuperResolutionCoordinator::EnsurePipeline(uint64_t aPipeline) {
+  if (PipelineState* found = FindPipeline(aPipeline)) {
+    return *found;
+  }
+  if (mPipelines.Length() >= 16) {
+    mPipelines[0] = PipelineState{};
+    mPipelines[0].pipeline = aPipeline;
+    return mPipelines[0];
+  }
+  PipelineState* appended = mPipelines.AppendElement(PipelineState{});
+  appended->pipeline = aPipeline;
+  return *appended;
+}
+
+bool VideoSuperResolutionCoordinator::NoteSelected(
+    uint64_t aPipeline, const SuperResolutionFrameToken& aToken) {
+  MutexAutoLock lock(mLock);
+  if (aPipeline == 0 || !aToken.HasIdentity()) {
+    return false;
+  }
+
+  PipelineState& state = EnsurePipeline(aPipeline);
+
+  const bool unique = !state.hasSelected || state.lastSelected != aToken;
+  if (unique) {
+    if (state.hasSelected &&
+        (!state.lastSelected.MatchesStream(aToken) ||
+         aToken.frame < state.lastSelected.frame)) {
+      state.completed.Clear();
+      state.hasPresented = false;
+    }
+    state.hasSelected = true;
+    state.lastSelected = aToken;
+  }
+  return unique;
+}
+
+bool VideoSuperResolutionCoordinator::LookupReady(
+    uint64_t aPipeline, const SuperResolutionFrameToken& aCurrent,
+    SuperResolutionFrameToken* aMatched) {
+  MutexAutoLock lock(mLock);
+  PipelineState* state = FindPipeline(aPipeline);
+  if (!state || !aCurrent.HasIdentity()) {
+    return false;
+  }
+
+  const SuperResolutionFrameToken* best = nullptr;
+  for (const auto& candidate : state->completed) {
+    if (!aCurrent.MatchesStream(candidate)) {
+      continue;
+    }
+    const int64_t lag = static_cast<int64_t>(aCurrent.frame) -
+                        static_cast<int64_t>(candidate.frame);
+    if (lag < 0 || lag > kMaxFrameLag ||
+        (state->hasPresented && state->lastPresented.MatchesStream(candidate) &&
+         candidate.frame < state->lastPresented.frame)) {
+      continue;
+    }
+    if (!best || candidate.frame > best->frame) {
+      best = &candidate;
+    }
+  }
+  if (best) {
+    if (aMatched) {
+      *aMatched = *best;
+    }
+    return true;
+  }
+  return false;
+}
+
+bool VideoSuperResolutionCoordinator::NoteExternalCompleted(
+    uint64_t aPipeline, const SuperResolutionFrameToken& aToken) {
+  MutexAutoLock lock(mLock);
+  PipelineState* state = FindPipeline(aPipeline);
+  if (!state || !state->hasSelected || !aToken.HasIdentity()) {
+    return false;
+  }
+
+  const int64_t lag = static_cast<int64_t>(state->lastSelected.frame) -
+                      static_cast<int64_t>(aToken.frame);
+  if (!aToken.MatchesStream(state->lastSelected) || lag < 0 ||
+      lag > kMaxFrameLag) {
+    return false;
+  }
+
+  for (const auto& c : state->completed) {
+    if (c == aToken) {
+      return true;
+    }
+  }
+
+  if (state->completed.Length() >= 8) {
+    state->completed.RemoveElementAt(0);
+  }
+  state->completed.AppendElement(aToken);
+  return true;
+}
+
+void VideoSuperResolutionCoordinator::NotePresented(
+    uint64_t aPipeline, const SuperResolutionFrameToken& aToken) {
+  MutexAutoLock lock(mLock);
+  PipelineState* state = FindPipeline(aPipeline);
+  if (!state) {
+    return;
+  }
+  state->hasPresented = true;
+  state->lastPresented = aToken;
+
+  for (size_t i = 0; i < state->completed.Length();) {
+    if (state->completed[i] == aToken ||
+        state->completed[i].frame < aToken.frame) {
+      state->completed.RemoveElementAt(i);
+    } else {
+      ++i;
+    }
+  }
+}
+
+bool VideoSuperResolutionCoordinator::WasPresented(
+    uint64_t aPipeline, const SuperResolutionFrameToken& aToken) {
+  MutexAutoLock lock(mLock);
+  for (const auto& state : mPipelines) {
+    if (state.pipeline == aPipeline) {
+      return state.hasPresented && state.lastPresented == aToken;
+    }
+  }
+  return false;
+}
+
+void VideoSuperResolutionCoordinator::InvalidatePipeline(uint64_t aPipeline) {
+  MutexAutoLock lock(mLock);
+  for (size_t i = 0; i < mPipelines.Length(); ++i) {
+    if (mPipelines[i].pipeline == aPipeline) {
+      mPipelines.RemoveElementAt(i);
+      return;
+    }
+  }
+}
+
+void VideoSuperResolutionCoordinator::InvalidateAll() {
+  MutexAutoLock lock(mLock);
+  mPipelines.Clear();
+}
+
+uint64_t VideoSuperResolutionCoordinator::SyncConfigFromPrefs() {
+  MutexAutoLock lock(mLock);
+  const SuperResolutionConfig config =
+      VideoSuperResolutionScalePolicy::ReadConfigFromPrefs();
+  if (!mConfigInitialized || !mLastConfig.SemanticallyEquals(config)) {
+    if (mConfigInitialized) {
+      ++mConfigGeneration;
+      mPipelines.Clear();
+    }
+    mLastConfig = config;
+    mConfigInitialized = true;
+  }
+  return mConfigGeneration;
+}
+
+}  // namespace mozilla::zen

--- a/src/zen/video-super-resolution/VideoSuperResolutionCoordinator.h
+++ b/src/zen/video-super-resolution/VideoSuperResolutionCoordinator.h
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_zen_VideoSuperResolutionCoordinator_h
+#define mozilla_zen_VideoSuperResolutionCoordinator_h
+
+#include <stdint.h>
+
+#include "mozilla/Mutex.h"
+#include "mozilla/zen/VideoSuperResolutionTypes.h"
+#include "nsTArray.h"
+
+namespace mozilla::zen {
+
+class VideoSuperResolutionCoordinator {
+ public:
+  static VideoSuperResolutionCoordinator& Get();
+
+  bool NoteSelected(uint64_t aPipeline, const SuperResolutionFrameToken& aToken);
+
+  bool LookupReady(uint64_t aPipeline, const SuperResolutionFrameToken& aCurrent,
+                   SuperResolutionFrameToken* aMatched);
+
+  void NotePresented(uint64_t aPipeline, const SuperResolutionFrameToken& aToken);
+
+  bool WasPresented(uint64_t aPipeline, const SuperResolutionFrameToken& aToken);
+
+  bool NoteExternalCompleted(uint64_t aPipeline,
+                             const SuperResolutionFrameToken& aToken);
+
+  void InvalidatePipeline(uint64_t aPipeline);
+
+  void InvalidateAll();
+
+  uint64_t SyncConfigFromPrefs();
+
+ private:
+  VideoSuperResolutionCoordinator();
+  ~VideoSuperResolutionCoordinator() = default;
+  VideoSuperResolutionCoordinator(const VideoSuperResolutionCoordinator&) = delete;
+  VideoSuperResolutionCoordinator& operator=(const VideoSuperResolutionCoordinator&) = delete;
+
+  struct PipelineState {
+    uint64_t pipeline = 0;
+    bool hasSelected = false;
+    SuperResolutionFrameToken lastSelected;
+    bool hasPresented = false;
+    SuperResolutionFrameToken lastPresented;
+    nsTArray<SuperResolutionFrameToken> completed;
+  };
+
+  PipelineState* FindPipeline(uint64_t aPipeline);
+  PipelineState& EnsurePipeline(uint64_t aPipeline);
+
+  Mutex mLock{"VideoSuperResolutionCoordinator"};
+  AutoTArray<PipelineState, 4> mPipelines;
+  uint64_t mConfigGeneration = 1;
+  bool mConfigInitialized = false;
+  SuperResolutionConfig mLastConfig;
+};
+
+}  // namespace mozilla::zen
+
+#endif  // mozilla_zen_VideoSuperResolutionCoordinator_h

--- a/src/zen/video-super-resolution/VideoSuperResolutionOwnerPolicy.cpp
+++ b/src/zen/video-super-resolution/VideoSuperResolutionOwnerPolicy.cpp
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "VideoSuperResolutionOwnerPolicy.h"
+
+namespace mozilla::zen {
+
+bool VideoSuperResolutionOwnerPolicy::ShouldTakeOwnership(
+    const SuperResolutionOwnerCandidate& aChallenger,
+    const SuperResolutionOwnerCandidate* aCurrentOwner,
+    SuperResolutionHandoffReason* aOutReason) {
+  if (aOutReason) {
+    *aOutReason = SuperResolutionHandoffReason::None;
+  }
+
+  if (!aChallenger.eligible || !aChallenger.hasPresentationArea) {
+    return false;
+  }
+
+  if (!aCurrentOwner || aCurrentOwner->pipelineId == 0) {
+    if (aOutReason) {
+      *aOutReason = SuperResolutionHandoffReason::ClaimInitial;
+    }
+    return true;
+  }
+
+  if (aChallenger.pipelineId == aCurrentOwner->pipelineId) {
+    return true;
+  }
+
+  if (!aCurrentOwner->eligible) {
+    if (aOutReason) {
+      *aOutReason = SuperResolutionHandoffReason::OwnerIneligible;
+    }
+    return true;
+  }
+
+  if (!aCurrentOwner->hasPresentationArea ||
+      aCurrentOwner->presentationArea == 0) {
+    if (aOutReason) {
+      *aOutReason = SuperResolutionHandoffReason::OwnerNoPresentationArea;
+    }
+    return true;
+  }
+
+  const double requiredArea =
+      double(aCurrentOwner->presentationArea) * double(kAreaHysteresisRatio);
+  if (double(aChallenger.presentationArea) >= requiredArea) {
+    if (aOutReason) {
+      *aOutReason = SuperResolutionHandoffReason::ChallengerAreaHysteresis;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace mozilla::zen

--- a/src/zen/video-super-resolution/VideoSuperResolutionOwnerPolicy.h
+++ b/src/zen/video-super-resolution/VideoSuperResolutionOwnerPolicy.h
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_zen_VideoSuperResolutionOwnerPolicy_h
+#define mozilla_zen_VideoSuperResolutionOwnerPolicy_h
+
+#include <cstdint>
+
+namespace mozilla::zen {
+
+struct SuperResolutionOwnerCandidate {
+  uint64_t pipelineId = 0;
+  bool eligible = false;
+  bool hasPresentationArea = false;
+  uint64_t presentationArea = 0;
+};
+
+enum class SuperResolutionHandoffReason {
+  None,
+  ClaimInitial,
+  OwnerIneligible,
+  OwnerNoPresentationArea,
+  ChallengerAreaHysteresis,
+  TieBreaker,
+};
+
+inline const char* SuperResolutionHandoffReasonToString(SuperResolutionHandoffReason aReason) {
+  switch (aReason) {
+    case SuperResolutionHandoffReason::None:
+      return "none";
+    case SuperResolutionHandoffReason::ClaimInitial:
+      return "claim-initial";
+    case SuperResolutionHandoffReason::OwnerIneligible:
+      return "owner-ineligible";
+    case SuperResolutionHandoffReason::OwnerNoPresentationArea:
+      return "owner-no-presentation-area";
+    case SuperResolutionHandoffReason::ChallengerAreaHysteresis:
+      return "challenger-area-hysteresis";
+    case SuperResolutionHandoffReason::TieBreaker:
+      return "tie-breaker";
+  }
+  return "unknown";
+}
+
+class VideoSuperResolutionOwnerPolicy {
+ public:
+  static constexpr float kAreaHysteresisRatio = 1.15f;
+
+  static bool ShouldTakeOwnership(
+      const SuperResolutionOwnerCandidate& aChallenger,
+      const SuperResolutionOwnerCandidate* aCurrentOwner,
+      SuperResolutionHandoffReason* aOutReason = nullptr);
+};
+
+}  // namespace mozilla::zen
+
+#endif  // mozilla_zen_VideoSuperResolutionOwnerPolicy_h

--- a/src/zen/video-super-resolution/VideoSuperResolutionProfiler.h
+++ b/src/zen/video-super-resolution/VideoSuperResolutionProfiler.h
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_zen_VideoSuperResolutionProfiler_h
+#define mozilla_zen_VideoSuperResolutionProfiler_h
+
+#include "GeckoProfiler.h"
+#include "mozilla/ProfilerMarkerTypes.h"
+#include "VideoSuperResolutionTypes.h"
+
+namespace mozilla::zen {
+
+inline constexpr char kMarkerSnapshot[] = "VideoSuperResolution Snapshot";
+inline constexpr char kMarkerSubmit[] = "VideoSuperResolution Submit";
+inline constexpr char kMarkerVfxStart[] = "VideoSuperResolution VFX Start";
+inline constexpr char kMarkerVfxEnd[] = "VideoSuperResolution VFX End";
+inline constexpr char kMarkerComplete[] = "VideoSuperResolution Complete";
+inline constexpr char kMarkerReady[] = "VideoSuperResolution Ready";
+inline constexpr char kMarkerPresent[] = "VideoSuperResolution Present";
+inline constexpr char kMarkerDrop[] = "VideoSuperResolution Drop";
+inline constexpr char kMarkerOwnerChange[] = "VideoSuperResolution OwnerChange";
+inline constexpr char kMarkerContextReset[] = "VideoSuperResolution ContextReset";
+inline constexpr char kMarkerComposition[] = "VideoSuperResolution Composition";
+
+inline bool SuperResolutionProfilerActive() {
+  return profiler_thread_is_being_profiled_for_markers();
+}
+
+template <size_t N>
+inline void MarkToken(const char (&aMarker)[N],
+                      const SuperResolutionFrameToken& aToken,
+                      const char* aReason = nullptr) {
+  if (!SuperResolutionProfilerActive()) {
+    return;
+  }
+  if (aReason) {
+    PROFILER_MARKER_FMT(
+        aMarker, GRAPHICS, {},
+        "producer={} frame={} session={} config={} context={} src={}x{} out={}x{} reason={}",
+        aToken.producer, aToken.frame, aToken.sessionGeneration,
+        aToken.configGeneration, aToken.contextGeneration, aToken.sourceWidth,
+        aToken.sourceHeight, aToken.outputWidth, aToken.outputHeight, aReason);
+  } else {
+    PROFILER_MARKER_FMT(
+        aMarker, GRAPHICS, {},
+        "producer={} frame={} session={} config={} context={} src={}x{} out={}x{}",
+        aToken.producer, aToken.frame, aToken.sessionGeneration,
+        aToken.configGeneration, aToken.contextGeneration, aToken.sourceWidth,
+        aToken.sourceHeight, aToken.outputWidth, aToken.outputHeight);
+  }
+}
+
+inline void MarkComposition(uint64_t aPipeline, bool aSelected,
+                            const char* aReason) {
+  if (!SuperResolutionProfilerActive()) {
+    return;
+  }
+  PROFILER_MARKER_FMT(kMarkerComposition, GRAPHICS, {},
+                      "pipe={} path={} reason={}", aPipeline,
+                      aSelected ? "enhanced-rgba" : "normal-nv12",
+                      aReason ? aReason : "");
+}
+
+}  // namespace mozilla::zen
+
+#endif  // mozilla_zen_VideoSuperResolutionProfiler_h

--- a/src/zen/video-super-resolution/VideoSuperResolutionScalePolicy.cpp
+++ b/src/zen/video-super-resolution/VideoSuperResolutionScalePolicy.cpp
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "VideoSuperResolutionScalePolicy.h"
+
+#include <algorithm>
+#include <cmath>
+
+#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
+#include "mozilla/StaticPrefs_zen.h"
+#endif
+
+namespace mozilla::zen {
+
+SuperResolutionConfig VideoSuperResolutionScalePolicy::ReadConfigFromPrefs() {
+  SuperResolutionConfig config;
+#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
+  config.enabled = StaticPrefs::zen_video_super_resolution_enabled();
+  config.scaleMode = SuperResolutionScaleModeFromPref(
+      StaticPrefs::zen_video_super_resolution_scale_mode());
+  config.manualScalePercent =
+      StaticPrefs::zen_video_super_resolution_scale();
+  config.quality = SuperResolutionQualityFromPref(
+      StaticPrefs::zen_video_super_resolution_quality());
+#endif
+  return config;
+}
+
+SuperResolutionTargetDecision VideoSuperResolutionScalePolicy::EvaluateTarget(
+    const gfx::IntSize& aSourceSize, float aDisplayW, float aDisplayH) {
+  const SuperResolutionConfig config = ReadConfigFromPrefs();
+  return ComputeTarget(aSourceSize.width, aSourceSize.height, aDisplayW,
+                       aDisplayH, config.scaleMode, config.manualScalePercent,
+                       config.quality);
+}
+
+SuperResolutionTargetDecision VideoSuperResolutionScalePolicy::ComputeTarget(
+    int aSourceW, int aSourceH, float aDisplayW, float aDisplayH,
+    SuperResolutionScaleMode aMode, unsigned int aManualScalePercent,
+    SuperResolutionQuality aQuality) {
+  SuperResolutionTargetDecision decision;
+  decision.scaleMode = aMode;
+  decision.quality = aQuality;
+
+  if (aSourceW <= 0 || aSourceH <= 0) {
+    decision.bypassReason = "unsupported-source-resolution";
+    return decision;
+  }
+  const int shortSide = std::min(aSourceW, aSourceH);
+  const int longSide = std::max(aSourceW, aSourceH);
+  if (shortSide < kMinSourceShortSide || longSide > kMaxSourceLongSide) {
+    decision.bypassReason = "unsupported-source-resolution";
+    return decision;
+  }
+
+  if (!std::isfinite(aDisplayW) || !std::isfinite(aDisplayH) ||
+      aDisplayW <= 0.0f || aDisplayH <= 0.0f) {
+    decision.bypassReason = "invalid-display-dimensions";
+    return decision;
+  }
+
+  const float upscaleW = aDisplayW / float(aSourceW);
+  const float upscaleH = aDisplayH / float(aSourceH);
+  const float fitUpscale = std::min(upscaleW, upscaleH);
+  if (fitUpscale < 1.0f) {
+    decision.bypassReason = "downscale-not-eligible";
+    return decision;
+  }
+
+  int targetW = 0;
+  int targetH = 0;
+
+  if (aMode == SuperResolutionScaleMode::Auto) {
+    // Native-size presentation still uses VFX enhancement for denoise/detail
+    // recovery; only true downscales bypass above.
+    targetW = static_cast<int>(std::ceil(float(aSourceW) * fitUpscale));
+    targetH = static_cast<int>(std::ceil(float(aSourceH) * fitUpscale));
+  } else {
+    unsigned int percent = aManualScalePercent;
+    if (percent < 133) percent = 133;
+    if (percent > 400) percent = 400;
+    targetW = static_cast<int>(
+        std::round(float(aSourceW) * float(percent) / 100.0f));
+    targetH = static_cast<int>(
+        std::round(float(aSourceH) * float(percent) / 100.0f));
+  }
+
+  if (targetW > kMaxOutputWidth || targetH > kMaxOutputHeight) {
+    const float scaleX = float(kMaxOutputWidth) / float(targetW);
+    const float scaleY = float(kMaxOutputHeight) / float(targetH);
+    const float clampScale = std::min(scaleX, scaleY);
+    targetW = std::max(aSourceW, static_cast<int>(std::floor(float(targetW) * clampScale)));
+    targetH = std::max(aSourceH, static_cast<int>(std::floor(float(targetH) * clampScale)));
+  }
+
+  targetW = (targetW + 1) & ~1;
+  targetH = (targetH + 1) & ~1;
+
+  if (targetW < aSourceW || targetH < aSourceH) {
+    decision.bypassReason = "clamped-below-source";
+    return decision;
+  }
+
+  decision.eligible = true;
+  decision.outputWidth = targetW;
+  decision.outputHeight = targetH;
+  return decision;
+}
+
+}  // namespace mozilla::zen

--- a/src/zen/video-super-resolution/VideoSuperResolutionScalePolicy.h
+++ b/src/zen/video-super-resolution/VideoSuperResolutionScalePolicy.h
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_zen_VideoSuperResolutionScalePolicy_h
+#define mozilla_zen_VideoSuperResolutionScalePolicy_h
+
+#include "mozilla/gfx/Point.h"
+#include "mozilla/zen/VideoSuperResolutionTypes.h"
+
+namespace mozilla::zen {
+
+class VideoSuperResolutionScalePolicy {
+ public:
+  static constexpr int kMinSourceShortSide = 360;
+  static constexpr int kMaxSourceLongSide = 2560;
+  static constexpr int kMaxOutputWidth = 3840;
+  static constexpr int kMaxOutputHeight = 2160;
+
+  static SuperResolutionConfig ReadConfigFromPrefs();
+
+  static SuperResolutionTargetDecision EvaluateTarget(
+      const gfx::IntSize& aSourceSize, float aDisplayW, float aDisplayH);
+
+  static SuperResolutionTargetDecision ComputeTarget(
+      int aSourceW, int aSourceH, float aDisplayW, float aDisplayH,
+      SuperResolutionScaleMode aMode, unsigned int aManualScalePercent,
+      SuperResolutionQuality aQuality);
+
+  static SuperResolutionTargetDecision ComputeTarget(
+      int aSourceW, int aSourceH, float aDisplayW, float aDisplayH,
+      SuperResolutionScaleMode aMode, unsigned int aManualScalePercent) {
+    return ComputeTarget(aSourceW, aSourceH, aDisplayW, aDisplayH, aMode,
+                         aManualScalePercent, kDefaultQuality);
+  }
+};
+
+}  // namespace mozilla::zen
+
+#endif  // mozilla_zen_VideoSuperResolutionScalePolicy_h

--- a/src/zen/video-super-resolution/VideoSuperResolutionTexturePool.cpp
+++ b/src/zen/video-super-resolution/VideoSuperResolutionTexturePool.cpp
@@ -1,0 +1,1503 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "VideoSuperResolutionTexturePool.h"
+
+#include <cmath>
+
+#include "GLBlitHelper.h"
+#include "GLContext.h"
+#include "ScopedGLHelpers.h"
+#include "WebRenderAPI.h"
+#include "mozilla/layers/AsyncImagePipelineManager.h"
+#include "mozilla/layers/CompositorThread.h"
+#include "mozilla/layers/CompositorVsyncScheduler.h"
+#include "mozilla/layers/DMABUFSurfaceImage.h"
+#include "mozilla/layers/WebRenderBridgeParent.h"
+#include "mozilla/layers/WebRenderImageHost.h"
+#include "mozilla/webrender/RenderThread.h"
+#include "mozilla/webrender/WebRenderTypes.h"
+#include "mozilla/widget/DMABufSurface.h"
+#include "nsThreadUtils.h"
+
+#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
+#include "mozilla/StaticPrefs_zen.h"
+#endif
+
+#include "NvidiaVfxSession.h"
+#include "VideoSuperResolutionCapability.h"
+#include "VideoSuperResolutionCoordinator.h"
+#include "VideoSuperResolutionOwnerPolicy.h"
+#include "VideoSuperResolutionProfiler.h"
+#include "VideoSuperResolutionScalePolicy.h"
+
+namespace mozilla::zen {
+
+VideoSuperResolutionTexturePool& VideoSuperResolutionTexturePool::Get() {
+  static VideoSuperResolutionTexturePool sInstance;
+  return sInstance;
+}
+
+VideoSuperResolutionTexturePool::VideoSuperResolutionTexturePool() = default;
+
+RefPtr<NvidiaVfxSession> VideoSuperResolutionTexturePool::GetSession() {
+  MutexAutoLock lock(mLock);
+  return mSession;
+}
+
+CudaDeviceHandle VideoSuperResolutionTexturePool::GetGlCudaDevice() {
+  MutexAutoLock lock(mLock);
+  return mGlCudaDevice;
+}
+
+int VideoSuperResolutionTexturePool::GetCudaOrdinal() {
+  MutexAutoLock lock(mLock);
+  return mCudaOrdinal;
+}
+
+uint64_t VideoSuperResolutionTexturePool::GetContextGeneration(uint64_t aPipeline) {
+  MutexAutoLock lock(mLock);
+  return EnsurePipe(aPipeline).contextGeneration;
+}
+
+bool VideoSuperResolutionTexturePool::VfxEnabled() {
+#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
+  const bool enabled = StaticPrefs::zen_video_super_resolution_enabled();
+  if (mLastVfxEnabled.exchange(enabled) != enabled) {
+    MutexAutoLock lock(mLock);
+    mSawCapabilityFailed = false;
+    VideoSuperResolutionCapability::Get().Invalidate(nullptr);
+  }
+  return enabled;
+#else
+  return false;
+#endif
+}
+
+bool VideoSuperResolutionTexturePool::CanClaimOwner(uint64_t aPipeline,
+                                                     float aDisplayW,
+                                                     float aDisplayH) {
+  MutexAutoLock lock(mLock);
+  if (aPipeline == 0 || !std::isfinite(aDisplayW) ||
+      !std::isfinite(aDisplayH) || aDisplayW <= 0.0f || aDisplayH <= 0.0f) {
+    return false;
+  }
+
+  SuperResolutionOwnerCandidate* candidate = nullptr;
+  for (auto& c : mCandidates) {
+    if (c.pipelineId == aPipeline) {
+      candidate = &c;
+      break;
+    }
+  }
+  if (!candidate) {
+    if (mCandidates.Length() >= 8) {
+      for (size_t i = 0; i < mCandidates.Length(); ++i) {
+        if (mCandidates[i].pipelineId != mCurrentOwner) {
+          mCandidates.RemoveElementAt(i);
+          break;
+        }
+      }
+    }
+    candidate = mCandidates.AppendElement(SuperResolutionOwnerCandidate{});
+    candidate->pipelineId = aPipeline;
+  }
+
+  candidate->hasPresentationArea = true;
+  const double area = double(aDisplayW) * double(aDisplayH);
+  candidate->presentationArea =
+      area >= double(UINT64_MAX) ? UINT64_MAX : static_cast<uint64_t>(area);
+  candidate->eligible = true;
+
+  if (mCurrentOwner == 0) {
+    mCurrentOwner = aPipeline;
+    mInputPipeline = aPipeline;
+    return true;
+  }
+
+  if (mCurrentOwner == aPipeline) {
+    return true;
+  }
+
+  const SuperResolutionOwnerCandidate* ownerCand = nullptr;
+  for (const auto& c : mCandidates) {
+    if (c.pipelineId == mCurrentOwner) {
+      ownerCand = &c;
+      break;
+    }
+  }
+
+  SuperResolutionHandoffReason reason = SuperResolutionHandoffReason::None;
+  if (VideoSuperResolutionOwnerPolicy::ShouldTakeOwnership(*candidate, ownerCand, &reason)) {
+    const uint64_t oldOwner = mCurrentOwner;
+    mCurrentOwner = aPipeline;
+    mInputPipeline = aPipeline;
+    mSnapshotRequests.Clear();
+    mHasLastSnapshotRequest = false;
+    for (size_t i = 0; i < mPipeSubmissions.Length();) {
+      if (mPipeSubmissions[i].pipeline == oldOwner) {
+        mPipeSubmissions.RemoveElementAt(i);
+      } else {
+        ++i;
+      }
+    }
+    if (SuperResolutionProfilerActive()) {
+      PROFILER_MARKER_FMT(kMarkerOwnerChange, GRAPHICS, {},
+                          "old={} new={} reason={}", oldOwner, aPipeline,
+                          SuperResolutionHandoffReasonToString(reason));
+    }
+    return true;
+  }
+
+  return false;
+}
+
+bool VideoSuperResolutionTexturePool::ShouldActivate(bool aIsHardwareBackend) {
+  return aIsHardwareBackend && VfxEnabled();
+}
+
+bool VideoSuperResolutionTexturePool::IsAvailable(gl::GLContext* aGL) {
+  if (!VfxEnabled() || !aGL) {
+    return false;
+  }
+  if (!EnsureCudaDevice(aGL)) {
+    return false;
+  }
+  return EnsureInitialized();
+}
+
+bool VideoSuperResolutionTexturePool::HasFailed() {
+  RefPtr<NvidiaVfxSession> session;
+  bool sawCapabilityFailed = false;
+  {
+    MutexAutoLock lock(mLock);
+    session = mSession;
+    sawCapabilityFailed = mSawCapabilityFailed;
+  }
+  if (session && session->State() == SuperResolutionSessionState::Failed) {
+    return true;
+  }
+  return sawCapabilityFailed;
+}
+
+bool VideoSuperResolutionTexturePool::EnsureInitialized() {
+  MutexAutoLock lock(mLock);
+  if (!mSession) {
+    mSession = new NvidiaVfxSession();
+  }
+  while (mSlots.Length() < mSlotCount) {
+    const int index = (int)mSlots.Length();
+    RefPtr<SuperResolutionSlotTextureHost> host =
+        new SuperResolutionSlotTextureHost(index);
+    const wr::ExternalImageId id =
+        layers::AsyncImagePipelineManager::GetNextExternalImageId();
+    RefPtr<wr::RenderTextureHost> base = host.get();
+    wr::RenderThread::Get()->RegisterExternalImage(id, base.forget());
+    mSlots.AppendElement(Slot{});
+    mHosts.AppendElement(host);
+    mExtIds.AppendElement(id);
+  }
+  return !mSlots.IsEmpty();
+}
+
+int VideoSuperResolutionTexturePool::SlotCount() {
+  MutexAutoLock lock(mLock);
+  return (int)mSlots.Length();
+}
+
+int VideoSuperResolutionTexturePool::FindFreeSlot() {
+  mLock.AssertCurrentThreadOwns();
+  for (size_t i = 0; i < mSlots.Length(); i++) {
+    if (mSlots[i].state == SlotState::Free) {
+      return (int)i;
+    }
+  }
+  return -1;
+}
+
+int VideoSuperResolutionTexturePool::AcquireDownloadSlot(
+    const SuperResolutionFrameToken& aToken, uint32_t aRenderer) {
+  MutexAutoLock lock(mLock);
+  for (size_t i = 0; i < mSlots.Length(); i++) {
+    if (mSlots[i].state == SlotState::Ready && mSlots[i].token == aToken) {
+      return (int)i;
+    }
+  }
+
+  int slot = FindFreeSlot();
+
+  if (slot < 0) {
+    // Keep the displayed and retiring textures immutable. A ready result has
+    // not reached the display yet, so replacing it favors the newer frame.
+    for (size_t i = 0; i < mSlots.Length(); ++i) {
+      if (mSlots[i].state == SlotState::Ready) {
+        slot = static_cast<int>(i);
+        mSlots[slot] = Slot{};
+        break;
+      }
+    }
+    if (slot < 0) {
+      return -1;
+    }
+  }
+
+  mSlots[slot].state = SlotState::Ready;
+  mSlots[slot].token = aToken;
+  mSlots[slot].renderer = aRenderer;
+  mSlots[slot].contentReady = false;
+  return slot;
+}
+
+int VideoSuperResolutionTexturePool::FindReadySlot(
+    const SuperResolutionFrameToken& aToken, uint32_t aRenderer) {
+  MutexAutoLock lock(mLock);
+  for (size_t i = 0; i < mSlots.Length(); ++i) {
+    const Slot& slot = mSlots[i];
+    if ((slot.state == SlotState::Ready || slot.state == SlotState::Published) &&
+        slot.contentReady && slot.token == aToken &&
+        (!aRenderer || slot.renderer == aRenderer)) {
+      return static_cast<int>(i);
+    }
+  }
+  return -1;
+}
+
+void VideoSuperResolutionTexturePool::DiscardReady(int aSlot) {
+  MutexAutoLock lock(mLock);
+  if (aSlot < 0 || (size_t)aSlot >= mSlots.Length() ||
+      mSlots[aSlot].state != SlotState::Ready) {
+    return;
+  }
+  mSlots[aSlot] = Slot{};
+}
+
+bool VideoSuperResolutionTexturePool::Publish(
+    uint64_t aPipeline, int aSlot, const SuperResolutionFrameToken& aToken,
+    wr::ExternalImageId* aExtId) {
+  MutexAutoLock lock(mLock);
+  if (aSlot < 0 || (size_t)aSlot >= mSlots.Length()) {
+    return false;
+  }
+  PipeDisplay& pipe = EnsurePipe(aPipeline);
+  if (mSlots[aSlot].token.contextGeneration != pipe.contextGeneration) {
+    return false;
+  }
+  if (mSlots[aSlot].renderer != pipe.renderer) {
+    return false;
+  }
+  if (mSlots[aSlot].token != aToken) {
+    return false;
+  }
+  if (!mSlots[aSlot].contentReady) {
+    return false;
+  }
+  if (pipe.slot == aSlot) {
+    if (aExtId) {
+      *aExtId = mExtIds[aSlot];
+    }
+    return true;
+  }
+  if (mSlots[aSlot].state != SlotState::Ready &&
+      mSlots[aSlot].state != SlotState::Published) {
+    return false;
+  }
+  if (pipe.slot >= 0 && pipe.slot != aSlot) {
+    RetireSlot(pipe, pipe.slot);
+  }
+  pipe.slot = aSlot;
+  mSlots[aSlot].state = SlotState::Published;
+  if (aExtId) {
+    *aExtId = mExtIds[aSlot];
+  }
+  return true;
+}
+
+void VideoSuperResolutionTexturePool::Unpublish(uint64_t aPipeline) {
+  MutexAutoLock lock(mLock);
+  PipeDisplay* pipe = FindPipe(aPipeline);
+  if (!pipe || pipe->slot < 0) {
+    return;
+  }
+  RetireSlot(*pipe, pipe->slot);
+  pipe->slot = -1;
+  pipe->keyValid = false;
+  pipe->keySlot = -1;
+}
+
+bool VideoSuperResolutionTexturePool::TryHoldPublished(
+    uint64_t aPipeline, const SuperResolutionFrameToken& aCurrent,
+    SuperResolutionFrameToken* aHeldToken) {
+  MutexAutoLock lock(mLock);
+  PipeDisplay* pipe = FindPipe(aPipeline);
+  if (!pipe || pipe->slot < 0 || (size_t)pipe->slot >= mSlots.Length()) {
+    return false;
+  }
+  const Slot& slot = mSlots[pipe->slot];
+  if (slot.state != SlotState::Published || !slot.contentReady) {
+    return false;
+  }
+  if (!aCurrent.MatchesStream(slot.token)) {
+    return false;
+  }
+  const int64_t dist = static_cast<int64_t>(aCurrent.frame) -
+                       static_cast<int64_t>(slot.token.frame);
+  if (dist < 0 || dist > kMaxFrameLag) {
+    return false;
+  }
+  if (aHeldToken) {
+    *aHeldToken = slot.token;
+  }
+  return true;
+}
+
+VideoSuperResolutionTexturePool::PipeDisplay&
+VideoSuperResolutionTexturePool::EnsurePipe(uint64_t aPipeline) {
+  mLock.AssertCurrentThreadOwns();
+  for (auto& p : mPipes) {
+    if (p.pipeline == aPipeline) {
+      return p;
+    }
+  }
+  PipeDisplay* created = mPipes.AppendElement(PipeDisplay{});
+  created->pipeline = aPipeline;
+  created->contextGeneration = ++mNextContextGeneration;
+  return *created;
+}
+
+VideoSuperResolutionTexturePool::PipeDisplay*
+VideoSuperResolutionTexturePool::FindPipe(uint64_t aPipeline) {
+  mLock.AssertCurrentThreadOwns();
+  for (auto& p : mPipes) {
+    if (p.pipeline == aPipeline) {
+      return &p;
+    }
+  }
+  return nullptr;
+}
+
+bool VideoSuperResolutionTexturePool::DisplayedElsewhere(int aSlot,
+                                                          uint64_t aExceptPipeline) {
+  mLock.AssertCurrentThreadOwns();
+  for (const auto& p : mPipes) {
+    if (p.pipeline != aExceptPipeline && p.slot == aSlot) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void VideoSuperResolutionTexturePool::RetireSlot(PipeDisplay& aPipe, int aSlot,
+                                                  uint64_t aEpoch) {
+  mLock.AssertCurrentThreadOwns();
+  if (aSlot < 0 || static_cast<size_t>(aSlot) >= mSlots.Length()) {
+    return;
+  }
+  aPipe.retiringSlot = aSlot;
+  if (DisplayedElsewhere(aSlot, aPipe.pipeline)) {
+    return;
+  }
+  mSlots[aSlot].state = SlotState::Retiring;
+  for (const auto& fence : mRetireFences) {
+    if (fence.pipeline == aPipe.pipeline && fence.slot == aSlot) {
+      return;
+    }
+  }
+  RetireFence fence;
+  fence.pipeline = aPipe.pipeline;
+  fence.renderer = aPipe.renderer;
+  fence.slot = aSlot;
+  fence.epoch = aEpoch;
+  mRetireFences.AppendElement(fence);
+}
+
+void VideoSuperResolutionTexturePool::BindPipelineImageHost(
+    uint64_t aPipeline, const RefPtr<layers::WebRenderImageHost>& aHost,
+    uint32_t aRenderer) {
+  MutexAutoLock lock(mLock);
+  PipeDisplay& pipe = EnsurePipe(aPipeline);
+  pipe.imageHost = aHost;
+  pipe.renderer = aRenderer;
+}
+
+void VideoSuperResolutionTexturePool::QueueCompositionWakeup(
+    uint64_t aPipeline, const SuperResolutionFrameToken& aToken,
+    bool aForcePollRender) {
+  {
+    MutexAutoLock lock(mLock);
+    PipeDisplay* pipe = FindPipe(aPipeline);
+    if (!pipe || !pipe->imageHost) {
+      return;
+    }
+    bool& pending = aForcePollRender ? pipe->pollWakePending
+                                     : pipe->presentationWakePending;
+    if (pending) {
+      return;
+    }
+    pending = true;
+  }
+  if (!layers::CompositorThread()) {
+    MutexAutoLock lock(mLock);
+    if (PipeDisplay* pipe = FindPipe(aPipeline)) {
+      if (aForcePollRender) {
+        pipe->pollWakePending = false;
+      } else {
+        pipe->presentationWakePending = false;
+      }
+    }
+    return;
+  }
+  layers::CompositorThread()->Dispatch(NS_NewRunnableFunction(
+      "VideoSuperResolutionTexturePool::ProcessCompositionWakeup",
+      [aPipeline, aToken, aForcePollRender]() {
+        VideoSuperResolutionTexturePool::Get().ProcessCompositionWakeup(
+            aPipeline, aToken, aForcePollRender);
+      }));
+}
+
+void VideoSuperResolutionTexturePool::ProcessCompositionWakeup(
+    uint64_t aPipeline, const SuperResolutionFrameToken& aToken,
+    bool aForcePollRender) {
+  RefPtr<layers::WebRenderImageHost> imageHost;
+  {
+    MutexAutoLock lock(mLock);
+    PipeDisplay* pipe = FindPipe(aPipeline);
+    if (!pipe) {
+      return;
+    }
+    bool& pending = aForcePollRender ? pipe->pollWakePending
+                                     : pipe->presentationWakePending;
+    if (!pending) {
+      return;
+    }
+    pending = false;
+    imageHost = pipe->imageHost;
+  }
+  if (!imageHost) {
+    return;
+  }
+  if (aForcePollRender) {
+    imageHost->RequestSuperResolutionRenderPoll();
+  } else {
+    bool recentlyComposited = false;
+    {
+      MutexAutoLock lock(mLock);
+      PipeDisplay* pipe = FindPipe(aPipeline);
+      if (pipe && !pipe->lastCompositeTime.IsNull()) {
+        recentlyComposited =
+            (TimeStamp::Now() - pipe->lastCompositeTime).ToMilliseconds() < 50.0;
+      }
+    }
+    bool needSchedule =
+        !recentlyComposited ||
+        !VideoSuperResolutionCoordinator::Get().WasPresented(aPipeline, aToken);
+    if (needSchedule) {
+      imageHost->RequestSuperResolutionComposition();
+    }
+  }
+}
+
+void VideoSuperResolutionTexturePool::NotifyVfxStreamComplete(
+    const SuperResolutionFrameToken& aToken) {
+  uint64_t pipeline = 0;
+  {
+    MutexAutoLock lock(mLock);
+    for (const auto& submission : mPipeSubmissions) {
+      if (submission.token == aToken) {
+        pipeline = submission.pipeline;
+        break;
+      }
+    }
+  }
+  if (pipeline) {
+    QueueCompositionWakeup(pipeline, aToken, /* aForcePollRender */ true);
+  }
+}
+
+bool VideoSuperResolutionTexturePool::EnsureKeyResource(
+    wr::TransactionBuilder& aTxn, bool aIsAdd, const wr::ImageKey& aKey,
+    uint64_t aPipeline) {
+  MutexAutoLock lock(mLock);
+  PipeDisplay* pipe = FindPipe(aPipeline);
+  if (!pipe || pipe->slot < 0) {
+    return false;
+  }
+  if (!aIsAdd && pipe->keyValid && pipe->keySlot == pipe->slot) {
+    return true;
+  }
+  const Slot& slot = mSlots[pipe->slot];
+  if (slot.token.contextGeneration != pipe->contextGeneration ||
+      slot.token.sessionGeneration == 0) {
+    return false;
+  }
+  const gfx::IntSize size(slot.token.outputWidth, slot.token.outputHeight);
+  if (size.width <= 0 || size.height <= 0) {
+    return false;
+  }
+  wr::ImageDescriptor desc(size, wr::ImageFormat::RGBA8, wr::OpacityType::Opaque);
+  auto imageType = wr::ExternalImageType::TextureHandle(wr::ImageBufferKind::Texture2D);
+  if (aIsAdd) {
+    aTxn.AddExternalImage(aKey, desc, mExtIds[pipe->slot], imageType, 0, false);
+  } else {
+    aTxn.UpdateExternalImage(aKey, desc, mExtIds[pipe->slot], imageType, 0, false);
+  }
+  pipe->keyValid = true;
+  pipe->keySlot = pipe->slot;
+  return true;
+}
+
+void VideoSuperResolutionTexturePool::ReleasePipeline(uint64_t aPipeline,
+                                                      uint64_t aEpoch) {
+  MutexAutoLock lock(mLock);
+  for (size_t i = 0; i < mPipes.Length(); ++i) {
+    if (mPipes[i].pipeline == aPipeline) {
+      RetireSlot(mPipes[i], mPipes[i].slot, aEpoch);
+      RetireSlot(mPipes[i], mPipes[i].retiringSlot, aEpoch);
+      mPipes.RemoveElementAt(i);
+      break;
+    }
+  }
+  for (size_t i = 0; i < mCandidates.Length(); ++i) {
+    if (mCandidates[i].pipelineId == aPipeline) {
+      mCandidates.RemoveElementAt(i);
+      break;
+    }
+  }
+  if (mCurrentOwner == aPipeline || mInputPipeline == aPipeline) {
+    mCurrentOwner = 0;
+    mInputPipeline = 0;
+    mSnapshotRequests.Clear();
+    mHasLastSnapshotRequest = false;
+  }
+  for (size_t i = 0; i < mPipeSubmissions.Length();) {
+    if (mPipeSubmissions[i].pipeline == aPipeline) {
+      mPipeSubmissions.RemoveElementAt(i);
+    } else {
+      ++i;
+    }
+  }
+}
+
+void VideoSuperResolutionTexturePool::NoteTransaction(uint64_t aPipeline,
+                                                      uint64_t aEpoch) {
+  MutexAutoLock lock(mLock);
+  for (auto& fence : mRetireFences) {
+    if (fence.pipeline == aPipeline && fence.epoch == 0) {
+      fence.epoch = aEpoch;
+    }
+  }
+}
+
+void VideoSuperResolutionTexturePool::NotePipelineComposite(uint64_t aPipeline) {
+  MutexAutoLock lock(mLock);
+  PipeDisplay* pipe = FindPipe(aPipeline);
+  if (!pipe) {
+    return;
+  }
+  pipe->lastCompositeTime = TimeStamp::Now();
+}
+
+void VideoSuperResolutionTexturePool::NotePipelineRendered(
+    uint64_t aPipeline, uint64_t aEpoch, uint64_t aRenderedFrame,
+    uint32_t aRenderer, uint64_t aCompletedFrame) {
+  MutexAutoLock lock(mLock);
+  for (auto& fence : mRetireFences) {
+    if (fence.pipeline == aPipeline && fence.renderer == aRenderer &&
+        fence.epoch <= aEpoch && fence.renderedFrame == 0) {
+      fence.renderedFrame = aRenderedFrame;
+    }
+  }
+  RecycleCompleted(aRenderer, aCompletedFrame);
+}
+
+void VideoSuperResolutionTexturePool::NotePipelineRemoved(
+    uint64_t aPipeline, uint64_t aRenderedFrame, uint32_t aRenderer,
+    uint64_t aCompletedFrame) {
+  MutexAutoLock lock(mLock);
+  for (auto& fence : mRetireFences) {
+    if (fence.pipeline == aPipeline && fence.renderer == aRenderer &&
+        fence.renderedFrame == 0) {
+      fence.renderedFrame = aRenderedFrame;
+    }
+  }
+  RecycleCompleted(aRenderer, aCompletedFrame);
+}
+
+void VideoSuperResolutionTexturePool::NoteCompletedRender(
+    uint32_t aRenderer, uint64_t aCompletedFrame) {
+  MutexAutoLock lock(mLock);
+  RecycleCompleted(aRenderer, aCompletedFrame);
+}
+
+void VideoSuperResolutionTexturePool::OnRendererDestroyed(uint32_t aRenderer,
+                                                          gl::GLContext* aGL) {
+  if (!aRenderer) {
+    return;
+  }
+
+  RefPtr<NvidiaVfxSession> session;
+  AutoTArray<RefPtr<SuperResolutionSlotTextureHost>, 4> hosts;
+  unsigned int stagingTex = 0;
+  unsigned int stagingFbo = 0;
+  {
+    MutexAutoLock lock(mLock);
+    for (size_t i = 0; i < mPipes.Length();) {
+      if (mPipes[i].renderer != aRenderer) {
+        ++i;
+        continue;
+      }
+      const uint64_t pipeline = mPipes[i].pipeline;
+      if (mCurrentOwner == pipeline || mInputPipeline == pipeline) {
+        mCurrentOwner = 0;
+        mInputPipeline = 0;
+      }
+      for (size_t candidate = 0; candidate < mCandidates.Length(); ++candidate) {
+        if (mCandidates[candidate].pipelineId == pipeline) {
+          mCandidates.RemoveElementAt(candidate);
+          break;
+        }
+      }
+      mPipes.RemoveElementAt(i);
+    }
+    for (size_t i = 0; i < mSlots.Length(); ++i) {
+      const bool slotOwned = mSlots[i].renderer == aRenderer;
+      const bool unusedOldContextHost =
+          aGL && mSlots[i].state == SlotState::Free && i < mHosts.Length() &&
+          mHosts[i] && static_cast<SuperResolutionSlotTextureHost*>(mHosts[i].get())
+                           ->UsesGL(aGL);
+      if (!slotOwned && !unusedOldContextHost) {
+        continue;
+      }
+      if (slotOwned) {
+        uint32_t survivingRenderer = 0;
+        for (const auto& pipe : mPipes) {
+          if (pipe.slot == static_cast<int>(i)) {
+            survivingRenderer = pipe.renderer;
+            break;
+          }
+        }
+        if (survivingRenderer) {
+          mSlots[i].renderer = survivingRenderer;
+          continue;
+        }
+        mSlots[i] = Slot{};
+      }
+      if (i < mHosts.Length() && mHosts[i]) {
+        hosts.AppendElement(
+            static_cast<SuperResolutionSlotTextureHost*>(mHosts[i].get()));
+      }
+    }
+    for (size_t i = 0; i < mPipeSubmissions.Length();) {
+      uint64_t pipeline = mPipeSubmissions[i].pipeline;
+      bool stillLive = false;
+      for (const auto& pipe : mPipes) {
+        if (pipe.pipeline == pipeline) {
+          stillLive = true;
+          break;
+        }
+      }
+      if (stillLive) {
+        ++i;
+      } else {
+        mPipeSubmissions.RemoveElementAt(i);
+      }
+    }
+    for (size_t i = 0; i < mRetireFences.Length();) {
+      if (mRetireFences[i].renderer == aRenderer) {
+        mRetireFences.RemoveElementAt(i);
+      } else {
+        ++i;
+      }
+    }
+    const bool ownsSession = mSessionRenderer == aRenderer || mCudaGL == aGL;
+    if (ownsSession) {
+      session = std::move(mSession);
+      mSessionRenderer = 0;
+      stagingTex = mStagingTex;
+      stagingFbo = mStagingFbo;
+      mStagingTex = 0;
+      mStagingFbo = 0;
+      mStagingW = 0;
+      mStagingH = 0;
+      mPipeSubmissions.Clear();
+      mSnapshotRequests.Clear();
+      mSourceSurfaces.Clear();
+      mHasLastSnapshotRequest = false;
+       mGlCudaDevice = -1;
+       mCudaOrdinal = -1;
+       mCudaGL = nullptr;
+       mSawCapabilityFailed = false;
+       mSessionGeneration = 0;
+    }
+  }
+
+  if (session) {
+    session->Shutdown();
+  }
+
+  bool glCleanupComplete = true;
+  if (aGL && aGL->MakeCurrent()) {
+    for (auto& host : hosts) {
+      if (host) {
+        glCleanupComplete = host->DestroyTexture(aGL) && glCleanupComplete;
+      }
+    }
+    if (stagingTex || stagingFbo) {
+      glCleanupComplete =
+          DeleteStagingResources(aGL, stagingTex, stagingFbo) && glCleanupComplete;
+    }
+  } else if (!hosts.IsEmpty() || stagingTex || stagingFbo) {
+    glCleanupComplete = false;
+  }
+  if (glCleanupComplete && aGL) {
+    VideoSuperResolutionCapability::Get().Invalidate(aGL);
+  }
+  if (SuperResolutionProfilerActive()) {
+    PROFILER_MARKER_FMT(kMarkerContextReset, GRAPHICS, {},
+                        "renderer={}", aRenderer);
+  }
+}
+
+void VideoSuperResolutionTexturePool::RecycleCompleted(uint32_t aRenderer,
+                                                      uint64_t aCompletedFrame) {
+  for (size_t i = 0; i < mRetireFences.Length();) {
+    const RetireFence& fence = mRetireFences[i];
+    if (fence.renderer != aRenderer || fence.renderedFrame == 0 ||
+        fence.renderedFrame > aCompletedFrame) {
+      ++i;
+      continue;
+    }
+    const int slot = fence.slot;
+    mRetireFences.RemoveElementAt(i);
+    bool stillFenced = false;
+    for (const auto& remaining : mRetireFences) {
+      if (remaining.slot == slot) {
+        stillFenced = true;
+        break;
+      }
+    }
+    if (stillFenced) {
+      continue;
+    }
+    if (slot >= 0 && (size_t)slot < mSlots.Length() &&
+        mSlots[slot].state == SlotState::Retiring) {
+      mSlots[slot] = Slot{};
+    }
+  }
+}
+
+uint64_t VideoSuperResolutionTexturePool::GetSessionGeneration() {
+  MutexAutoLock lock(mLock);
+  return mSessionGeneration;
+}
+
+bool VideoSuperResolutionTexturePool::UnregisterSlotTexture(unsigned int aTex) {
+  RefPtr<NvidiaVfxSession> session;
+  {
+    MutexAutoLock lock(mLock);
+    session = mSession;
+  }
+  if (!session) {
+    return true;
+  }
+  return session->UnregisterTexture(aTex);
+}
+
+void VideoSuperResolutionTexturePool::InvalidateSlot(int aSlot) {
+  MutexAutoLock lock(mLock);
+  InvalidateSlotLocked(aSlot);
+}
+
+void VideoSuperResolutionTexturePool::InvalidateSlotLocked(int aSlot) {
+  mLock.AssertCurrentThreadOwns();
+  if (aSlot < 0 || (size_t)aSlot >= mSlots.Length()) {
+    return;
+  }
+  const SlotState state = mSlots[aSlot].state;
+  mSlots[aSlot].contentReady = false;
+  for (auto& pipe : mPipes) {
+    if (pipe.keySlot == aSlot) {
+      pipe.keySlot = -1;
+      pipe.keyValid = false;
+    }
+  }
+  if (state == SlotState::Published || state == SlotState::Retiring) {
+    for (auto& pipe : mPipes) {
+      if (pipe.retiringSlot == aSlot) {
+        pipe.retiringSlot = -1;
+      }
+    }
+    return;
+  }
+  for (auto& pipe : mPipes) {
+    if (pipe.slot == aSlot) {
+      pipe.slot = -1;
+    }
+    if (pipe.retiringSlot == aSlot) {
+      pipe.retiringSlot = -1;
+    }
+  }
+  mSlots[aSlot] = Slot{};
+  for (size_t i = 0; i < mRetireFences.Length();) {
+    if (mRetireFences[i].slot == aSlot) {
+      mRetireFences.RemoveElementAt(i);
+    } else {
+      ++i;
+    }
+  }
+}
+
+void VideoSuperResolutionTexturePool::PollVfxResults(gl::GLContext* aGL) {
+#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
+  if (!StaticPrefs::zen_video_super_resolution_enabled()) {
+    return;
+  }
+#endif
+  if (!IsAvailable(aGL)) {
+    return;
+  }
+  PollSessionDownloads(aGL);
+}
+
+void VideoSuperResolutionTexturePool::RequestSnapshot(
+    const SuperResolutionFrameToken& aToken, uint64_t aPipeline,
+    uint64_t aSourceIdentity) {
+  bool needWakeup = false;
+  {
+    MutexAutoLock lock(mLock);
+    if (!aToken.HasIdentity()) {
+      return;
+    }
+    PipeDisplay& pipe = EnsurePipe(aPipeline);
+    if (aToken.contextGeneration != pipe.contextGeneration) {
+      return;
+    }
+    if (!aSourceIdentity) {
+      return;
+    }
+    if (mInputPipeline && mInputPipeline != aPipeline) {
+      return;
+    }
+    mInputPipeline = aPipeline;
+    if (mHasLastSnapshotRequest && mLastSnapshotPipeline == aPipeline &&
+        mLastSnapshotRequest == aToken) {
+      return;
+    }
+    mLastSnapshotRequest = aToken;
+    mLastSnapshotPipeline = aPipeline;
+    mHasLastSnapshotRequest = true;
+    for (size_t i = 0; i < mSnapshotRequests.Length();) {
+      if (mSnapshotRequests[i].pipeline == aPipeline) {
+        mSnapshotRequests.RemoveElementAt(i);
+      } else {
+        ++i;
+      }
+    }
+    SnapshotRequest req;
+    req.token = aToken;
+    req.pipeline = aPipeline;
+    req.sourceIdentity = aSourceIdentity;
+    mSnapshotRequests.AppendElement(req);
+    needWakeup = true;
+    MarkToken(kMarkerSnapshot, aToken);
+
+    if (mOutW != aToken.outputWidth || mOutH != aToken.outputHeight) {
+      for (size_t i = 0; i < mSlots.Length(); ++i) {
+        if (mSlots[i].state == SlotState::Ready) {
+          mSlots[i] = Slot{};
+        }
+      }
+      mOutW = aToken.outputWidth;
+      mOutH = aToken.outputHeight;
+    }
+  }
+
+  if (needWakeup) {
+    QueueCompositionWakeup(aPipeline, aToken, /* aForcePollRender */ true);
+  }
+}
+
+void VideoSuperResolutionTexturePool::RegisterSourceSurface(
+    uint64_t aIdentity, DMABufSurface* aSurface) {
+  if (!aIdentity || !aSurface) {
+    return;
+  }
+  uint64_t pipeline = 0;
+  SuperResolutionFrameToken token;
+  {
+    MutexAutoLock lock(mLock);
+    bool found = false;
+    for (auto& entry : mSourceSurfaces) {
+      if (entry.identity == aIdentity) {
+        entry.surface = aSurface;
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      if (mSourceSurfaces.Length() >= kMaxSourceSurfaces) {
+        mSourceSurfaces.RemoveElementAt(0);
+      }
+      mSourceSurfaces.AppendElement(SourceSurfaceEntry{aIdentity, aSurface});
+    }
+
+    for (const auto& request : mSnapshotRequests) {
+      if (request.sourceIdentity == aIdentity) {
+        pipeline = request.pipeline;
+        token = request.token;
+        break;
+      }
+    }
+  }
+  if (pipeline) {
+    QueueCompositionWakeup(pipeline, token, /* aForcePollRender */ true);
+  }
+}
+
+void VideoSuperResolutionTexturePool::UnregisterSourceSurface(
+    uint64_t aIdentity, DMABufSurface* aSurface) {
+  if (!aIdentity || !aSurface) {
+    return;
+  }
+  MutexAutoLock lock(mLock);
+  for (size_t i = 0; i < mSourceSurfaces.Length(); ++i) {
+    if (mSourceSurfaces[i].identity == aIdentity &&
+        mSourceSurfaces[i].surface == aSurface) {
+      mSourceSurfaces.RemoveElementAt(i);
+      return;
+    }
+  }
+}
+
+void VideoSuperResolutionTexturePool::ProcessPendingSnapshots(gl::GLContext* aGL) {
+#if defined(XP_LINUX) && defined(MOZ_WIDGET_GTK)
+  if (!StaticPrefs::zen_video_super_resolution_enabled()) {
+    return;
+  }
+#endif
+  if (!IsAvailable(aGL)) {
+    uint64_t pipeline = 0;
+    SuperResolutionFrameToken token;
+    {
+      MutexAutoLock lock(mLock);
+      if (!mSnapshotRequests.IsEmpty()) {
+        const SnapshotRequest& request = mSnapshotRequests.LastElement();
+        pipeline = request.pipeline;
+        token = request.token;
+        mSnapshotRequests.Clear();
+      }
+    }
+    if (pipeline) {
+      QueueCompositionWakeup(pipeline, token, /* aForcePollRender */ false);
+    }
+    return;
+  }
+  RefPtr<DMABufSurface> surface;
+  uint64_t sourceIdentity = 0;
+  {
+    MutexAutoLock lock(mLock);
+    if (mSnapshotRequests.IsEmpty()) {
+      return;
+    }
+    for (int i = (int)mSnapshotRequests.Length() - 1; i >= 0; --i) {
+      const auto& req = mSnapshotRequests[i];
+      for (const auto& entry : mSourceSurfaces) {
+        if (entry.identity == req.sourceIdentity && entry.surface) {
+          surface = entry.surface;
+          sourceIdentity = req.sourceIdentity;
+          if (i > 0) {
+            mSnapshotRequests.RemoveElementsAt(0, (size_t)i);
+          }
+          break;
+        }
+      }
+      if (surface) {
+        break;
+      }
+    }
+  }
+  if (surface) {
+    SnapshotFromSurface(surface, aGL, sourceIdentity);
+  }
+}
+
+void VideoSuperResolutionTexturePool::SnapshotFromSurface(
+    DMABufSurface* aSurface, gl::GLContext* aGL, uint64_t aSourceIdentity) {
+  using namespace gl;
+  SuperResolutionFrameToken request;
+  uint64_t pipeline = 0;
+  {
+    MutexAutoLock lock(mLock);
+    const uint64_t sourceIdentity = aSourceIdentity;
+    size_t requestIndex = mSnapshotRequests.Length();
+    for (size_t i = 0; i < mSnapshotRequests.Length(); ++i) {
+      if (mSnapshotRequests[i].sourceIdentity == sourceIdentity) {
+        requestIndex = i;
+        break;
+      }
+    }
+    if (requestIndex == mSnapshotRequests.Length()) {
+      return;
+    }
+    request = mSnapshotRequests[requestIndex].token;
+    pipeline = mSnapshotRequests[requestIndex].pipeline;
+    mSnapshotRequests.RemoveElementAt(requestIndex);
+    PipeDisplay* pipe = FindPipe(pipeline);
+    if (!pipe || request.contextGeneration != pipe->contextGeneration ||
+        mInputPipeline != pipeline) {
+      return;
+    }
+  }
+
+  if (!aSurface || !aGL || !aGL->MakeCurrent()) {
+    return;
+  }
+
+  const int w = aSurface->GetWidth();
+  const int h = aSurface->GetHeight();
+  if (aSurface->GetFormat() != gfx::SurfaceFormat::NV12 ||
+      aSurface->IsHDRSurface() || w <= 0 || h <= 0 || w > 4096 || h > 4096 ||
+      w != request.sourceWidth || h != request.sourceHeight ||
+      request.outputWidth <= 0 || request.outputHeight <= 0 ||
+      request.outputWidth > VideoSuperResolutionScalePolicy::kMaxOutputWidth ||
+      request.outputHeight > VideoSuperResolutionScalePolicy::kMaxOutputHeight) {
+    return;
+  }
+
+  bool needAlloc = false;
+  {
+    MutexAutoLock lock(mLock);
+    needAlloc = (mStagingTex == 0 || mStagingW != w || mStagingH != h);
+  }
+  unsigned int tex = 0;
+  unsigned int fbo = 0;
+  {
+    MutexAutoLock lock(mLock);
+    tex = mStagingTex;
+    fbo = mStagingFbo;
+  }
+  if (needAlloc) {
+    bool createdTexture = false;
+    bool createdFbo = false;
+    if (tex == 0) {
+      aGL->fGenTextures(1, &tex);
+      createdTexture = true;
+    }
+    aGL->fBindTexture(LOCAL_GL_TEXTURE_2D, tex);
+    aGL->fTexParameteri(LOCAL_GL_TEXTURE_2D, LOCAL_GL_TEXTURE_MIN_FILTER, LOCAL_GL_LINEAR);
+    aGL->fTexParameteri(LOCAL_GL_TEXTURE_2D, LOCAL_GL_TEXTURE_MAG_FILTER, LOCAL_GL_LINEAR);
+    aGL->fTexParameteri(LOCAL_GL_TEXTURE_2D, LOCAL_GL_TEXTURE_WRAP_S, LOCAL_GL_CLAMP_TO_EDGE);
+    aGL->fTexParameteri(LOCAL_GL_TEXTURE_2D, LOCAL_GL_TEXTURE_WRAP_T, LOCAL_GL_CLAMP_TO_EDGE);
+    aGL->fTexImage2D(LOCAL_GL_TEXTURE_2D, 0, LOCAL_GL_RGBA8, w, h, 0,
+                     LOCAL_GL_RGBA, LOCAL_GL_UNSIGNED_BYTE, nullptr);
+    if (fbo == 0) {
+      aGL->fGenFramebuffers(1, &fbo);
+      createdFbo = true;
+    }
+    {
+      ScopedBindFramebuffer bind(aGL, fbo);
+      aGL->fFramebufferTexture2D(LOCAL_GL_FRAMEBUFFER, LOCAL_GL_COLOR_ATTACHMENT0,
+                                LOCAL_GL_TEXTURE_2D, tex, 0);
+      if (aGL->fCheckFramebufferStatus(LOCAL_GL_FRAMEBUFFER) !=
+          LOCAL_GL_FRAMEBUFFER_COMPLETE) {
+        aGL->fBindTexture(LOCAL_GL_TEXTURE_2D, 0);
+        if (createdFbo && fbo) {
+          aGL->fDeleteFramebuffers(1, &fbo);
+        }
+        if (createdTexture && tex) {
+          aGL->fDeleteTextures(1, &tex);
+        }
+        return;
+      }
+    }
+    aGL->fBindTexture(LOCAL_GL_TEXTURE_2D, 0);
+    {
+      MutexAutoLock lock(mLock);
+      mStagingTex = tex;
+      mStagingFbo = fbo;
+      mStagingW = w;
+      mStagingH = h;
+    }
+  }
+
+  const int planeCount = aSurface->GetTextureCount();
+  for (int i = 0; i < planeCount; ++i) {
+    if (auto texture = aSurface->GetTexture(i)) {
+      aSurface->MaybeSemaphoreWait(texture);
+    }
+  }
+
+  GLBlitHelper* blit = aGL->BlitHelper();
+  if (!blit) {
+    return;
+  }
+
+  {
+    ScopedBindFramebuffer bind(aGL, fbo);
+    ScopedViewportRect view(aGL, 0, 0, w, h);
+    const bool blitOk = blit->Blit(aSurface, gfx::IntRect(0, 0, w, h),
+                                   gl::OriginPos::TopLeft);
+    if (!blitOk) {
+      return;
+    }
+  }
+
+  if (!IsAvailable(aGL)) {
+    return;
+  }
+  RefPtr<NvidiaVfxSession> session = GetSession();
+  if (!session) {
+    return;
+  }
+  const SuperResolutionConfig config =
+      VideoSuperResolutionScalePolicy::ReadConfigFromPrefs();
+  CudaDeviceHandle glCudaDevice = GetGlCudaDevice();
+  int cudaOrdinal = GetCudaOrdinal();
+  const uint64_t gen = session->EnsureWorker(
+      w, h, request.outputWidth, request.outputHeight,
+      config.quality, glCudaDevice, cudaOrdinal);
+  {
+    MutexAutoLock lock(mLock);
+    if (gen != mSessionGeneration) {
+      mSessionGeneration = gen;
+    }
+  }
+  if (gen == 0) {
+    return;
+  }
+  {
+    MutexAutoLock lock(mLock);
+    if (PipeDisplay* pipe = FindPipe(pipeline)) {
+      mSessionRenderer = pipe->renderer;
+    }
+  }
+  if (request.sessionGeneration != gen) {
+    request.sessionGeneration = gen;
+    MutexAutoLock lock(mLock);
+    for (auto& submission : mPipeSubmissions) {
+      if (submission.pipeline == pipeline &&
+          submission.token.producer == request.producer &&
+          submission.token.frame == request.frame) {
+        submission.token = request;
+        break;
+      }
+    }
+  }
+  PollSessionDownloads(aGL);
+  unsigned int stagingTex = 0;
+  {
+    MutexAutoLock lock(mLock);
+    stagingTex = mStagingTex;
+  }
+  {
+    MutexAutoLock lock(mLock);
+    for (size_t i = 0; i < mPipeSubmissions.Length();) {
+      if (mPipeSubmissions[i].token == request) {
+        mPipeSubmissions.RemoveElementAt(i);
+      } else {
+        ++i;
+      }
+    }
+    if (mPipeSubmissions.Length() >= 2) {
+      mPipeSubmissions.RemoveElementAt((size_t)0);
+    }
+    PipeSubmission submission;
+    submission.pipeline = pipeline;
+    submission.token = request;
+    mPipeSubmissions.AppendElement(submission);
+  }
+  if (session->SubmitInput(request, stagingTex, w, h)) {
+    MarkToken(kMarkerSubmit, request);
+  } else {
+    MutexAutoLock lock(mLock);
+    for (size_t i = 0; i < mPipeSubmissions.Length(); ++i) {
+      if (mPipeSubmissions[i].pipeline == pipeline &&
+          mPipeSubmissions[i].token == request) {
+        mPipeSubmissions.RemoveElementAt(i);
+        break;
+      }
+    }
+  }
+}
+
+bool VideoSuperResolutionTexturePool::IsSlotReady(int aSlot) {
+  MutexAutoLock lock(mLock);
+  if (aSlot < 0 || (size_t)aSlot >= mSlots.Length()) {
+    return false;
+  }
+  return mSlots[aSlot].contentReady &&
+         (mSlots[aSlot].state == SlotState::Ready ||
+          mSlots[aSlot].state == SlotState::Published ||
+          mSlots[aSlot].state == SlotState::Retiring);
+}
+
+bool VideoSuperResolutionTexturePool::EnsureCudaDevice(gl::GLContext* aGL) {
+  if (!aGL) {
+    return false;
+  }
+  VideoSuperResolutionCapability& cap = VideoSuperResolutionCapability::Get();
+  RefPtr<gl::GLContext> cudaGL;
+  {
+    MutexAutoLock lock(mLock);
+    cudaGL = mCudaGL;
+  }
+  if (cudaGL && cudaGL.get() != aGL) {
+    return false;
+  }
+  if (cap.GetState() == SuperResolutionCapabilityState::Available &&
+      cudaGL.get() == aGL) {
+    return true;
+  }
+  if (cap.GetState() == SuperResolutionCapabilityState::Failed) {
+    MutexAutoLock lock(mLock);
+    mSawCapabilityFailed = true;
+    return false;
+  }
+  if (!cap.Probe(aGL)) {
+    MutexAutoLock lock(mLock);
+    mGlCudaDevice = -1;
+    mCudaOrdinal = -1;
+    mSawCapabilityFailed = true;
+    return false;
+  }
+  MutexAutoLock lock(mLock);
+  mGlCudaDevice = cap.GetGlCudaDevice();
+  mCudaOrdinal = cap.GetCudaOrdinal();
+  mCudaGL = aGL;
+  mSawCapabilityFailed = false;
+  return true;
+}
+
+bool VideoSuperResolutionTexturePool::DeleteStagingResources(
+    gl::GLContext* aGL, unsigned int aTexture, unsigned int aFbo) {
+  if (!aGL || !aGL->MakeCurrent()) {
+    return false;
+  }
+  if (aFbo) {
+    aGL->fDeleteFramebuffers(1, &aFbo);
+  }
+  if (aTexture) {
+    aGL->fDeleteTextures(1, &aTexture);
+  }
+  return true;
+}
+
+void VideoSuperResolutionTexturePool::PollSessionDownloads(gl::GLContext* aGL) {
+  RefPtr<NvidiaVfxSession> session = GetSession();
+  if (!session) {
+    return;
+  }
+  SuperResolutionFrameToken ready;
+  if (!session->PeekReady(&ready) || !ready.HasIdentity()) {
+    return;
+  }
+  uint64_t pipe = 0;
+  {
+    MutexAutoLock lock(mLock);
+    for (const auto& submission : mPipeSubmissions) {
+      if (submission.token == ready) {
+        pipe = submission.pipeline;
+        break;
+      }
+    }
+  }
+  if (!pipe) {
+    SuperResolutionFrameToken dropped;
+    session->TakeReady(&dropped);
+    MarkToken(kMarkerDrop, dropped, "no-submission-route");
+    return;
+  }
+  if (ready.contextGeneration != GetContextGeneration(pipe)) {
+    SuperResolutionFrameToken dropped;
+    session->TakeReady(&dropped);
+    MarkToken(kMarkerDrop, dropped, "context-changed");
+    return;
+  }
+  if (!session->IsReadyComplete()) {
+    return;
+  }
+  int slot = AcquireDownloadSlot(ready, mSessionRenderer);
+  if (slot < 0) {
+    return;
+  }
+  SuperResolutionSlotTextureHost* host = nullptr;
+  {
+    MutexAutoLock lock(mLock);
+    if ((size_t)slot < mHosts.Length()) {
+      host = static_cast<SuperResolutionSlotTextureHost*>(mHosts[slot].get());
+    }
+  }
+  if (!host || !host->EnsureTexture(aGL, ready.outputWidth, ready.outputHeight)) {
+    DiscardReady(slot);
+    SuperResolutionFrameToken dropped;
+    session->TakeReady(&dropped);
+    MarkToken(kMarkerDrop, dropped, "output-texture-unavailable");
+    return;
+  }
+  if (!session->DownloadSlot((size_t)slot, host->Texture(),
+                             ready.outputWidth, ready.outputHeight)) {
+    DiscardReady(slot);
+    SuperResolutionFrameToken dropped;
+    session->TakeReady(&dropped);
+    MarkToken(kMarkerDrop, dropped, "output-download-failed");
+    return;
+  }
+  {
+    MutexAutoLock lock(mLock);
+    if ((size_t)slot < mSlots.Length() &&
+        mSlots[slot].state == SlotState::Ready &&
+        mSlots[slot].token == ready) {
+      mSlots[slot].contentReady = true;
+    } else {
+      return;
+    }
+  }
+  SuperResolutionFrameToken taken;
+  session->TakeReady(&taken);
+  if (!(taken == ready)) {
+    InvalidateSlot(slot);
+    return;
+  }
+  {
+    MutexAutoLock lock(mLock);
+    for (size_t i = 0; i < mPipeSubmissions.Length(); ++i) {
+      if (mPipeSubmissions[i].token == taken) {
+        mPipeSubmissions.RemoveElementAt(i);
+        break;
+      }
+    }
+  }
+  if (!VideoSuperResolutionCoordinator::Get().NoteExternalCompleted(pipe, taken)) {
+    DiscardReady(slot);
+    MarkToken(kMarkerDrop, taken, "stale-result");
+  } else {
+    MarkToken(kMarkerComplete, taken);
+    QueueCompositionWakeup(pipe, taken, /* aForcePollRender */ false);
+  }
+}
+
+bool VideoSuperResolutionTexturePool::GetSlotToken(int aSlot,
+                                                   SuperResolutionFrameToken* aOut) {
+  MutexAutoLock lock(mLock);
+  if (aSlot < 0 || (size_t)aSlot >= mSlots.Length()) {
+    return false;
+  }
+  if (!mSlots[aSlot].token.HasIdentity()) {
+    return false;
+  }
+  if (aOut) {
+    *aOut = mSlots[aSlot].token;
+  }
+  return true;
+}
+
+SuperResolutionSlotTextureHost::SuperResolutionSlotTextureHost(int aSlot)
+    : mSlot(aSlot) {
+  MOZ_COUNT_CTOR_INHERITED(SuperResolutionSlotTextureHost, RenderTextureHost);
+}
+
+SuperResolutionSlotTextureHost::~SuperResolutionSlotTextureHost() {
+  MOZ_COUNT_DTOR_INHERITED(SuperResolutionSlotTextureHost, RenderTextureHost);
+  DeleteTexture();
+}
+
+wr::WrExternalImage SuperResolutionSlotTextureHost::Lock(uint8_t aChannelIndex,
+                                                        gl::GLContext* aGL) {
+  if (aChannelIndex != 0 || !aGL || !aGL->MakeCurrent()) {
+    return wr::InvalidToWrExternalImage();
+  }
+  if (mGL && mGL.get() != aGL) {
+    VideoSuperResolutionTexturePool::Get().InvalidateSlot(mSlot);
+    return wr::InvalidToWrExternalImage();
+  }
+  SuperResolutionFrameToken token;
+  if (!VideoSuperResolutionTexturePool::Get().GetSlotToken(mSlot, &token)) {
+    return wr::InvalidToWrExternalImage();
+  }
+  if (token.sessionGeneration == 0 ||
+      !VideoSuperResolutionTexturePool::Get().IsSlotReady(mSlot) || !mTexture ||
+      mTexW != token.outputWidth || mTexH != token.outputHeight) {
+    return wr::InvalidToWrExternalImage();
+  }
+  return wr::NativeTextureToWrExternalImage(
+      mTexture, 0.0f, 0.0f, (float)mTexW, (float)mTexH);
+}
+
+void SuperResolutionSlotTextureHost::ClearCachedResources() {
+  if (DeleteTexture()) {
+    mGL = nullptr;
+  }
+  VideoSuperResolutionTexturePool::Get().InvalidateSlot(mSlot);
+}
+
+size_t SuperResolutionSlotTextureHost::Bytes() {
+  return static_cast<size_t>(mTexW) * static_cast<size_t>(mTexH) * 4;
+}
+
+bool SuperResolutionSlotTextureHost::DestroyTexture(gl::GLContext* aGL) {
+  if (!aGL || (mGL && mGL.get() != aGL) || !aGL->MakeCurrent()) {
+    return false;
+  }
+  if (!DeleteTexture()) {
+    return false;
+  }
+  mGL = nullptr;
+  return true;
+}
+
+bool SuperResolutionSlotTextureHost::DeleteTexture() {
+  if (mTexture) {
+    if (!mGL || !mGL->MakeCurrent() ||
+        !VideoSuperResolutionTexturePool::Get().UnregisterSlotTexture(mTexture)) {
+      return false;
+    }
+    mGL->fDeleteTextures(1, &mTexture);
+  }
+  mTexture = 0;
+  mTexW = 0;
+  mTexH = 0;
+  return true;
+}
+
+bool SuperResolutionSlotTextureHost::EnsureTexture(gl::GLContext* aGL, int aW, int aH) {
+  using namespace gl;
+  if (!aGL || !aGL->MakeCurrent()) {
+    return false;
+  }
+  if (mGL && mGL.get() != aGL) {
+    return false;
+  }
+  mGL = aGL;
+  if (aW <= 0 || aH <= 0 || aW > 7680 || aH > 4320) {
+    return false;
+  }
+  if (mTexture && mTexW == aW && mTexH == aH) {
+    return true;
+  }
+  unsigned int tex = 0;
+  aGL->fGenTextures(1, &tex);
+  aGL->fBindTexture(LOCAL_GL_TEXTURE_2D, tex);
+  aGL->fTexParameteri(LOCAL_GL_TEXTURE_2D, LOCAL_GL_TEXTURE_MIN_FILTER, LOCAL_GL_LINEAR);
+  aGL->fTexParameteri(LOCAL_GL_TEXTURE_2D, LOCAL_GL_TEXTURE_MAG_FILTER, LOCAL_GL_LINEAR);
+  aGL->fTexParameteri(LOCAL_GL_TEXTURE_2D, LOCAL_GL_TEXTURE_WRAP_S, LOCAL_GL_CLAMP_TO_EDGE);
+  aGL->fTexParameteri(LOCAL_GL_TEXTURE_2D, LOCAL_GL_TEXTURE_WRAP_T, LOCAL_GL_CLAMP_TO_EDGE);
+  aGL->fTexImage2D(LOCAL_GL_TEXTURE_2D, 0, LOCAL_GL_RGBA8, aW, aH, 0,
+                   LOCAL_GL_RGBA, LOCAL_GL_UNSIGNED_BYTE, nullptr);
+  aGL->fBindTexture(LOCAL_GL_TEXTURE_2D, 0);
+  if (!tex) {
+    return false;
+  }
+  if (mTexture) {
+    if (!VideoSuperResolutionTexturePool::Get().UnregisterSlotTexture(mTexture)) {
+      aGL->fDeleteTextures(1, &tex);
+      return false;
+    }
+    aGL->fDeleteTextures(1, &mTexture);
+  }
+  mTexture = tex;
+  mTexW = aW;
+  mTexH = aH;
+  return true;
+}
+
+}  // namespace mozilla::zen

--- a/src/zen/video-super-resolution/VideoSuperResolutionTexturePool.h
+++ b/src/zen/video-super-resolution/VideoSuperResolutionTexturePool.h
@@ -1,0 +1,252 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_zen_VideoSuperResolutionTexturePool_h
+#define mozilla_zen_VideoSuperResolutionTexturePool_h
+
+#include <stdint.h>
+
+#include "mozilla/Atomics.h"
+#include "mozilla/Mutex.h"
+#include "mozilla/RefPtr.h"
+#include "mozilla/TimeStamp.h"
+#include "mozilla/webrender/RenderTextureHost.h"
+#include "mozilla/zen/VideoSuperResolutionOwnerPolicy.h"
+#include "mozilla/zen/VideoSuperResolutionTypes.h"
+#include "nsTArray.h"
+
+class DMABufSurface;
+
+namespace mozilla {
+
+namespace gl {
+class GLContext;
+}
+
+namespace layers {
+class WebRenderImageHost;
+}
+
+namespace wr {
+class TransactionBuilder;
+struct ExternalImageId;
+struct ImageKey;
+}
+
+namespace zen {
+
+class NvidiaVfxSession;
+
+class VideoSuperResolutionTexturePool {
+ public:
+  static VideoSuperResolutionTexturePool& Get();
+
+  static constexpr size_t kMaxSourceSurfaces = 8;
+
+  bool ShouldActivate(bool aIsHardwareBackend);
+  bool IsAvailable(gl::GLContext* aGL);
+  bool HasFailed();
+
+  bool CanClaimOwner(uint64_t aPipeline, float aDisplayW, float aDisplayH);
+  CudaDeviceHandle GetGlCudaDevice();
+  int GetCudaOrdinal();
+  uint64_t GetContextGeneration(uint64_t aPipeline);
+
+  bool EnsureInitialized();
+  int SlotCount();
+
+  int AcquireDownloadSlot(const SuperResolutionFrameToken& aToken,
+                          uint32_t aRenderer = 0);
+  int FindReadySlot(const SuperResolutionFrameToken& aToken,
+                    uint32_t aRenderer = 0);
+  void DiscardReady(int aSlot);
+
+  bool Publish(uint64_t aPipeline, int aSlot,
+               const SuperResolutionFrameToken& aToken,
+               wr::ExternalImageId* aExtId);
+  void Unpublish(uint64_t aPipeline);
+
+  bool TryHoldPublished(uint64_t aPipeline,
+                        const SuperResolutionFrameToken& aCurrent,
+                        SuperResolutionFrameToken* aHeldToken);
+
+  bool EnsureKeyResource(wr::TransactionBuilder& aTxn, bool aIsAdd,
+                         const wr::ImageKey& aKey, uint64_t aPipeline);
+
+  void RequestSnapshot(const SuperResolutionFrameToken& aToken, uint64_t aPipeline,
+                       uint64_t aSourceIdentity);
+  void BindPipelineImageHost(uint64_t aPipeline,
+                             const RefPtr<layers::WebRenderImageHost>& aHost,
+                             uint32_t aRenderer);
+  void NotifyVfxStreamComplete(const SuperResolutionFrameToken& aToken);
+
+  void SnapshotFromSurface(DMABufSurface* aSurface, gl::GLContext* aGL,
+                           uint64_t aSourceIdentity);
+
+  void RegisterSourceSurface(uint64_t aIdentity, DMABufSurface* aSurface);
+  void UnregisterSourceSurface(uint64_t aIdentity, DMABufSurface* aSurface);
+  void ProcessPendingSnapshots(gl::GLContext* aGL);
+
+  uint64_t GetSessionGeneration();
+  bool VfxEnabled();
+
+  bool UnregisterSlotTexture(unsigned int aTex);
+  bool IsSlotReady(int aSlot);
+  void InvalidateSlot(int aSlot);
+
+  void ReleasePipeline(uint64_t aPipeline, uint64_t aEpoch);
+
+  void NoteTransaction(uint64_t aPipeline, uint64_t aEpoch);
+  void NotePipelineComposite(uint64_t aPipeline);
+  void NotePipelineRendered(uint64_t aPipeline, uint64_t aEpoch,
+                            uint64_t aRenderedFrame, uint32_t aRenderer,
+                            uint64_t aCompletedFrame);
+  void NotePipelineRemoved(uint64_t aPipeline, uint64_t aRenderedFrame,
+                           uint32_t aRenderer, uint64_t aCompletedFrame);
+  void NoteCompletedRender(uint32_t aRenderer, uint64_t aCompletedFrame);
+  void OnRendererDestroyed(uint32_t aRenderer, gl::GLContext* aGL);
+
+  void PollVfxResults(gl::GLContext* aGL);
+
+  bool GetSlotToken(int aSlot, SuperResolutionFrameToken* aOut);
+
+ private:
+  RefPtr<NvidiaVfxSession> GetSession();
+
+  VideoSuperResolutionTexturePool();
+  ~VideoSuperResolutionTexturePool() = default;
+  VideoSuperResolutionTexturePool(const VideoSuperResolutionTexturePool&) = delete;
+  VideoSuperResolutionTexturePool& operator=(const VideoSuperResolutionTexturePool&) = delete;
+
+  enum class SlotState { Free, Ready, Published, Retiring };
+
+  struct Slot {
+    SlotState state = SlotState::Free;
+    SuperResolutionFrameToken token;
+    uint32_t renderer = 0;
+    bool contentReady = false;
+  };
+
+  struct PipeDisplay {
+    uint64_t pipeline = 0;
+    uint32_t renderer = 0;
+    uint64_t contextGeneration = 0;
+    int slot = -1;
+    bool keyValid = false;
+    int keySlot = -1;
+    int retiringSlot = -1;
+    RefPtr<layers::WebRenderImageHost> imageHost;
+    bool pollWakePending = false;
+    bool presentationWakePending = false;
+    TimeStamp lastCompositeTime;
+  };
+
+  struct PipeSubmission {
+    uint64_t pipeline = 0;
+    SuperResolutionFrameToken token;
+  };
+
+  struct SnapshotRequest {
+    SuperResolutionFrameToken token;
+    uint64_t pipeline = 0;
+    uint64_t sourceIdentity = 0;
+  };
+
+  struct RetireFence {
+    uint64_t pipeline = 0;
+    uint32_t renderer = 0;
+    int slot = -1;
+    uint64_t epoch = 0;
+    uint64_t renderedFrame = 0;
+  };
+
+  int FindFreeSlot();
+  void RetireSlot(PipeDisplay& aPipe, int aSlot, uint64_t aEpoch = 0);
+  void InvalidateSlotLocked(int aSlot);
+  void RecycleCompleted(uint32_t aRenderer, uint64_t aCompletedFrame);
+  void QueueCompositionWakeup(uint64_t aPipeline,
+                              const SuperResolutionFrameToken& aToken,
+                              bool aForcePollRender);
+  void ProcessCompositionWakeup(uint64_t aPipeline,
+                                const SuperResolutionFrameToken& aToken,
+                                bool aForcePollRender);
+  bool EnsureCudaDevice(gl::GLContext* aGL);
+  bool DeleteStagingResources(gl::GLContext* aGL, unsigned int aTexture,
+                              unsigned int aFbo);
+  void PollSessionDownloads(gl::GLContext* aGL);
+  PipeDisplay& EnsurePipe(uint64_t aPipeline);
+  PipeDisplay* FindPipe(uint64_t aPipeline);
+  bool DisplayedElsewhere(int aSlot, uint64_t aExceptPipeline);
+
+  Mutex mLock{"VideoSuperResolutionTexturePool"};
+  AutoTArray<Slot, 4> mSlots;
+  AutoTArray<PipeDisplay, 4> mPipes;
+  AutoTArray<PipeSubmission, 4> mPipeSubmissions;
+  AutoTArray<RetireFence, 8> mRetireFences;
+  AutoTArray<RefPtr<wr::RenderTextureHost>, 4> mHosts;
+  AutoTArray<wr::ExternalImageId, 4> mExtIds;
+
+  int mOutW = 0;
+  int mOutH = 0;
+  RefPtr<NvidiaVfxSession> mSession;
+  uint64_t mSessionGeneration = 0;
+  uint64_t mNextContextGeneration = 0;
+  uint32_t mSessionRenderer = 0;
+  CudaDeviceHandle mGlCudaDevice = -2;
+  int mCudaOrdinal = -2;
+  RefPtr<gl::GLContext> mCudaGL;
+
+  unsigned int mStagingTex = 0;
+  unsigned int mStagingFbo = 0;
+  int mStagingW = 0;
+  int mStagingH = 0;
+
+  struct SourceSurfaceEntry {
+    uint64_t identity = 0;
+    RefPtr<DMABufSurface> surface;
+  };
+  AutoTArray<SourceSurfaceEntry, kMaxSourceSurfaces> mSourceSurfaces;
+
+  AutoTArray<SnapshotRequest, 4> mSnapshotRequests;
+  uint64_t mInputPipeline = 0;
+  uint64_t mCurrentOwner = 0;
+  AutoTArray<SuperResolutionOwnerCandidate, 4> mCandidates;
+  SuperResolutionFrameToken mLastSnapshotRequest;
+  uint64_t mLastSnapshotPipeline = 0;
+  bool mHasLastSnapshotRequest = false;
+  bool mSawCapabilityFailed = false;
+  Atomic<bool> mLastVfxEnabled{false};
+  size_t mSlotCount = 3;
+};
+
+class SuperResolutionSlotTextureHost final : public wr::RenderTextureHost {
+ public:
+  explicit SuperResolutionSlotTextureHost(int aSlot);
+
+  wr::WrExternalImage Lock(uint8_t aChannelIndex,
+                           gl::GLContext* aGL) override;
+  void Unlock() override {}
+  void ClearCachedResources() override;
+  size_t Bytes() override;
+
+  bool EnsureTexture(gl::GLContext* aGL, int aW, int aH);
+  bool DestroyTexture(gl::GLContext* aGL);
+  bool UsesGL(const gl::GLContext* aGL) const { return mGL.get() == aGL; }
+  unsigned int Texture() const { return mTexture; }
+
+ private:
+  ~SuperResolutionSlotTextureHost();
+  bool DeleteTexture();
+
+  const int mSlot;
+  RefPtr<gl::GLContext> mGL;
+  unsigned int mTexture = 0;
+  int mTexW = 0;
+  int mTexH = 0;
+};
+
+}  // namespace zen
+}  // namespace mozilla
+
+#endif  // mozilla_zen_VideoSuperResolutionTexturePool_h

--- a/src/zen/video-super-resolution/VideoSuperResolutionTypes.h
+++ b/src/zen/video-super-resolution/VideoSuperResolutionTypes.h
@@ -1,0 +1,256 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_zen_VideoSuperResolutionTypes_h
+#define mozilla_zen_VideoSuperResolutionTypes_h
+
+#include <cstdint>
+
+namespace mozilla::zen {
+
+using CudaDeviceHandle = int;
+
+struct CudaDeviceUuid {
+  char bytes[16];
+};
+static_assert(sizeof(CudaDeviceUuid) == 16, "CudaDeviceUuid must match CUuuid (16 bytes)");
+static_assert(alignof(CudaDeviceUuid) == 1, "CudaDeviceUuid has 1-byte natural alignment");
+
+inline constexpr unsigned int kDefaultScalePercent = 200;
+inline constexpr int64_t kMaxFrameLag = 3;
+
+enum class SuperResolutionQuality : unsigned int {
+  Bicubic = 0,
+  Low = 1,
+  Medium = 2,
+  High = 3,
+  Ultra = 4,
+};
+
+inline constexpr SuperResolutionQuality kDefaultQuality = SuperResolutionQuality::High;
+
+inline SuperResolutionQuality SuperResolutionQualityFromPref(uint32_t aPref) {
+  switch (aPref) {
+    case 0:
+      return SuperResolutionQuality::Bicubic;
+    case 1:
+      return SuperResolutionQuality::Low;
+    case 2:
+      return SuperResolutionQuality::Medium;
+    case 3:
+      return SuperResolutionQuality::High;
+    case 4:
+      return SuperResolutionQuality::Ultra;
+    default:
+      return kDefaultQuality;
+  }
+}
+
+inline uint32_t SuperResolutionQualityToNvVfx(SuperResolutionQuality aQuality) {
+  return static_cast<uint32_t>(aQuality);
+}
+
+inline const char* SuperResolutionQualityToString(SuperResolutionQuality aQuality) {
+  switch (aQuality) {
+    case SuperResolutionQuality::Bicubic:
+      return "Bicubic";
+    case SuperResolutionQuality::Low:
+      return "Low";
+    case SuperResolutionQuality::Medium:
+      return "Medium";
+    case SuperResolutionQuality::High:
+      return "High";
+    case SuperResolutionQuality::Ultra:
+      return "Ultra";
+  }
+  return "High";
+}
+
+enum class SuperResolutionScaleMode : unsigned int {
+  Auto = 0,
+  Manual = 1,
+};
+
+inline SuperResolutionScaleMode SuperResolutionScaleModeFromPref(uint32_t aPref) {
+  switch (aPref) {
+    case 0:
+      return SuperResolutionScaleMode::Auto;
+    case 1:
+      return SuperResolutionScaleMode::Manual;
+    default:
+      return SuperResolutionScaleMode::Auto;
+  }
+}
+
+inline const char* SuperResolutionScaleModeToString(SuperResolutionScaleMode aMode) {
+  switch (aMode) {
+    case SuperResolutionScaleMode::Auto:
+      return "Auto";
+    case SuperResolutionScaleMode::Manual:
+      return "Manual";
+  }
+  return "Auto";
+}
+
+enum class SuperResolutionCapabilityState {
+  Unknown,
+  Probing,
+  Available,
+  Unavailable,
+  Failed,
+};
+
+struct SuperResolutionConfig {
+  bool enabled = false;
+  SuperResolutionScaleMode scaleMode = SuperResolutionScaleMode::Auto;
+  unsigned int manualScalePercent = kDefaultScalePercent;
+  SuperResolutionQuality quality = kDefaultQuality;
+
+  bool SemanticallyEquals(const SuperResolutionConfig& aOther) const {
+    if (enabled != aOther.enabled ||
+        scaleMode != aOther.scaleMode ||
+        quality != aOther.quality) {
+      return false;
+    }
+    if (scaleMode == SuperResolutionScaleMode::Manual) {
+      if (manualScalePercent != aOther.manualScalePercent) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool operator==(const SuperResolutionConfig& aOther) const {
+    return SemanticallyEquals(aOther);
+  }
+  bool operator!=(const SuperResolutionConfig& aOther) const {
+    return !SemanticallyEquals(aOther);
+  }
+};
+
+struct SuperResolutionFrameToken {
+  uint32_t producer = 0;
+  int32_t frame = 0;
+  uint64_t sessionGeneration = 0;
+  uint64_t configGeneration = 0;
+  uint64_t contextGeneration = 0;
+  int sourceWidth = 0;
+  int sourceHeight = 0;
+  int outputWidth = 0;
+  int outputHeight = 0;
+
+  bool HasIdentity() const { return producer != 0; }
+
+  bool MatchesStream(const SuperResolutionFrameToken& aOther) const {
+    return producer == aOther.producer &&
+           sessionGeneration == aOther.sessionGeneration &&
+           configGeneration == aOther.configGeneration &&
+           contextGeneration == aOther.contextGeneration &&
+           sourceWidth == aOther.sourceWidth &&
+           sourceHeight == aOther.sourceHeight &&
+           outputWidth == aOther.outputWidth &&
+           outputHeight == aOther.outputHeight;
+  }
+
+  bool MatchesExact(const SuperResolutionFrameToken& aOther) const {
+    return frame == aOther.frame && MatchesStream(aOther);
+  }
+
+  bool operator==(const SuperResolutionFrameToken& aOther) const {
+    return MatchesExact(aOther);
+  }
+  bool operator!=(const SuperResolutionFrameToken& aOther) const {
+    return !MatchesExact(aOther);
+  }
+};
+
+struct SuperResolutionTargetDecision {
+  bool eligible = false;
+  int outputWidth = 0;
+  int outputHeight = 0;
+  SuperResolutionScaleMode scaleMode = SuperResolutionScaleMode::Auto;
+  SuperResolutionQuality quality = kDefaultQuality;
+  const char* bypassReason = nullptr;
+};
+
+struct NvCVImage {
+  unsigned int width = 0;
+  unsigned int height = 0;
+  int pitch = 0;
+  int pixelFormat = 0;
+  int componentType = 0;
+  unsigned char pixelBytes = 0;
+  unsigned char componentBytes = 0;
+  unsigned char numComponents = 0;
+  unsigned char planar = 0;
+  unsigned char gpuMem = 0;
+  unsigned char colorspace = 0;
+  unsigned char reserved[2] = {};
+  void* pixels = nullptr;
+  void* deletePtr = nullptr;
+  void* deleteProc = nullptr;
+  unsigned long long bufferBytes = 0;
+};
+static_assert(sizeof(NvCVImage) == 64, "NvCVImage must match 64-bit layout");
+
+inline constexpr int kNvFormatRGBA = 6;
+inline constexpr int kNvTypeU8 = 1;
+inline constexpr int kNvChunky = 0;
+inline constexpr int kNvGpuMem = 1;
+
+inline constexpr char kVideoSuperResEffect[] = "VideoSuperRes";
+inline constexpr char kQualityLevelParam[] = "QualityLevel";
+inline constexpr char kGpuParam[] = "GPU";
+inline constexpr char kSrcImageParam[] = "SrcImage0";
+inline constexpr char kDstImageParam[] = "DstImage0";
+inline constexpr char kCudaStreamParam[] = "CudaStream";
+
+enum class SuperResolutionSessionState {
+  Uninitialized,
+  Loading,
+  Ready,
+  Failed,
+  ShuttingDown,
+};
+
+enum class SuperResolutionCompositionReason {
+  OwnerActivated,
+  OwnerSelected,
+  OwnerLost,
+  Disabled,
+  ScaleBypass,
+  FormatBypass,
+  Failure,
+  RendererReset,
+  PipelineRemoved,
+};
+
+inline const char* SuperResolutionCompositionReasonToString(
+    SuperResolutionCompositionReason aReason) {
+  switch (aReason) {
+    case SuperResolutionCompositionReason::OwnerActivated:
+      return "owner-activated";
+    case SuperResolutionCompositionReason::OwnerSelected:
+      return "owner-selected";
+    case SuperResolutionCompositionReason::OwnerLost:
+      return "owner-lost";
+    case SuperResolutionCompositionReason::Disabled:
+      return "disabled";
+    case SuperResolutionCompositionReason::ScaleBypass:
+      return "scale-bypass";
+    case SuperResolutionCompositionReason::FormatBypass:
+      return "format-bypass";
+    case SuperResolutionCompositionReason::Failure:
+      return "failure";
+    case SuperResolutionCompositionReason::RendererReset:
+      return "renderer-reset";
+    case SuperResolutionCompositionReason::PipelineRemoved:
+      return "pipeline-removed";
+  }
+  return "unknown";
+}
+
+}  // namespace mozilla::zen
+
+#endif  // mozilla_zen_VideoSuperResolutionTypes_h

--- a/src/zen/video-super-resolution/moz.build
+++ b/src/zen/video-super-resolution/moz.build
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+EXPORTS.mozilla.zen += [
+    "CudaGlInterop.h",
+    "NvidiaVfxLoader.h",
+    "NvidiaVfxSession.h",
+    "VideoSuperResolutionCapability.h",
+    "VideoSuperResolutionCoordinator.h",
+    "VideoSuperResolutionOwnerPolicy.h",
+    "VideoSuperResolutionProfiler.h",
+    "VideoSuperResolutionScalePolicy.h",
+    "VideoSuperResolutionTexturePool.h",
+    "VideoSuperResolutionTypes.h",
+]
+
+SOURCES += [
+    "CudaGlInterop.cpp",
+    "NvidiaVfxLoader.cpp",
+    "NvidiaVfxSession.cpp",
+    "VideoSuperResolutionCapability.cpp",
+    "VideoSuperResolutionCoordinator.cpp",
+    "VideoSuperResolutionOwnerPolicy.cpp",
+    "VideoSuperResolutionScalePolicy.cpp",
+    "VideoSuperResolutionTexturePool.cpp",
+]
+
+LOCAL_INCLUDES += [
+    "/gfx/gl",
+    "/gfx/layers",
+    "/gfx/webrender_bindings",
+    "/widget/gtk",
+]
+
+include("/ipc/chromium/chromium-config.mozbuild")
+
+FINAL_LIBRARY = "xul"


### PR DESCRIPTION
## Summary

Adds optional NVIDIA Video Super Resolution (VSR) support for Linux.

This follows the Linux VSR proposal in #15264. It is separate from Zen's existing Windows DirectComposition/NVIDIA driver-overlay path: Linux uses NVIDIA's VFX VideoSuperRes API instead.

The feature is Linux/NVIDIA-only and disabled by default.

## Behavior

- `zen.video.super-resolution.enabled` defaults to `false`.
- VSR requires explicit user opt-in and runtime capability checks.
- The initial supported path is SDR, limited-range BT.709 NV12 external video.
- Existing decoder paths remain unchanged.
- The intended frame path remains GPU-resident: DMA-BUF -> GL -> CUDA/GL interop -> NVIDIA VFX -> GL -> WebRender.
- VFX execution uses a worker-owned CUDA stream.

Normal playback always takes priority. When VSR is unavailable or fails, Zen transparently presents the original video frame.

## NVIDIA Runtime

NVIDIA VFX is proprietary. This PR does not bundle or automatically download the VFX runtime or models.

The current implementation expects the NVIDIA VFX SDK Core and `nvvfxvideosuperres` feature/model to be installed externally. If unavailable, normal video playback continues.

Feedback on the preferred runtime installation and packaging approach would be welcome.

## Validation

Tested locally on Linux/Wayland with a GeForce RTX 4070 SUPER and Vulkan H.264 hardware decoding.

- Built successfully.
- Verified VSR playback and fallback behavior with 360p to 1080p content at 30 and 60 fps.
- Confirmed RDD sandbox observations remained `Seccomp=2` and `NoNewPrivs=1`.
- Verified exported VSR patches match the local engine changes.
