### PR TITLE
gh-15387: Fix #writeToDom crash when mod has checkbox preferences

### DIFF
--- a/src/zen/mods/ZenMods.mjs
+++ b/src/zen/mods/ZenMods.mjs
@@ -187,7 +187,7 @@ class nsZenMods extends nsZenPreloadedFeature {
           type,
           sanitizedProperty: property?.replaceAll(DOT_RE, "-"),
           value:
-            enabled === undefined || enabled
+            (enabled === undefined || enabled) && type !== "checkbox"
               ? Services.prefs.getStringPref(property, "")
               : "",
         })),


### PR DESCRIPTION
## Summary
- Fetch boolean preferences using `Services.prefs.getBoolPref` instead of calling `Services.prefs.getStringPref` on `checkbox` preferences in `#writeToDom`.
- Fixes an unhandled `NS_ERROR_UNEXPECTED` exception in Gecko XPCOM caused by attempting to read boolean preferences as strings, which was crashing `#writeToDom` and preventing all mod styles and DOM attributes from applying.

fix: #15387

## Test plan
- [ ] Install or enable a Zen Mod that contains a `checkbox` preference in its `preferences.json`
- [ ] Verify that no `NS_ERROR_UNEXPECTED` error is thrown in the Browser Console
- [ ] Verify that DOM styles and attributes for enabled mods are applied as expected
- [ ] Verify that mods with `string` and `dropdown` preferences still work as expected without regression
