### PR TITLE
Float Picture-in-Picture over native-fullscreen Spaces on macOS

### DIFF
--- a/prefs/zen/macos.yaml
+++ b/prefs/zen/macos.yaml
@@ -35,3 +35,13 @@
 - name: zen.widget.macos.override-system-swipe-gestures
   value: true
   condition: "defined(XP_MACOSX)"
+
+# Let the Picture-in-Picture player float above other applications'
+# native-fullscreen Spaces. Requires BaseWindow to be an NSPanel; see
+# nsCocoaWindow::SetWindowClass in nsCocoaWindow.mm (bug 1688932).
+- name: zen.widget.macos.pip-over-fullscreen.enabled
+  value: true
+  condition: "defined(XP_MACOSX)"
+  cpptype: bool
+  mirror: always
+  type: static

--- a/src/toolkit/components/pictureinpicture/content/player-xhtml.patch
+++ b/src/toolkit/components/pictureinpicture/content/player-xhtml.patch
@@ -1,7 +1,16 @@
 diff --git a/toolkit/components/pictureinpicture/content/player.xhtml b/toolkit/components/pictureinpicture/content/player.xhtml
-index 09c9c5000de96fcd4a9d26328408996540c2cbda..b6d93850bbfe63a4e21756c97415a6c1908dae25 100644
+index a723bc582857601d7fd048f3b4ac203bff28b616..c1d09bdb08555ba091116db316908b672172aaae 100644
 --- a/toolkit/components/pictureinpicture/content/player.xhtml
 +++ b/toolkit/components/pictureinpicture/content/player.xhtml
+@@ -6,7 +6,7 @@
+ <html xmlns="http://www.w3.org/1999/xhtml"
+       xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+       windowtype="Toolkit:PictureInPicture"
+-      macnativefullscreen="true"
++      macnativefullscreen="false"
+       customtitlebar="true"
+       scrolling="false"
+       >
 @@ -18,6 +18,7 @@
      <link rel="localization" href="browser/browserSets.ftl"/>
      <script src="chrome://global/content/pictureinpicture/player.js"></script>

--- a/src/widget/cocoa/nsCocoaWindow-h.patch
+++ b/src/widget/cocoa/nsCocoaWindow-h.patch
@@ -1,8 +1,26 @@
 diff --git a/widget/cocoa/nsCocoaWindow.h b/widget/cocoa/nsCocoaWindow.h
-index 22a2a7ef3a5e9257c8bb00ba6a55e8d39d2abbd9..6d8353fd11921585f7101f5717bdb3dd8f2a5eae 100644
+index 22a2a7ef3a5e9257c8bb00ba6a55e8d39d2abbd9..e829b10260960a7c346cc95d4a5948e28f070390 100644
 --- a/widget/cocoa/nsCocoaWindow.h
 +++ b/widget/cocoa/nsCocoaWindow.h
