### PR TITLE
Add draft filtering and repository labels to GitHub PR live folders

### DIFF
--- a/locales/en-US/browser/browser/zen-live-folders.ftl
+++ b/locales/en-US/browser/browser/zen-live-folders.ftl
@@ -20,6 +20,9 @@ zen-live-folder-github-option-assigned-self =
 zen-live-folder-github-option-review-requested =
     .label = Review Requests
 
+zen-live-folder-github-option-include-drafts =
+    .label = Include Draft Pull Requests
+
 zen-live-folder-type-rss =
     .label = RSS Feed
 

--- a/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
@@ -253,6 +253,13 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
       "sort:updated-desc",
     ];
 
+    if (
+      this.state.type === "pull-requests" &&
+      !(this.state.options.includeDrafts ?? true)
+    ) {
+      baseQuery.push("draft:false");
+    }
+
     const options = [
       {
         value: "author:@me",
@@ -334,6 +341,12 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
         l10nId: "zen-live-folder-github-option-review-requested",
         key: "reviewRequested",
         checked: this.state.options.reviewRequested ?? false,
+        hidden: this.state.type === "issues",
+      },
+      {
+        l10nId: "zen-live-folder-github-option-include-drafts",
+        key: "includeDrafts",
+        checked: this.state.options.includeDrafts ?? true,
         hidden: this.state.type === "issues",
       },
       { type: "separator" },

--- a/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
@@ -347,7 +347,7 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
         l10nId: "zen-live-folder-github-option-include-drafts",
         key: "includeDrafts",
         checked: this.state.options.includeDrafts ?? true,
-        hidden: this.state.type === "issues",
+        hidden: this.state.type !== "pull-requests",
       },
       { type: "separator" },
       {

--- a/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
@@ -135,7 +135,7 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
         items.push({
           id: `${pr.repoNameWithOwner}#${pr.number}`,
           title: pr.title,
-          subtitle: pr.author.displayLogin,
+          subtitle: `${pr.author.displayLogin} • ${pr.repoNameWithOwner}`,
           icon: "chrome://browser/content/zen-images/favicons/github.svg",
           url: pr.permalink,
         });
@@ -173,7 +173,7 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
 
         items.push({
           title,
-          subtitle: author,
+          subtitle: `${author} • ${repo}`,
           icon: "chrome://browser/content/zen-images/favicons/github.svg",
           url: new URL(titles[i].href, this.state.url),
           id: `${repo}${idMatch}`,

--- a/src/zen/tests/live-folders/browser_github_live_folder.js
+++ b/src/zen/tests/live-folders/browser_github_live_folder.js
@@ -76,6 +76,10 @@ add_task(async function test_fetch_items_url_construction() {
     !query.includes("review-requested:@me"),
     "Should NOT include review-requested"
   );
+  Assert.ok(
+    !query.includes("draft:false"),
+    "Should include draft pull requests by default"
+  );
 
   sandbox.restore();
 });
@@ -88,6 +92,7 @@ add_task(async function test_fetch_items_url_complex_options() {
   let instance = getGithubProviderForTest(sandbox, {
     authorMe: true,
     assignedMe: true,
+    includeDrafts: false,
     reviewRequested: true,
   });
 
@@ -106,6 +111,10 @@ add_task(async function test_fetch_items_url_complex_options() {
   Assert.ok(
     query.includes("review-requested:@me"),
     "Should include review-requested"
+  );
+  Assert.ok(
+    query.includes("draft:false"),
+    "Should exclude draft pull requests"
   );
 
   Assert.ok(query.includes(" OR "), "Should contain OR operators");

--- a/src/zen/tests/live-folders/browser_github_live_folder.js
+++ b/src/zen/tests/live-folders/browser_github_live_folder.js
@@ -306,7 +306,7 @@ add_task(async function test_pull_requests_json_api_parsing() {
   Assert.equal(items.length, 2, "Should parse two PRs from the JSON payload");
   Assert.equal(items[0].id, "zen-browser/desktop#42");
   Assert.equal(items[0].title, "Add live folders");
-  Assert.equal(items[0].subtitle, "alice");
+  Assert.equal(items[0].subtitle, "alice • zen-browser/desktop");
   Assert.equal(items[0].url, "https://github.com/zen-browser/desktop/pull/42");
   Assert.equal(items[1].id, "zen-browser/desktop#43");
   Assert.ok(


### PR DESCRIPTION
## Summary

- add an option to include or exclude draft pull requests
- limit the draft option and query filter to Pull Request live folders
- show each pull request repository beside its author in the tab subtitle

## Testing

- Updated the existing GitHub live-folder parser assertions
- Not run locally