### PR TITLE
gh-15355: Fix folder unload TypeError by using String.includes

### DIFF
--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -356,7 +356,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
         alwaysUnload &&
         ["close", "reset", "switch", "reset-switch"].includes(behavior)
       ) {
-        behavior = behavior.contains("reset")
+        behavior = behavior.includes("reset")
           ? "reset-unload-switch"
           : "unload-switch";
       }


### PR DESCRIPTION
## Summary
- Replace invalid `String.prototype.contains` with `String.prototype.includes` in pinned-tab close/unload behavior remapping.
- Fixes a TypeError that breaks folder unload when `alwaysUnload` remaps `close`/`reset`/`switch`/`reset-switch` preferences.

## Test plan
- [ ] Set `zen.pinned-tab-manager.close-shortcut-behavior` to `switch` (or `close` / `reset` / `reset-switch`)
- [ ] Create a folder with active tabs and use unload-all / close folder unload path
- [ ] Confirm no TypeError in browser console and tabs unload as expected
- [ ] Repeat with default `reset-unload-switch` to ensure no regression