### PR TITLE
gh-15351: Show repository names in GitHub PR live folders

### DIFF
--- a/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
+++ b/src/zen/live-folders/providers/GithubLiveFolder.sys.mjs
@@ -136,7 +136,7 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
         items.push({
           id: `${pr.repoNameWithOwner}#${pr.number}`,
           title: pr.title,
-          subtitle: pr.author.displayLogin,
+          subtitle: `${pr.author.displayLogin} • ${pr.repoNameWithOwner}`,
           icon: "chrome://browser/content/zen-images/favicons/github.svg",
           url: pr.permalink,
         });
@@ -174,7 +174,7 @@ export class nsGithubLiveFolderProvider extends nsZenLiveFolderProvider {
 
         items.push({
           title,
-          subtitle: author,
+          subtitle: `${author} • ${repo}`,
           icon: "chrome://browser/content/zen-images/favicons/github.svg",
           url: new URL(titles[i].href, this.state.url),
           id: `${repo}${idMatch}`,

--- a/src/zen/tests/live-folders/browser_github_live_folder.js
+++ b/src/zen/tests/live-folders/browser_github_live_folder.js
@@ -313,7 +313,7 @@ add_task(async function test_pull_requests_json_api_parsing() {
   Assert.equal(items.length, 2, "Should parse two PRs from the JSON payload");
   Assert.equal(items[0].id, "zen-browser/desktop#42");
   Assert.equal(items[0].title, "Add live folders");
-  Assert.equal(items[0].subtitle, "alice");
+  Assert.equal(items[0].subtitle, "alice • zen-browser/desktop");
   Assert.equal(items[0].url, "https://github.com/zen-browser/desktop/pull/42");
   Assert.equal(items[1].id, "zen-browser/desktop#43");
   Assert.ok(


### PR DESCRIPTION
## Summary

- show the full repository name beside the author in Pull Request live-folder subtitles
- apply the subtitle consistently to GitHub JSON and HTML responses

Closes #15351

## Testing

- Updated the existing parser assertion
- Not run locally