### PR TITLE
gh-15356: Fix pinned tabs missing `_zenPinnedInitialState`

### DIFF
--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabbrowser.js b/browser/components/tabbrowser/content/tabbrowser.js
-index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc37dbadc37 100644
+index 43180487a2fac15b7a65fac94f233eeed9094990..17ec5170bc57d2276338b595ec6457cbc872b947 100644
 --- a/browser/components/tabbrowser/content/tabbrowser.js
 +++ b/browser/components/tabbrowser/content/tabbrowser.js
 @@ -514,6 +514,7 @@
@@ -331,7 +331,22 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
  
        // Find the tab that opened this one, if any. This is used for
        // determining positioning, and inherited attributes such as the
-@@ -3453,6 +3562,22 @@
+@@ -3442,6 +3551,14 @@
+ 
+       let usingPreloadedContent = false;
+       let b, t;
++      let targetGroup = tabGroup ?? (openerTab || ownerTab)?.group;
++      if (
++        !pinned &&
++          targetGroup?.isZenFolder &&
++          Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder", false)
++      ) {
++        pinned = true;
++      }
+ 
+       try {
+         t = this._createTab({
+@@ -3453,6 +3570,22 @@
            noInitialLabel,
            skipBackgroundNotify,
          });
@@ -354,7 +369,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
          if (insertTab) {
            // Insert the tab into the tab container in the correct position.
            this.#insertTabAtIndex(t, {
-@@ -3461,6 +3586,7 @@
+@@ -3461,6 +3594,7 @@
              ownerTab,
              openerTab,
              pinned,
@@ -362,7 +377,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
              bulkOrderedOpen,
              tabGroup: tabGroup ?? openerTab?.group,
            });
-@@ -3479,6 +3605,7 @@
+@@ -3479,6 +3613,7 @@
            openWindowInfo,
            skipLoad,
            triggeringRemoteType,
@@ -370,7 +385,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
          }));
  
          if (focusUrlBar) {
-@@ -3603,6 +3730,12 @@
+@@ -3603,6 +3738,12 @@
          }
        }
  
@@ -383,7 +398,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        // Additionally send pinned tab events
        if (pinned) {
          this.#notifyPinnedStatus(t);
-@@ -3613,6 +3746,15 @@
+@@ -3613,6 +3754,15 @@
        if (!inBackground) {
          this.selectedTab = t;
        }
@@ -399,7 +414,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        return t;
      }
  
-@@ -3836,6 +3978,7 @@
+@@ -3836,6 +3986,7 @@
          insertBefore = null,
          isAdoptingGroup = false,
          metricsContext = this.TabMetrics.UNKNOWN_CONTEXT,
@@ -407,7 +422,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        } = {}
      ) {
        if (
-@@ -3846,9 +3989,6 @@
+@@ -3846,9 +3997,6 @@
              !this.isSplitViewWrapper(tabOrSplitView)
          )
        ) {
@@ -417,7 +432,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        }
  
        if (!color) {
-@@ -3869,9 +4009,14 @@
+@@ -3869,9 +4017,14 @@
          label,
          isAdoptingGroup
        );
@@ -434,7 +449,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        );
        group.addTabs(tabsAndSplitViews, metricsContext);
  
-@@ -3975,7 +4120,7 @@
+@@ -3975,7 +4128,7 @@
        }
  
        this.#handleTabMove(tab, () =>
@@ -443,7 +458,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        );
      }
  
-@@ -4061,6 +4206,7 @@
+@@ -4061,6 +4214,7 @@
          color: group.color,
          insertBefore: newTabs[0],
          isAdoptingGroup: true,
@@ -451,7 +466,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        });
      }
  
-@@ -4271,6 +4417,7 @@
+@@ -4271,6 +4425,7 @@
          openWindowInfo,
          skipLoad,
          triggeringRemoteType,
@@ -459,7 +474,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        }
      ) {
        // If we don't have a preferred remote type (or it is `NOT_REMOTE`), and
-@@ -4331,6 +4478,7 @@
+@@ -4331,6 +4486,7 @@
            openWindowInfo,
            name,
            skipLoad,
@@ -467,7 +482,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
          });
        }
  
