### PR TITLE
Show system screenshot folder in the downloads panel

### DIFF
--- a/docs/screenshot-folder.md
+++ b/docs/screenshot-folder.md
@@ -1,0 +1,50 @@
+# Screenshots in the downloads panel
+
+Open the downloads popup, select **Choose screenshots folder…**, and choose
+the folder where your operating system saves screenshots. The panel shows the
+ten most recently modified images in that folder. Drag a filename into a drop
+target, or select it to reveal the file in the system file manager.
+
+The folder is checked when the popup opens and every two seconds while it is
+open. Closed popups do no scanning. **Change folder…** selects another folder;
+**Disconnect** forgets the selection without touching the files.
+
+The selection is local to the browser profile and is not opted into Sync.
+This feature is disabled in private windows. It does not access the clipboard,
+upload images, decode previews, launch files, or add entries to download history.
+Existing downloads and their commands are unchanged.
+
+## File handling
+
+- Only direct children with PNG, JPEG, WebP, GIF, HEIC, TIFF, or BMP extensions
+  qualify. A selected folder may contain images other than screenshots; filenames
+  are not used to guess which application created them.
+- Hidden dotfiles, directories, symbolic links, empty files, and files modified
+  within the last second are excluded. The delay avoids common partial writes;
+  it is not a guarantee that another application has finished writing a file.
+- Scans reject folders with more than 2,000 entries and limit concurrent metadata
+  requests to 32. Use a dedicated, accessible screenshots folder.
+- Folder ancestors and the selected file are checked again at the drag/reveal
+  gesture. Native file drags permit copying only and supply no text or URL flavors.
+  As with other native path-based drags, an external application can still modify
+  a file after validation; this is not a snapshot or a sandbox for local programs.
+- File names are inserted as text, and errors do not log local paths. Disconnect,
+  folder changes, panel closure, and window teardown invalidate pending scans.
+
+## Validation
+
+With a built Zen development tree, run `npm test -- downloads` and `npm run lint`.
+Browser tests cover filtering, recency, ordering, the display limit, removed and
+rewritten files, out-of-folder paths, cancellation, live panel updates, native
+drag payloads, disconnect, and private windows.
+
+Before release, check on macOS, Windows, and Linux:
+
+1. Choose a screenshots folder, save a screenshot with the system shortcut,
+   and drag it from the popup into a web upload target and a native application.
+2. Change and disconnect the folder, cancel the chooser, and reopen the popup.
+   Confirm normal downloads still work and filenames remain keyboard accessible.
+3. Delete an image, replace it with a symlink, and replace the selected folder
+   or one of its ancestors with a symlink. Confirm no linked files can be dragged.
+4. Test inaccessible/missing folders, long filenames, private windows, multiple
+   normal windows, and closing the popup or window during a scan.

--- a/locales/en-US/browser/browser/zen-general.ftl
+++ b/locales/en-US/browser/browser/zen-general.ftl
@@ -166,3 +166,13 @@ zen-window-sync-migration-dialog-accept = Got It
 zen-appmenu-new-blank-window =
     .label = New Blank Window
 
+zen-screenshots-heading = Screenshots
+zen-screenshots-description = Choose your screenshots folder to show recent images here. Drag a file to share it, or select it to show it in its folder.
+zen-screenshots-choose-folder = Choose screenshots folder…
+zen-screenshots-change-folder = Change folder…
+zen-screenshots-disconnect = Disconnect
+zen-screenshots-picker-title = Choose your screenshots folder
+zen-screenshots-empty = No screenshots found. Recent images will appear here after they are saved.
+zen-screenshots-unavailable = This folder cannot be read. Choose an accessible screenshots folder with at most 2,000 items.
+zen-screenshots-file =
+    .title = Drag to share, or select to show in folder

--- a/prefs/zen/downloads.yaml
+++ b/prefs/zen/downloads.yaml
@@ -5,6 +5,10 @@
 - name: zen.downloads.download-animation
   value: true
 
+# Local-only, explicitly selected through the downloads panel. Empty disables it.
+- name: zen.downloads.screenshots.folder
+  value: ""
+
 - name: zen.downloads.download-animation-duration
   value: 1000 # ms
 

