### PR TITLE
gh-15341: Show colored macOS traffic lights when the window is focused

### DIFF
--- a/src/zen/common/styles/zen-browser-ui.css
+++ b/src/zen/common/styles/zen-browser-ui.css
@@ -210,7 +210,9 @@ body,
 
   /* stylelint-disable-next-line media-query-no-invalid */
   @media -moz-pref("zen.widget.mac.mono-window-controls") {
-    :root:not([window-modal-open="true"]) .titlebar-buttonbox-container {
+    /* Inactive: mono gray placeholders until hover reveals native buttons */
+    :root:not([window-modal-open="true"]):-moz-window-inactive
+      .titlebar-buttonbox-container {
       color: var(--toolbox-textcolor);
 
       --zen-traffic-light-size: 6px;
@@ -232,6 +234,16 @@ body,
 
       &:not([zen-has-hover="true"]) > .titlebar-buttonbox {
         opacity: 0;
+      }
+    }
+
+    /* Active: always show native colored traffic lights */
+    :root:not([window-modal-open="true"]):not(:-moz-window-inactive)
+      .titlebar-buttonbox-container {
+      background-image: none;
+
+      & > .titlebar-buttonbox {
+        opacity: 1;
       }
     }
   }


### PR DESCRIPTION
## Summary
- Scope `zen.widget.mac.mono-window-controls` gray placeholders to `:-moz-window-inactive` only
- Keep native red/yellow/green traffic lights visible whenever the window is focused (no hover required)

fixes #15341

## Test plan
- [x] Static CSS: inactive mono rules gated on `:-moz-window-inactive` (gray radial-gradient + `opacity: 0` without hover)
- [x] Static CSS: active window (`:not(:-moz-window-inactive)`) forces `opacity: 1` and `background-image: none`
- [x] Static CSS: unconditional always-gray selector removed; still wrapped in `zen.widget.mac.mono-window-controls` pref
- [x] Static CSS: pref-off path unchanged (entire block remains behind the pref media query)
- [ ] Manual macOS: with pref `true`, focus Zen → traffic lights colored immediately (needs local build with this patch)
- [ ] Manual macOS: unfocus Zen → mono gray placeholders return
- [ ] Manual macOS: hover inactive controls still reveals button glyphs
- [ ] Manual macOS: pref `false` → always native colors (unchanged)

> Note: No local `engine/` build was available, so visual macOS QA could not be run against this patch. Static selector/property checks above all passed (8/8).