### PR TITLE
gh-15260: fix essentials appearing during workspace creation

### DIFF
--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -434,7 +434,7 @@ class nsZenWorkspaces {
     if (
       this.activeWorkspace === this.creatingWorkspaceId ||
       (this.containerSpecificEssentials &&
-        this.getActiveWorkspaceFromCache()?.containerTabId != container)
+        this.getActiveWorkspaceFromCache()?.containerTabId + 0 != container)
     ) {
       essentialsContainer.setAttribute("hidden", "true");
     } else {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -432,8 +432,9 @@ class nsZenWorkspaces {
     // Set a hidden state if the essentials section is not supposed
     // to be shown on the current workspace, else remove the hidden state
     if (
-      this.containerSpecificEssentials &&
-      this.getActiveWorkspaceFromCache()?.containerTabId != container
+      this.activeWorkspace === this.creatingWorkspaceId ||
+      (this.containerSpecificEssentials &&
+        this.getActiveWorkspaceFromCache()?.containerTabId != container)
     ) {
       essentialsContainer.setAttribute("hidden", "true");
     } else {

--- a/src/zen/tests/container_essentials/browser_container_specific_essentials.js
+++ b/src/zen/tests/container_essentials/browser_container_specific_essentials.js
@@ -46,3 +46,38 @@ add_task(async function test_Check_Creation() {
 
   await gZenWorkspaces.removeWorkspace(newWorkspaceUUID);
 });
+
+add_task(async function test_Essentials_Hidden_Workspace_Creation() {
+  const originalWorkspace = gZenWorkspaces.getActiveWorkspace();
+
+  const essentialTab = BrowserTestUtils.addTab(gBrowser, "about:blank", {
+    skipAnimation: true,
+    userContextId: 0,
+  });
+  gZenPinnedTabManager.addToEssentials(essentialTab);
+  const essentialsContainer = essentialTab.parentNode;
+
+  await gZenWorkspaces.createAndSaveWorkspace(
+    "Empty Container Workspace",
+    undefined,
+    false,
+    1
+  );
+  const emptyWorkspace = gZenWorkspaces.getActiveWorkspace();
+
+  // The temporary creation workspace uses container 0, which previously
+  // caused the container 0 Essentials to reappear over the form.
+  await gZenWorkspaces.openWorkspaceCreation();
+
+  const creationForm = document.querySelector("zen-workspace-creation");
+  ok(creationForm, "Workspace creation form is shown");
+  ok(
+    BrowserTestUtils.isHidden(essentialsContainer),
+    "Essentials remain hidden while creating a workspace"
+  );
+
+  await creationForm.onCancelButtonCommand();
+  await gZenWorkspaces.changeWorkspace(originalWorkspace);
+  await gZenWorkspaces.removeWorkspace(emptyWorkspace.uuid);
+  await BrowserTestUtils.removeTab(essentialTab);
+});


### PR DESCRIPTION
when creating a new space, the temporary workspace would use container `0`, which could cause essentials from another space using the same container to appear over the creation form.

added small if check to make sure essentials stay hidden while the creation workspace is active.

demo showing workspace A having essentials then workspace B not, then creating space in workspace B hides essentials

https://github.com/user-attachments/assets/240b5639-8a15-4d57-9c65-5fa3b5601f33

closes #15260 