--- a/src/zen/common/ZenPreloadedScripts.js
+++ b/src/zen/common/ZenPreloadedScripts.js
@@ -28,6 +28,7 @@
     "chrome://browser/content/zen-components/ZenEmojiPicker.mjs",
     "chrome://browser/content/zen-components/ZenLiveFoldersUI.mjs",
     "chrome://browser/content/zen-components/ZenDownloadAnimation.mjs",
+    "chrome://browser/content/zen-components/ZenScreenshots.mjs",
     "resource:///modules/zen/share/ZenShareManager.mjs",
   ];
 

--- a/src/zen/downloads/ZenScreenshotFiles.mjs
+++ b/src/zen/downloads/ZenScreenshotFiles.mjs
@@ -1,0 +1,100 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+export const SCREENSHOT_FOLDER_PREF = "zen.downloads.screenshots.folder";
+const IMAGE_NAME = /^[^.].*\.(?:png|jpe?g|webp|gif|heic|tiff?|bmp)$/i;
+const MAX_CHILDREN = 2000;
+const MAX_VISIBLE = 10;
+
+function localFile(path) {
+  const file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
+  file.initWithPath(path);
+  return file;
+}
+
+// Check every ancestor as well as the leaf: replacing the selected directory
+// with a link must not grant access to a different directory on the next scan.
+export function screenshotDirectory(path) {
+  const directory = localFile(path);
+  for (let ancestor = directory; ancestor; ancestor = ancestor.parent) {
+    if (ancestor.isSymlink()) {
+      throw new Error("Screenshot folder contains a symbolic link");
+    }
+  }
+  if (!directory.isDirectory()) {
+    throw new Error("Screenshot folder is not a directory");
+  }
+  return directory;
+}
+
+// Revalidate at the user gesture, not just when the row was first displayed.
+// This returns only a native file for dragging/revealing; never a launch URL.
+export function screenshotFile(folder, path) {
+  const directory = screenshotDirectory(folder);
+  const file = localFile(path);
+  if (
+    !file.parent?.equals(directory) ||
+    !IMAGE_NAME.test(file.leafName) ||
+    file.isSymlink() ||
+    !file.isFile() ||
+    file.fileSize <= 0 ||
+    file.lastModifiedTime > Date.now() - 1000
+  ) {
+    throw new Error("Screenshot is unavailable");
+  }
+  return file;
+}
+
+export async function scanScreenshots(folder, isCurrent = () => true) {
+  screenshotDirectory(folder);
+  const children = await IOUtils.getChildren(folder);
+  // A screenshots folder should be small. Avoid thousands of outstanding I/O
+  // requests if a user accidentally selects a large general-purpose directory.
+  if (children.length > MAX_CHILDREN) {
+    throw new Error("Screenshot folder has too many entries");
+  }
+  const candidates = [];
+  const cutoff = Date.now() - 1000;
+  for (let offset = 0; offset < children.length; offset += 32) {
+    if (!isCurrent()) {
+      return [];
+    }
+    const batch = children
+      .slice(offset, offset + 32)
+      .filter((path) => IMAGE_NAME.test(PathUtils.filename(path)));
+    const results = await Promise.allSettled(
+      batch.map((path) => IOUtils.stat(path)),
+    );
+    for (let index = 0; index < results.length; index++) {
+      const result = results[index];
+      if (
+        result.status === "fulfilled" &&
+        result.value.type === "regular" &&
+        result.value.size > 0 &&
+        result.value.lastModified <= cutoff
+      ) {
+        candidates.push({ ...result.value, path: batch[index] });
+      }
+    }
+  }
+  candidates.sort(
+    (a, b) => b.lastModified - a.lastModified || a.path.localeCompare(b.path),
+  );
+  const files = [];
+  for (const candidate of candidates) {
+    if (!isCurrent()) {
+      return [];
+    }
+    try {
+      screenshotFile(folder, candidate.path);
+      files.push(candidate);
+      if (files.length === MAX_VISIBLE) {
+        break;
+      }
+    } catch {
+      // A file can disappear or become a link between enumeration and stat.
+    }
+  }
+  return files;
+}

