### PR TITLE
gh-15288: add missing margin for space selector in BMPanel

### DIFF
--- a/src/zen/common/styles/zen-panels/bookmarks.css
+++ b/src/zen/common/styles/zen-panels/bookmarks.css
@@ -64,6 +64,10 @@ hbox.editBMPanel_folderRow {
   margin-right: 10px;
 }
 
+#editBMPanel_workspaceSummary .workspace-trigger {
+  margin-inline-end: 16px;
+}
+
 /* Bookmarks in toolbar */
 #PersonalToolbar {
   background: transparent;


### PR DESCRIPTION
Added margin-inline-end that was missing for space selector / workspace summary on "Add bookmark" panel.

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/1e995d77-514e-401b-b59a-df34205a0955" />

How it looked before changes:

<img width="633" height="512" alt="image" src="https://github.com/user-attachments/assets/cc68a39a-8126-452b-b41a-978858df6ee4" />

I tested the bit myself by editing the CSS for `chrome://browser/skin/places/editBookmark.css` in Parent process Browser Toolbox