### PR TITLE
gh-14938: fix continue where you left off for only pinned/essential tabs

### DIFF
--- a/src/browser/components/sessionstore/SessionStore-sys-mjs.patch
+++ b/src/browser/components/sessionstore/SessionStore-sys-mjs.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/sessionstore/SessionStore.sys.mjs b/browser/components/sessionstore/SessionStore.sys.mjs
-index 76a984f6e21409941ea038218d161e67f2e0c23d..845080748b018130506848104c83632d57fdffe6 100644
+index 76a984f6e21409941ea038218d161e67f2e0c23d..52408568a33a89c0e3d0d1514152ded2eaa1afed 100644
 --- a/browser/components/sessionstore/SessionStore.sys.mjs
 +++ b/browser/components/sessionstore/SessionStore.sys.mjs
 @@ -126,6 +126,11 @@ const TAB_EVENTS = [
@@ -334,7 +334,14 @@ index 76a984f6e21409941ea038218d161e67f2e0c23d..845080748b018130506848104c83632d
  
      let promiseParts = Promise.withResolvers();
      aWindow.setTimeout(() => {
-@@ -7654,7 +7717,7 @@ var SessionStoreInternal = {
+@@ -7356,5 +7419,6 @@ var SessionStoreInternal = {
+    */
+   _isCmdLineEmpty: function ssi_isCmdLineEmpty(aWindow, aState) {
+     var pinnedOnly =
++      !Services.prefs.getBoolPref("zen.workspaces.continue-where-left-off") &&
+       aState.windows &&
+       aState.windows.every(win => win.tabs.every(tab => tab.pinned));
+@@ -7654,7 +7718,7 @@ var SessionStoreInternal = {
  
        let groupsToSave = new Map();
        for (let tIndex = 0; tIndex < window.tabs.length; ) {
@@ -343,7 +350,7 @@ index 76a984f6e21409941ea038218d161e67f2e0c23d..845080748b018130506848104c83632d
            // Adjust window.selected
            if (tIndex + 1 < window.selected) {
              window.selected -= 1;
-@@ -7669,7 +7732,7 @@ var SessionStoreInternal = {
+@@ -7669,7 +7733,7 @@ var SessionStoreInternal = {
            );
            // We don't want to increment tIndex here.
            continue;
@@ -352,7 +359,7 @@ index 76a984f6e21409941ea038218d161e67f2e0c23d..845080748b018130506848104c83632d
            // Convert any open groups into saved groups.
            let groupStateToSave = window.groups.find(
              groupState => groupState.id == window.tabs[tIndex].groupId
-@@ -8233,7 +8296,6 @@ var SessionStoreInternal = {
+@@ -8233,7 +8297,6 @@ var SessionStoreInternal = {
      timer.initWithCallback(
        function () {
          if (beats <= 0) {
@@ -360,7 +367,7 @@ index 76a984f6e21409941ea038218d161e67f2e0c23d..845080748b018130506848104c83632d
            Glean.sessionRestore.shutdownFlushAllOutcomes.timed_out.add(1);
            deferred.resolve();
          }
-@@ -8711,6 +8773,7 @@ var SessionStoreInternal = {
+@@ -8711,6 +8774,7 @@ var SessionStoreInternal = {
      if (
        !savedTabGroupState.tabs.length ||
        this.getSavedTabGroup(savedTabGroupState.id)


### PR DESCRIPTION
fixes CWYLO selecting an empty new tab when the session only contains pinned or essential tabs. when CWYLO is enabled, these sessions now follow the normal restoration path so the previously active pinned/essential tab is selected.

BEFORE demo showing that CWYLO doesn't properly go back to a pinned or essentials tab with no other normal tab open:

https://github.com/user-attachments/assets/e815bdd3-cf9e-483f-a946-e19eac339860

AFTER: demo showing same setup properly goes back to the pinned or essentials tab with no other normal tab open:

https://github.com/user-attachments/assets/17f1b6ea-4a73-489c-955f-6cb4237db30b

related to #14938 