--- a/src/zen/downloads/ZenScreenshots.mjs
+++ b/src/zen/downloads/ZenScreenshots.mjs
@@ -1,0 +1,263 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { nsZenDOMOperatedFeature } from "chrome://browser/content/zen-components/ZenCommonUtils.mjs";
+import {
+  SCREENSHOT_FOLDER_PREF,
+  scanScreenshots,
+  screenshotDirectory,
+  screenshotFile,
+} from "chrome://browser/content/zen-components/ZenScreenshotFiles.mjs";
+
+export class ZenScreenshots extends nsZenDOMOperatedFeature {
+  #section;
+  #rows;
+  #status;
+  #choose;
+  #disconnect;
+  #timer;
+  #generation = 0;
+  #open = false;
+  #destroyed = false;
+  #choosing = false;
+  #signature = "";
+  #dragging = false;
+
+  init() {
+    if (PrivateBrowsingUtils.isWindowPrivate(window)) {
+      return;
+    }
+    document.addEventListener("popupshowing", this);
+    document.addEventListener("popuphidden", this);
+    window.addEventListener("unload", this, { once: true });
+    Services.prefs.addObserver(SCREENSHOT_FOLDER_PREF, this);
+  }
+
+  handleEvent(event) {
+    if (event.type === "unload") {
+      this.#destroyed = true;
+      this.#stop();
+      Services.prefs.removeObserver(SCREENSHOT_FOLDER_PREF, this);
+      document.removeEventListener("popupshowing", this);
+      document.removeEventListener("popuphidden", this);
+    } else if (event.target.id === "downloadsPanel") {
+      if (event.type === "popupshowing") {
+        this.#createSection();
+        this.#open = true;
+        this.#refresh();
+      } else {
+        this.#open = false;
+        this.#stop();
+        this.#rows.replaceChildren();
+        this.#signature = "";
+        this.#dragging = false;
+      }
+    }
+  }
+
+  observe() {
+    this.#stop();
+    this.#rows?.replaceChildren();
+    this.#signature = "";
+    if (this.#open) {
+      this.#refresh();
+    }
+  }
+
+  #stop() {
+    this.#generation++;
+    window.clearTimeout(this.#timer);
+  }
+
+  #createSection() {
+    if (this.#section) {
+      return;
+    }
+    const style = document.createElement("link");
+    style.rel = "stylesheet";
+    style.href = "chrome://browser/content/zen-styles/zen-screenshots.css";
+    document.documentElement.appendChild(style);
+    this.#section = document.createElement("section");
+    this.#section.id = "zen-screenshots";
+    this.#section.setAttribute("aria-labelledby", "zen-screenshots-heading");
+    const heading = document.createElement("h2");
+    heading.id = "zen-screenshots-heading";
+    document.l10n.setAttributes(heading, "zen-screenshots-heading");
+    this.#status = document.createElement("p");
+    this.#status.setAttribute("role", "status");
+    this.#rows = document.createElement("div");
+    this.#rows.id = "zen-screenshots-files";
+    const controls = document.createElement("div");
+    controls.className = "zen-screenshots-controls";
+    this.#choose = document.createElement("button");
+    this.#choose.type = "button";
+    this.#choose.addEventListener("click", (event) => {
+      if (event.isTrusted) {
+        this.#chooseFolder();
+      }
+    });
+    this.#disconnect = document.createElement("button");
+    this.#disconnect.type = "button";
+    document.l10n.setAttributes(this.#disconnect, "zen-screenshots-disconnect");
+    this.#disconnect.addEventListener("click", (event) => {
+      if (event.isTrusted) {
+        Services.prefs.clearUserPref(SCREENSHOT_FOLDER_PREF);
+      }
+    });
+    controls.append(this.#choose, this.#disconnect);
+    this.#section.append(heading, this.#status, this.#rows, controls);
+    // Keep these files outside DownloadsView and all of its commands/history.
+    document.getElementById("downloadsFooter").before(this.#section);
+    this.#section.addEventListener("keydown", (event) => {
+      if (event.key !== "Escape" && event.key !== "Tab") {
+        event.stopPropagation();
+      }
+    });
+    this.#section.addEventListener("dragend", () => {
+      this.#dragging = false;
+    });
+  }
+
+  async #chooseFolder() {
+    if (this.#choosing) {
+      return;
+    }
+    this.#choosing = true;
+    try {
+      const title = await document.l10n.formatValue(
+        "zen-screenshots-picker-title",
+      );
+      if (this.#destroyed) {
+        return;
+      }
+      const picker = Cc["@mozilla.org/filepicker;1"].createInstance(
+        Ci.nsIFilePicker,
+      );
+      picker.init(
+        window.browsingContext,
+        title,
+        Ci.nsIFilePicker.modeGetFolder,
+      );
+      const result = await new Promise((resolve) => picker.open(resolve));
+      if (this.#destroyed || result !== Ci.nsIFilePicker.returnOK) {
+        return;
+      }
+      const folder = picker.file;
+      folder.normalize();
+      screenshotDirectory(folder.path);
+      Services.prefs.setStringPref(SCREENSHOT_FOLDER_PREF, folder.path);
+    } catch {
+      if (!this.#destroyed) {
+        this.#setStatus("zen-screenshots-unavailable");
+      }
+    } finally {
+      this.#choosing = false;
+    }
+  }
+
+  #setStatus(id) {
+    this.#status.hidden = !id;
+    if (id) {
+      document.l10n.setAttributes(this.#status, id);
+    }
+  }
+
+  async #refresh() {
+    this.#stop();
+    const generation = this.#generation;
+    const isCurrent = () =>
+      !this.#destroyed && this.#open && generation === this.#generation;
+    const folder = Services.prefs.getStringPref(SCREENSHOT_FOLDER_PREF, "");
+    document.l10n.setAttributes(
+      this.#choose,
+      folder
+        ? "zen-screenshots-change-folder"
+        : "zen-screenshots-choose-folder",
+    );
+    this.#disconnect.hidden = !folder;
+    if (!folder) {
+      this.#rows.replaceChildren();
+      this.#setStatus("zen-screenshots-description");
+      return;
+    }
+    try {
+      const files = await scanScreenshots(folder, isCurrent);
+      if (!isCurrent()) {
+        return;
+      }
+      this.#setStatus(files.length ? "" : "zen-screenshots-empty");
+      const signature = JSON.stringify(
+        files.map((file) => [file.path, file.size, file.lastModified]),
+      );
+      if (signature !== this.#signature && !this.#dragging) {
+        const focusedPath = document.activeElement?.dataset.screenshotPath;
+        const rows = files.map((info) => this.#createRow(folder, info));
+        this.#rows.replaceChildren(...rows);
+        this.#signature = signature;
+        if (focusedPath) {
+          (
+            rows.find((row) => row.dataset.screenshotPath === focusedPath) ||
+            this.#choose
+          ).focus();
+        }
+      }
+    } catch {
+      if (!isCurrent()) {
+        return;
+      }
+      this.#rows.replaceChildren();
+      this.#signature = "";
+      this.#setStatus("zen-screenshots-unavailable");
+    }
+    if (isCurrent()) {
+      this.#timer = window.setTimeout(() => this.#refresh(), 2000);
+    }
+  }
+
+  #createRow(folder, info) {
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = "zen-screenshot-file";
+    row.draggable = true;
+    row.dataset.screenshotPath = info.path;
+    // Filenames are untrusted text, never markup, URLs, or image previews.
+    row.textContent = PathUtils.filename(info.path);
+    document.l10n.setAttributes(row, "zen-screenshots-file");
+    const getFile = () => {
+      if (folder !== Services.prefs.getStringPref(SCREENSHOT_FOLDER_PREF, "")) {
+        throw new Error("Screenshot folder changed");
+      }
+      return screenshotFile(folder, info.path);
+    };
+    row.addEventListener("click", (event) => {
+      if (!event.isTrusted) {
+        return;
+      }
+      try {
+        getFile().reveal();
+      } catch {
+        this.#refresh();
+      }
+    });
+    row.addEventListener("dragstart", (event) => {
+      event.stopPropagation();
+      if (!event.isTrusted) {
+        event.preventDefault();
+        return;
+      }
+      try {
+        const file = getFile();
+        event.dataTransfer.mozSetDataAt("application/x-moz-file", file, 0);
+        event.dataTransfer.effectAllowed = "copy";
+        this.#dragging = true;
+      } catch {
+        event.preventDefault();
+        this.#refresh();
+      }
+    });
+    return row;
+  }
+}
+
+new ZenScreenshots();

