### PR TITLE
gh-15369: Add 'Reopen Closed Tab' urlbar action

### DIFF
--- a/locales/en-US/browser/browser/zen-command-palette.ftl
+++ b/locales/en-US/browser/browser/zen-command-palette.ftl
@@ -18,6 +18,7 @@ zen-action-new-boost = New Boost
 zen-action-next-space = Next Space
 zen-action-previous-space = Previous Space
 zen-action-close-tab = Close Tab
+zen-action-reopen-closed-tab = Reopen Closed Tab
 zen-action-reload-tab = Reload Tab
 zen-action-reload-tab-without-cache = Reload Tab Without Cache
 zen-action-next-tab = Next Tab

--- a/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
+++ b/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
@@ -17,6 +17,10 @@ ChromeUtils.defineLazyGetter(lazy, "l10n", () => {
   return new Localization(["browser/zen-command-palette.ftl"], true);
 });
 
+ChromeUtils.defineESModuleGetters(lazy, {
+  SessionStore: "resource:///modules/sessionstore/SessionStore.sys.mjs",
+});
+
 function isNotEmptyTab(window) {
   return !window.gBrowser.selectedTab.hasAttribute("zen-empty-tab");
 }
@@ -156,6 +160,14 @@ const globalActionsTemplate = [
     icon: "chrome://browser/skin/zen-icons/close.svg",
     isAvailable: window => {
       return isNotEmptyTab(window);
+    },
+  },
+  {
+    l10nId: "zen-action-reopen-closed-tab",
+    command: "History:RestoreLastClosedTabOrWindowOrSession",
+    icon: "chrome://browser/skin/zen-icons/history.svg",
+    isAvailable: window => {
+      return lazy.SessionStore.getClosedTabCount(window) > 0;
     },
   },
   {


### PR DESCRIPTION
Adds a **"Reopen Closed Tab"** entry to the URL bar actions, next to "Close Tab".

Idea / motivation: #15369

### What
- One new entry in `ZenUBGlobalActions.sys.mjs` that reuses Firefox's `History:RestoreLastClosedTabOrWindowOrSession` command (same behaviour as Cmd/Ctrl+Shift+T and the tab context menu's "Reopen Closed Tab").
- `isAvailable` returns true only when `SessionStore.getClosedTabCount(window) > 0`, so the action hides when there is nothing to reopen, same pattern as Pin/Unpin Tab.
- en-US string `zen-action-reopen-closed-tab = Reopen Closed Tab`.
- Icon: existing `zen-icons/history.svg`.

### Testing
- Behaviour verified on Zen 1.22b (macOS, arm64) by pushing the same action object into `globalActions` at runtime via an autoconfig hook: the entry appears after closing a tab, disappears when no closed tab exists, and Enter restores the tab.
- Not verified from a local build. `browser_ub_actions_search.js` iterates all actions and skips unavailable ones, so it passes with or without a closed tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
