### PR TITLE
gh-15371: Match urlbar actions by word and by localized keywords

### DIFF
--- a/locales/en-US/browser/browser/zen-command-palette.ftl
+++ b/locales/en-US/browser/browser/zen-command-palette.ftl
@@ -4,11 +4,15 @@
 
 zen-action-toggle-compact-mode = Toggle Compact Mode
 zen-action-open-theme-picker = Open Theme Picker
+zen-action-open-theme-picker-keywords = change theme, pick theme, appearance
 zen-action-new-split-view = New Split View
 zen-action-new-folder = New Folder
 zen-action-copy-current-url = Copy Current URL
+zen-action-copy-current-url-keywords = copy link, copy address
 zen-action-settings = Settings
+zen-action-settings-keywords = preferences, options
 zen-action-open-private-window = Open Private Window
+zen-action-open-private-window-keywords = incognito, private browsing
 zen-action-open-new-window = Open New Window
 zen-action-new-blank-window = New Blank Window
 zen-action-pin-tab = Pin Tab
@@ -27,6 +31,7 @@ zen-action-toggle-tabs-on-right = Toggle Tabs on right
 zen-action-add-to-essentials = Add to Essentials
 zen-action-remove-from-essentials = Remove from Essentials
 zen-action-find-in-page = Find in Page
+zen-action-find-in-page-keywords = find on page, search page, search in page
 zen-action-manage-extensions = Manage Extensions
 zen-action-switch-to-automatic-appearance = Switch to Automatic Appearance
 zen-action-switch-to-light-mode = Switch to Light Mode

--- a/src/zen/tests/ub-actions/browser.toml
+++ b/src/zen/tests/ub-actions/browser.toml
@@ -4,5 +4,7 @@
 
 [DEFAULT]
 
+["browser_ub_actions_keywords.js"]
+
 ["browser_ub_actions_search.js"]
 ["browser_workspace_restrict_search.js"]

--- a/src/zen/tests/ub-actions/browser_ub_actions_keywords.js
+++ b/src/zen/tests/ub-actions/browser_ub_actions_keywords.js
@@ -1,0 +1,47 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+ChromeUtils.defineESModuleGetters(this, {
+  globalActions: "resource:///modules/ZenUBGlobalActions.sys.mjs",
+  UrlbarTestUtils: "resource://testing-common/UrlbarTestUtils.sys.mjs",
+});
+
+async function assertFirstAction(query, expectedCommand) {
+  const action = globalActions.find(a => a.command === expectedCommand);
+  ok(action, `Action ${expectedCommand} exists`);
+  await UrlbarTestUtils.promiseAutocompleteResultPopup({
+    window,
+    waitForFocus,
+    value: query,
+  });
+  await new Promise(resolve =>
+    setTimeout(async () => {
+      const { result } = await UrlbarTestUtils.getRowAt(window, 1);
+      Assert.equal(
+        result.providerName,
+        "ZenUrlbarProviderGlobalActions",
+        `"${query}" returns an action`
+      );
+      Assert.equal(
+        result.payload.title,
+        action.label,
+        `"${query}" returns ${expectedCommand}`
+      );
+      resolve();
+    }, 0)
+  );
+}
+
+// Query words may appear in any order.
+add_task(async function test_Ub_Actions_Word_Order() {
+  await assertFirstAction("pick theme", "cmd_zenOpenZenThemePicker");
+  await assertFirstAction("picker theme open", "cmd_zenOpenZenThemePicker");
+});
+
+// Localized keywords act as synonyms for the label.
+add_task(async function test_Ub_Actions_Keywords() {
+  await assertFirstAction("change theme", "cmd_zenOpenZenThemePicker");
+  await assertFirstAction("incognito", "Tools:PrivateBrowsing");
+});

--- a/src/zen/urlbar/ZenUBActionsProvider.sys.mjs
+++ b/src/zen/urlbar/ZenUBActionsProvider.sys.mjs
@@ -18,6 +18,12 @@ const MAX_RECENT_ACTIONS = 5;
 const MINIMUM_QUERY_SCORE = 92;
 const MINIMUM_PREFIXED_QUERY_SCORE = 30;
 