--- a/src/zen/downloads/jar.inc.mn
+++ b/src/zen/downloads/jar.inc.mn
@@ -3,5 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
         content/browser/zen-components/ZenDownloadAnimation.mjs                 (../../zen/downloads/ZenDownloadAnimation.mjs)
+        content/browser/zen-components/ZenScreenshots.mjs                       (../../zen/downloads/ZenScreenshots.mjs)
+        content/browser/zen-components/ZenScreenshotFiles.mjs                   (../../zen/downloads/ZenScreenshotFiles.mjs)
+        content/browser/zen-styles/zen-screenshots.css                          (../../zen/downloads/zen-screenshots.css)
         content/browser/zen-styles/zen-download-arc-animation.css               (../../zen/downloads/zen-download-arc-animation.css)
         content/browser/zen-styles/zen-download-box-animation.css               (../../zen/downloads/zen-download-box-animation.css)

--- a/src/zen/downloads/zen-screenshots.css
+++ b/src/zen/downloads/zen-screenshots.css
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#zen-screenshots {
+  border-block-start: 1px solid var(--panel-separator-color);
+  padding: 8px 12px;
+  min-width: 0;
+  max-width: 34em;
+  box-sizing: border-box;
+
+  h2 {
+    font-size: 1em;
+    margin: 0 0 8px;
+  }
+
+  p {
+    max-width: 32em;
+    margin: 0 0 8px;
+  }
+
+  button {
+    color: inherit;
+    font: inherit;
+    border: 1px solid transparent;
+    border-radius: var(--border-radius-small);
+    padding: 6px 8px;
+    background: transparent;
+
+    &:hover {
+      background: var(--button-background-color-hover);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--focus-outline-color);
+      outline-offset: -2px;
+    }
+  }
+}
+
+#zen-screenshots-files {
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.zen-screenshot-file {
+  display: block;
+  width: 100%;
+  text-align: start;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: grab;
+}
+
+.zen-screenshots-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}

