### PR TITLE
gh-15280: respect theme colors in styled status panel

### DIFF
--- a/src/zen/common/styles/zen-single-components.css
+++ b/src/zen/common/styles/zen-single-components.css
@@ -273,8 +273,14 @@
       border: 1px solid rgba(225, 225, 225, 0.15) !important;
       padding: 4px 8px 5px 8px !important;
       font-weight: 600 !important;
-      background: color-mix(in srgb, var(--zen-primary-color), black 70%) !important;
-      color: rgba(255, 255, 255, 0.8) !important;
+      background: light-dark(
+        var(--zen-colors-tertiary),
+        color-mix(in srgb, var(--zen-primary-color), black 70%)
+      ) !important;
+      color: light-dark(
+        var(--zen-colors-primary-foreground),
+        rgba(255, 255, 255, 0.8)
+      ) !important;
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #15280.

The styled status panel was using hard-coded dark-theme colors, which caused it to appear dark even when a light theme was active.

This change makes the status panel theme-aware:

- Light themes use Zen's existing light theme colors.
- Dark themes retain the existing dark appearance.
- Uses existing Zen theme variables rather than introducing new colors.

## Testing

- `git diff --check` passes.
- Verified the change is limited to the styled status panel CSS.