-@@ -4544,9 +4692,9 @@
+@@ -4544,9 +4700,9 @@
          }
  
          // Add a new tab if needed.
@@ -479,7 +494,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
  
            let url = "about:blank";
            if (tabData.entries?.length) {
-@@ -4579,8 +4727,10 @@
+@@ -4579,8 +4735,10 @@
              insertTab: false,
              skipLoad: true,
              preferredRemoteType,
@@ -491,7 +506,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
            if (select) {
              tabToSelect = tab;
            }
-@@ -4602,7 +4752,8 @@
+@@ -4602,7 +4760,8 @@
            this.pinTab(tab);
            // Then ensure all the tab open/pinning information is sent.
            this._fireTabOpen(tab, {});
@@ -501,7 +516,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
            let { groupId } = tabData;
            const tabGroup = tabGroupWorkingData.get(groupId);
            // if a tab refers to a tab group we don't know, skip any group
-@@ -4622,7 +4773,10 @@
+@@ -4622,7 +4781,10 @@
                  tabGroup.stateData.id,
                  tabGroup.stateData.color,
                  tabGroup.stateData.collapsed,
@@ -513,7 +528,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
                );
                tabsFragment.appendChild(tabGroup.node);
              }
-@@ -4677,9 +4831,21 @@
+@@ -4677,9 +4839,21 @@
        // to remove the old selected tab.
        if (tabToSelect) {
          let leftoverTab = this.selectedTab;
@@ -535,7 +550,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
  
        if (tabs.length > 1 || !tabs[0].selected) {
          this._updateTabsAfterInsert();
-@@ -4884,11 +5050,17 @@
+@@ -4884,11 +5058,17 @@
        if (ownerTab) {
          tab.owner = ownerTab;
        }
@@ -554,7 +569,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
          if (
            !bulkOrderedOpen &&
            ((openerTab &&
-@@ -4900,7 +5072,7 @@
+@@ -4900,7 +5080,7 @@
            let lastRelatedTab =
              openerTab && this.#lastRelatedTabMap.get(openerTab);
            let previousTab = lastRelatedTab || openerTab || this.selectedTab;
@@ -563,7 +578,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
              tabGroup = previousTab.group;
            }
            if (
-@@ -4916,7 +5088,7 @@
+@@ -4916,7 +5096,7 @@
                  previousTab.splitview
                ) + 1;
            } else if (previousTab.visible) {
@@ -572,7 +587,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
            } else if (previousTab == FirefoxViewHandler.tab) {
              elementIndex = 0;
            }
-@@ -4944,14 +5116,14 @@
+@@ -4944,14 +5124,14 @@
        }
        // Ensure index is within bounds.
        if (tab.pinned) {
@@ -591,7 +606,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
  
        if (pinned && !itemAfter?.pinned) {
          itemAfter = null;
-@@ -4968,7 +5140,7 @@
+@@ -4968,7 +5148,7 @@
  
        this.tabContainer._invalidateCachedTabs();
  
@@ -600,7 +615,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
          if (
            (this.isTab(itemAfter) && itemAfter.group == tabGroup) ||
            this.isSplitViewWrapper(itemAfter)
-@@ -4999,7 +5171,11 @@
+@@ -4999,7 +5179,11 @@
          const tabContainer = pinned
            ? this.tabContainer.pinnedTabsContainer
            : this.tabContainer;
@@ -612,7 +627,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        }
  
        if (tab.group?.collapsed) {
-@@ -5014,6 +5190,7 @@
+@@ -5014,6 +5198,7 @@
        if (pinned) {
          this._updateTabBarForPinnedTabs();
        }
@@ -620,7 +635,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
  
        TabBarVisibility.update();
      }
-@@ -5577,6 +5754,7 @@
+@@ -5577,6 +5762,7 @@
          metricsContext,
        } = {}
      ) {
@@ -628,7 +643,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        // When 'closeWindowWithLastTab' pref is enabled, closing all tabs
        // can be considered equivalent to closing the window.
        if (
-@@ -5687,6 +5865,7 @@
+@@ -5687,6 +5873,7 @@
              closedTabCount -= 1;
            }
          }
@@ -636,7 +651,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
  
          if (closedTabCount > 0) {
            this.recordTabMetrics(
-@@ -5761,6 +5940,14 @@
+@@ -5761,6 +5948,14 @@
          return;
        }
  
@@ -651,7 +666,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        let isVisibleTab = aTab.visible;
        // We have to sample the tab width now, since _beginRemoveTab might
        // end up modifying the DOM in such a way that aTab gets a new
-@@ -5768,6 +5955,9 @@
+@@ -5768,6 +5963,9 @@
        // state).
        let tabWidth = window.windowUtils.getBoundsWithoutFlushing(aTab).width;
        let isLastTab = this.#isLastTabInWindow(aTab);
@@ -661,7 +676,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        if (
          !this._beginRemoveTab(aTab, {
            closeWindowFastpath: true,
-@@ -5778,13 +5968,14 @@
+@@ -5778,13 +5976,14 @@
            metricsContext,
          })
        ) {
@@ -677,7 +692,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        let lockTabSizing =
          !this.tabContainer.verticalMode &&
          !aTab.pinned &&
-@@ -5815,7 +6006,13 @@
+@@ -5815,7 +6014,13 @@
          // We're not animating, so we can cancel the animation stopwatch.
          Glean.browserTabclose.timeAnim.cancel(aTab._closeTimeAnimTimerId);
          aTab._closeTimeAnimTimerId = null;
@@ -692,7 +707,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
          return;
        }
  
-@@ -5855,7 +6052,9 @@
+@@ -5855,7 +6060,9 @@
      get #shouldCloseWindowWithLastTab() {
        return (
          !window.toolbar.visible ||
@@ -703,7 +718,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        );
      }
  
-@@ -5871,7 +6070,7 @@
+@@ -5871,7 +6078,7 @@
       */
      #isLastTabInWindow(tab) {
        for (const otherTab of this.tabs) {
@@ -712,7 +727,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
            return false;
          }
        }
-@@ -5982,6 +6181,7 @@
+@@ -5982,6 +6189,7 @@
  
          newTab = true;
        }