--- a/src/zen/tests/downloads/browser.toml
+++ b/src/zen/tests/downloads/browser.toml
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+[DEFAULT]
+
+["browser_screenshot_files.js"]
+
+["browser_screenshot_panel.js"]

--- a/src/zen/tests/downloads/browser_screenshot_files.js
+++ b/src/zen/tests/downloads/browser_screenshot_files.js
@@ -1,0 +1,126 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { scanScreenshots, screenshotFile } = ChromeUtils.importESModule(
+  "chrome://browser/content/zen-components/ZenScreenshotFiles.mjs",
+  { global: "current" },
+);
+
+async function screenshotTestFolder() {
+  const folder = await IOUtils.createUniqueDirectory(
+    PathUtils.tempDir,
+    "zen-screenshots-test",
+  );
+  registerCleanupFunction(() => IOUtils.remove(folder, { recursive: true }));
+  const directory = await IOUtils.getDirectory(folder);
+  directory.normalize();
+  return directory.path;
+}
+
+async function writeScreenshot(folder, name, age = 5000) {
+  const path = PathUtils.join(folder, name);
+  await IOUtils.writeUTF8(path, "test fixture; never decoded or launched");
+  await IOUtils.setModificationTime(path, Date.now() - age);
+  return path;
+}
+
+add_task(async function test_filter_sort_limit_and_removal() {
+  const folder = await screenshotTestFolder();
+  for (let index = 0; index < 12; index++) {
+    await writeScreenshot(
+      folder,
+      `Screenshot ${index}.png`,
+      5000 + index * 1000,
+    );
+  }
+  await writeScreenshot(folder, "not-an-image.html");
+  await writeScreenshot(folder, "image.png.exe");
+  await writeScreenshot(folder, ".hidden.png");
+  await writeScreenshot(folder, "active.png", 0);
+  await IOUtils.writeUTF8(PathUtils.join(folder, "empty.png"), "");
+  await IOUtils.makeDirectory(PathUtils.join(folder, "subdirectory.png"));
+  await writeScreenshot(
+    PathUtils.join(folder, "subdirectory.png"),
+    "nested.png",
+  );
+
+  const files = await scanScreenshots(folder);
+  Assert.equal(
+    files.length,
+    10,
+    "Only the ten newest eligible files are shown",
+  );
+  Assert.equal(
+    PathUtils.filename(files[0].path),
+    "Screenshot 0.png",
+    "Newest first",
+  );
+  Assert.equal(
+    PathUtils.filename(files[9].path),
+    "Screenshot 9.png",
+    "Old files stay out of the panel",
+  );
+  await IOUtils.remove(files[0].path);
+  Assert.throws(
+    () => screenshotFile(folder, files[0].path),
+    /./,
+    "Deleted files cannot be dragged",
+  );
+  Assert.equal(
+    (await scanScreenshots(folder))[0].path,
+    files[1].path,
+    "Deleted rows disappear",
+  );
+});
+
+add_task(async function test_outside_paths_and_changed_files() {
+  const folder = await screenshotTestFolder();
+  const outside = await screenshotTestFolder();
+  const outsidePath = await writeScreenshot(outside, "outside.png");
+  Assert.throws(
+    () => screenshotFile(folder, outsidePath),
+    /./,
+    "Sibling folders are out of scope",
+  );
+  const path = await writeScreenshot(folder, "safe.PNG");
+  Assert.equal(
+    screenshotFile(folder, path).path,
+    path,
+    "Mixed case image extension is accepted",
+  );
+  await IOUtils.setModificationTime(path, Date.now());
+  Assert.throws(
+    () => screenshotFile(folder, path),
+    /./,
+    "A file being rewritten cannot be dragged",
+  );
+  await IOUtils.remove(path);
+  await IOUtils.makeDirectory(path);
+  Assert.throws(
+    () => screenshotFile(folder, path),
+    /./,
+    "Replacing an image with a directory is rejected",
+  );
+});
+
+add_task(async function test_unavailable_and_cancelled_scan() {
+  const folder = await screenshotTestFolder();
+  await writeScreenshot(folder, "Screenshot.png");
+  Assert.deepEqual(
+    await scanScreenshots(folder, () => false),
+    [],
+    "Cancelled scans yield no files",
+  );
+  await Assert.rejects(
+    scanScreenshots(PathUtils.join(folder, "missing")),
+    /./,
+    "Missing folders fail closed",
+  );
+  await Assert.rejects(
+    scanScreenshots(PathUtils.join(folder, "Screenshot.png")),
+    /./,
+    "A regular file is not a watch folder",
+  );
+});