+// Query words that may be skipped when they don't match anything, as long as
+// at least one other word matched. Kept deliberately small.
+const STOP_WORDS = new Set(["a", "an", "the", "to", "in", "on", "of", "for"]);
+// Keyword matches rank slightly below equally good label matches.
+const KEYWORD_SCORE_FACTOR = 0.9;
+
 ChromeUtils.defineESModuleGetters(lazy, {
   UrlbarResult: "chrome://browser/content/urlbar/UrlbarResult.mjs",
   BrowserWindowTracker: "resource:///modules/BrowserWindowTracker.sys.mjs",
@@ -254,7 +260,7 @@ export class ZenUrlbarProviderGlobalActions extends UrlbarProvider {
         continue;
       }
       const label = action.extraPayload?.prettyName || action.label;
-      const score = this.#calculateFuzzyScore(label, query);
+      const score = this.#scoreAction(label, action.keywords, query);
       if (
         score >
         (isPrefixed ? MINIMUM_PREFIXED_QUERY_SCORE : MINIMUM_QUERY_SCORE)
@@ -271,6 +277,68 @@ export class ZenUrlbarProviderGlobalActions extends UrlbarProvider {
       return results.map(r => r.action);
     }
     return results.slice(0, MAX_RECENT_ACTIONS).map(r => r.action);
+  }
+
+  /**
+   * Scores an action against the query. The whole label is scored as today,
+   * and additionally the query is matched word by word against the label
+   * words and the action's keywords, in any order. The best of the two wins,
+   * so queries that already match keep their score.
+   *
+   * @param {string} label The action's label.
+   * @param {string[]} keywords Optional keyword phrases for the action.
+   * @param {string} query The user's search query.
+   * @returns {number} A score representing the match quality.
+   */
+  #scoreAction(label, keywords, query) {
+    const wholeScore = this.#calculateFuzzyScore(label, query);
+    const queryWords = query.toLowerCase().split(/\s+/).filter(Boolean);
+    if (!queryWords.length) {
+      return wholeScore;
+    }
+    const labelWords = label.toLowerCase().split(/\s+/).filter(Boolean);
+    const keywordWords = (keywords || [])
+      .flatMap(keyword => keyword.toLowerCase().split(/\s+/))
+      .filter(Boolean);
+    const keywordPhrases = (keywords || []).map(keyword =>
+      keyword.toLowerCase()
+    );
+
+    let total = 0;
+    let matched = 0;
+    let skipped = 0;
+    for (const queryWord of queryWords) {
+      let best = 0;
+      for (const labelWord of labelWords) {
+        best = Math.max(best, this.#calculateFuzzyScore(labelWord, queryWord));
+      }
+      for (const keywordWord of keywordWords) {
+        best = Math.max(
+          best,
+          this.#calculateFuzzyScore(keywordWord, queryWord) *
+            KEYWORD_SCORE_FACTOR
+        );
+      }
+      if (best > 0) {
+        total += best;
+        matched++;
+      } else if (STOP_WORDS.has(queryWord)) {
+        skipped++;
+      } else {
+        // A meaningful query word matched nothing: not a match.
+        return wholeScore;
+      }
+    }
+    if (!matched || skipped === queryWords.length) {
+      return wholeScore;
+    }
+    let wordScore = total / matched;
+    // The whole query equals a keyword phrase: nearly as good as an exact
+    // label match.
+    if (keywordPhrases.includes(queryWords.join(" "))) {
+      wordScore = Math.max(wordScore, 200 * KEYWORD_SCORE_FACTOR);
+    }
+    return Math.max(wholeScore, wordScore);
   }
 
   /**

--- a/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
+++ b/src/zen/urlbar/ZenUBGlobalActions.sys.mjs
@@ -29,6 +29,7 @@ const globalActionsTemplate = [
   },
   {
     l10nId: "zen-action-open-theme-picker",
+    keywordsL10nId: "zen-action-open-theme-picker-keywords",
     command: "cmd_zenOpenZenThemePicker",
     icon: "chrome://browser/skin/zen-icons/edit-theme.svg",
   },
@@ -44,16 +45,19 @@ const globalActionsTemplate = [
   },
   {
     l10nId: "zen-action-copy-current-url",
+    keywordsL10nId: "zen-action-copy-current-url-keywords",
     command: "cmd_zenCopyCurrentURL",
     icon: "chrome://browser/skin/zen-icons/link.svg",
   },
   {
     l10nId: "zen-action-settings",
+    keywordsL10nId: "zen-action-settings-keywords",
     command: window => window.openPreferences(),
     icon: "chrome://browser/skin/zen-icons/settings.svg",
   },
   {
     l10nId: "zen-action-open-private-window",
+    keywordsL10nId: "zen-action-open-private-window-keywords",
     command: "Tools:PrivateBrowsing",
     icon: "chrome://browser/skin/zen-icons/private-window.svg",
   },
@@ -214,6 +218,7 @@ const globalActionsTemplate = [
   },
   {
     l10nId: "zen-action-find-in-page",
+    keywordsL10nId: "zen-action-find-in-page-keywords",
     command: "cmd_find",
     icon: "chrome://browser/skin/zen-icons/search-page.svg",
     isAvailable: window => {
@@ -275,5 +280,15 @@ export const globalActions = globalActionsTemplate.map(action => ({
   ...action,
   get label() {
     return lazy.l10n.formatValueSync(action.l10nId);
+  },
+  get keywords() {
+    if (!action.keywordsL10nId) {
+      return [];
+    }
+    return lazy.l10n
+      .formatValueSync(action.keywordsL10nId)
+      .split(",")
+      .map(keyword => keyword.trim())
+      .filter(Boolean);
   },
 }));


### PR DESCRIPTION
Idea / motivation: #15371

### Problem
The URL bar action search matched the query as one ordered character subsequence against the label. Natural queries failed: `pick theme` (word order), `find on page` (no `o` after "find "), `change theme` (synonym). The feature only worked when you knew the exact label wording.

### What
- **Word-level matching** in `ZenUBActionsProvider`: the query is split into words, each word is scored against the label words (any order) and the action's keywords. The result is the average per-word score, compared against the existing thresholds. The whole-label score is still computed and the higher one wins, so everything that matched before keeps its score and rank.
- **Optional localized keywords**: actions may declare `keywordsL10nId`; the comma-separated string lives in `zen-command-palette.ftl` next to the label. Keyword matches are scaled by 0.9 so label matches rank first. Seeded for theme picker, find in page, settings, copy URL, private window.
- **Precision guard**: every meaningful query word must match something. Only `a, an, the, to, in, on, of, for` may be skipped, and only when another word matched. No global synonym list, no additional typo tolerance.

### Behaviour (from a scoring simulation over the current action list, threshold 92)
| query | before | after |
|---|---|---|
| `pick theme` | nothing | Open Theme Picker |
| `change theme` | nothing | Open Theme Picker |
| `find on page` | nothing | Find in Page |
| `copy link` | nothing | Copy Current URL |
| `theme` | Open Theme Picker | unchanged |
| `open` | Open Theme Picker, Open Private Window | unchanged |
| `xyz theme` | nothing | nothing |

### Testing
- New `browser_ub_actions_keywords.js` covers word order and keyword matching. Existing `browser_ub_actions_search.js` (full label queries) is unaffected since exact matches still score 200.
- Scoring logic verified with a Node simulation of the two functions.
- Behaviour verified at runtime in Zen 1.22b (macOS, arm64) by loading this exact provider and actions module through a resource substitution and swapping the registered provider: `pick theme`, `change theme`, `find on page`, `copy link` resolve; unrelated queries still return nothing. A local build with the mochitests is in progress and results will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