@@ -720,7 +735,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        aTab._endRemoveArgs = [closeWindow, newTab];
  
        // swapBrowsersAndCloseOther will take care of closing the window without animation.
-@@ -6029,13 +6229,7 @@
+@@ -6029,13 +6237,7 @@
        }
  
        if (newTab) {
@@ -735,7 +750,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        } else {
          TabBarVisibility.update();
        }
-@@ -6192,6 +6386,7 @@
+@@ -6192,6 +6394,7 @@
          this.tabs[i]._tPos = i;
        }
  
@@ -743,7 +758,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        if (!this.#windowIsClosing) {
          // update tab close buttons state
          this.tabContainer._updateCloseButtons();
-@@ -6377,6 +6572,7 @@
+@@ -6377,6 +6580,7 @@
          memory_after: await getTotalMemoryUsage(),
          time_to_unload_in_ms: timeElapsed,
        });
@@ -751,7 +766,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
      }
  
      /**
-@@ -6422,11 +6618,12 @@
+@@ -6422,11 +6626,12 @@
        }
  
        let excludeTabs = new Set(aExcludeTabs);
@@ -765,7 +780,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        }
  
        if (
-@@ -6434,13 +6631,13 @@
+@@ -6434,13 +6639,13 @@
          !excludeTabs.has(aTab.owner) &&
          Services.prefs.getBoolPref("browser.tabs.selectOwnerOnClose")
        ) {
@@ -781,7 +796,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        );
  
        if (Services.prefs.getBoolPref("browser.tabs.selectMRUOnClose", false)) {
-@@ -6456,6 +6653,13 @@
+@@ -6456,6 +6661,13 @@
          }
        }
  
@@ -795,7 +810,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        let tab = this.tabContainer.findNextTab(aTab, {
          direction: 1,
          filter: _tab => remainingTabs.includes(_tab),
-@@ -6469,7 +6673,7 @@
+@@ -6469,7 +6681,7 @@
        }
  
        if (tab) {
@@ -804,7 +819,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        }
  
        // If no qualifying visible tab was found, see if there is a tab in
-@@ -6490,7 +6694,7 @@
+@@ -6490,7 +6702,7 @@
          });
        }
  
@@ -813,7 +828,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
      }
  
      _blurTab(aTab) {
-@@ -6501,7 +6705,7 @@
+@@ -6501,7 +6713,7 @@
       * @returns {boolean}
       *   False if swapping isn't permitted, true otherwise.
       */