--- a/src/zen/tests/downloads/browser_screenshot_panel.js
+++ b/src/zen/tests/downloads/browser_screenshot_panel.js
@@ -1,0 +1,95 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_panel_refresh_and_disconnect() {
+  const pref = "zen.downloads.screenshots.folder";
+  const temporaryFolder = await IOUtils.createUniqueDirectory(
+    PathUtils.tempDir,
+    "zen-screenshot-panel",
+  );
+  const directory = await IOUtils.getDirectory(temporaryFolder);
+  directory.normalize();
+  const folder = directory.path;
+  await SpecialPowers.pushPrefEnv({ set: [[pref, folder]] });
+  registerCleanupFunction(async () => {
+    DownloadsPanel.hidePanel();
+    await IOUtils.remove(folder, { recursive: true });
+  });
+  DownloadsPanel.showPanel();
+  await TestUtils.waitForCondition(
+    () => document.getElementById("zen-screenshots"),
+    "Screenshot section is attached",
+  );
+  const path = PathUtils.join(folder, "Screenshot.png");
+  await IOUtils.writeUTF8(path, "test fixture");
+  await IOUtils.setModificationTime(path, Date.now() - 5000);
+  await TestUtils.waitForCondition(
+    () => document.querySelector(".zen-screenshot-file"),
+    "New screenshots appear while the popup is open",
+  );
+  const row = document.querySelector(".zen-screenshot-file");
+  Assert.equal(row.textContent, "Screenshot.png", "Filename is plain text");
+  Assert.ok(row.draggable, "Screenshot supports native drag");
+  const drag = new DragEvent("dragstart", {
+    bubbles: true,
+    cancelable: true,
+    dataTransfer: new DataTransfer(),
+  });
+  row.dispatchEvent(drag);
+  // Events constructed with the system principal are trusted in Gecko.
+  Assert.equal(
+    drag.dataTransfer
+      .mozGetDataAt("application/x-moz-file", 0)
+      .QueryInterface(Ci.nsIFile).path,
+    path,
+    "Trusted drags carry the selected native file",
+  );
+  Assert.equal(
+    drag.dataTransfer.effectAllowed,
+    "copy",
+    "Dragging never moves the original",
+  );
+  await IOUtils.remove(path);
+  const stale = new DragEvent("dragstart", {
+    bubbles: true,
+    cancelable: true,
+    dataTransfer: new DataTransfer(),
+  });
+  row.dispatchEvent(stale);
+  Assert.ok(
+    stale.defaultPrevented,
+    "Dragging a deleted screenshot is cancelled",
+  );
+  Assert.equal(
+    stale.dataTransfer.types.length,
+    0,
+    "Deleted files cannot be exported",
+  );
+  Services.prefs.setStringPref(pref, "");
+  Assert.equal(
+    document.querySelectorAll(".zen-screenshot-file").length,
+    0,
+    "Disconnect clears rows immediately",
+  );
+});
+
+add_task(async function test_private_window_has_no_screenshot_section() {
+  const privateWindow = await BrowserTestUtils.openNewBrowserWindow({
+    private: true,
+  });
+  try {
+    privateWindow.DownloadsPanel.showPanel();
+    await TestUtils.waitForCondition(
+      () => privateWindow.DownloadsPanel.panel.state === "open",
+      "Private downloads popup is open",
+    );
+    Assert.ok(
+      !privateWindow.document.getElementById("zen-screenshots"),
+      "Private windows do not expose the screenshot folder",
+    );
+  } finally {
+    await BrowserTestUtils.closeWindow(privateWindow);
+  }
+});

