### PR TITLE
gh-15363: Fix boost font shuffle off-by-one index

### DIFF
--- a/src/zen/boosts/ZenBoostsEditor.mjs
+++ b/src/zen/boosts/ZenBoostsEditor.mjs
@@ -1521,7 +1521,7 @@ ${cssSelector} {
   shuffleBoost() {
     const availFonts = this.fetchFontList();
     const commonFonts = this.commonFonts;
-    let font = commonFonts[Math.round(Math.random() * commonFonts.length)];
+    let font = commonFonts[Math.floor(Math.random() * commonFonts.length)];
     if (availFonts.includes(font)) {
       this.currentBoostData.fontFamily = font;
     }


### PR DESCRIPTION
## Summary
- Use `Math.floor` instead of `Math.round` when picking a random font in `shuffleBoost()`.
- Prevents an out-of-range index (`length`) that left `font` undefined and skipped the font update ~3% of the time.

fix: #15363

## Test plan
- [ ] Open Zen Boosts editor and trigger font shuffle repeatedly
- [ ] Confirm a font is applied on each shuffle (no silent no-ops)
- [ ] Confirm other shuffle fields (invert, brightness, contrast, saturation, gradient) still update as before