@@ -822,7 +837,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        // Do not allow transfering a private tab to a non-private window
        // and vice versa.
        if (
-@@ -6555,6 +6759,7 @@
+@@ -6555,6 +6767,7 @@
        // fire the beforeunload event in the process.  Close the other
        // window if this was its last tab.
        if (
@@ -830,7 +845,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
          !remoteBrowser._beginRemoveTab(aOtherTab, {
            adoptedByTab: aOurTab,
            closeWindowWithLastTab: true,
-@@ -6566,7 +6771,7 @@
+@@ -6566,7 +6779,7 @@
        // If this is the last tab of the window, hide the window
        // immediately without animation before the docshell swap, to avoid
        // about:blank being painted.
@@ -839,7 +854,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        if (closeWindow) {
          let win = aOtherTab.documentGlobal;
          win.windowUtils.suppressAnimation(true);
-@@ -6700,11 +6905,13 @@
+@@ -6700,11 +6913,13 @@
        }
  
        // Finish tearing down the tab that's going away.
@@ -853,7 +868,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
  
        this.setTabTitle(aOurTab);
  
-@@ -6928,10 +7135,10 @@
+@@ -6928,10 +7143,10 @@
        SessionStore.deleteCustomTabValue(aTab, "hiddenBy");
      }
  
@@ -866,7 +881,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
          aTab.selected ||
          aTab.closing ||
          // Tabs that are sharing the screen, microphone or camera cannot be hidden.
-@@ -6991,7 +7198,8 @@
+@@ -6991,7 +7206,8 @@
       * @param {object} [aOptions={}]
       *   Key-value pairs that will be serialized into the features string.
       */
@@ -876,7 +891,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        if (this.tabs.length == 1) {
          return null;
        }
-@@ -7008,7 +7216,7 @@
+@@ -7008,7 +7224,7 @@
        // tell a new window to take the "dropped" tab
        let args = Cc["@mozilla.org/array;1"].createInstance(Ci.nsIMutableArray);
        args.appendElement(aTab.splitview ?? aTab);
@@ -885,7 +900,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
          private: PrivateBrowsingUtils.isWindowPrivate(window),
          features: Object.entries(aOptions)
            .map(([key, value]) => `${key}=${value}`)
-@@ -7016,6 +7224,8 @@
+@@ -7016,6 +7232,8 @@
          openerWindow: window,
          args,
        });
@@ -894,7 +909,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
      }
  
      /**
-@@ -7142,7 +7352,7 @@
+@@ -7142,7 +7360,7 @@
       *   `true` if element is a `<tab-group>`
       */
      isTabGroup(element) {
@@ -903,7 +918,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
      }
  
      /**
-@@ -7214,8 +7424,8 @@
+@@ -7214,8 +7432,8 @@
        }
  
        // Don't allow mixing pinned and unpinned tabs.
@@ -914,7 +929,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        } else {
          tabIndex = Math.max(tabIndex, this.pinnedTabCount);
        }
-@@ -7261,8 +7471,8 @@
+@@ -7261,8 +7479,8 @@
        this.#handleTabMove(
          element,
          () => {
@@ -925,7 +940,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
              neighbor = neighbor.group;
            }
            if (neighbor?.splitview) {
-@@ -7273,6 +7483,12 @@
+@@ -7273,6 +7491,12 @@
                return;
              }
            }
@@ -938,7 +953,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
  
            if (movingForwards && neighbor) {
              neighbor.after(element);
-@@ -7346,23 +7562,31 @@
+@@ -7346,23 +7570,31 @@
      ) {
        if (this.isTabGroupLabel(targetElement)) {
          targetElement = targetElement.group;
@@ -976,7 +991,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        } else if (!element.pinned && targetElement && targetElement.pinned) {
          // If the caller asks to move an unpinned element next to a pinned
          // tab, move the unpinned element to be the first unpinned element
-@@ -7375,12 +7599,35 @@
+@@ -7375,12 +7607,35 @@
          //    move the tab group right before the first unpinned tab.
          // 4. Moving a tab group and the first unpinned tab is grouped:
          //    move the tab group right before the first unpinned tab's tab group.
@@ -1013,7 +1028,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
  
        // We want to include the splitview wrapper if it's the targetElement, but
        // not in the case where we want to reverse tabs within the same splitview.
-@@ -7389,6 +7636,7 @@
+@@ -7389,6 +7644,7 @@
        }
  
        let getContainer = () =>
@@ -1021,7 +1036,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
          element.pinned
            ? this.tabContainer.pinnedTabsContainer
            : this.tabContainer;
-@@ -7397,11 +7645,15 @@
+@@ -7397,11 +7653,15 @@
          element,
          () => {
            if (moveBefore) {
@@ -1038,7 +1053,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
            }
          },
          { metricsContext }
-@@ -7479,11 +7731,15 @@
+@@ -7479,11 +7739,15 @@
       *   The context for the operation for telemetry purposes.
       */
      moveTabToExistingGroup(aTab, aGroup, { metricsContext } = {}) {
@@ -1057,7 +1072,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        }
        if (aTab.group && aTab.group.id === aGroup.id) {
          return;
-@@ -7557,6 +7813,7 @@
+@@ -7557,6 +7821,7 @@
  
        let state = {
          tabIndex: tab._tPos,
@@ -1065,7 +1080,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        };
        if (tab.visible) {
          state.elementIndex = tab.elementIndex;
-@@ -7595,7 +7852,7 @@
+@@ -7595,7 +7860,7 @@
        let changedSplitView =
          previousTabState.splitViewId != currentTabState.splitViewId;
  
@@ -1074,7 +1089,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
          tab.dispatchEvent(
            new CustomEvent("TabMove", {
              bubbles: true,
-@@ -7647,6 +7904,10 @@
+@@ -7647,6 +7912,10 @@
  
        moveActionCallback();
  
@@ -1085,7 +1100,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        // Clear tabs cache after moving nodes because the order of tabs may have
        // changed.
        this.tabContainer._invalidateCachedTabs();
-@@ -7694,7 +7955,22 @@
+@@ -7694,7 +7963,22 @@
       * @returns {object}
       *    The new tab in the current window, null if the tab couldn't be adopted.
       */
@@ -1109,7 +1124,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        // Swap the dropped tab with a new one we create and then close
        // it in the other window (making it seem to have moved between
        // windows). We also ensure that the tab we create to swap into has
-@@ -7737,6 +8013,8 @@
+@@ -7737,6 +8021,8 @@
        }
        params.skipLoad = true;
        let newTab = this.addWebTab("about:blank", params);
@@ -1118,7 +1133,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
  
        aTab.container.tabDragAndDrop.finishAnimateTabMove();
  
-@@ -8516,7 +8794,7 @@
+@@ -8516,7 +8802,7 @@
          // preventDefault(). It will still raise the window if appropriate.
          return;
        }
@@ -1127,7 +1142,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        window.focus();
        aEvent.preventDefault();
      }
-@@ -8533,7 +8811,6 @@
+@@ -8533,7 +8819,6 @@
  
      on_TabGroupCollapse(aEvent) {
        aEvent.target.tabs.forEach(tab => {
@@ -1135,7 +1150,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
        });
      }
  
-@@ -8887,7 +9164,9 @@
+@@ -8887,7 +9172,9 @@
  
          let filter = this.#tabFilters.get(tab);
          if (filter) {
@@ -1145,7 +1160,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
  
            let listener = this.#tabListeners.get(tab);
            if (listener) {
-@@ -9676,6 +9955,7 @@
+@@ -9676,6 +9963,7 @@
              aWebProgress.isTopLevel
            ) {
              this._tab.setAttribute("busy", "true");
@@ -1153,7 +1168,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
              gBrowser._tabAttrModified(this._tab, ["busy"]);
              this._tab._notselectedsinceload = !this._tab.selected;
            }
-@@ -9756,6 +10036,7 @@
+@@ -9756,6 +10044,7 @@
          // known defaults. Note we use the original URL since about:newtab
          // redirects to a prerendered page.
          const shouldRemoveFavicon =
@@ -1161,7 +1176,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..ef6d30eb681caeae48d15280687b3bc3
            !this._browser.mIconURL &&
            !ignoreBlank &&
            !(originalLocation.spec in FAVICON_DEFAULTS);
-@@ -9930,13 +10211,6 @@
+@@ -9930,13 +10219,6 @@
              this._browser.originalURI = aRequest.originalURI;
            }
  

--- a/src/browser/components/tabbrowser/content/tabbrowser-js.patch
+++ b/src/browser/components/tabbrowser/content/tabbrowser-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/components/tabbrowser/content/tabbrowser.js b/browser/components/tabbrowser/content/tabbrowser.js
-index 43180487a2fac15b7a65fac94f233eeed9094990..17ec5170bc57d2276338b595ec6457cbc872b947 100644
+index 43180487a2fac15b7a65fac94f233eeed9094990..ed529d8eb6dbfb4a4024cb5a6a234fc0e1985ba2 100644
 --- a/browser/components/tabbrowser/content/tabbrowser.js
 +++ b/browser/components/tabbrowser/content/tabbrowser.js
 @@ -514,6 +514,7 @@
@@ -227,7 +227,7 @@ index 43180487a2fac15b7a65fac94f233eeed9094990..17ec5170bc57d2276338b595ec6457cb
 +        return false;
 +      }
 +      aLabel = (typeof aTab.zenStaticLabel === "string" && aTab.zenStaticLabel) ? aTab.zenStaticLabel : aLabel;
-+      gZenPinnedTabManager.onTabLabelChanged(aTab);
++      gZenPinnedTabManager.onTabLabelChanged(aTab, aLabel, { isContentTitle });
        if (!aLabel || (isURL && /^about:reader\?url=/.test(aLabel))) {
          return false;
        }

--- a/src/zen/folders/ZenFolders.mjs
+++ b/src/zen/folders/ZenFolders.mjs
@@ -228,7 +228,6 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     window.addEventListener("FolderGrouped", this);
     window.addEventListener("FolderUngrouped", this);
     window.addEventListener("TabSelect", this);
-    window.addEventListener("TabOpen", this);
     const onNewFolder = this.#onNewFolder.bind(this);
     document
       .getElementById("zen-context-menu-new-folder")
@@ -412,21 +411,6 @@ class nsZenFolders extends nsZenDOMOperatedFeature {
     collapsedRoot.setAttribute("has-active", "true");
     await this.animateSelect(collapsedRoot);
     gBrowser.tabContainer._invalidateCachedTabs();
-  }
-
-  on_TabOpen(event) {
-    const tab = event.target;
-    const group = tab.group;
-    if (!group?.isZenFolder || tab.pinned) {
-      return;
-    }
-    // Edge case: In occations where we add a tab with an ownerTab
-    // inside a folder, the tab gets added into the folder in an
-    // unpinned state. We need to pin it and re-add it into the folder.
-    if (Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder")) {
-      gBrowser.pinTab(tab);
-      group.addTabs([tab]);
-    }
   }
 
   async on_TabUngrouped(event) {

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -1245,7 +1245,7 @@ class nsZenWindowSync {
       if (url) {
         this.setPinnedInitialState(
           aTab,
-          { url, title: entryToUse?.title ?? aTab.label },
+          { url, title: entryToUse?.title },
           image
         );
       }
@@ -1270,6 +1270,31 @@ class nsZenWindowSync {
   }
 
   /**
+   * Updates the canonical title for a pinned tab across all windows.
+   *
+   * @param {object} aTab - Any window's instance of the tab.
+   * @param {string} aTitle - The loaded page title.
+   */
+  setPinnedTitle(aTab, aTitle) {
+    if (!aTitle) {
+      return;
+    }
+    this.#runOnAllWindows(null, win => {
+      const targetTab = this.getItemFromWindow(win, aTab.id);
+      const initialState = targetTab?._zenPinnedInitialState;
+      if (!initialState?.entry?.url || initialState.titleCaptured) {
+        return;
+      }
+      if (initialState.entry.title) {
+        initialState.titleCaptured = true;
+        return;
+      }
+      initialState.entry.title = aTitle;
+      initialState.titleCaptured = true;
+    });
+  }
+
+  /**
    * Sets the pinned initial state (canonical entry and icon) for a tab's
    * instances across all windows.
    *
@@ -1278,7 +1303,11 @@ class nsZenWindowSync {
    * @param {string} [aImage] - Optional icon to store.
    */
   setPinnedInitialState(aTab, aEntry, aImage) {
-    const initialState = { entry: aEntry, image: aImage };
+    const initialState = {
+      entry: aEntry,
+      image: aImage,
+      titleCaptured: Boolean(aEntry?.title),
+    };
     this.#runOnAllWindows(null, win => {
       const targetTab = this.getItemFromWindow(win, aTab.id);
       if (targetTab) {

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -294,13 +294,13 @@ class nsZenWindowSync {
         if (!tab.id) {
           tab.id = this.#newTabSyncId;
         }
-        if (tab.pinned && !tab._zenPinnedInitialState?.entry?.url) {
+        if (tab.pinned && !tab._zenPinnedInitialState) {
           await this.setPinnedTabState(tab);
         }
         // Lets clear extra values to save some memory, we only really
         // care about the URL and title for the initial state, and we want
         // to avoid keeping the whole session history around.
-        if (tab._zenPinnedInitialState?.entry) {
+        if (tab._zenPinnedInitialState) {
           tab._zenPinnedInitialState = {
             ...tab._zenPinnedInitialState,
             entry: {
@@ -1470,7 +1470,7 @@ class nsZenWindowSync {
     // wan't to override the initial state we stored when the tab was created.
     // For example, when session restore pins a tab again.
     let tabStatePromise;
-    if (!tab._zenPinnedInitialState?.entry?.url) {
+    if (!tab._zenPinnedInitialState) {
       tabStatePromise = this.setPinnedTabState(tab);
     }
     return Promise.all([

--- a/src/zen/sessionstore/ZenWindowSync.sys.mjs
+++ b/src/zen/sessionstore/ZenWindowSync.sys.mjs
@@ -294,13 +294,13 @@ class nsZenWindowSync {
         if (!tab.id) {
           tab.id = this.#newTabSyncId;
         }
-        if (tab.pinned && !tab._zenPinnedInitialState) {
+        if (tab.pinned && !tab._zenPinnedInitialState?.entry?.url) {
           await this.setPinnedTabState(tab);
         }
         // Lets clear extra values to save some memory, we only really
         // care about the URL and title for the initial state, and we want
         // to avoid keeping the whole session history around.
-        if (tab._zenPinnedInitialState) {
+        if (tab._zenPinnedInitialState?.entry) {
           tab._zenPinnedInitialState = {
             ...tab._zenPinnedInitialState,
             entry: {
@@ -1234,11 +1234,21 @@ class nsZenWindowSync {
       activeIndex = Math.min(activeIndex, entries.length - 1);
       activeIndex = Math.max(activeIndex, 0);
       let entryToUse = (entries[activeIndex] || entries[0]) ?? null;
-      this.setPinnedInitialState(
-        aTab,
-        { url: entryToUse?.url, title: entryToUse?.title },
-        image
-      );
+      let url = entryToUse?.url;
+      if (
+        !url &&
+        aTab.linkedBrowser?.currentURI?.spec &&
+        aTab.linkedBrowser.currentURI.spec !== "about:blank"
+      ) {
+        url = aTab.linkedBrowser.currentURI.spec;
+      }
+      if (url) {
+        this.setPinnedInitialState(
+          aTab,
+          { url, title: entryToUse?.title ?? aTab.label },
+          image
+        );
+      }
     });
   }
 
@@ -1460,7 +1470,7 @@ class nsZenWindowSync {
     // wan't to override the initial state we stored when the tab was created.
     // For example, when session restore pins a tab again.
     let tabStatePromise;
-    if (!tab._zenPinnedInitialState) {
+    if (!tab._zenPinnedInitialState?.entry?.url) {
       tabStatePromise = this.setPinnedTabState(tab);
     }
     return Promise.all([

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -3348,6 +3348,9 @@ class nsZenWorkspaces {
         essentialsSection.appendChild(tab);
       }
     } else if (tab.pinned) {
+      if (tab?.group?.isZenFolder && Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder", false)) {
+        return;
+      }
       // Pinned tabs should always be inserted at the end of the pinned tabs container
       const pinnedContainer = this.pinnedTabsContainer;
       if (pinnedContainer) {

--- a/src/zen/spaces/ZenSpaceManager.mjs
+++ b/src/zen/spaces/ZenSpaceManager.mjs
@@ -3348,7 +3348,10 @@ class nsZenWorkspaces {
         essentialsSection.appendChild(tab);
       }
     } else if (tab.pinned) {
-      if (tab?.group?.isZenFolder && Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder", false)) {
+      if (
+        tab?.group?.isZenFolder &&
+        Services.prefs.getBoolPref("zen.folders.owned-tabs-in-folder", false)
+      ) {
         return;
       }
       // Pinned tabs should always be inserted at the end of the pinned tabs container

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -460,7 +460,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     const state = this.#getTabState(tab);
 
     const initialState = tab._zenPinnedInitialState;
-    if (!initialState?.entry?.url) {
+    if (!initialState?.entry) {
       return;
     }
 
@@ -954,7 +954,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     }
     const initialState = tab._zenPinnedInitialState;
     if (!initialState?.entry?.url) {
-      window.gZenWindowSync?.setPinnedInitialState(
+      window.gZenWindowSync.setPinnedInitialState(
         tab,
         { url: location, title: initialState?.entry?.title || tab.label },
         initialState?.image ??

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -460,7 +460,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     const state = this.#getTabState(tab);
 
     const initialState = tab._zenPinnedInitialState;
-    if (!initialState?.entry) {
+    if (!initialState?.entry?.url) {
       return;
     }
 
@@ -949,16 +949,22 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
       return;
     }
     const tab = gBrowser.getTabForBrowser(aBrowser);
-    if (
-      !tab ||
-      !tab.pinned ||
-      tab.hasAttribute("zen-essential") ||
-      !tab._zenPinnedInitialState?.entry
-    ) {
+    if (!tab || !tab.pinned || tab.hasAttribute("zen-essential")) {
+      return;
+    }
+    const initialState = tab._zenPinnedInitialState;
+    if (!initialState?.entry?.url) {
+      window.gZenWindowSync?.setPinnedInitialState(
+        tab,
+        { url: location, title: initialState?.entry?.title || tab.label },
+        initialState?.image ??
+          tab.getAttribute("image") ??
+          gBrowser.getIcon(tab)
+      );
       return;
     }
     // Remove # from the URL
-    const pinUrl = tab._zenPinnedInitialState.entry.url.split("#")[0];
+    const pinUrl = initialState.entry.url.split("#")[0];
     const currentUrl = location.split("#")[0];
     // Add an indicator that the pin has been changed
     if (

--- a/src/zen/tabs/ZenPinnedTabManager.mjs
+++ b/src/zen/tabs/ZenPinnedTabManager.mjs
@@ -956,7 +956,7 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     if (!initialState?.entry?.url) {
       window.gZenWindowSync.setPinnedInitialState(
         tab,
-        { url: location, title: initialState?.entry?.title || tab.label },
+        { url: location, title: initialState?.entry?.title },
         initialState?.image ??
           tab.getAttribute("image") ??
           gBrowser.getIcon(tab)
@@ -1181,7 +1181,15 @@ class nsZenPinnedTabManager extends nsZenDOMOperatedFeature {
     }
   }
 
-  onTabLabelChanged(tab) {
+  onTabLabelChanged(tab, label, { isContentTitle = false } = {}) {
+    if (
+      isContentTitle &&
+      !tab.zenStaticLabel &&
+      label &&
+      tab._zenPinnedInitialState?.entry?.url
+    ) {
+      window.gZenWindowSync.setPinnedTitle(tab, label);
+    }
     tab.dispatchEvent(
       new CustomEvent("ZenTabLabelChanged", { bubbles: true, detail: { tab } })
     );


### PR DESCRIPTION
Initialize pinned tab state only when a valid URL is available and recover it on the first real
location change.
Keep folder-owned tabs pinned during creation and preserve their position next to the opener instead of
moving them to the end of the pinned section.

fix: #15356
fix: #14448
close: #14449