--- a/src/zen/tests/moz.build
+++ b/src/zen/tests/moz.build
@@ -6,6 +6,7 @@ BROWSER_CHROME_MANIFESTS += [
     "boosts/browser.toml",
     "compact_mode/browser.toml",
     "container_essentials/browser.toml",
+    "downloads/browser.toml",
     "folders/browser.toml",
     "glance/browser.toml",
     "live-folders/browser.toml",


### PR DESCRIPTION
Adds a Screenshots section to the downloads popup that defaults to the operating system's screenshot folder. Users can drag recent image files directly from the popup or select a filename to reveal it in the file manager, with no initial folder picker when discovery succeeds.

The section shows the ten newest eligible images, refreshes on opening and every two seconds while open, and offers Change folder, Use system folder, and Disconnect controls. On macOS, discovery reads the screenshot preference with Gecko's plist reader (bounded to 1 MiB), expands `~/` paths, and uses Desktop if no location is configured. Other platforms use Gecko's screenshot-directory provider when available; otherwise the chooser remains available rather than guessing another folder. It reads only direct children; there is no clipboard integration or background polling while the popup is closed.

### Privacy and file handling

- Excluded from private windows. Automatic discovery does not persist a path; custom overrides and disconnect are local to the profile and are not opted into Sync. Disconnect persists across restarts; Use system folder removes the override. The default preference is `system` so an explicitly empty override is preserved by Firefox.
- Does not create download records, change download commands, upload files, decode previews, or launch files. Names are rendered as text and errors do not log paths.
- Rejects symbolic links in files and folder ancestors, directories, dotfiles, empty files, and files modified within the last second. Rechecks files at drag/reveal time. Native drag payloads contain only `application/x-moz-file` and permit copying only.
- Invalidates pending results on folder changes, disconnect, popup closure, and window unload. Scans cap directories at 2,000 entries and metadata concurrency at 32.
- A native path-based drag cannot prevent another local application from replacing the file after validation; this does not claim snapshot semantics or a security boundary against local programs.

### Validation

- Added browser-chrome tests registered under `zen/tests/downloads` for system-default/custom/disconnected precedence, filtering, ordering/limits, changed/deleted files, out-of-folder paths, cancellation, popup refresh, native drag payloads, disconnect, and private-window exclusion.
- Executed the file tests and additional integration checks by loading the source modules into an isolated temporary profile of installed Zen 1.21.16b (Firefox 154.0.1) on macOS. Passed live refresh, native copy-only drag payload, rejection of deleted files and nonempty file/folder symlinks, immediate disconnect clearing, and private-window exclusion.
- Repackaged a separate local test copy and verified automatic module loading, localization, actual macOS screenshot-location discovery with a `~/` setting, custom override, restoring the system folder, and disconnect persistence after a browser restart. The test installation and profiles are local artifacts, not part of this PR.
- JavaScript syntax, repository-provided Prettier, and `git diff --check` pass. No dependencies or lockfiles changed.
- **Not yet validated:** a full build of this `dev` revision (Firefox 155.0.1), the full `mach` browser-chrome harness, upstream lint, Windows/Linux, and end-to-end OS drags into web/native targets. Local `npm run lint` cannot run without the downloaded Firefox engine. This PR is a draft pending those checks and maintainer review.

Usage, behavior limits, and a manual release checklist are in `docs/screenshot-folder.md`.