-@@ -461,6 +461,10 @@ class nsCocoaWindow final : public nsIWidget {
+@@ -41,7 +41,16 @@ class TextInputHandler;
+ // We don't save shadow, transparency mode or background color because it's not
+ // worth the hassle - Gecko will reset them anyway as soon as the window is
+ // resized.
+-@interface BaseWindow : NSWindow {
++//
++// BaseWindow derives from NSPanel rather than NSWindow purely so that a window
++// can carry NSWindowStyleMaskNonactivatingPanel: AppKit silently strips that
++// style bit from any window whose class is not an NSPanel, and it is the bit
++// the WindowServer keys "float above another application's native-fullscreen
++// Space" off (bug 1688932). NSPanel is a strict subclass of NSWindow; the only
++// default behaviours it changes (-isReleasedWhenClosed, -hidesOnDeactivate,
++// -canBecomeMainWindow) are restored to NSWindow's below, so windows that do
++// not carry the bit behave exactly as before.
++@interface BaseWindow : NSPanel {
+   // Data Storage
+   NSMutableDictionary* mState;
+   BOOL mDrawsIntoWindowFrame;
+@@ -461,6 +470,10 @@ class nsCocoaWindow final : public nsIWidget {
    void SetHideTitlebarSeparator(bool) override;
    bool IsMacTitlebarDirectionRTL() override;
    void SetCustomTitlebar(bool) override;
@@ -13,7 +31,7 @@ index 22a2a7ef3a5e9257c8bb00ba6a55e8d39d2abbd9..6d8353fd11921585f7101f5717bdb3dd
    void UpdateThemeGeometries(
        const nsTArray<ThemeGeometry>& aThemeGeometries) override;
    void LockAspectRatio(bool aShouldLock) override;
-@@ -674,6 +678,7 @@ class nsCocoaWindow final : public nsIWidget {
+@@ -674,6 +687,7 @@ class nsCocoaWindow final : public nsIWidget {
    // show (e.g. a window created by detaching a tab from a fullscreen window).
    bool mIsInitialFullscreenSuppressed = false;
    bool mWasShown = false;

--- a/src/widget/cocoa/nsCocoaWindow-mm.patch
+++ b/src/widget/cocoa/nsCocoaWindow-mm.patch
@@ -1,5 +1,5 @@
 diff --git a/widget/cocoa/nsCocoaWindow.mm b/widget/cocoa/nsCocoaWindow.mm
-index 2efd02e4a92433fd29bbfdb707aa81cfec45031e..3b763c3927f07e529c826f8e4f62bc80a324b247 100644
+index 887e4c052d5dd2b73d4c2059463529fb4b09dcab..28e3e31fd11099be6c334f8f0b3287aa474dfa80 100644
 --- a/widget/cocoa/nsCocoaWindow.mm
 +++ b/widget/cocoa/nsCocoaWindow.mm
 @@ -86,6 +86,7 @@
@@ -10,7 +10,7 @@ index 2efd02e4a92433fd29bbfdb707aa81cfec45031e..3b763c3927f07e529c826f8e4f62bc80
  #include "mozilla/WritingModes.h"
  #include "mozilla/dom/Document.h"
  #include "mozilla/layers/CompositorBridgeChild.h"
-@@ -1332,6 +1333,110 @@ - (NSRect)_opaqueRectForWindowMoveWhenInTitlebar {
+@@ -1332,6 +1333,133 @@ mozilla::VibrancyManager& nsCocoaWindow::EnsureVibrancyManager() {
  }
  @end
  
@@ -82,6 +82,29 @@ index 2efd02e4a92433fd29bbfdb707aa81cfec45031e..3b763c3927f07e529c826f8e4f62bc80
 +void nsCocoaWindow::SetWindowClass(const nsAString& aXulWinType,
 +                                   const nsAString& aXulWinClass,
 +                                   const nsAString& aXulWinName) {
++  if (mWindow && aXulWinType.EqualsLiteral("Toolkit:PictureInPicture") &&
++      StaticPrefs::zen_widget_macos_pip_over_fullscreen_enabled()) {
++    // Let the Picture-in-Picture player float above other applications'
++    // native-fullscreen Spaces (bug 1688932). Empirically (macOS 26) exactly
++    // two things are load-bearing: the window must carry
++    // NSWindowStyleMaskNonactivatingPanel -- which only sticks on an NSPanel,
++    // hence BaseWindow's superclass -- and it must not carry
++    // FullScreenPrimary. The window level is irrelevant. The bit can be added
++    // after creation, which is why this lives here rather than in
++    // CreateNativeWindow: the XUL windowtype is the cleanest identity we have.
++    // player.xhtml sets macnativefullscreen="false" so that
++    // SyncAttributesToWidget() does not put FullScreenPrimary back afterwards.
++    mWindow.styleMask |= NSWindowStyleMaskNonactivatingPanel;
++    mWindow.hidesOnDeactivate = NO;
++    mWindow.collectionBehavior =
++        (mWindow.collectionBehavior &
++         ~(NSWindowCollectionBehaviorFullScreenPrimary |
++           NSWindowCollectionBehaviorFullScreenAllowsTiling)) |
++        NSWindowCollectionBehaviorCanJoinAllSpaces |
++        NSWindowCollectionBehaviorFullScreenAuxiliary |
++        NSWindowCollectionBehaviorFullScreenDisallowsTiling;
++    return;
++  }
 +  if (mWindowType != WindowType::TopLevel || mIsBrowserWindow ||
 +      !aXulWinType.EqualsLiteral("navigator:browser")) {
 +    return;
@@ -121,7 +144,7 @@ index 2efd02e4a92433fd29bbfdb707aa81cfec45031e..3b763c3927f07e529c826f8e4f62bc80
  void nsCocoaWindow::UpdateWindowDraggingRegion(
      const LayoutDeviceIntRegion& aRegion) {
    // mChildView returns YES from mouseDownCanMoveWindow, so we need to put
-@@ -4919,6 +5024,10 @@ - (BOOL)wantsBestResolutionOpenGLSurface {
+@@ -4919,6 +5047,10 @@ void nsCocoaWindow::DestroyNativeWindow() {
  nsCocoaWindow::~nsCocoaWindow() {
    NS_OBJC_BEGIN_TRY_IGNORE_BLOCK;
  
@@ -132,3 +155,50 @@ index 2efd02e4a92433fd29bbfdb707aa81cfec45031e..3b763c3927f07e529c826f8e4f62bc80
    RemoveAllChildren();
    if (mWindow && mWindowMadeHere) {
      CancelAllTransitions();
+@@ -8111,9 +8243,46 @@ static NSMutableSet* gSwizzledFrameViewClasses = nil;
+   mTouchBar = nil;
+   mIsAnimationSuppressed = NO;
+ 
++  // BaseWindow is an NSPanel (see nsCocoaWindow.h). Restore the two NSWindow
++  // defaults NSPanel changes, via the setters -- AppKit reads its own internal
++  // state, so getter overrides would not be honoured.
++  // nsCocoaWindow::DestroyNativeWindow() asserts releasedWhenClosed and relies
++  // on -close to release the window; Gecko manages visibility itself and must
++  // never have windows vanish when the app deactivates.
++  self.releasedWhenClosed = YES;
++  self.hidesOnDeactivate = NO;
++
+   return self;
+ }
+ 
++// NSPanel's -canBecomeMainWindow unconditionally returns NO, and NSWindow's own
++// implementation refuses any NSPanel-derived instance, so it cannot simply be
++// forwarded to. Re-state NSWindow's documented rule instead: visible, and has
++// a title bar or a resizable border. A non-activating panel must never become
++// main -- that is what keeps a click on it from pulling the user out of another
++// application's fullscreen Space.
++- (BOOL)canBecomeMainWindow {
++  if (self.styleMask & NSWindowStyleMaskNonactivatingPanel) {
++    return NO;
++  }
++  return self.isVisible && (self.styleMask & (NSWindowStyleMaskTitled |
++                                              NSWindowStyleMaskResizable)) != 0;
++}
++
++// NSPanel closes itself on Escape when nothing consumes the key. Gecko owns
++// Escape (ChildView consumes keyDown:), so make this a no-op for every window.
++- (void)cancel:(id)sender {
++}
++
++// NSPanel reports AXDialog / AXSystemDialog as its accessibility subrole;
++// keep VoiceOver announcing ordinary windows as windows.
++- (NSAccessibilitySubrole)accessibilitySubrole {
++  if (self.styleMask & NSWindowStyleMaskNonactivatingPanel) {
++    return NSAccessibilityFloatingWindowSubrole;
++  }
++  return NSAccessibilityStandardWindowSubrole;
++}
++
+ static CGFloat GetMenuCornerRadius() {
+   return nsCocoaFeatures::OnTahoeOrLater() ? 12.0f : 6.0f;
+ }


### PR DESCRIPTION
Refs #6555 (discussion — 43 upvotes, no fix until now).

**TL;DR:** on macOS the PiP player is hidden behind any other app's native-fullscreen
Space. Reparenting `BaseWindow` to `NSPanel` (pref-gated, PiP-only) fixes it; every
other window is unchanged. Video attached in the first comment.

Makes the macOS Picture-in-Picture player float above other applications'
native-fullscreen Spaces. It already floats over normal desktops — this fixes the
fullscreen case, which is the long-standing gap discussed in #6555 (43 upvotes).

**Pref-gated on `zen.widget.macos.pip-over-fullscreen.enabled`, and every window
that is not the PiP player is byte-for-byte unchanged.**

### Why it works

Measured on macOS 26.6 against a real fullscreen Space, using
`SLSFindWindowByGeometry` as a hit-test oracle:

| Window configuration | Floats over another app's fullscreen Space? |
|---|---|
| NSWindow, any level, CanJoinAllSpaces + FullScreenAuxiliary | no |
| **Real NSPanel + NSWindowStyleMaskNonactivatingPanel + CanJoinAllSpaces, no FullScreenPrimary** | **yes** |
| same, but FullScreenPrimary still present | no |
| NSPanel without the nonactivating bit | no |

Exactly two things are load-bearing: the window must be a genuine `NSPanel` so the
nonactivating style bit sticks, and it must not carry `FullScreenPrimary`. Window
**level is irrelevant** — the existing `NSFloatingWindowLevel` is sufficient.

This is also why Mozilla's 2023 attempt at the same bug
([D170673](https://phabricator.services.mozilla.com/D170673)) had no visible effect:
it overrode the `-styleMask` *getter* on a window that was not an `NSPanel`, and
AppKit silently strips the bit from any non-panel class. The reviewer applied it,
saw no change, asked "what am I missing here?", and the patch was abandoned.

### What changed

- **`nsCocoaWindow.h`** — `BaseWindow` reparented from `NSWindow` to `NSPanel`
  (a strict subclass).
- **`nsCocoaWindow.mm`** — the three defaults `NSPanel` changes are restored so all
  other windows behave exactly as before (`-isReleasedWhenClosed`,
  `-hidesOnDeactivate`, `-canBecomeMainWindow`); `-cancel:` becomes a no-op because
  an `NSPanel` closes itself on Escape and Gecko owns Escape; `-accessibilitySubrole`
  is pinned because an `NSPanel` otherwise reports `AXDialog` to VoiceOver. The PiP
  flag flip lives in the existing `nsCocoaWindow::SetWindowClass` hook.
- **`player.xhtml`** — `macnativefullscreen="false"`, so `SyncAttributesToWidget()`
  doesn't put `FullScreenPrimary` back after the flip.
- **`prefs/zen/macos.yaml`** — the static pref.

No new patch files, and no new upstream anchor lines: the diff anchors on Zen's own
`SetWindowClass` block and on the stable `@interface BaseWindow` line.

### Testing

macOS 26.6. The behaviour only reproduces against a real fullscreen Space, so
this is manual; `browser_test_fullscreen_size.js` shows the same environmental
failures with and without the patch (native fullscreen can't complete unfocused).

Verified on a local build of the same change:

- PiP floats over another application's native-fullscreen Space, and over Zen's
  own fullscreen.
- Clicking the PiP controls pauses/resumes playback **without** switching Spaces
  and without taking the menu bar away from the fullscreen app.
- Escape does not close the player; ⌘W, "back to tab" and keyboard controls
  behave as before.
- With the pref off, the old behaviour returns exactly — PiP is hidden behind
  the fullscreen app again.
- Daily-driven a patched release build with a real profile (extensions, mods,
  workspaces): main-window focus and traffic lights, ⌘Tab, popovers and context
  menus, compact mode and session restore all unchanged.
- `leakcheck`: no window leaks at shutdown — the check that matters for a
  base-class change.
- `npm run lint` clean; patches apply cleanly on a fresh `dev` import at
  Firefox 155.0.1, and the tree builds (`./mach build`, opt).
- Screen recording attached below: the player floats over another app's
  fullscreen Space with the pref on, and is hidden with it off. The window
  server agrees — the PiP panel reports `onscreen=1` with the pref on and
  `onscreen=false` with it off, while the fullscreen app is frontmost.

### Upstream

This is Mozilla [bug 1688932](https://bugzilla.mozilla.org/show_bug.cgi?id=1688932)
(NEW, unassigned, open since 2021). I've written it up there too, including why the
2023 patch didn't work.

If you'd rather not carry this in `src/widget/cocoa/`, I'm happy to move it to
`src/external-patches/firefox/` and track it as an upstream-pending patch — the same
way the native-popovers fix is handled — so the delta disappears once it lands in
Firefox. Just say which you prefer.
